### PR TITLE
Ignore junk files

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,6 +15,7 @@ const marked = require('marked')
 const path = require('path')
 const fs = require('fs')
 const ncp = require('ncp')
+const junk = require('junk')
 
 const filterStylusPartials = require('./scripts/plugins/filter-stylus-partials')
 const mapHandlebarsPartials = require('./scripts/plugins/map-handlebars-partials')
@@ -188,7 +189,7 @@ function fullbuild () {
     }
 
     fs.readdir(path.join(__dirname, 'locale'), function (e, locales) {
-      locales.forEach(function (locale) {
+      locales.filter(junk.not).forEach(function (locale) {
         buildlocale(source, locale)
       })
     })

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "autoprefixer-stylus": "0.7.1",
     "chokidar": "1.2.0",
     "handlebars": "3.0.3",
+    "junk": "1.0.2",
     "map-async": "0.1.1",
     "marked": "0.3.5",
     "metalsmith": "2.1.0",


### PR DESCRIPTION
This fixes the following annoyance:

``` bash
$ npm run serve

> new.nodejs.org@1.0.0 serve /Users/luigi/repos/new.nodejs.org
> node build.js serve

http://localhost:8080/en/
[metalsmith] build/static finished: 276ms
module.js:338
    throw err;
    ^

Error: Cannot find module '/Users/luigi/repos/new.nodejs.org/locale/.DS_Store/site.json'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at buildlocale (/Users/luigi/repos/new.nodejs.org/build.js:63:13)
    at /Users/luigi/repos/new.nodejs.org/build.js:193:9
    at Array.forEach (native)
    at /Users/luigi/repos/new.nodejs.org/build.js:192:15
    at FSReqWrap.oncomplete (fs.js:82:15)
```
