### PR TITLE
added an npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "node build.js",
     "serve": "node build.js serve",
     "lint": "eslint scripts build.js",
-    "load-versions": "node scripts/load-versions.js"
+    "load-versions": "node scripts/load-versions.js",
+    "start": "npm run serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Makes npm start command available. Just runs 'npm run serve' but means people can start the website using npm start without having to look at the package.json file.
