### PR TITLE
fix typo

### DIFF
--- a/locale/en/about/working-groups.md
+++ b/locale/en/about/working-groups.md
@@ -147,7 +147,7 @@ Each language community maintains its own membership.
 ### [Evangelism](https://github.com/nodejs/evangelism)
 
 The evangelism working group promotes the accomplishments
-of and lets the community know how they can get involved.
+of Node.js and lets the community know how they can get involved.
 
 Their responsibilities are:
 * Project messaging.


### PR DESCRIPTION
It looks like when io.js was replaced with Node.js, it got replaced
with nothing instead in at least one place.
