### PR TITLE
Removes reference to nodebug.me in FAQ

### DIFF
--- a/locale/en/docs/faq.md
+++ b/locale/en/docs/faq.md
@@ -10,8 +10,6 @@ Everyone can help. Node.js adheres to a [code of conduct](https://github.com/nod
 
 To get started, there are open [discussions on GitHub](https://github.com/nodejs/node/issues), and we'd love to hear your feedback. Becoming involved in discussions is a good way to get a feel of where you can help out further. If there is something there you feel you can tackle, please [make a pull request](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-contributions).
 
-In addition, using [Nodebug.me](http://nodebug.me/) is a good way to help Triage the issues in the backlog.
-
 ## Where do discussions take place?
 
 There is an #node.js channel on Freenode IRC. We keep logs of the channel [here](http://logs.libuv.org/node.js/latest).


### PR DESCRIPTION
Nodebug.me appears to currently be down (on 10/31/2015). There's no mentions or activity on the Web about it this year (2015). Repo (https://github.com/nodebugme) also appears dead since late last year, only with some issues made earlier this year before the Node.js foundation was formed.

Considering it seemed like a great tool, would be great to revive it, but in the interim, this removes the dead link.
