### PR TITLE
Excluded header when creating release blog post

### DIFF
--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -55,6 +55,7 @@ function download (url) {
 // ## 2015-07-09, Version 0.12.7 (Stable)
 // ## 2015-08-04, Version 3.0.0, @rvagg
 const rxReleaseSection = /## \d{4}-\d{2}-\d{2}, Version ([^,( ]+)[\s\S]*?(?=## \d{4})/g
+const rxSectionBody = /### Notable changes[\s\S]*/g
 
 function explicitVersion (version) {
   return version ? Promise.resolve(version) : Promise.reject()
@@ -94,9 +95,12 @@ function fetchChangelog (version) {
 
       /* eslint-disable no-cond-assign */
       while (matches = rxReleaseSection.exec(data)) {
+        const section = matches[0]
         const releaseVersion = matches[1]
-        if (releaseVersion === version) {
-          return matches[0]
+        const bodyMatch = rxSectionBody.exec(section)
+
+        if (releaseVersion === version && bodyMatch) {
+          return bodyMatch[0]
         }
       }
       /* eslint-enable no-cond-assign */

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -121,20 +121,33 @@ test('fetchChangelog(<version>)', (t) => {
       t.true(github.isDone(), 'githubusercontent.com was requested')
 
       t.end()
-    })
+    }, t.fail)
   })
 
   t.test('rejects when a matching version section could not be found in changelog', (t) => {
     const github = nock('https://raw.githubusercontent.com')
-      .get('/nodejs/node/v4.1.1/CHANGELOG.md')
+      .get('/nodejs/node/v0.14.0/CHANGELOG.md')
       .reply(200, 'A changelog without version sections...')
 
-    releasePost.fetchChangelog('4.1.1').then(null, (err) => {
-      t.equal(err.message, 'Couldnt find matching changelog for 4.1.1')
+    releasePost.fetchChangelog('0.14.0').then(t.fail, (err) => {
+      t.equal(err.message, 'Couldnt find matching changelog for 0.14.0')
       t.true(github.isDone(), 'githubusercontent.com was requested')
 
       t.end()
     })
+  })
+
+  t.test('does not include `## header` in matched version section', (t) => {
+    const github = nock('https://raw.githubusercontent.com')
+      .get('/nodejs/node/v4.1.0/CHANGELOG.md')
+      .replyWithFile(200, changelogFixture)
+
+    releasePost.fetchChangelog('4.1.0').then((changelog) => {
+      t.true(changelog.startsWith('### Notable changes'))
+      t.true(github.isDone(), 'githubusercontent.com was requested')
+
+      t.end()
+    }, t.fail)
   })
 
   t.end()


### PR DESCRIPTION
Previously the `## 2015-09-17, Version 4.1.0 ...` header was included from the changelog, when creating the release blog post.

These changes excludes that header and matching everything from the notable changes and below instead.

Refs #156 and @rvagg's [#186 comment](https://github.com/nodejs/new.nodejs.org/pull/186#issuecomment-142472144)
