### PR TITLE
Nest homepage download links under their respective version

### DIFF
--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -15,7 +15,7 @@
     $home-secondary-links-color = saturation($node-green, 20%)
 
     color $home-secondary-links-color
-    font-size 1rem
+    font-size 0.9rem
 
     a
         color $home-secondary-links-color
@@ -27,14 +27,18 @@
 #home-intro
     max-width: $body-max-width * 0.75
     margin 0 auto
-    padding-top 30px
+    padding 30px 0
     text-align center
 
     h2
         margin-bottom 0
 
-.home-downloadbutton
+.home-downloadblock
     display inline-block
+    margin 0 8px
+
+.home-downloadbutton
+    display block
     margin 10px 4px
     padding 0.2em 0.6em
 

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -21,44 +21,49 @@
 
                 <h2 id="home-downloadhead" data-dl-local="{{ labels.download-for }}">{{ labels.download }}</h2>
 
-                <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.currentVersions.lts }} {{ labels.lts }}" data-version="{{ project.currentVersions.lts }}">
-                    {{ project.currentVersions.lts }} {{ labels.lts }}
-                    <small>{{ labels.tagline-lts }}</small>
-                </a>
+                <div class="home-downloadblock">
+
+                  <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.currentVersions.lts }} {{ labels.lts }}" data-version="{{ project.currentVersions.lts }}">
+                      {{ project.currentVersions.lts }} {{ labels.lts }}
+                      <small>{{ labels.tagline-lts }}</small>
+                  </a>
+
+                  <ul class="list-divider-pipe home-secondary-links">
+                      <li>
+                        <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/">{{ labels.other-downloads }}</a>
+                      </li>
+                      <li>
+                          <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                      </li>
+                      <li>
+                        <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/docs/api/">{{ labels.api }}</a>
+                      </li>
+                  </ul>
+
+                </div>
 
                 {{#if project.currentVersions.stable}}
+                  <div class="home-downloadblock">
+
                     <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.currentVersions.stable }} {{ labels.stable }}"  data-version="{{ project.currentVersions.stable }}">
                         {{ project.currentVersions.stable }} {{ labels.stable }}
                         <small>{{ labels.tagline-stable }}</small>
                     </a>
-                {{/if}}
 
-                <ul class="list-divider-pipe home-secondary-links">
-                    <li>
-
-                        {{#if project.currentVersions.stable}}
-                            {{ labels.other-downloads}}: <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/" title="{{ labels.other-lts-downloads }}">{{ labels.lts }}</a>
-                            &#47; <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/" title="{{ labels.other-stable-downloads }}">
-                                {{ labels.stable }}
-                            </a>
-                        {{else}}
-                            <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/">{{ labels.other-lts-downloads }}</a>
-                        {{/if}}
-                    </li>
-                    <li>
-                        {{ labels.changelog }}:
-                        <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.lts }}</a>
-                        &#47; <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.stable }}</a>
-                    </li>
-                    <li>
-                      {{#if project.currentVersions.stable}}
-                          {{ labels.api }}: <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/docs/api/">{{ labels.lts }}</a>
-                          &#47; <a href="{{ site.docs.api.link }}">{{ labels.stable }}</a>
-                      {{else}}
+                    <ul class="list-divider-pipe home-secondary-links">
+                        <li>
+                          <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/">{{ labels.other-downloads }}</a>
+                        </li>
+                        <li>
+                            <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                        </li>
+                        <li>
                           <a href="{{ site.docs.api.link }}">{{ labels.api }}</a>
-                      {{/if}}
-                    </li>
-                </ul>
+                        </li>
+                    </ul>
+
+                  </div>
+                {{/if}}
 
             </div>
 


### PR DESCRIPTION
Style change to the homepage that makes the Other downloads, Changelog and API Docs much easier to read by nesting them under their respective version.

<img width="1086" alt="screen shot 2015-11-21 at 1 54 29 pm" src="https://cloud.githubusercontent.com/assets/1316152/11319946/9a6c140c-9057-11e5-84f6-d34ff346c20e.png">
