### PR TITLE
Document node v5.x exclusive ES2015 features

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -33,21 +33,22 @@ All ECMAScript 2015 (ES6) features are split into three groups for **shipping**,
 * [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
 * [Template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings)
 * [Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
-* [new.target](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target)
+* [new.target](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target) [[2]](#ref-2)<span id="backref-2"></span>
 * [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
-* [Spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator)
+* [Spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator) [[2]](#ref-2)<span id="backref-2"></span>
 
 You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
 
-<small id="ref-1">[[1](#backref-1)]: As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES6 specification compliance.</small>
+<small id="ref-1">[[1](#backref-1)]: As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES6 specification compliance.</small><br>
+<small id="ref-2">[[2](#backref-2)]: Only available in Node.js >= 5.x.x
 
 ## Which features are behind the --es_staging flag?
 
 * [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (user-definable results for `Object.prototype.toString`, behind flag `--harmony_tostring`)
 * [`Array.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) (determine whether
-an array includes a certain element, behind flag `--harmony_array_includes`)
+an array includes a certain element, behind flag `--harmony_array_includes`) [[2]](#ref-2)<span id="backref-2"></span>
 * [Rest Parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) (represent an indefinite number
-of arguments as an array, behind flag `--harmony_rest_parameters`)
+of arguments as an array, behind flag `--harmony_rest_parameters`) [[2]](#ref-2)<span id="backref-2"></span>
 
 ## Which features are in progress?
 


### PR DESCRIPTION
As the site now hosts both v4 and v5, ES2015 features page should document which features are exclusive for v5.

Refs #268.
