### PR TITLE
Make the preposition consistent

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -2,7 +2,7 @@
 title: ES6
 layout: docs.hbs
 ---
-# ES6 on Node.js
+# ES6 in Node.js
 
 Node.js is built against modern versions of [V8](https://developers.google.com/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to Node.js developers in a timely manner, as well as continued performance and stability improvements.
 


### PR DESCRIPTION
As it is, the title of the page says `ES6 in Node.js`, but the main heading says `ES6 on Node.js`. This patch changes the main heading to `ES6 in Node.js`
