### PR TITLE
replace custom logic in loadVersions with node-version-data package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "metalsmith-serve": "0.0.3",
     "metalsmith-stylus": "1.0.0",
     "ncp": "2.0.0",
+    "node-version-data": "1.0.0",
     "octonode": "0.7.4",
     "require-dir": "0.3.0",
     "semver": "5.0.3",

--- a/scripts/load-versions.js
+++ b/scripts/load-versions.js
@@ -3,68 +3,21 @@
 'use strict'
 
 const fs = require('fs')
-const semver = require('semver')
-const map = require('map-async')
-const https = require('https')
+const nodeVersionData = require('node-version-data')
 
-function loadVersions (callback) {
-  map(
-    [ 'https://nodejs.org/dist/index.json', 'https://iojs.org/dist/index.json' ],
-    download,
-    function (err, versions) {
-      if (err) { return callback(err) }
-      versions = munge(versions)
-      callback(null, versions)
-    }
-  )
-}
-
-function download (url, cb) {
-  let data = ''
-  https.get(url, function (res) {
-    res.on('data', function (chunk) { data += chunk })
-    res.on('end', function () {
-      try {
-        cb(null, JSON.parse(data))
-      } catch (e) {
-        return cb(e)
-      }
-    })
-  }).on('error', function (e) {
-    console.error('Error downloading file from %s: %s', url, e.message)
-    cb(e)
-  })
-}
-
-function munge (versions) {
-  versions[0].forEach(function (v) {
-    v.url = 'https://nodejs.org/dist/' + v.version + '/'
-    v.name = 'Node.js'
-  })
-  versions[1].forEach(function (v) {
-    v.url = 'https://iojs.org/dist/' + v.version + '/'
-    v.name = 'io.js'
-  })
-
-  let allVersions = versions[0].concat(versions[1])
-
-  allVersions.sort(function (a, b) {
-    return semver.compare(b.version, a.version)
-  })
-
-  return allVersions
-}
-
-module.exports = loadVersions
+module.exports = nodeVersionData
 
 if (require.main === module) {
-  loadVersions(function (err, versions) {
+  nodeVersionData((err, versions) => {
     if (err) {
       console.error('Aborting due to download error from node or iojs')
       console.error(err.stack)
       return process.exit(1)
     }
 
-    fs.writeFileSync(__dirname + '/../source/versions.json', JSON.stringify(versions, null, 2))
+    fs.writeFileSync(
+      __dirname + '/../source/versions.json'
+      , JSON.stringify(versions, null, 2)
+    )
   })
 }

--- a/source/versions.json
+++ b/source/versions.json
@@ -1,12 +1,152 @@
 [
   {
+    "version": "v4.2.1",
+    "date": "2015-10-13",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-msi",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.7",
+    "v8": "4.5.103.35",
+    "uv": "1.7.5",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "lts": "Argon",
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.2.1/"
+  },
+  {
+    "version": "v4.2.0",
+    "date": "2015-10-12",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-msi",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.7",
+    "v8": "4.5.103.35",
+    "uv": "1.7.5",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "lts": "Argon",
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.2.0/"
+  },
+  {
+    "version": "v4.1.2",
+    "date": "2015-10-05",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-msi",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.4",
+    "v8": "4.5.103.35",
+    "uv": "1.7.5",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.1.2/"
+  },
+  {
+    "version": "v4.1.1",
+    "date": "2015-09-23",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-msi",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.4",
+    "v8": "4.5.103.33",
+    "uv": "1.7.4",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.1.1/"
+  },
+  {
+    "version": "v4.1.0",
+    "date": "2015-09-18",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-msi",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.3",
+    "v8": "4.5.103.33",
+    "uv": "1.7.4",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "46",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.1.0/"
+  },
+  {
     "version": "v4.0.0",
     "date": "2015-09-08",
     "files": [
       "headers",
       "linux-arm64",
-      "linux-armv7l",
       "linux-armv6l",
+      "linux-armv7l",
       "linux-x64",
       "linux-x86",
       "osx-x64-pkg",
@@ -23,8 +163,38 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "46",
-    "url": "https://nodejs.org/dist/v4.0.0/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v4.0.0/"
+  },
+  {
+    "version": "v3.3.1",
+    "date": "2015-09-15",
+    "files": [
+      "headers",
+      "linux-arm64",
+      "linux-armv6l",
+      "linux-armv7l",
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x64-msi",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "2.14.3",
+    "v8": "4.4.63.30",
+    "uv": "1.7.4",
+    "zlib": "1.2.8",
+    "openssl": "1.0.2d",
+    "modules": "45",
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v3.3.1/"
   },
   {
     "version": "v3.3.0",
@@ -49,8 +219,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "45",
-    "url": "https://iojs.org/dist/v3.3.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v3.3.0/"
   },
   {
     "version": "v3.2.0",
@@ -75,8 +245,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "45",
-    "url": "https://iojs.org/dist/v3.2.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v3.2.0/"
   },
   {
     "version": "v3.1.0",
@@ -101,8 +271,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "45",
-    "url": "https://iojs.org/dist/v3.1.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v3.1.0/"
   },
   {
     "version": "v3.0.0",
@@ -127,8 +297,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "45",
-    "url": "https://iojs.org/dist/v3.0.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v3.0.0/"
   },
   {
     "version": "v2.5.0",
@@ -153,8 +323,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.5.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.5.0/"
   },
   {
     "version": "v2.4.0",
@@ -179,8 +349,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.4.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.4.0/"
   },
   {
     "version": "v2.3.4",
@@ -205,8 +375,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.3.4/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.3.4/"
   },
   {
     "version": "v2.3.3",
@@ -231,8 +401,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2c",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.3.3/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.3.3/"
   },
   {
     "version": "v2.3.2",
@@ -257,8 +427,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2c",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.3.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.3.2/"
   },
   {
     "version": "v2.3.1",
@@ -282,8 +452,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2c",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.3.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.3.1/"
   },
   {
     "version": "v2.3.0",
@@ -307,8 +477,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2c",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.3.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.3.0/"
   },
   {
     "version": "v2.2.1",
@@ -332,8 +502,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.2.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.2.1/"
   },
   {
     "version": "v2.2.0",
@@ -357,8 +527,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.2.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.2.0/"
   },
   {
     "version": "v2.1.0",
@@ -382,8 +552,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.1.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.1.0/"
   },
   {
     "version": "v2.0.2",
@@ -407,8 +577,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.0.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.0.2/"
   },
   {
     "version": "v2.0.1",
@@ -432,8 +602,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.0.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.0.1/"
   },
   {
     "version": "v2.0.0",
@@ -457,8 +627,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "44",
-    "url": "https://iojs.org/dist/v2.0.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v2.0.0/"
   },
   {
     "version": "v1.8.4",
@@ -483,8 +653,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2d",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.8.4/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.8.4/"
   },
   {
     "version": "v1.8.3",
@@ -509,8 +679,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2c",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.8.3/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.8.3/"
   },
   {
     "version": "v1.8.2",
@@ -534,8 +704,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.8.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.8.2/"
   },
   {
     "version": "v1.8.1",
@@ -559,8 +729,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.2a",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.8.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.8.1/"
   },
   {
     "version": "v1.7.1",
@@ -584,8 +754,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.7.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.7.1/"
   },
   {
     "version": "v1.6.4",
@@ -609,8 +779,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.6.4/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.6.4/"
   },
   {
     "version": "v1.6.3",
@@ -634,8 +804,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.6.3/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.6.3/"
   },
   {
     "version": "v1.6.2",
@@ -659,8 +829,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.6.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.6.2/"
   },
   {
     "version": "v1.6.1",
@@ -684,8 +854,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.6.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.6.1/"
   },
   {
     "version": "v1.6.0",
@@ -709,8 +879,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.6.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.6.0/"
   },
   {
     "version": "v1.5.1",
@@ -734,8 +904,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.5.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.5.1/"
   },
   {
     "version": "v1.5.0",
@@ -759,8 +929,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.5.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.5.0/"
   },
   {
     "version": "v1.4.3",
@@ -784,8 +954,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.4.3/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.4.3/"
   },
   {
     "version": "v1.4.2",
@@ -809,8 +979,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.4.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.4.2/"
   },
   {
     "version": "v1.4.1",
@@ -834,8 +1004,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.4.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.4.1/"
   },
   {
     "version": "v1.3.0",
@@ -859,8 +1029,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.3.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.3.0/"
   },
   {
     "version": "v1.2.0",
@@ -884,8 +1054,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.2.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.2.0/"
   },
   {
     "version": "v1.1.0",
@@ -908,8 +1078,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "43",
-    "url": "https://iojs.org/dist/v1.1.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.1.0/"
   },
   {
     "version": "v1.0.4",
@@ -932,8 +1102,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "42",
-    "url": "https://iojs.org/dist/v1.0.4/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.0.4/"
   },
   {
     "version": "v1.0.3",
@@ -956,8 +1126,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "42",
-    "url": "https://iojs.org/dist/v1.0.3/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.0.3/"
   },
   {
     "version": "v1.0.2",
@@ -980,8 +1150,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "42",
-    "url": "https://iojs.org/dist/v1.0.2/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.0.2/"
   },
   {
     "version": "v1.0.1",
@@ -1004,8 +1174,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "42",
-    "url": "https://iojs.org/dist/v1.0.1/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.0.1/"
   },
   {
     "version": "v1.0.0",
@@ -1028,8 +1198,8 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1k",
     "modules": "42",
-    "url": "https://iojs.org/dist/v1.0.0/",
-    "name": "io.js"
+    "name": "io.js",
+    "url": "https://iojs.org/download/release/v1.0.0/"
   },
   {
     "version": "v0.12.7",
@@ -1053,8 +1223,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1p",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.7/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.7/"
   },
   {
     "version": "v0.12.6",
@@ -1078,8 +1249,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1o",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.6/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.6/"
   },
   {
     "version": "v0.12.5",
@@ -1103,8 +1275,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1o",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.5/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.5/"
   },
   {
     "version": "v0.12.4",
@@ -1128,8 +1301,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.4/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.4/"
   },
   {
     "version": "v0.12.3",
@@ -1153,8 +1327,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.3/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.3/"
   },
   {
     "version": "v0.12.2",
@@ -1178,8 +1353,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.2/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.2/"
   },
   {
     "version": "v0.12.1",
@@ -1203,8 +1379,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.1/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.1/"
   },
   {
     "version": "v0.12.0",
@@ -1228,8 +1405,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1l",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.12.0/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.12.0/"
   },
   {
     "version": "v0.11.16",
@@ -1253,8 +1431,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1l",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.16/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.16/"
   },
   {
     "version": "v0.11.15",
@@ -1278,8 +1457,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1j",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.15/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.15/"
   },
   {
     "version": "v0.11.14",
@@ -1303,8 +1483,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1i",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.14/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.14/"
   },
   {
     "version": "v0.11.13",
@@ -1328,8 +1509,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1g",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.13/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.13/"
   },
   {
     "version": "v0.11.12",
@@ -1353,8 +1535,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1f",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.12/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.12/"
   },
   {
     "version": "v0.11.11",
@@ -1378,8 +1561,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1f",
     "modules": "14",
-    "url": "https://nodejs.org/dist/v0.11.11/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.11/"
   },
   {
     "version": "v0.11.10",
@@ -1403,8 +1587,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "13",
-    "url": "https://nodejs.org/dist/v0.11.10/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.10/"
   },
   {
     "version": "v0.11.9",
@@ -1428,8 +1613,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "13",
-    "url": "https://nodejs.org/dist/v0.11.9/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.9/"
   },
   {
     "version": "v0.11.8",
@@ -1453,8 +1639,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "13",
-    "url": "https://nodejs.org/dist/v0.11.8/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.8/"
   },
   {
     "version": "v0.11.7",
@@ -1478,8 +1665,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.7/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.7/"
   },
   {
     "version": "v0.11.6",
@@ -1501,8 +1689,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.6/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.6/"
   },
   {
     "version": "v0.11.5",
@@ -1526,8 +1715,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.5/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.5/"
   },
   {
     "version": "v0.11.4",
@@ -1549,8 +1739,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.4/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.4/"
   },
   {
     "version": "v0.11.3",
@@ -1574,8 +1765,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.3/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.3/"
   },
   {
     "version": "v0.11.2",
@@ -1599,8 +1791,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.2/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.2/"
   },
   {
     "version": "v0.11.1",
@@ -1624,8 +1817,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.1/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.1/"
   },
   {
     "version": "v0.11.0",
@@ -1649,8 +1843,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000C",
-    "url": "https://nodejs.org/dist/v0.11.0/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.11.0/"
   },
   {
     "version": "v0.10.40",
@@ -1674,8 +1869,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1p",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.40/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.40/"
   },
   {
     "version": "v0.10.39",
@@ -1699,8 +1895,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1o",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.39/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.39/"
   },
   {
     "version": "v0.10.38",
@@ -1724,8 +1921,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1m",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.38/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.38/"
   },
   {
     "version": "v0.10.37",
@@ -1749,8 +1947,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1l",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.37/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.37/"
   },
   {
     "version": "v0.10.36",
@@ -1774,8 +1973,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1l",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.36/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.36/"
   },
   {
     "version": "v0.10.35",
@@ -1799,8 +1999,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1j",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.35/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.35/"
   },
   {
     "version": "v0.10.34",
@@ -1824,8 +2025,9 @@
     "zlib": "1.2.8",
     "openssl": "1.0.1j",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.34/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.34/"
   },
   {
     "version": "v0.10.33",
@@ -1849,8 +2051,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1j",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.33/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.33/"
   },
   {
     "version": "v0.10.32",
@@ -1874,8 +2077,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1i",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.32/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.32/"
   },
   {
     "version": "v0.10.31",
@@ -1899,8 +2103,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1i",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.31/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.31/"
   },
   {
     "version": "v0.10.30",
@@ -1924,8 +2129,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1h",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.30/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.30/"
   },
   {
     "version": "v0.10.29",
@@ -1949,8 +2155,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1h",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.29/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.29/"
   },
   {
     "version": "v0.10.28",
@@ -1974,8 +2181,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1g",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.28/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.28/"
   },
   {
     "version": "v0.10.27",
@@ -1999,8 +2207,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1g",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.27/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.27/"
   },
   {
     "version": "v0.10.26",
@@ -2024,8 +2233,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.26/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.26/"
   },
   {
     "version": "v0.10.25",
@@ -2049,8 +2259,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.25/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.25/"
   },
   {
     "version": "v0.10.24",
@@ -2074,8 +2285,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.24/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.24/"
   },
   {
     "version": "v0.10.23",
@@ -2099,8 +2311,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.23/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.23/"
   },
   {
     "version": "v0.10.22",
@@ -2124,8 +2337,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.22/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.22/"
   },
   {
     "version": "v0.10.21",
@@ -2149,8 +2363,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.21/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.21/"
   },
   {
     "version": "v0.10.20",
@@ -2174,8 +2389,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.20/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.20/"
   },
   {
     "version": "v0.10.19",
@@ -2199,8 +2415,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.19/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.19/"
   },
   {
     "version": "v0.10.18",
@@ -2224,8 +2441,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.18/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.18/"
   },
   {
     "version": "v0.10.17",
@@ -2249,8 +2467,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.17/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.17/"
   },
   {
     "version": "v0.10.16",
@@ -2274,8 +2493,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.16/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.16/"
   },
   {
     "version": "v0.10.15",
@@ -2299,8 +2519,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.15/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.15/"
   },
   {
     "version": "v0.10.14",
@@ -2324,8 +2545,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.14/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.14/"
   },
   {
     "version": "v0.10.13",
@@ -2349,8 +2571,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.13/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.13/"
   },
   {
     "version": "v0.10.12",
@@ -2374,8 +2597,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.12/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.12/"
   },
   {
     "version": "v0.10.11",
@@ -2399,8 +2623,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.11/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.11/"
   },
   {
     "version": "v0.10.10",
@@ -2424,8 +2649,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.10/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.10/"
   },
   {
     "version": "v0.10.9",
@@ -2449,8 +2675,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.9/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.9/"
   },
   {
     "version": "v0.10.8",
@@ -2474,8 +2701,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.8/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.8/"
   },
   {
     "version": "v0.10.7",
@@ -2499,8 +2727,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.7/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.7/"
   },
   {
     "version": "v0.10.6",
@@ -2524,8 +2753,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.6/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.6/"
   },
   {
     "version": "v0.10.5",
@@ -2549,8 +2779,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.5/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.5/"
   },
   {
     "version": "v0.10.4",
@@ -2574,8 +2805,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "11",
-    "url": "https://nodejs.org/dist/v0.10.4/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.4/"
   },
   {
     "version": "v0.10.3",
@@ -2599,8 +2831,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000B",
-    "url": "https://nodejs.org/dist/v0.10.3/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.3/"
   },
   {
     "version": "v0.10.2",
@@ -2624,8 +2857,9 @@
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000B",
-    "url": "https://nodejs.org/dist/v0.10.2/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.2/"
   },
   {
     "version": "v0.10.1",
@@ -2645,12 +2879,13 @@
     ],
     "npm": "1.2.15",
     "v8": "3.14.5.8",
-    "uv": "",
+    "uv": "0.10",
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000B",
-    "url": "https://nodejs.org/dist/v0.10.1/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.1/"
   },
   {
     "version": "v0.10.0",
@@ -2670,12 +2905,344 @@
     ],
     "npm": "1.2.14",
     "v8": "3.14.5.8",
-    "uv": "",
+    "uv": "0.9",
     "zlib": "1.2.3",
     "openssl": "1.0.1e",
     "modules": "0x000B",
-    "url": "https://nodejs.org/dist/v0.10.0/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.10.0/"
+  },
+  {
+    "version": "v0.9.12",
+    "date": "2013-03-07",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.12",
+    "v8": "3.14.5.8",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1e",
+    "modules": "0x000B",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.12/"
+  },
+  {
+    "version": "v0.9.11",
+    "date": "2013-03-01",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.12",
+    "v8": "3.14.5.0",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1e",
+    "modules": "0x000B",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.11/"
+  },
+  {
+    "version": "v0.9.10",
+    "date": "2013-02-25",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.12",
+    "v8": "3.15.11.15",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000B",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.10/"
+  },
+  {
+    "version": "v0.9.9",
+    "date": "2013-02-07",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.10",
+    "v8": "3.15.11.10",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000B",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.9/"
+  },
+  {
+    "version": "v0.9.8",
+    "date": "2013-02-02",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.3",
+    "v8": "3.15.11.10",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.8/"
+  },
+  {
+    "version": "v0.9.7",
+    "date": "2013-01-18",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.2",
+    "v8": "3.15.11.7",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.7/"
+  },
+  {
+    "version": "v0.9.6",
+    "date": "2013-01-11",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.0",
+    "v8": "3.15.11.5",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.6/"
+  },
+  {
+    "version": "v0.9.5",
+    "date": "2012-12-30",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.70",
+    "v8": "3.13.7.4",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.5/"
+  },
+  {
+    "version": "v0.9.4",
+    "date": "2012-12-21",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.70",
+    "v8": "3.13.7.4",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.4/"
+  },
+  {
+    "version": "v0.9.3",
+    "date": "2015-10-14",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.64",
+    "v8": "3.13.7.4",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.3/"
+  },
+  {
+    "version": "v0.9.2",
+    "date": "2012-09-17",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.61",
+    "v8": "3.11.10.22",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.1c",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.2/"
+  },
+  {
+    "version": "v0.9.1",
+    "date": "2012-09-13",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.59",
+    "v8": "3.11.10.19",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "0x000A",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.1/"
+  },
+  {
+    "version": "v0.9.0",
+    "date": "2012-07-20",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.44",
+    "v8": "3.11.10.15",
+    "uv": "0.9",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.9.0/"
   },
   {
     "version": "v0.8.28",
@@ -2694,12 +3261,13 @@
     ],
     "npm": "1.2.30",
     "v8": "3.11.10.26",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.28/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.28/"
   },
   {
     "version": "v0.8.27",
@@ -2717,12 +3285,13 @@
     ],
     "npm": "1.2.30",
     "v8": "3.11.10.26",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.27/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.27/"
   },
   {
     "version": "v0.8.26",
@@ -2742,12 +3311,13 @@
     ],
     "npm": "1.2.30",
     "v8": "3.11.10.26",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.26/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.26/"
   },
   {
     "version": "v0.8.25",
@@ -2767,12 +3337,13 @@
     ],
     "npm": "1.2.30",
     "v8": "3.11.10.25",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.25/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.25/"
   },
   {
     "version": "v0.8.24",
@@ -2792,12 +3363,13 @@
     ],
     "npm": "1.2.24",
     "v8": "3.11.10.25",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.24/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.24/"
   },
   {
     "version": "v0.8.23",
@@ -2817,11 +3389,2120 @@
     ],
     "npm": "1.2.18",
     "v8": "3.11.10.25",
-    "uv": "",
+    "uv": "0.8",
     "zlib": "1.2.3",
     "openssl": "1.0.0f",
     "modules": "1",
-    "url": "https://nodejs.org/dist/v0.8.23/",
-    "name": "Node.js"
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.23/"
+  },
+  {
+    "version": "v0.8.22",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.14",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.22/"
+  },
+  {
+    "version": "v0.8.21",
+    "date": "2013-02-25",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.11",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.21/"
+  },
+  {
+    "version": "v0.8.20",
+    "date": "2013-02-15",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.11",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.20/"
+  },
+  {
+    "version": "v0.8.19",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.10",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.19/"
+  },
+  {
+    "version": "v0.8.18",
+    "date": "2013-01-18",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.2",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.18/"
+  },
+  {
+    "version": "v0.8.17",
+    "date": "2013-01-13",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.2.0",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.17/"
+  },
+  {
+    "version": "v0.8.16",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.69",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.16/"
+  },
+  {
+    "version": "v0.8.15",
+    "date": "2012-11-26",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.66",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.15/"
+  },
+  {
+    "version": "v0.8.14",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.65",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.14/"
+  },
+  {
+    "version": "v0.8.13",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.65",
+    "v8": "3.11.10.25",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.13/"
+  },
+  {
+    "version": "v0.8.12",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.63",
+    "v8": "3.11.10.22",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.12/"
+  },
+  {
+    "version": "v0.8.11",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.62",
+    "v8": "3.11.10.22",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.11/"
+  },
+  {
+    "version": "v0.8.10",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.62",
+    "v8": "3.11.10.22",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.10/"
+  },
+  {
+    "version": "v0.8.9",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.61",
+    "v8": "3.11.10.22",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.9/"
+  },
+  {
+    "version": "v0.8.8",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x64-msi",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.59",
+    "v8": "3.11.10.19",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.8/"
+  },
+  {
+    "version": "v0.8.7",
+    "date": "2015-09-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.49",
+    "v8": "3.11.10.17",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.7/"
+  },
+  {
+    "version": "v0.8.6",
+    "date": "2012-08-06",
+    "files": [
+      "linux-x64",
+      "linux-x86",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "osx-x86-tar",
+      "src",
+      "sunos-x64",
+      "sunos-x86",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.48",
+    "v8": "3.11.10.17",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.6/"
+  },
+  {
+    "version": "v0.8.5",
+    "date": "2015-09-06",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.46",
+    "v8": "3.11.10.17",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.5/"
+  },
+  {
+    "version": "v0.8.4",
+    "date": "2015-09-06",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.45",
+    "v8": "3.11.10.17",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.4/"
+  },
+  {
+    "version": "v0.8.3",
+    "date": "2015-09-06",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.43",
+    "v8": "3.11.10.15",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.3/"
+  },
+  {
+    "version": "v0.8.2",
+    "date": "2012-07-09",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.36",
+    "v8": "3.11.10.14",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.2/"
+  },
+  {
+    "version": "v0.8.1",
+    "date": "2012-06-29",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.33",
+    "v8": "3.11.10.12",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.1/"
+  },
+  {
+    "version": "v0.8.0",
+    "date": "2012-06-22",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.32",
+    "v8": "3.11.10.10",
+    "uv": "0.8",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.8.0/"
+  },
+  {
+    "version": "v0.7.12",
+    "date": "2012-06-19",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.30",
+    "v8": "3.11.10.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.12/"
+  },
+  {
+    "version": "v0.7.11",
+    "date": "2012-06-15",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x64-msi",
+      "win-x86-exe",
+      "win-x86-msi"
+    ],
+    "npm": "1.1.26",
+    "v8": "3.11.10.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.11/"
+  },
+  {
+    "version": "v0.7.10",
+    "date": "2012-06-11",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.25",
+    "v8": "3.9.24.31",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.10/"
+  },
+  {
+    "version": "v0.7.9",
+    "date": "2012-05-29",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.23",
+    "v8": "3.11.1.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.9/"
+  },
+  {
+    "version": "v0.7.8",
+    "date": "2012-04-18",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.18",
+    "v8": "3.9.24.9",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "1.0.0f",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.8/"
+  },
+  {
+    "version": "v0.7.7",
+    "date": "2012-03-30",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.15",
+    "v8": "3.9.24.7",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.7/"
+  },
+  {
+    "version": "v0.7.6",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.8",
+    "v8": "3.9.17.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.6/"
+  },
+  {
+    "version": "v0.7.5",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.1",
+    "v8": "3.9.5.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.5/"
+  },
+  {
+    "version": "v0.7.4",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.1",
+    "v8": "3.9.5.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.4/"
+  },
+  {
+    "version": "v0.7.3",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-3",
+    "v8": "3.9.2.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.3/"
+  },
+  {
+    "version": "v0.7.2",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-3",
+    "v8": "3.8.9.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.2/"
+  },
+  {
+    "version": "v0.7.1",
+    "date": "2012-01-23",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-2",
+    "v8": "3.8.8.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.1/"
+  },
+  {
+    "version": "v0.7.0",
+    "date": "2012-01-17",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-2",
+    "v8": "3.8.6.0",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.7.0/"
+  },
+  {
+    "version": "v0.6.21",
+    "date": "2012-08-03",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.37",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.21/"
+  },
+  {
+    "version": "v0.6.20",
+    "date": "2012-07-10",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.37",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.20/"
+  },
+  {
+    "version": "v0.6.19",
+    "date": "2012-06-08",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.24",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.19/"
+  },
+  {
+    "version": "v0.6.18",
+    "date": "2012-05-14",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.21",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.18/"
+  },
+  {
+    "version": "v0.6.17",
+    "date": "2012-05-04",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.21",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.17/"
+  },
+  {
+    "version": "v0.6.16",
+    "date": "2012-04-27",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.19",
+    "v8": "3.6.6.25",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.16/"
+  },
+  {
+    "version": "v0.6.15",
+    "date": "2012-04-09",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.16",
+    "v8": "3.6.6.24",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.15/"
+  },
+  {
+    "version": "v0.6.14",
+    "date": "2012-03-23",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.12",
+    "v8": "3.6.6.24",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.14/"
+  },
+  {
+    "version": "v0.6.13",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x64-exe",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.9",
+    "v8": "3.6.6.24",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.13/"
+  },
+  {
+    "version": "v0.6.12",
+    "date": "2012-03-02",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.4",
+    "v8": "3.6.6.24",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.12/"
+  },
+  {
+    "version": "v0.6.11",
+    "date": "2012-02-17",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.1",
+    "v8": "3.6.6.20",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.11/"
+  },
+  {
+    "version": "v0.6.10",
+    "date": "2012-02-04",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-3",
+    "v8": "3.6.6.20",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.10/"
+  },
+  {
+    "version": "v0.6.9",
+    "date": "2012-01-27",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-3",
+    "v8": "3.6.6.19",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.9/"
+  },
+  {
+    "version": "v0.6.8",
+    "date": "2012-01-23",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-2",
+    "v8": "3.6.6.19",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.8/"
+  },
+  {
+    "version": "v0.6.7",
+    "date": "2012-01-07",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-beta-10",
+    "v8": "3.6.6.15",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.7/"
+  },
+  {
+    "version": "v0.6.6",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-beta-4",
+    "v8": "3.6.6.14",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.6/"
+  },
+  {
+    "version": "v0.6.5",
+    "date": "2012-03-31",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-alpha-6",
+    "v8": "3.6.6.11",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.5/"
+  },
+  {
+    "version": "v0.6.4",
+    "date": "2011-12-03",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-alpha-6",
+    "v8": "3.6.6.8",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.4/"
+  },
+  {
+    "version": "v0.6.3",
+    "date": "2011-11-25",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "npm": "1.1.0-alpha-2",
+    "v8": "3.6.6.8",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.3/"
+  },
+  {
+    "version": "v0.6.2",
+    "date": "2011-11-18",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.6.8",
+    "uv": "0.6",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.2/"
+  },
+  {
+    "version": "v0.6.1",
+    "date": "2011-11-11",
+    "files": [
+      "osx-x64-pkg",
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.6.7",
+    "uv": "0.1",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.1/"
+  },
+  {
+    "version": "v0.6.0",
+    "date": "2011-11-04",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.6.6",
+    "uv": "0.1",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.6.0/"
+  },
+  {
+    "version": "v0.5.10",
+    "date": "2011-10-22",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.7.0.0",
+    "uv": "0.1",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.10/"
+  },
+  {
+    "version": "v0.5.9",
+    "date": "2011-10-11",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.4.0",
+    "uv": "0.1",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.9/"
+  },
+  {
+    "version": "v0.5.8",
+    "date": "2011-09-30",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.4.0",
+    "uv": "0.1",
+    "zlib": "1.2.3",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.8/"
+  },
+  {
+    "version": "v0.5.7",
+    "date": "2011-09-16",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.4.0",
+    "uv": "0.1",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.7/"
+  },
+  {
+    "version": "v0.5.6",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.6.2.0",
+    "uv": "0.1",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.6/"
+  },
+  {
+    "version": "v0.5.5",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.5.8.0",
+    "uv": "0.1",
+    "openssl": "0.9.8r",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.5/"
+  },
+  {
+    "version": "v0.5.4",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.5.4.3",
+    "uv": "0.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.4/"
+  },
+  {
+    "version": "v0.5.3",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.4.14.0",
+    "uv": "0.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.3/"
+  },
+  {
+    "version": "v0.5.2",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.4.14.0",
+    "uv": "0.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.2/"
+  },
+  {
+    "version": "v0.5.1",
+    "date": "2011-08-26",
+    "files": [
+      "src",
+      "win-x86-exe"
+    ],
+    "v8": "3.4.10.0",
+    "uv": "0.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.1/"
+  },
+  {
+    "version": "v0.5.0",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.25",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.5.0/"
+  },
+  {
+    "version": "v0.4.12",
+    "date": "2015-10-17",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.26",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.12/"
+  },
+  {
+    "version": "v0.4.11",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.26",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.11/"
+  },
+  {
+    "version": "v0.4.10",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.26",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.10/"
+  },
+  {
+    "version": "v0.4.9",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.25",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.9/"
+  },
+  {
+    "version": "v0.4.8",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.16",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.8/"
+  },
+  {
+    "version": "v0.4.7",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.10",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.7/"
+  },
+  {
+    "version": "v0.4.6",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.10",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.6/"
+  },
+  {
+    "version": "v0.4.5",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.8",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.5/"
+  },
+  {
+    "version": "v0.4.4",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.5",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.4/"
+  },
+  {
+    "version": "v0.4.3",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.3",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.3/"
+  },
+  {
+    "version": "v0.4.2",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.2/"
+  },
+  {
+    "version": "v0.4.1",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.5.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.1/"
+  },
+  {
+    "version": "v0.4.0",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.2.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.4.0/"
+  },
+  {
+    "version": "v0.3.8",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.1.1.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.8/"
+  },
+  {
+    "version": "v0.3.7",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.10.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.7/"
+  },
+  {
+    "version": "v0.3.6",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.9.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.6/"
+  },
+  {
+    "version": "v0.3.5",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.4.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.5/"
+  },
+  {
+    "version": "v0.3.4",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.4.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.4/"
+  },
+  {
+    "version": "v0.3.3",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.4.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.3/"
+  },
+  {
+    "version": "v0.3.2",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "3.0.3.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.2/"
+  },
+  {
+    "version": "v0.3.1",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.5.3.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.1/"
+  },
+  {
+    "version": "v0.3.0",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.5.1.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.3.0/"
+  },
+  {
+    "version": "v0.2.6",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.6/"
+  },
+  {
+    "version": "v0.2.5",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.5/"
+  },
+  {
+    "version": "v0.2.4",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.4/"
+  },
+  {
+    "version": "v0.2.3",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.3/"
+  },
+  {
+    "version": "v0.2.2",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.2/"
+  },
+  {
+    "version": "v0.2.1",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.1/"
+  },
+  {
+    "version": "v0.2.0",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.8.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.2.0/"
+  },
+  {
+    "version": "v0.1.104",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.6.1",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.104/"
+  },
+  {
+    "version": "v0.1.103",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.5.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.103/"
+  },
+  {
+    "version": "v0.1.102",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.2.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.102/"
+  },
+  {
+    "version": "v0.1.101",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.3.0.0",
+    "modules": "1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.101/"
+  },
+  {
+    "version": "v0.1.100",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.21.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.100/"
+  },
+  {
+    "version": "v0.1.99",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.18.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.99/"
+  },
+  {
+    "version": "v0.1.98",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.16.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.98/"
+  },
+  {
+    "version": "v0.1.97",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.12.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.97/"
+  },
+  {
+    "version": "v0.1.96",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.96/"
+  },
+  {
+    "version": "v0.1.95",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.95/"
+  },
+  {
+    "version": "v0.1.94",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.8.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.94/"
+  },
+  {
+    "version": "v0.1.93",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.6.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.93/"
+  },
+  {
+    "version": "v0.1.92",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.4.2",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.92/"
+  },
+  {
+    "version": "v0.1.91",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.3.1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.91/"
+  },
+  {
+    "version": "v0.1.90",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.2.0.3",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.90/"
+  },
+  {
+    "version": "v0.1.33",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.6.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.33/"
+  },
+  {
+    "version": "v0.1.32",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.3.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.32/"
+  },
+  {
+    "version": "v0.1.31",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.2.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.31/"
+  },
+  {
+    "version": "v0.1.30",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.1.1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.30/"
+  },
+  {
+    "version": "v0.1.29",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.29/"
+  },
+  {
+    "version": "v0.1.28",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.28/"
+  },
+  {
+    "version": "v0.1.27",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.1.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.27/"
+  },
+  {
+    "version": "v0.1.26",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.6.1",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.26/"
+  },
+  {
+    "version": "v0.1.25",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.5.4",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.25/"
+  },
+  {
+    "version": "v0.1.24",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.5.4",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.24/"
+  },
+  {
+    "version": "v0.1.23",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.23/"
+  },
+  {
+    "version": "v0.1.22",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.22/"
+  },
+  {
+    "version": "v0.1.21",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.21/"
+  },
+  {
+    "version": "v0.1.20",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.2.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.20/"
+  },
+  {
+    "version": "v0.1.19",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "2.0.2.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.19/"
+  },
+  {
+    "version": "v0.1.18",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "1.3.18.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.18/"
+  },
+  {
+    "version": "v0.1.17",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "1.3.18.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.17/"
+  },
+  {
+    "version": "v0.1.16",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "1.3.18.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.16/"
+  },
+  {
+    "version": "v0.1.15",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "1.3.16.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.15/"
+  },
+  {
+    "version": "v0.1.14",
+    "date": "2011-08-26",
+    "files": [
+      "src"
+    ],
+    "v8": "1.3.15.0",
+    "lts": false,
+    "name": "Node.js",
+    "url": "https://nodejs.org/download/release/v0.1.14/"
   }
 ]


### PR DESCRIPTION
I'm encouraging the npm team to use this same package to fetch the data they need for mapping node to npm versions
