### PR TITLE
Use * instead of _ as em tags in markdown

### DIFF
--- a/locale/en/blog/release/v5.0.0.md
+++ b/locale/en/blog/release/v5.0.0.md
@@ -17,7 +17,7 @@ The general rule for deciding which version of Node.js to use is:
 * Stay on or upgrade to Node.js v4.2.x if you need **stability and have a complex production environment**, e.g. you are a medium or large enterprise.
 * Upgrade to Node.js v5.x if you have the ability to upgrade versions quickly and easily without distributing your environment and want to play with the latest features as they arrive.
 
-The release notes below are annotated with the main breaking changes that warrant the jump to v5. Note that because this new version of Node.js is shipping with a new version of V8, you will need to recompile any native add-ons you have already installed or you will receive a runtime error when trying to load them. Use `npm rebuild` or simply remove your _node_modules_ directory and `npm install` from scratch.
+The release notes below are annotated with the main breaking changes that warrant the jump to v5. Note that because this new version of Node.js is shipping with a new version of V8, you will need to recompile any native add-ons you have already installed or you will receive a runtime error when trying to load them. Use `npm rebuild` or simply remove your *node_modules* directory and `npm install` from scratch.
 
 ### Notable Changes
 


### PR DESCRIPTION
In [this page](https://nodejs.org/en/blog/release/v5.0.0/),

`_node_modules_` compiled to a wrong result: `_node<em>modules</em>`

 Problem solved when using `*` instead of `_` as `<em>` tags in markdown.
