### PR TITLE
Add link to official Node.js Docker Image

### DIFF
--- a/layouts/partials/download-matrix.hbs
+++ b/layouts/partials/download-matrix.hbs
@@ -71,6 +71,11 @@
             </tr>
 
             <tr>
+                <th>Docker Image</th>
+                <td colspan="6"><a href="https://hub.docker.com/_/node/">Official Node.js Docker Image</a></td>
+            </tr>
+
+            <tr>
                 <th>Source Code</th>
                 <td colspan="6">
                     <a href="https://nodejs.org/dist/{{version}}/node-{{version}}.tar.gz">node-{{version}}.tar.gz</a>


### PR DESCRIPTION
This PR adds a link on the download page to the official Docker Image for Node.js maintained by @nodejs/docker @ https://github.com/nodejs/docker-node. 

Related: #179
