### PR TITLE
Reduce greenkeeper noise for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "strftime": "0.9.2"
   },
   "devDependencies": {
-    "faucet": "0.0.1",
-    "nock": "2.17.0",
-    "pre-commit": "1.1.2",
-    "proxyquire": "1.7.3",
-    "sinon": "1.17.2",
-    "standard": "5.3.1",
-    "tape": "4.2.2"
+    "faucet": "^0.0.1",
+    "nock": "^2.17.0",
+    "pre-commit": "^1.1.2",
+    "proxyquire": "^1.7.3",
+    "sinon": "^1.17.2",
+    "standard": "^5.3.1",
+    "tape": "^4.2.2"
   }
 }


### PR DESCRIPTION
As some of us has noticed, the greenkeeper PRs are getting pretty noisy and time consuming. Greenkeeper has added support for using version ranges and will only open PRs if new releases actually fail.

From https://github.com/greenkeeperio/greenkeeper/issues/27#issuecomment-146212266

> For new versions inside the existing range you’ll get pull-requests **only if the update breaks your build**. We are doing this by only creating the branch and then waiting for results from your CI. If it passes the branch gets deleted again, if it fails however the pull requests gets opened, because it should definitely have your attention.
