### PR TITLE
standard linting ./scripts/*.js and dont auto format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve": "node build.js serve",
     "load-versions": "node scripts/load-versions.js",
     "start": "npm run serve",
-    "test": "standard build.js scripts/**/*.js --format"
+    "test": "standard build.js scripts/*.js scripts/**/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Auto formatting seems to have some issues atm, could we disable it?

A couple of examples:

``` js
const a = { foo }
// will get "fixed" into
const a = { foo}
// ends in a standard violation, will have to manually edit
const a = {foo}

return {
  version,
  changelog,
  shasums,
  files
}
// will end up as
return {
  version,
  changelog,
  shasums,
files}
// havent found a fix to satisfy 
// formatter AND standard in this case 
```

Related standard-format issue https://github.com/maxogden/standard-format/issues/95
