### PR TITLE
add NODE_MODULE_VERSION column to the releases table

### DIFF
--- a/layouts/css/page-modules/_download.styl
+++ b/layouts/css/page-modules/_download.styl
@@ -74,6 +74,9 @@ td.download-table-last
     > a
         padding 0 10px
 
+#modules-description
+    font-size: small
+
 @media (max-width: 700px)
     .download-hero ul
         width auto

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -25,6 +25,7 @@
                                 <td>Date</td>
                                 <td>V8</td>
                                 <td>npm</td>
+                                <td>NODE_MODULE_VERSION</td>
                                 <td></td>
                             </tr>
                         </thead>
@@ -35,6 +36,7 @@
                                     <td data-label="Date"><time>{{date}}</time></td>
                                     <td data-label="V8">{{v8}}</td>
                                     <td data-label="npm">{{npm}}</td>
+                                    <td data-label="NODE_MODULE_VERSION">{{modules}}</td>
                                     <td class="download-table-last">
                                         <a href="{{url}}">
                                             {{i18n 'releases.downloads'}}

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -49,7 +49,7 @@
                             {{/project.versions}}
                         </tbody>
                     </table>
-                    <p id="modules-description">{{modules}}</p>
+                    <p id="modules-description">{{{modules}}}</p>
                 </section>
             </article>
 

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -25,7 +25,7 @@
                                 <td>Date</td>
                                 <td>V8</td>
                                 <td>npm</td>
-                                <td>NODE_MODULE_VERSION</td>
+                                <td>Modules</td>
                                 <td></td>
                             </tr>
                         </thead>
@@ -36,7 +36,7 @@
                                     <td data-label="Date"><time>{{date}}</time></td>
                                     <td data-label="V8">{{v8}}</td>
                                     <td data-label="npm">{{npm}}</td>
-                                    <td data-label="NODE_MODULE_VERSION">{{modules}}</td>
+                                    <td data-label="Modules">{{modules}}</td>
                                     <td class="download-table-last">
                                         <a href="{{url}}">
                                             {{i18n 'releases.downloads'}}
@@ -49,6 +49,7 @@
                             {{/project.versions}}
                         </tbody>
                     </table>
+                    <p id="modules-description">{{modules}}</p>
                 </section>
             </article>
 

--- a/locale/en/download/releases.md
+++ b/locale/en/download/releases.md
@@ -3,4 +3,5 @@ layout: download-releases.hbs
 title: Previous Releases
 iojs:
   intro: "Releases 1.x through 3.x were called \"io.js\" as they were part of the io.js fork. As of Node.js 4.0.0 the former release lines of io.js converged with Node.js 0.12.x into unified Node.js releases."
+modules: "\"Modules\" refers to the ABI (application binary interface) version number of Node.js, used to determine which versions of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled. This version number is also referred to as NODE_MODULE_VERSION."
 ---

--- a/locale/en/download/releases.md
+++ b/locale/en/download/releases.md
@@ -3,5 +3,5 @@ layout: download-releases.hbs
 title: Previous Releases
 iojs:
   intro: "Releases 1.x through 3.x were called \"io.js\" as they were part of the io.js fork. As of Node.js 4.0.0 the former release lines of io.js converged with Node.js 0.12.x into unified Node.js releases."
-modules: "\"Modules\" refers to the ABI (application binary interface) version number of Node.js, used to determine which versions of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled. This version number is also referred to as NODE_MODULE_VERSION."
+modules: "\"Modules\" refers to the ABI (application binary interface) version number of Node.js, used to determine which versions of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled. This version number is also referred to as <code>NODE_MODULE_VERSION</code>."
 ---


### PR DESCRIPTION
why this is valuable: https://gist.github.com/maxogden/e81e0f1d222106146828

what it looks like:

<img width="1092" alt="screen shot 2015-09-15 at 2 51 21 pm" src="https://cloud.githubusercontent.com/assets/39759/9891164/5598deb4-5bb9-11e5-8f1a-50930be09f7c.png">
