### PR TITLE
Download: Switch Windows link between x64/x86

### DIFF
--- a/layouts/download.hbs
+++ b/layouts/download.hbs
@@ -16,7 +16,7 @@
                     <div class="download-hero full-width">
                         <ul class="no-padding">
                             <li>
-                                <a href="https://nodejs.org/dist/{{project.currentVersion}}/node-{{project.currentVersion}}-x86.msi">
+                                <a href="https://nodejs.org/dist/{{project.currentVersion}}/node-{{project.currentVersion}}-x86.msi" id="windows-downloadbutton" data-version="{{ project.currentVersion }}">
                                     <img src="/static/images/platform-icon-win.png" height="50" width="45" alt="">
                                     Windows Installer
                                     <p class="small color-lightgray pad-bottom-small">node-{{project.currentVersion}}-x86.msi</p>
@@ -137,5 +137,6 @@
     </div>
 
     {{> footer }}
+    <script src="/static/js/download.js" async defer></script>
 </body>
 </html>

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -4,24 +4,35 @@
   var os = n.platform.match(/(Win|Mac|Linux)/);
   var x = n.userAgent.match(/x86_64|Win64|WOW64/) ||
     n.cpuClass === 'x64' ? 'x64' : 'x86';
+  var text = 'textContent' in d ? 'textContent' : 'innerText';
   var db = d.getElementById('home-downloadbutton');
-  if (!db) { return; }
-  var version = db.dataset.version;
-  var dlLocal = db.dataset.dlLocal;
-  var text = 'textContent' in db ? 'textContent' : 'innerText';
-  switch (os && os[1]) {
-    case 'Mac':
-      db.href += 'node-' + version + '.pkg';
-      db[text] = dlLocal + ' OS X (x64)';
-      break;
-    case 'Win':
-      // Windows 64-bit files for 0.x.x need to be prefixed with 'x64/'
-      db.href += (version[1] == '0' && x == 'x64' ? x + '/' : '') + 'node-' + version + '-' + x + '.msi';
-      db[text] = dlLocal + ' Windows (' + x +')';
-      break;
-    case 'Linux':
-      db.href += 'node-' + version + '-linux-' + x + '.tar.gz';
-      db[text] = dlLocal + ' Linux (' + x + ')';
-      break;
+  var version;
+  if (db) {
+    version = db.dataset.version;
+    var dlLocal = db.dataset.dlLocal;
+    switch (os && os[1]) {
+      case 'Mac':
+        db.href += 'node-' + version + '.pkg';
+        db[text] = dlLocal + ' OS X (x64)';
+        break;
+      case 'Win':
+        // Windows 64-bit files for 0.x.x need to be prefixed with 'x64/'
+        db.href += (version[1] == '0' && x == 'x64' ? x + '/' : '') + 'node-' + version + '-' + x + '.msi';
+        db[text] = dlLocal + ' Windows (' + x +')';
+        break;
+      case 'Linux':
+        db.href += 'node-' + version + '-linux-' + x + '.tar.gz';
+        db[text] = dlLocal + ' Linux (' + x + ')';
+        break;
+    }
+  }
+
+  // Windows button on download page
+  var winButton = d.getElementById('windows-downloadbutton');
+  if (winButton && os && os[1] === 'Win') {
+    var winText = winButton.getElementsByTagName('p')[0];
+    version = winButton.dataset.version;
+    winButton.href = winButton.href.replace(/x(86|64)/, x);
+    winText[text] = winText[text].replace(/x(86|64)/, x);
   }
 })(document, navigator);

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -8,8 +8,8 @@
   var db = d.getElementById('home-downloadbutton');
   var version;
   if (db) {
-    version = db.dataset.version;
-    var dlLocal = db.dataset.dlLocal;
+    version = db.getAttribute('data-version');
+    var dlLocal = db.getAttribute('data-dl-local');
     switch (os && os[1]) {
       case 'Mac':
         db.href += 'node-' + version + '.pkg';
@@ -31,7 +31,7 @@
   var winButton = d.getElementById('windows-downloadbutton');
   if (winButton && os && os[1] === 'Win') {
     var winText = winButton.getElementsByTagName('p')[0];
-    version = winButton.dataset.version;
+    version = winButton.getAttribute('data-version');
     winButton.href = winButton.href.replace(/x(86|64)/, x);
     winText[text] = winText[text].replace(/x(86|64)/, x);
   }


### PR DESCRIPTION
The homepage (/) points to the x64 installer, but the link on /downloads
(the one above the table of platforms/architectures) points to the x86 installer.

See https://github.com/nodejs/nodejs.org/issues/123
