### PR TITLE
Adding a high contrast color for none code pre tags

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -61,13 +61,14 @@ code
 
 pre
     background-color $node-gray
+    color #f0f0f0
     border-radius 3px
     padding 0.75em 1.2em
     font-size 0.8em
     white-space pre-wrap
 
     code
-        color #f0f0f0
+        color inherit
         background-color inherit
 
 // Import specific page sections and layout parts


### PR DESCRIPTION
Intermediate style fix for content in`pre` tags that are explicitly code or missing the prism classes needed for syntax highlighting

This should resolve #272 
