### PR TITLE
Add "strict mode only" to block scoping in es6 page.

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -15,7 +15,7 @@ All ES6 features are split into three groups for **shipping**, **staged**, and *
 ## Which ES6 features ship with Node.js by default (no runtime flag required)?
 
 
-* Block scoping
+* Block scoping (strict mode only)
 
     * [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
 


### PR DESCRIPTION
While I was testing node v4.x block scoping, I get error message `uncaughtException SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`. Perhaps documentation could be a little clearer about this.
