### PR TITLE
style: make header fit on one line

### DIFF
--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -31,7 +31,7 @@ header
     a,
     a:link,
     a:active
-        padding 0 12px
+        padding 0 8px
         text-transform uppercase
         font-size 14px
         color #ccc !important


### PR DESCRIPTION
Reduce padding for header links to make them fit on a single line

Before:
![screen shot 2015-08-07 at 8 10 20 am](https://cloud.githubusercontent.com/assets/677994/9136511/be537a50-3cdc-11e5-845f-7c3a5615f259.png)

After:

![screen shot 2015-08-07 at 8 09 36 am](https://cloud.githubusercontent.com/assets/677994/9136512/c27ce012-3cdc-11e5-9427-9bf41b7e49e9.png)
