### PR TITLE
Remove the metalsmith-serve dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "metalsmith-metadata": "0.0.2",
     "metalsmith-permalinks": "0.4.0",
     "metalsmith-prism": "2.1.1",
-    "metalsmith-serve": "0.0.3",
     "metalsmith-stylus": "1.0.0",
     "ncp": "2.0.0",
     "node-version-data": "1.0.0",


### PR DESCRIPTION
The [`metalsmith-serve`](https://github.com/mayo/metalsmith-serve) dependency has been removed [here](https://github.com/nodejs/new.nodejs.org/commit/7effb50e12c4a3a868ab31133f1370ce0b01292b#diff-efd59cd1bdc5c9ac6d0eaa368f1e149f) and since then, it has no longer been used.
