### PR TITLE
Improve write to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "nock": "^2.17.0",
     "pre-commit": "^1.1.2",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.17.2",
     "standard": "^5.3.1",
     "tape": "^4.2.2"
   }

--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -181,12 +181,21 @@ function renderPost (results) {
 function writeToFile (results) {
   const filepath = path.resolve(__dirname, '..', 'locale', 'en', 'blog', 'release', `v${results.version}.md`)
 
-  if (fs.existsSync(filepath)) {
-    return Promise.reject(new Error(`Release post for ${results.version} already exists!`))
-  }
+  return new Promise(function (resolve, reject) {
+    fs.access(filepath, fs.F_OK, function (err) {
+      if (!err) {
+        return reject(new Error(`Release post for ${results.version} already exists!`))
+      }
 
-  fs.writeFileSync(filepath, results.content)
-  return Promise.resolve(filepath)
+      fs.writeFile(filepath, results.content, function (err1) {
+        if (err1) {
+          return reject(new Error(`Failed to write Release post: Reason: ${err1.message}`))
+        }
+
+        resolve(filepath)
+      })
+    })
+  })
 }
 
 function slugify (str) {


### PR DESCRIPTION
`writeToFile` function uses `exists` which is deprecated. This patch replaces that with `access` function.
Apart from that, the `writeToFile` function is fully asynchronous now. This patch removes `sinon` dependency as well. `writeToFile` tests have been written in such a way that the spying is not necessary.
