### PR TITLE
Added latest.json file that contains the latest versions

### DIFF
--- a/build.js
+++ b/build.js
@@ -196,6 +196,10 @@ function fullbuild () {
       }
     }
 
+    fs.writeFileSync(path.join(__dirname, 'build', 'latest.json'),
+      JSON.stringify(source.project.currentVersions, null, '\t')
+    )
+
     fs.readdir(path.join(__dirname, 'locale'), function (e, locales) {
       locales.filter(junk.not).forEach(function (locale) {
         buildlocale(source, locale)


### PR DESCRIPTION
I didn't find a good way to figure out programmatically what the latest version of node.js is. So it thought it might be good to be able to have it directly on the nodejs homepage as a json file that people can parse to see what the latest versions/lts versions are. In case some writes a nice cli tool like `n` or `nvm`
