### PR TITLE
download windows x64 .msi files from x64/ for 0.x.x

### DIFF
--- a/static/js/download.js
+++ b/static/js/download.js
@@ -14,7 +14,7 @@
       db.innerText = dlLocal + ' OS X (x64)';
       break;
     case 'Win':
-      db.href += 'node-' + version + '-' + x + '.msi';
+      db.href += (version[0] == '0' && x == 'x64' ? x + '/' : '') + 'node-' + version + '-' + x + '.msi';
       db.innerText = dlLocal + ' Windows (' + x +')';
       break;
     case 'Linux':


### PR DESCRIPTION
I haven't actually tested this works at all but windows 64-bit files for 0.x.x need to be prefixed with x64/, because reasons, so the big download button on the front page is giving a dead link for those visitors
