### PR TITLE
Less versions coupling in .hbs templates

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,8 +15,9 @@ const path = require('path');
 const fs = require('fs');
 const ncp = require('ncp');
 
-const filterStylusPartials = require('./plugins/filter-stylus-partials.js');
-const mapHandlebarsPartials = require('./plugins/map-handlebars-partials.js');
+const filterStylusPartials = require('./plugins/filter-stylus-partials');
+const mapHandlebarsPartials = require('./plugins/map-handlebars-partials');
+const versions = require('./source/versions');
 
 /** Build **/
 
@@ -49,7 +50,8 @@ function traverse (obj, str) {
 
 const source = {
   project: {
-    versions: require('./source/versions.json')
+    versions,
+    currentVersion: versions[0].version
   }
 };
 

--- a/layouts/download.hbs
+++ b/layouts/download.hbs
@@ -28,7 +28,7 @@ section h2 {
 
             <section>
               <h2>io.js</h2>
-              <strong>Current version: {{project.versions.0.version}}</strong>
+              <strong>{{current-version}}: {{project.currentVersion}}</strong>
               <p>
                 {{iojs.intro}}
               </p>

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -14,13 +14,13 @@
             <div class="home-download">
                 <img src="/static/images/logo-hexagon.svg" alt="node.js" class="home-logo">
                 <div class="home-download-details">
-                    <p class="home-download-version"><a href="https://iojs.org/dist/v{{ version }}/">Version {{ version }}</a></p>
+                    <p class="home-download-version"><a href="https://iojs.org/dist/{{ project.currentVersion }}/">Version {{ project.currentVersion }}</a></p>
                     <p class="home-download-list">
-                        {{download-text}} <a href="https://iojs.org/dist/v{{ version }}/iojs-v{{ version }}-linux-x64.tar.xz">Linux</a>,
-                        <a href="https://iojs.org/dist/v{{ version }}/iojs-v{{ version }}-x86.msi">Win32</a>,
-                        <a href="https://iojs.org/dist/v{{ version }}/iojs-v{{ version }}-x64.msi">Win64</a>,
-                        <a href="https://iojs.org/dist/v{{ version }}/iojs-v{{ version }}.pkg">Mac</a> &amp;
-                        <a href="https://iojs.org/dist/v{{ version }}/">Others</a>
+                        {{download-text}} <a href="https://iojs.org/dist/{{ project.currentVersion }}/iojs-{{ project.currentVersion }}-linux-x64.tar.xz">Linux</a>,
+                        <a href="https://iojs.org/dist/{{ project.currentVersion }}/iojs-{{ project.currentVersion }}-x86.msi">Win32</a>,
+                        <a href="https://iojs.org/dist/{{ project.currentVersion }}/iojs-{{ project.currentVersion }}-x64.msi">Win64</a>,
+                        <a href="https://iojs.org/dist/{{ project.currentVersion }}/iojs-{{ project.currentVersion }}.pkg">Mac</a> &amp;
+                        <a href="https://iojs.org/dist/{{ project.currentVersion }}/">Others</a>
                     </p>
                     <p><a href="https://github.com/nodejs/io.js/blob/master/CHANGELOG.md">Changelog</a></p>
                 </div>

--- a/locale/en/download.md
+++ b/locale/en/download.md
@@ -2,6 +2,7 @@
 layout: download.hbs
 title: Download
 introduction: Download the Node.js source code or a pre-built installer for your platform, and start developing today.
+current-version: Current version
 iojs:
   intro: "In May 2015, the io.js project TSC voted to join the Node.js Foundation and merge back with Node.js.
           While the project streams are being converged, io.js releases will continue in parallel."

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -1,7 +1,6 @@
 ---
 title: new.nodejs.org
 layout: index.hbs
-version: 2.5.0
 download-text: 'Download for'
 description: Bringing the converged nodejs.org/iojs.org to the Node Community!
 updates:


### PR DESCRIPTION
Simpler way of fetching current version of the project: `project.currentVersion` rather than `project.versions.0.version` meaning less coupling and in a sence logic in the .hbs templates.

Also replaced and removed the `version` property in `locale/en/index.md` as it should be read from the versions configuration rather than a locale property.
