### PR TITLE
Display LTS and Stable on the frontpage

### DIFF
--- a/build.js
+++ b/build.js
@@ -21,6 +21,7 @@ const filterStylusPartials = require('./scripts/plugins/filter-stylus-partials')
 const mapHandlebarsPartials = require('./scripts/plugins/map-handlebars-partials')
 const anchorMarkdownHeadings = require('./scripts/plugins/anchor-markdown-headings')
 const loadVersions = require('./scripts/load-versions')
+const latestVersion = require('./scripts/helpers/latestversion')
 
 /** Build **/
 
@@ -181,8 +182,12 @@ function fullbuild () {
       project: {
         versions,
         currentVersion: versions[0].version,
+        currentVersions: {
+          stable: latestVersion.stable(versions),
+          lts: latestVersion.lts(versions)
+        },
         banner: {
-          visible: true,
+          visible: false,
           content: '<a href="https://nodejs.org/en/blog/release/v4.2.1/">Long Term Support Release</a>'
         }
       }

--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -12,8 +12,11 @@
     margin-top 1em
 
 .home-secondary-links
+    $home-secondary-links-color = saturation($node-green, 20%)
+
+    color $home-secondary-links-color
+
     a
-        $home-secondary-links-color = saturation($node-green, 20%)
         font-size 1rem
         color $home-secondary-links-color
 
@@ -27,13 +30,16 @@
     padding-top 30px
     text-align center
 
-#home-downloadbutton
+    h2
+        margin-bottom 0
+
+.home-downloadbutton
     display inline-block
     margin 10px 4px
     padding 0.2em 0.6em
 
     background-color $node-green
-    color #fff
+    color #fff !important
     border-radius 2px
     font-size 30px
     font-weight 400
@@ -43,4 +49,6 @@
     &:hover
         background-color saturation($node-green, 80%)
 
-
+    small
+        display block
+        font-size 1rem

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -17,14 +17,32 @@
                         {{ labels.current-version }}: {{ project.currentVersion }}<br>
                         {{{ project.banner.content }}}
                     </p>
-                {{else}}
-                      <p class="home-version">{{ labels.current-version }}: {{ project.currentVersion }}</p>
                 {{/if}}
 
-                <a href="https://nodejs.org/dist/{{ project.currentVersion }}/" id="home-downloadbutton" data-version="{{ project.currentVersion }}" data-dl-local="{{ labels.download-for }}">{{ labels.download }}</a>
+                <h2 id="home-downloadhead" data-dl-local="{{ labels.download-for }}">{{ labels.download }}</h2>
+
+                <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.currentVersions.lts }} {{ labels.lts }}" data-version="{{ project.currentVersions.lts }}">
+                    {{ project.currentVersions.lts }} {{ labels.lts }}
+                    <small>{{ labels.tagline-lts }}</small>
+                </a>
+
+                {{#if project.currentVersions.stable}}
+                    <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.currentVersions.stable }} {{ labels.stable }}"  data-version="{{ project.currentVersions.stable }}">
+                        {{ project.currentVersions.stable }} {{ labels.stable }}
+                        <small>{{ labels.tagline-stable }}</small>
+                    </a>
+                {{/if}}
 
                 <ul class="list-divider-pipe home-secondary-links">
-                    <li><a href="https://nodejs.org/dist/{{ project.currentVersion }}/">{{ labels.other-downloads }}</a></li>
+                    <li>
+                        <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/">{{ labels.other-lts-downloads }}</a>
+
+                        {{#if project.currentVersions.stable}}
+                            &#47; <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/" title="{{ labels.other-stable-downloads }}">
+                                {{ labels.stable }}
+                            </a>
+                        {{/if}}
+                    </li>
                     <li><a href="https://github.com/nodejs/node/blob/{{ project.currentVersion }}/CHANGELOG.md">{{ labels.changelog }}</a></li>
                     <li><a href="{{ site.docs.api.link }}">{{ labels.api }}</a></li>
                 </ul>
@@ -73,5 +91,6 @@
 
     {{> footer }}
     <script src="/static/js/download.js" async defer></script>
+
 </body>
 </html>

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -5,6 +5,12 @@ labels:
   download: Download
   download-for: Download for
   other-downloads: Other Downloads
+  other-lts-downloads: Other LTS Downloads
+  other-stable-downloads: Other Stable Downloads
+  stable: Stable
+  lts: LTS
+  tagline-stable: Latest Features
+  tagline-lts: Mature and Dependable
   changelog: Changelog
   api: API Docs
 ---

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const semver = require('semver')
+
+exports.stable = (releases) => {
+  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
+  return match && match.version
+}
+
+exports.lts = (releases) => releases.find((release) => release.lts).version


### PR DESCRIPTION
Until v5.0.0 exists in https://nodejs.org/dist/index.json, only v4.x LTS will be displayed, in other words just as before besides some design changes:

![lts screenshot](https://cloud.githubusercontent.com/assets/1231635/10574133/584a73ce-7654-11e5-89d9-e77e4f51ffc0.png)

Will display two buttons side by side automagically, as soon as `index.json` contains a v5.0.0 release which is not marked as `lts`:

![skjermbilde 2015-10-19 kl 10 52 47](https://cloud.githubusercontent.com/assets/1231635/10574130/56380600-7654-11e5-8b93-137312e7bbae.png)

Any thoughts?

Refs https://github.com/nodejs/new.nodejs.org/issues/200.
