### PR TITLE
variables weren't passed on properly

### DIFF
--- a/build.js
+++ b/build.js
@@ -222,10 +222,10 @@ function server () {
     return p.slice(pre.length + 1, p.indexOf('/', pre.length + 1))
   }
   locales.on('change', function (p) {
-    buildlocale(getlocale(p))
+    buildlocale(p, getlocale(p))
   })
   locales.on('add', function (p) {
-    buildlocale(getlocale(p))
+    buildlocale(p, getlocale(p))
     locales.add(p)
   })
 

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -26,6 +26,8 @@ right place. Explore our community resources to find out how you can help:
 
 - An [Italian Node.js Conference](http://nodejsconf.it/) is held in Brescia.
 
+- [NodeConf Barcelona](http://barcelona.nodeconfeu.com/) is a Node conference in Spain, organized by BarcelonaJS.
+
 - [Node Summit](http://nodesummit.com/) is a conference in San Francisco focusing on the adoption of Node in larger companies.
 
 - [JSConf](http://jsconf.com/) organizes the main JavaScript conferences.


### PR DESCRIPTION
fixed:

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:8:11)
    at Object.posix.join (path.js:477:5)
    at buildlocale (/Sites/new.nodejs.org/build.js:48:25)
```

and added Barcelona to the NodeConf list.
