### PR TITLE
Update ES6 docs for v5.0.0

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -55,11 +55,23 @@ All ES6 features are split into three groups for **shipping**, **staged**, and *
 
 * [Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 
+* [new.target](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target)
+
+* [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
+
+* [Spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator)
+
 You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
 
 ## Which ES6 features are behind the --es_staging flag?
 
 * [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (user-definable results for `Object.prototype.toString`, behind flag `--harmony_tostring`)
+
+* [`Array.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) (determine whether
+an array includes a certain element, behind flag `--harmony_array_includes`)
+
+* [Rest Parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) (represent an indefinite number
+of arguments as an array, behind flag `--harmony_rest_parameters`)
 
 ## Which ES6 features are in progress?
 


### PR DESCRIPTION
With node v5.0.0 will come an updated v8 that includes additional ES6
features. This adds some of those additional features to the ES6 doc

**This should not be merged until v5.0.0 is released**
