### PR TITLE
style: make site more readable on mobile

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -117,6 +117,17 @@ pre
     article
         margin-left 200px
 
+@media screen and (max-width: 480px)
+    .has-side-nav
+        aside
+            width 100%
+            float none
+        article
+            margin-left 0px
+
+            pre
+              overflow-x scroll
+
 .full-width
     width 100%
 


### PR DESCRIPTION
The side nav breaks and is centered above article now.

pre blocks also have scrolling for overflow-x on mobile.

Before:

![screen shot 2015-08-30 at 7 21 10 am](https://cloud.githubusercontent.com/assets/677994/9567195/c04239c4-4ee7-11e5-8633-507f1f0e8d93.png)

After:

![screen shot 2015-08-30 at 7 19 13 am](https://cloud.githubusercontent.com/assets/677994/9567197/c664cdbc-4ee7-11e5-8277-1be99f4ddfbc.png)
