### PR TITLE
LTS and Stable changelog links on the frontpage

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -45,7 +45,11 @@
                             <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/">{{ labels.other-lts-downloads }}</a>
                         {{/if}}
                     </li>
-                    <li><a href="https://github.com/nodejs/node/blob/{{ project.currentVersion }}/CHANGELOG.md">{{ labels.changelog }}</a></li>
+                    <li>
+                        {{ labels.changelog }}:
+                        <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.lts }}</a>
+                        &#47; <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.stable }}</a>
+                    </li>
                     <li><a href="{{ site.docs.api.link }}">{{ labels.api }}</a></li>
                 </ul>
 


### PR DESCRIPTION
We're currently only link to the stable changelog on the frontpage. This adds a link to LTS changelog aswell.

<img width="498" alt="skjermbilde 2015-10-29 kl 23 17 32" src="https://cloud.githubusercontent.com/assets/1231635/10833595/8b896ef6-7e93-11e5-9fbb-72759aff0e39.png">
