### PR TITLE
Made code spans more visible

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -51,8 +51,9 @@ img
 
 
 code
-    color $darkgray
-
+    background-color #f2f2f2
+    font-size 85%
+    padding 0.2em
 
 pre
     background-color $node-gray


### PR DESCRIPTION
More visible code spans as discussed in #121.
### BEFORE

![image](https://cloud.githubusercontent.com/assets/1231635/9814265/ecf43c02-588c-11e5-8ca3-e2ced936af04.png)
### AFTER

![image](https://cloud.githubusercontent.com/assets/1231635/9814245/ba78480e-588c-11e5-8de7-69d45f914dfd.png)
