### PR TITLE
Remove /download/ directory from robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,9 +1,6 @@
 User-Agent: *
 Disallow: /dist/
 Disallow: /docs/
-Disallow: /download/
-Allow: /download/release/latest/
-Allow: /download/release/latest/docs/api/
 Allow: /dist/latest/
 Allow: /dist/latest/docs/api/
 Allow: /api/


### PR DESCRIPTION
fixes #240 . 

As per instructions in #240, /download/ requests are now being returned with header `x-robots-tag: noindex` https://github.com/nodejs/build/pull/231 .

Final step is to remove the entries from `robots.txt` because otherwise search crawlers will not be able to see the new header https://support.google.com/webmasters/answer/93710?hl=en&ref_topic=4598466
