### PR TITLE
Replace iojs with node in npm run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "New Nodejs.org website",
   "homepage": "https://new.nodejs.org",
   "scripts": {
-    "build": "iojs build.js",
-    "gulp": "iojs node_modules/gulp/bin/gulp.js",
-    "serve": "iojs build.js serve",
+    "build": "node build.js",
+    "gulp": "gulp",
+    "serve": "node build.js serve",
     "lint": "eslint scripts build.js plugins"
   },
   "repository": {


### PR DESCRIPTION
Use `node` instead of `iojs` in run scripts as this project isnt iojs exclusive. This will work as intended
for those running iojs anyways, as iojs creates a node symlink.

Also simplified gulp script as npm adds all dependencies into `$PATH` when running npm scripts.

Addresses one of the issues seen in #46.
