### PR TITLE
Add link to help repo

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -8,6 +8,7 @@
                 <ul class="list-divider-pipe issue-link">
                     <li><a href="https://github.com/nodejs/node/issues">{{i18n.reportNodeIssue}}</a></li>
                     <li><a href="https://github.com/nodejs/nodejs.org/issues">{{i18n.reportWebsiteIssue}}</a></li>
+                    <li><a href="https://github.com/nodejs/help/issues">{{i18n.getHelpIssue}}</a></li>
                 </ul>
                 <a class="linuxfoundation-logo" href="http://collabprojects.linuxfoundation.org">Linux Foundation Collaborative Projects</a>
             </div>

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -6,6 +6,7 @@
     "scrollToTop": "Scroll to top",
     "reportNodeIssue": "Report Node.js issue",
     "reportWebsiteIssue": "Report website issue",
+    "getHelpIssue": "Get Help",
     "by": "by",
     "all-downloads": "All download options",
     "feeds": [


### PR DESCRIPTION
The nodejs/node repo has been getting a lot of help related issues and
it would be nice if there was a link to the help repo.
