### PR TITLE
footer: change "here" link

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -13,7 +13,7 @@
             </div>
 
             <p>© 2015 Node.js Foundation. All Rights Reserved. Portions of this site originally © 2015 Joyent. </p>
-            <p>Node.js is a trademark of Joyent, Inc. and is used with its permission. Please review the Trademark Guidelines of the Node.js Foundation <a href="/static/documents/trademark-policy.pdf">here</a>.</p>
+            <p>Node.js is a trademark of Joyent, Inc. and is used with its permission. Please review the <a href="/static/documents/trademark-policy.pdf">Trademark Guidelines of the Node.js Foundation</a>.</p>
             <p>Linux Foundation is a registered trademark of The Linux Foundation.</p>
             <p>Linux is a registered <a href="http://www.linuxfoundation.org/programs/legal/trademark" title="Linux Mark Institute">trademark</a> of Linus Torvalds.</p>
             <p>


### PR DESCRIPTION
Context: Avoiding link text consisting of `here` (or `click here` or `more` etc.) is beneficial to users of screen readers and others who may tab from link to link.
