### PR TITLE
Update st to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "octonode": "0.7.4",
     "require-dir": "0.3.0",
     "semver": "5.0.3",
-    "st": "0.5.5",
+    "st": "1.0.0",
     "strftime": "0.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates [`st`](https://github.com/isaacs/st) to version `1.0.0`.

The breaking change is described here https://github.com/isaacs/st/issues/67. I see no problems, but correct me if I'm wrong.
