### PR TITLE
Reserve some space for the logo

### DIFF
--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -2,7 +2,7 @@
     <div class="container">
 
         <a href="/{{site.locale}}" id="logo">
-          <img src="/static/images/logo.svg" alt="node.js">
+          <img src="/static/images/logo.svg" height="75" width="180" alt="node.js">
         </a>
         <nav>
             <ul class="list-divider-pipe">


### PR DESCRIPTION
I observed that on slow networks, the logo takes a bit of time to load, then pushes the whole page down, so I reserved some space for it so that it wouldn't do that.
