### PR TITLE
Increase body font weight for readability

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -3,7 +3,7 @@
 // Base styles
 body
     box-sizing border-box
-    font 300 20px/1.5 'Source Sans Pro', Open Sans, Roboto, Helvetica, Arial, sans-serif
+    font 400 20px/1.5 'Source Sans Pro', Open Sans, Roboto, Helvetica, Arial, sans-serif
     color $node-gray
     margin 0
     background-color #fff

--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/{{ site.locale }}/styles.css" media="all">
 
     <script>
-        var WebFontConfig = { google: { families: ['Source Sans Pro:300,400,600'] } };
+        var WebFontConfig = { google: { families: ['Source Sans Pro:400,600'] } };
         !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
         (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
         s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';


### PR DESCRIPTION
This was brought up on [HN](https://news.ycombinator.com/item?id=10234265) (Also more feedback in there regarding scrolling), and I think I have to agree that the body text has reduced readability on non-retina displays at least. Here's the status quo:

![screen shot 2015-09-18 at 1 18 50 pm](https://cloud.githubusercontent.com/assets/115237/9958226/14216dd8-5e08-11e5-997c-52ea4f1dc2fa.png)

And here's with this change:

![screen shot 2015-09-18 at 1 19 20 pm](https://cloud.githubusercontent.com/assets/115237/9958264/7cc19bec-5e08-11e5-868e-9f30cd7ca538.png)

We import weights 300,400,600 from Google Fonts right now, and if we're sure 300 is used nowhere else, I'll update the PR to remove this weight for performance.
