### PR TITLE
Verify binaries while creating release blog post

### DIFF
--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -1,0 +1,69 @@
+const extend = require('util')._extend
+
+const downloads = [
+  {
+    'title': 'Windows 32-bit Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-x86.msi'
+  },
+  {
+    'title': 'Windows 64-bit Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-x64.msi'
+  },
+  {
+    'title': 'Windows 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/win-x86/node.exe'
+  },
+  {
+    'title': 'Windows 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/win-x64/node.exe'
+  },
+  {
+    'title': 'Mac OS X 64-bit Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.pkg'
+  },
+  {
+    'title': 'Mac OS X 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x64.tar.gz'
+  },
+  {
+    'title': 'Linux 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-x86.tar.gz'
+  },
+  {
+    'title': 'Linux 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-x64.tar.gz'
+  },
+  {
+    'title': 'SunOS 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-sunos-x86.tar.gz'
+  },
+  {
+    'title': 'SunOS 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-sunos-x64.tar.gz'
+  },
+  {
+    'title': 'ARMv6 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-armv6l.tar.gz'
+  },
+  {
+    'title': 'ARMv7 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-armv7.tar.gz'
+  },
+  {
+    'title': 'ARMv8 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-arm64.tar.gz'
+  },
+  {
+    'title': 'Source Code',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.tar.gz'
+  }
+]
+
+function resolveUrl (item, version) {
+  const url = item.templateUrl.replace(/%version%/g, version)
+  return extend({url}, item)
+}
+
+module.exports = (version) => {
+  return downloads.map((item) => resolveUrl(item, version))
+}

--- a/scripts/release.hbs
+++ b/scripts/release.hbs
@@ -9,20 +9,9 @@ layout: blog-post.hbs
 
 {{changelog}}
 
-Windows 32-bit Installer: https://nodejs.org/dist/v{{version}}/node-v{{version}}-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v{{version}}/node-v{{version}}-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v{{version}}/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v{{version}}/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v{{version}}/node-v{{version}}.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v{{version}}/node-v{{version}}-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v{{version}}/node-v{{version}}.tar.gz<br>
+{{#files}}
+{{.}}<br>
+{{/files}}
 Other release files: https://nodejs.org/dist/v{{version}}/<br>
 Documentation: https://nodejs.org/docs/v{{version}}/api/
 


### PR DESCRIPTION
At the moment of creating the release blog post, there's a chance not all binaries has been uploaded to nodejs.org/dist/ yet.

In these circumstances those specific binaries should have "Coming soon" rather than the actual download URL as those URLs would fail with a 404 page anyway.

This change enables that behaviour by verifying all the binaries about to be included in the blog post, by doing a HEAD request against each of the URLs where they're supposed to be located.

Refs https://github.com/nodejs/new.nodejs.org/issues/156

cc @nodejs/release 
