### PR TITLE
Add link to Code of Conduct from contributing section

### DIFF
--- a/layouts/contribute.hbs
+++ b/layouts/contribute.hbs
@@ -25,6 +25,9 @@
                     <li{{#equals path site.getinvolved.events.link}} class="active"{{/equals}}>
                         <a href="/{{site.locale}}/{{site.getinvolved.events.link}}/">{{site.getinvolved.events.text}}</a>
                     </li>
+                    <li>
+                        <a href="https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct">{{site.getinvolved.conduct.text}}</a>
+                    </li>
                 </ul>
             </aside>
 

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -121,6 +121,9 @@
         "events": {
           "link": "get-involved/events",
           "text": "Events"
+        },
+        "conduct": {
+            "text": "Conduct"
         }
     },
     "trademark"  : { "link": "about/trademark", "text": "Trademark" },


### PR DESCRIPTION
I was trying to find the Node community code of conduct to refer to, and it was more difficult to find on the site than I think it should be. This PR adds it to the left-hand sidebar in the "contributing" section.
