### PR TITLE
Resolved reformat of blog posts

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,6 +14,7 @@ const markdown = require('metalsmith-markdown')
 const prism = require('metalsmith-prism')
 const stylus = require('metalsmith-stylus')
 const permalinks = require('metalsmith-permalinks')
+const pagination = require('metalsmith-yearly-pagination')
 const marked = require('marked')
 const path = require('path')
 const fs = require('fs')
@@ -125,6 +126,13 @@ function buildlocale (source, locale) {
         pattern: 'docs/guides/!(index).md',
         refer: false
       }
+    }))
+    .use(pagination({
+      path: 'blog/year',
+      iteratee: (post, idx) => ({
+        post,
+        displaySummary: idx < 10
+      })
     }))
     .use(markdown(markedOptions))
     .use(githubLinks({ locale: locale }))

--- a/build.js
+++ b/build.js
@@ -182,7 +182,8 @@ function buildlocale (source, locale) {
         changeloglink: require('./scripts/helpers/changeloglink.js'),
         strftime: require('./scripts/helpers/strftime.js'),
         apidocslink: require('./scripts/helpers/apidocslink.js'),
-        majorapidocslink: require('./scripts/helpers/majorapidocslink.js')
+        majorapidocslink: require('./scripts/helpers/majorapidocslink.js'),
+        summary: require('./scripts/helpers/summary.js')
       }
     }))
     // Pipes the generated files into their respective subdirectory in the build

--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -13,7 +13,8 @@
                     {{#if title}}
                         <li>
                             <time datetime="{{ date }}">{{ strftime date "%d %b %y" }}</time>
-                            <a href="/{{../site.locale}}/{{ path }}/">{{ title }}</a>
+                            <a href="/{{../../site.locale}}/{{ path }}/">{{ title }}</a>
+                            {{{ summary contents }}}
                         </li>
                     {{/if}}
                 {{/each}}

--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -14,7 +14,9 @@
                         <li>
                             <time datetime="{{ date }}">{{ strftime date "%d %b %y" }}</time>
                             <a href="/{{../../site.locale}}/{{ path }}/">{{ title }}</a>
-                            {{{ summary contents }}}
+                            <div class="summary">
+                              {{{ summary contents ../../site.locale path }}}
+                            <div>
                         </li>
                     {{/if}}
                 {{/each}}

--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{site.locale}}">
+<html lang="{{ site.locale }}">
 {{> html-head }}
 
 <body>
@@ -7,21 +7,34 @@
 
     <div id="main">
         <div class="container">
+            <h2>News from {{ pagination.year }}</h2>
 
             <ul class="blog-index">
-                {{#each collections.blog}}
-                    {{#if title}}
-                        <li>
-                            <time datetime="{{ date }}">{{ strftime date "%d %b %y" }}</time>
-                            <a href="/{{../../site.locale}}/{{ path }}/">{{ title }}</a>
+                {{#each pagination.posts}}
+                    <li>
+                        <time datetime="{{ post.date }}">{{ strftime post.date "%d %b" }}</time>
+                        <a href="/{{ ../site.locale }}/{{ post.path }}/">{{ post.title }}</a>
+
+                        {{#if displaySummary}}
                             <div class="summary">
-                              {{{ summary contents ../../site.locale path }}}
+                              {{{ summary post.contents ../site.locale post.path }}}
                             <div>
-                        </li>
-                    {{/if}}
+                        {{/if}}
+                    </li>
                 {{/each}}
             </ul>
 
+            {{#if pagination}}
+                <nav class="pagination">
+                    {{#if pagination.prev.path}}
+                        <a href="/{{ site.locale }}/{{ pagination.prev.path }}">&lt; Newer</a>
+                    {{/if}}
+
+                    {{#if pagination.next.path}}
+                        <a href="/{{ site.locale }}/{{ pagination.next.path }}">Older &gt;</a>
+                    {{/if}}
+                </nav>
+            {{/if}}
         </div>
     </div>
 

--- a/layouts/css/page-modules/_blog-index.styl
+++ b/layouts/css/page-modules/_blog-index.styl
@@ -2,3 +2,6 @@
     time
         margin-right 1em
         color $light-gray
+
+    .summary
+      font-size: 75%

--- a/layouts/css/page-modules/_blog-index.styl
+++ b/layouts/css/page-modules/_blog-index.styl
@@ -1,7 +1,11 @@
 .blog-index
+    list-style none
+    padding 0
+
     time
         margin-right 1em
         color $light-gray
 
     .summary
-      font-size: 75%
+        margin-left 1em
+        font-size: 75%

--- a/locale/en/blog/index.md
+++ b/locale/en/blog/index.md
@@ -1,3 +1,4 @@
 ---
 layout: blog-index.hbs
+paginate: blog
 ---

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "metalsmith-permalinks": "0.4.0",
     "metalsmith-prism": "2.1.1",
     "metalsmith-stylus": "1.0.0",
+    "metalsmith-yearly-pagination": "2.0.0",
     "ncp": "2.0.0",
     "node-geocoder": "^3.4.1",
     "node-version-data": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "autoprefixer-stylus": "0.8.1",
     "changelog-url": "1.0.0",
+    "cheerio": "0.19.0",
     "chokidar": "1.2.0",
     "handlebars": "4.0.4",
     "html-to-text": "^1.5.0",

--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -2,15 +2,26 @@
 
 const cheerio = require('cheerio');
 
-module.exports = function (contents) {
-    var $ = cheerio.load('<div>'+contents+'</div>');
+const SUMMARY_LENGHT = 400;
 
-    var summary = $(':nth-child(1)').html();
-    console.log(contents);
+module.exports = function (contents, locale, path) {
+    let $ = cheerio.load(contents);
 
-    console.log("hello");
+    let summary = '';
+    let child = 1;
 
-    return summary;
+    $('*').each((i, elem) => {
+        if (summary.length > SUMMARY_LENGHT) {
+            summary += `<p><a href='/${locale}/${path}/'>Read more...</a></p>`;
+            return false;
+        }
+
+        if (elem.parent) {
+            return;
+        }
+
+        summary += $.html(elem);
+    })
+
+    return `${summary}`;
 };
-
-// module.exports('<h2 class="title">Hello world</h2><h2>asdfasd</h2>');

--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function (contents) {
+    return contents;
+};

--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -1,5 +1,16 @@
 'use strict'
 
+const cheerio = require('cheerio');
+
 module.exports = function (contents) {
-    return contents;
+    var $ = cheerio.load('<div>'+contents+'</div>');
+
+    var summary = $(':nth-child(1)').html();
+    console.log(contents);
+
+    console.log("hello");
+
+    return summary;
 };
+
+// module.exports('<h2 class="title">Hello world</h2><h2>asdfasd</h2>');

--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -1,27 +1,26 @@
 'use strict'
 
-const cheerio = require('cheerio');
+const cheerio = require('cheerio')
 
-const SUMMARY_LENGHT = 400;
+const SUMMARY_LENGHT = 400
 
 module.exports = function (contents, locale, path) {
-    let $ = cheerio.load(contents);
+  let $ = cheerio.load(contents)
 
-    let summary = '';
-    let child = 1;
+  let summary = ''
 
-    $('*').each((i, elem) => {
-        if (summary.length > SUMMARY_LENGHT) {
-            summary += `<p><a href='/${locale}/${path}/'>Read more...</a></p>`;
-            return false;
-        }
+  $('*').each((i, elem) => {
+    if (summary.length > SUMMARY_LENGHT) {
+      summary += `<p><a href='/${locale}/${path}/'>Read more...</a></p>`
+      return false
+    }
 
-        if (elem.parent) {
-            return;
-        }
+    if (elem.parent) {
+      return
+    }
 
-        summary += $.html(elem);
-    })
+    summary += $.html(elem)
+  })
 
-    return `${summary}`;
-};
+  return summary
+}


### PR DESCRIPTION
Hijacked PR #154 as it cannot be merged due to merge conflict issues and lack of response from the original authors.

This also needed cheerio added to package.json, which made the content generation to break. Not trying to make someone look bad, have forgot the same thing myself hundreds of times, but it highlights the need for smoketesting these PRs #225. That alert could have come from Travis when the initial PR was created, and of course prevented a bad merge & deploy.
#### UPDATED AFTER DISCUSSIONS BELOW

The original PR displayed title and first part of the blog post contents for _all_ blog posts ever written. This PR adds pagination by year, and title + blog contents for the first 10 posts, followed by the remaining posts in that year by title only.

Screenshots showing (1) the first page of blog posts as of 2016, clicking "older" will take you to (2) all the blog posts of 2015 and (3) how blog posts look from the 10th posts and below.
##### 1)

![screen shot 2016-01-01 at 22 40 48](https://cloud.githubusercontent.com/assets/1231635/12072315/0b677d8a-b0d9-11e5-8c10-63f8e23c92a3.png)
##### 2)

![screen shot 2016-01-01 at 22 40 59](https://cloud.githubusercontent.com/assets/1231635/12072314/04316eb8-b0d9-11e5-90c6-a0dda0d7ee9b.png)
##### 3)

![screen shot 2016-01-01 at 22 41 12](https://cloud.githubusercontent.com/assets/1231635/12072313/0163336a-b0d9-11e5-8cb7-4fa0a44a35a9.png)
