### PR TITLE
replace webfont.js with simple font stylesheet

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -25,7 +25,6 @@
 </footer>
 
 <link rel="stylesheet" href="/static/css/prism-tomorrow.css" media="all">
-<script src="https://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js" async defer></script>
 <script type="text/javascript">
     var $scrollToTop = document.getElementById('scrollToTop');
     (window.onscroll = function() {

--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -18,9 +18,8 @@
         <link rel="alternate" href="/{{ ../site.locale }}/{{ link }}" title="{{ text }}" type="application/rss+xml">
     {{/each}}
     <link rel="stylesheet" href="/{{ site.locale }}/styles.css" media="all">
-
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600">
     <script>
-        var WebFontConfig = { google: { families: ['Source Sans Pro:400,600'] } };
         !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
         (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
         s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';


### PR DESCRIPTION
Another attempt at https://github.com/nodejs/new.nodejs.org/issues/108. I don't think we really need `webfont.js` right now and a simple stylesheet from Google Fonts allows for native browser caching. So far, the only font flash I noticed is on initial uncached load, which I think is unavoidable.
