### PR TITLE
Update metalsmith-feed to version 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "marked": "0.3.5",
     "metalsmith": "2.1.0",
     "metalsmith-collections": "0.7.0",
-    "metalsmith-feed": "0.0.6",
+    "metalsmith-feed": "0.2.0",
     "metalsmith-layouts": "1.4.2",
     "metalsmith-markdown": "0.2.1",
     "metalsmith-metadata": "0.0.2",


### PR DESCRIPTION
This updates [`metalsmith-feed`](https://github.com/hurrymaplelad/metalsmith-feed) to version `0.2.0`.

There are 2 new options, `postDescription` and `postCustomElements`, but no breaking changes:
- `postDescription` defaults to `(file) -> file.less or file.excerpt or file.contents` like in version `0.0.6`.
- `postCustomElements` is disabled by default.
