### PR TITLE
Add API Documentation links to previous versions table.

### DIFF
--- a/build.js
+++ b/build.js
@@ -149,7 +149,8 @@ function buildlocale (locale) {
             startswith: require('./scripts/helpers/startswith.js'),
             i18n: require('./scripts/helpers/i18n.js'),
             changeloglink: require('./scripts/helpers/changeloglink.js'),
-            strftime: require('./scripts/helpers/strftime.js')
+            strftime: require('./scripts/helpers/strftime.js'),
+            apidocslink: require('./scripts/helpers/apidocslink.js')
         }
     }))
     .destination(path.join(__dirname, 'build', locale));

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -42,6 +42,9 @@
                                         <a href="{{changeloglink version}}">
                                             {{i18n 'links.pages.changelog'}}
                                         </a>
+                                        <a href="{{apidocslink version}}">
+                                            {{i18n 'docs.text'}}
+                                        </a>
                                     </td>
                                 </tr>
                             {{/project.versions}}

--- a/scripts/helpers/apidocslink.js
+++ b/scripts/helpers/apidocslink.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const semver = require('semver');
+
+
+module.exports = function (version) {
+
+    if (!version) { return ''; }
+
+    return semver.satisfies(version, '>=1.0.0 <4.0.0') ?
+        `https://iojs.org/dist/${version}/docs/api/` :
+        `https://nodejs.org/dist/${version}/docs/api/`;
+};


### PR DESCRIPTION
I have had to url hack this so many times, was stoked that the io.js website had it, let's get it on nodejs.org as well.

![selection_033](https://cloud.githubusercontent.com/assets/126482/9891681/f0ccd6e4-5bbc-11e5-916e-1be0a8a5daea.png)
