### PR TITLE
Refactored some global styling into .class

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -19,9 +19,6 @@ h4,
 h5
     font-weight normal
 
-ul
-    padding 0
-
 a,
 a:link,
 a:active
@@ -58,9 +55,6 @@ pre
     code
         color #f0f0f0
 
-small
-    font-size 10px
-
 // Import specific page sections and layout parts
 @import 'layout/_sticky-footer'
 @import 'layout/_grid'
@@ -72,7 +66,6 @@ small
 @import 'page-modules/_home'
 @import 'page-modules/_foundation-members'
 @import 'page-modules/_download'
-
 
 .intro
     margin-top 140px
@@ -120,3 +113,15 @@ small
 
 .full-width
     width 100%
+
+.small
+    font-size 10px
+
+.color-lightgray
+    color $lightgray
+
+.no-padding
+    padding 0
+
+.pad-bottom-small
+    padding-bottom 1em

--- a/layouts/css/page-modules/_download.styl
+++ b/layouts/css/page-modules/_download.styl
@@ -21,12 +21,6 @@
                     display block
                     margin 0 auto
 
-                small
-                    font-size 10px
-                    display block
-                    color $lightgray
-                    padding-bottom 1em
-
             a:hover, a:active
                 background $darkgray
                 color $node-green

--- a/layouts/download.hbs
+++ b/layouts/download.hbs
@@ -29,26 +29,26 @@ section h2 {
               <p>{{introduction}}</p>
 
               <div class="download-hero full-width">
-                <ul>
+                <ul class="no-padding">
                   <li>
                     <a href="https://iojs.org/dist/{{project.currentVersion}}/iojs-{{project.currentVersion}}-x86.msi">
                       <img src="/static/images/platform-icon-win.png" height="50" width="45" alt="">
                       Windows Installer
-                      <small>iojs-{{project.currentVersion}}-x86.msi</small>
+                      <p class="small color-lightgray pad-bottom-small">iojs-{{project.currentVersion}}-x86.msi</p>
                     </a>
                   </li>
                   <li>
                     <a href="https://iojs.org/dist/{{project.currentVersion}}/iojs-{{project.currentVersion}}.pkg">
                       <img src="/static/images/platform-icon-osx.png" height="50" width="45" alt="">
                       Macintosh Installer
-                      <small>iojs-{{project.currentVersion}}.pkg</small>
+                      <p class="small color-lightgray pad-bottom-small">iojs-{{project.currentVersion}}.pkg</p>
                     </a>
                   </li>
                   <li>
                     <a href="https://iojs.org/dist/{{project.currentVersion}}/iojs-{{project.currentVersion}}.tar.gz">
                       <img src="/static/images/platform-icon-generic.png" height="50" width="45" alt="">
                       Source Code
-                      <small>iojs-{{project.currentVersion}}.tar.gz</small>
+                      <p class="small color-lightgray pad-bottom-small">iojs-{{project.currentVersion}}.tar.gz</p>
                     </a>
                   </li>
                 </ul>


### PR DESCRIPTION
This removes some global styling on `ul` and `small` was added along with the download matrix.

Also refactored out some specific styling on small-elements inside the download matrix, extracting it into reusable .class'es instead.

I prefer adding reusable classes to elements rather than handcrafting specific styling all the time. Would appreciate your thoughts about adding more reusable .class'es going forward rather than very specific styling as most of the site has ATM.
