### PR TITLE
disallow most of /download/

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,9 @@
 User-Agent: *
 Disallow: /dist/
 Disallow: /docs/
+Disallow: /download/
+Allow: /download/release/latest/
+Allow: /download/release/latest/docs/api/
 Allow: /dist/latest/
 Allow: /dist/latest/docs/api/
 Allow: /api/


### PR DESCRIPTION
/cc @johnkpaul - thanks for pointing this out, disallowing /dist/, which it already did, is effectively the same as disallowing /download/ that has been newly introduced since v4.
