### PR TITLE
css: show vertical scrollbar on desktop browsers

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -7,6 +7,7 @@ body
     color #333
     margin 0
     background-color #fff
+    overflow-y scroll
 
 header,
 #main,


### PR DESCRIPTION
Without this, everything gets shifted left and right again when switching between pages with vertical scrollbar and no vertical scrollbar.
This shouldn't affect browsers that have zero-width scrollbars by default (mobile and safari).
