### PR TITLE
Use Shields.IO for all the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [nodejs.org](https://nodejs.org/)
-[![Build Status](https://api.travis-ci.org/nodejs/nodejs.org.svg?branch=master)](http://travis-ci.org/nodejs/nodejs.org)
-[![Dependency Status](https://david-dm.org/nodejs/nodejs.org.svg)](https://david-dm.org/nodejs/nodejs.org)
+
+[![Build Status](https://img.shields.io/travis/nodejs/nodejs.org/master.svg)](http://travis-ci.org/nodejs/nodejs.org)
+[![Dependency Status](https://img.shields.io/david/nodejs/nodejs.org.svg)](https://david-dm.org/nodejs/nodejs.org)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## What is this repo?


### PR DESCRIPTION
This updates the README to use http://shields.io/ for all the badges.

Right now the Travis badge is not working because the repo need to be resynced (the name has changed). This will also hopefully fix the pr integration. See https://github.com/nodejs/nodejs.org/issues/355#issuecomment-157890226.
