### PR TITLE
Display LTS and Stable API links on docs page

### DIFF
--- a/build.js
+++ b/build.js
@@ -158,7 +158,8 @@ function buildlocale (source, locale) {
         i18n: require('./scripts/helpers/i18n.js'),
         changeloglink: require('./scripts/helpers/changeloglink.js'),
         strftime: require('./scripts/helpers/strftime.js'),
-        apidocslink: require('./scripts/helpers/apidocslink.js')
+        apidocslink: require('./scripts/helpers/apidocslink.js'),
+        majorapidocslink: require('./scripts/helpers/majorapidocslink.js')
       }
     }))
     .destination(path.join(__dirname, 'build', locale))
@@ -188,7 +189,6 @@ function fullbuild () {
     const source = {
       project: {
         versions,
-        currentVersion: versions[0].version,
         currentVersions: {
           stable: latestVersion.stable(versions),
           lts: latestVersion.lts(versions)

--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -153,6 +153,9 @@ pre
 .color-lightgray
     color $light-gray
 
+a:hover .color-lightgray
+    color $white
+
 .no-padding
     padding 0
 

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -36,7 +36,7 @@
                           <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.changelog }}</a>
                       </li>
                       <li>
-                        <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/docs/api/">{{ labels.api }}</a>
+                        <a href="{{majorapidocslink project.currentVersions.lts}}">{{ labels.api }}</a>
                       </li>
                   </ul>
 
@@ -58,7 +58,7 @@
                             <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.changelog }}</a>
                         </li>
                         <li>
-                          <a href="{{ site.docs.api.link }}">{{ labels.api }}</a>
+                          <a href="{{majorapidocslink project.currentVersions.stable}}">{{ labels.api }}</a>
                         </li>
                     </ul>
 

--- a/layouts/partials/docs-menu.hbs
+++ b/layouts/partials/docs-menu.hbs
@@ -9,8 +9,15 @@
         <li{{#equals path site.docs.faq.link}} class="active"{{/equals}}>
             <a href="/{{site.locale}}/{{site.docs.faq.link}}/">{{site.docs.faq.text}}</a>
         </li>
-        <li{{#equals path site.docs.api.link}} class="active"{{/equals}}>
-            <a href="{{site.docs.api.link}}">{{site.docs.api.text}}</a>
+        <li>
+            <a href="{{majorapidocslink project.currentVersions.lts}}">
+                {{project.currentVersions.lts}} {{site.docs.api.text}} <span class="small color-lightgray">{{labels.lts}}</span>
+            </a>
+        </li>
+        <li>
+            <a href="{{majorapidocslink project.currentVersions.stable}}">
+                {{project.currentVersions.stable}} {{site.docs.api.text}}
+            </a>
         </li>
         <li{{#startswith path site.docs.guides.link}} class="active"{{/startswith}}>
             <a href="/{{site.locale}}/{{site.docs.guides.link}}">{{site.docs.guides.text}}</a>

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Docs
 layout: docs.hbs
+labels:
+  lts: LTS
 ---
 
 # About Docs

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -72,7 +72,6 @@
             "text": "FAQ"
         },
         "api": {
-            "link": "/api/",
             "text": "API"
         },
         "guides": {

--- a/scripts/helpers/majorapidocslink.js
+++ b/scripts/helpers/majorapidocslink.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const semver = require('semver')
+
+module.exports = function (version) {
+  const major = semver.major(version)
+  return `https://nodejs.org/dist/latest-v${major}.x/docs/api/`
+}


### PR DESCRIPTION
Part of the multiple version docs discussion in #305.

![skjermbilde 2015-11-04 kl 08 54 44](https://cloud.githubusercontent.com/assets/1231635/10932534/e277f538-82d1-11e5-8ec3-e5dec5db752a.png)

Using the same URLs as we've got on the frontpage, e.g:
- **v4.2.2**: https://nodejs.org/dist/4.2.2/docs/api/
- **v5.0.0**: https://nodejs.org/api/

Are those URLs appropriate or would we want to use any of these aliases?
- latest -> v5.0.0
- latest-argon -> v4.2.2
- latest-v0.10.x -> v0.10.40
- latest-v0.12.x -> v0.12.7
- latest-v4.x -> v4.2.2
- latest-v5.x -> v5.0.0
