### PR TITLE
add v0.12.8 announcement post

### DIFF
--- a/locale/en/blog/release/v0.12.8.md
+++ b/locale/en/blog/release/v0.12.8.md
@@ -1,0 +1,150 @@
+---
+date: 2015-11-24T23:59:09.993Z
+version: v0.12.8
+category: release
+title: Node v0.12.8 (LTS)
+slug: node-v0-12-8
+layout: blog-post.hbs
+author: Rod Vagg
+---
+
+This release of v0.12.8 represents the first release of the v0.12 line since it has moved from _Stable_ to _LTS_ (Long-term Support) status. According to the new [LTS plan](https://github.com/nodejs/LTS/#readme) for the Node.js project, v0.12 will continue as LTS until the end of 2015 at which point it will switch to _Maintenance_ and continue as such until the end of 2016 when support will cease.
+
+During LTS, changes included in v0.12.x releases will be limited to bug fixes, security updates, npm updates (limited to npm v2 LTS), documentation updates, and certain performance improvements that can be demonstrated to not break existing applications. After moving to Maintenance mode at the end of 2015, only critical bugs, critical security fixes, and documentation updates will be included.
+
+The Node.js core team will continue to ensure that v0.12 remains a viable platform for production deployment until the end of 2016. However, users of v0.12 should be working on plan to migrate to at least v4 LTS (Argon) as soon as practical.
+
+## New build infrastructure
+
+This is the first v0.12 release made with the new build infrastructure operated by the Node.js Foundation. Even though we have done our best to ensure that the build processes and tools are as close as possible to the previous infrastructure, it is possible that some unexpected issues arise from the changes. Please file bug reports on the [Node.js GitHub repository](https://github.com/nodejs/node) if you have trouble upgrading from v0.12.7 to v0.12.8.
+
+## Commits
+
+* [[`7d11208f68`](https://github.com/nodejs/node/commit/7d11208f68)] - **build**: backport tools/release.sh (Rod Vagg) [#3642](https://github.com/nodejs/node/pull/3642)
+* [[`6fb0b92fa0`](https://github.com/nodejs/node/commit/6fb0b92fa0)] - **build**: backport config for new CI infrastructure (Rod Vagg) [#3642](https://github.com/nodejs/node/pull/3642)
+* [[`83441616a5`](https://github.com/nodejs/node/commit/83441616a5)] - **build**: fix --without-ssl compile time error (Ben Noordhuis) [#3825](https://github.com/nodejs/node/pull/3825)
+* [[`8887666b0b`](https://github.com/nodejs/node/commit/8887666b0b)] - **build**: update manifest to include Windows 10 (Lucien Greathouse) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`08afe4ec8e`](https://github.com/nodejs/node/commit/08afe4ec8e)] - **build**: add MSVS 2015 support (Rod Vagg) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`4f2456369c`](https://github.com/nodejs/node/commit/4f2456369c)] - **build**: work around VS2015 issue in ICU <56 (Steven R. Loomis) [nodejs/node-v0.x-archive#25804](https://github.com/nodejs/node-v0.x-archive/pull/25804)
+* [[`15030f26fd`](https://github.com/nodejs/node/commit/15030f26fd)] - **build**: Intl: bump ICU4C from 54 to 55 (backport) (Steven R. Loomis) [nodejs/node-v0.x-archive#25856](https://github.com/nodejs/node-v0.x-archive/pull/25856)
+* [[`1083fa70f0`](https://github.com/nodejs/node/commit/1083fa70f0)] - **build**: run-ci makefile rule (Alexis Campailla) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`2d2494cf14`](https://github.com/nodejs/node/commit/2d2494cf14)] - **build**: support flaky tests in test-ci (Alexis Campailla) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`b25d26f2ef`](https://github.com/nodejs/node/commit/b25d26f2ef)] - **build**: support Jenkins via test-ci (Alexis Campailla) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`7e4b47f38a`](https://github.com/nodejs/node/commit/7e4b47f38a)] - **build,win**: fix node.exe resource version (João Reis) [#3053](https://github.com/nodejs/node/pull/3053)
+* [[`e07c86e240`](https://github.com/nodejs/node/commit/e07c86e240)] - **build,win**: try next MSVS version on failure (João Reis) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`b5a0abcfdf`](https://github.com/nodejs/node/commit/b5a0abcfdf)] - **child_process**: clone spawn options argument (cjihrig) [nodejs/node-v0.x-archive#9159](https://github.com/nodejs/node-v0.x-archive/pull/9159)
+* [[`8b81f98c41`](https://github.com/nodejs/node/commit/8b81f98c41)] - **configure**: add --without-mdb flag (cgalibern) [nodejs/node-v0.x-archive#25707](https://github.com/nodejs/node-v0.x-archive/pull/25707)
+* [[`071c860c2b`](https://github.com/nodejs/node/commit/071c860c2b)] - **crypto**: replace rwlocks with simple mutexes (Ben Noordhuis) [#2723](https://github.com/nodejs/node/pull/2723)
+* [[`ca97fb6be3`](https://github.com/nodejs/node/commit/ca97fb6be3)] - **deps**: upgrade npm to 2.14.9 (Forrest L Norvell) [#3684](https://github.com/nodejs/node/pull/3684)
+* [[`583734342e`](https://github.com/nodejs/node/commit/583734342e)] - **deps**: fix openssl for MSVS 2015 (Andy Polyakov) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`02c262a4c6`](https://github.com/nodejs/node/commit/02c262a4c6)] - **deps**: fix gyp to work on MacOSX without XCode (Shigeki Ohtsu) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`f0fba0bce8`](https://github.com/nodejs/node/commit/f0fba0bce8)] - **deps**: update gyp to 25ed9ac (João Reis) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`f693565813`](https://github.com/nodejs/node/commit/f693565813)] - **deps**: upgrade to npm 2.13.4 (Kat Marchán) [nodejs/node-v0.x-archive#25825](https://github.com/nodejs/node-v0.x-archive/pull/25825)
+* [[`618b142679`](https://github.com/nodejs/node/commit/618b142679)] - **deps,v8**: fix compilation in VS2015 (João Reis) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`64459c0fe8`](https://github.com/nodejs/node/commit/64459c0fe8)] - **doc**: backport README.md (Rod Vagg) [#3642](https://github.com/nodejs/node/pull/3642)
+* [[`2860c53562`](https://github.com/nodejs/node/commit/2860c53562)] - **doc**: fixed child_process.exec doc (Tyler Anton) [nodejs/node-v0.x-archive#14088](https://github.com/nodejs/node-v0.x-archive/pull/14088)
+* [[`4a91fa11a3`](https://github.com/nodejs/node/commit/4a91fa11a3)] - **doc**: Update docs for os.platform() (George Kotchlamazashvili) [nodejs/node-v0.x-archive#25777](https://github.com/nodejs/node-v0.x-archive/pull/25777)
+* [[`b03ab02fe8`](https://github.com/nodejs/node/commit/b03ab02fe8)] - **doc**: Change the link for v8 docs to v8dox.com (Chad Walker) [nodejs/node-v0.x-archive#25811](https://github.com/nodejs/node-v0.x-archive/pull/25811)
+* [[`1fd8f37efd`](https://github.com/nodejs/node/commit/1fd8f37efd)] - **doc**: buffer, adding missing backtick (Dyana Rose) [nodejs/node-v0.x-archive#25811](https://github.com/nodejs/node-v0.x-archive/pull/25811)
+* [[`162d0db3bb`](https://github.com/nodejs/node/commit/162d0db3bb)] - **doc**: tls.markdown, adjust version from v0.10.39 to v0.10.x (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`eda2560cdc`](https://github.com/nodejs/node/commit/eda2560cdc)] - **doc**: additional refinement to readable event (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`881d9bea01`](https://github.com/nodejs/node/commit/881d9bea01)] - **doc**: readable event clarification (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`b6378f0c75`](https://github.com/nodejs/node/commit/b6378f0c75)] - **doc**: stream.unshift does not reset reading state (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`4952e2b4d2`](https://github.com/nodejs/node/commit/4952e2b4d2)] - **doc**: clarify Readable._read and Readable.push (fresheneesz) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`14000b97d4`](https://github.com/nodejs/node/commit/14000b97d4)] - **doc**: two minor stream doc improvements (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`6b6bd21497`](https://github.com/nodejs/node/commit/6b6bd21497)] - **doc**: Clarified read method with specified size argument. (Philippe Laferriere) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`16f547600a`](https://github.com/nodejs/node/commit/16f547600a)] - **doc**: Document http.request protocol option (Ville Skyttä) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`618e4ecda9`](https://github.com/nodejs/node/commit/618e4ecda9)] - **doc**: add a note about readable in flowing mode (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`0b165be37b`](https://github.com/nodejs/node/commit/0b165be37b)] - **doc**: fix line wrapping in buffer.markdown (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`70dd13f88d`](https://github.com/nodejs/node/commit/70dd13f88d)] - **doc**: add CleartextStream deprecation notice (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`418cde0765`](https://github.com/nodejs/node/commit/418cde0765)] - **doc**: mention that mode is ignored if file exists (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`85bcb281e4`](https://github.com/nodejs/node/commit/85bcb281e4)] - **doc**: improve http.abort description (James M Snell) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`5ccb429ee8`](https://github.com/nodejs/node/commit/5ccb429ee8)] - **doc, comments**: Grammar and spelling fixes (Ville Skyttä) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`a24db43101`](https://github.com/nodejs/node/commit/a24db43101)] - **docs**: event emitter behavior notice (Samuel Mills (Henchman)) [nodejs/node-v0.x-archive#25467](https://github.com/nodejs/node-v0.x-archive/pull/25467)
+* [[`8cbf7cb021`](https://github.com/nodejs/node/commit/8cbf7cb021)] - **docs**: events clarify emitter.listener() behavior (Benjamin Steephenson) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`b7229debbe`](https://github.com/nodejs/node/commit/b7229debbe)] - **docs**: Fix default options for fs.createWriteStream() (Chris Neave) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`f0453caea2`](https://github.com/nodejs/node/commit/f0453caea2)] - **domains**: port caeb677 from v0.10 to v0.12 (Jeremy Whitlock) [nodejs/node-v0.x-archive#25835](https://github.com/nodejs/node-v0.x-archive/pull/25835)
+* [[`261fa3620f`](https://github.com/nodejs/node/commit/261fa3620f)] - **src**: fix intermittent SIGSEGV in resolveTxt (Evan Lucas) [nodejs/node-v0.x-archive#9300](https://github.com/nodejs/node-v0.x-archive/pull/9300)
+* [[`1f7257b02d`](https://github.com/nodejs/node/commit/1f7257b02d)] - **test**: mark test-https-aws-ssl flaky on linux (João Reis) [nodejs/node-v0.x-archive#25893](https://github.com/nodejs/node-v0.x-archive/pull/25893)
+* [[`cf435d55db`](https://github.com/nodejs/node/commit/cf435d55db)] - **test**: mark test-signal-unregister as flaky (Alexis Campailla) [nodejs/node-v0.x-archive#25750](https://github.com/nodejs/node-v0.x-archive/pull/25750)
+* [[`ceb6a8c131`](https://github.com/nodejs/node/commit/ceb6a8c131)] - **test**: fix test-debug-port-from-cmdline (João Reis) [nodejs/node-v0.x-archive#25748](https://github.com/nodejs/node-v0.x-archive/pull/25748)
+* [[`22997731e6`](https://github.com/nodejs/node/commit/22997731e6)] - **test**: add regression test for #25735 (Fedor Indutny) [nodejs/node-v0.x-archive#25739](https://github.com/nodejs/node-v0.x-archive/pull/25739)
+* [[`39e05639f4`](https://github.com/nodejs/node/commit/39e05639f4)] - **test**: mark http-pipeline-flood flaky on win32 (Julien Gilli) [nodejs/node-v0.x-archive#25707](https://github.com/nodejs/node-v0.x-archive/pull/25707)
+* [[`78d256e7f5`](https://github.com/nodejs/node/commit/78d256e7f5)] - **test**: unmark tests that are no longer flaky (João Reis) [nodejs/node-v0.x-archive#25676](https://github.com/nodejs/node-v0.x-archive/pull/25676)
+* [[`a9b642cf5b`](https://github.com/nodejs/node/commit/a9b642cf5b)] - **test**: runner should return 0 on flaky tests (Alexis Campailla) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`b48639befd`](https://github.com/nodejs/node/commit/b48639befd)] - **test**: support writing test output to file (Alexis Campailla) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`caa16b41d6`](https://github.com/nodejs/node/commit/caa16b41d6)] - **(SEMVER-MINOR)** **tls**: prevent server from using dhe keys < 768 (Michael Dawson) [#3890](https://github.com/nodejs/node/pull/3890)
+* [[`0363cf4a80`](https://github.com/nodejs/node/commit/0363cf4a80)] - **tls**: Closing parent socket also closes the tls sock (Devin Nakamura) [nodejs/node-v0.x-archive#25642](https://github.com/nodejs/node-v0.x-archive/pull/25642)
+* [[`75697112e8`](https://github.com/nodejs/node/commit/75697112e8)] - **tls**: do not hang without `newSession` handler (Fedor Indutny) [nodejs/node-v0.x-archive#25739](https://github.com/nodejs/node-v0.x-archive/pull/25739)
+* [[`d998a65058`](https://github.com/nodejs/node/commit/d998a65058)] - **tools**: pass constant to logger instead of string (Johan Bergström) [nodejs/node-v0.x-archive#25653](https://github.com/nodejs/node-v0.x-archive/pull/25653)
+* [[`1982ed6e63`](https://github.com/nodejs/node/commit/1982ed6e63)] - **v8**: port fbff705 from v0.10 to v0.12 (Jeremy Whitlock) [nodejs/node-v0.x-archive#25835](https://github.com/nodejs/node-v0.x-archive/pull/25835)
+* [[`44d7054252`](https://github.com/nodejs/node/commit/44d7054252)] - **win**: fix custom actions for WiX older than 3.9 (João Reis) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`586c4d8b8e`](https://github.com/nodejs/node/commit/586c4d8b8e)] - **win**: fix custom actions on Visual Studio != 2013 (Julien Gilli) [#2843](https://github.com/nodejs/node/pull/2843)
+* [[`14db629497`](https://github.com/nodejs/node/commit/14db629497)] - **win,msi**: correct installation path registry keys (João Reis) [nodejs/node-v0.x-archive#25640](https://github.com/nodejs/node-v0.x-archive/pull/25640)
+* [[`8e80528453`](https://github.com/nodejs/node/commit/8e80528453)] - **win,msi**: change InstallScope to perMachine (João Reis) [nodejs/node-v0.x-archive#25640](https://github.com/nodejs/node-v0.x-archive/pull/25640)
+* [[`35bbe98401`](https://github.com/nodejs/node/commit/35bbe98401)] - Update addons.markdown (Max Deepfield) [nodejs/node-v0.x-archive#25885](https://github.com/nodejs/node-v0.x-archive/pull/25885)
+* [[`9a6f1ce416`](https://github.com/nodejs/node/commit/9a6f1ce416)] - comma (Julien Valéry) [nodejs/node-v0.x-archive#25811](https://github.com/nodejs/node-v0.x-archive/pull/25811)
+* [[`d384bf8f84`](https://github.com/nodejs/node/commit/d384bf8f84)] - Update assert.markdown (daveboivin) [nodejs/node-v0.x-archive#25811](https://github.com/nodejs/node-v0.x-archive/pull/25811)
+* [[`89b22ccbe1`](https://github.com/nodejs/node/commit/89b22ccbe1)] - Fixed typo (Andrew Murray) [nodejs/node-v0.x-archive#25811](https://github.com/nodejs/node-v0.x-archive/pull/25811)
+* [[`5ad05af380`](https://github.com/nodejs/node/commit/5ad05af380)] - Update util.markdown (Daniel Rentz) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`cb660ab3d3`](https://github.com/nodejs/node/commit/cb660ab3d3)] - Update child_process.markdown, spelling (Jared Fox) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`59c67fe3cd`](https://github.com/nodejs/node/commit/59c67fe3cd)] - updated documentation for fs.createReadStream (Michele Caini) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`53b6a615a5`](https://github.com/nodejs/node/commit/53b6a615a5)] - Documentation update about Buffer initialization (Sarath) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
+* [[`b8d47a7b6f`](https://github.com/nodejs/node/commit/b8d47a7b6f)] - fix (Fedor Indutny) [nodejs/node-v0.x-archive#25739](https://github.com/nodejs/node-v0.x-archive/pull/25739)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8-x86.msi<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.8/x64/node-v0.12.8-x64.msi<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.8/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.8/x64/node.exe<br>
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8.pkg<br>
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.tar.gz<br>
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x86.tar.gz<br>
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x64.tar.gz<br>
+SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz<br>
+SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz<br>
+Source Code: https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz<br>
+Other release files: https://nodejs.org/dist/v0.12.8/<br>
+Documentation: https://nodejs.org/docs/v0.12.8/api/
+
+Shasums (GPG signing hash: SHA512, file hash: SHA256):
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+c510a03310053182b20af10e4400877421255c1a72d9c98d8ad87bb7602fcdf5  node.exe
+495c1e492874bac2cdaf0bbb6507476bc33ec2b8c30799d9dc50692d4d5ab553  node.exp
+60d6248a9073130e6c16ae79eafcce53acabe5565249364855242e15aa7de86b  node.lib
+aa790268a830e32678a851356dc9a848b2caa26b64ccf2a897f9a63447322cc0  node.pdb
+857155d09d62b59c675baf4091a4e76af0972f8c99a26259a18e3ac99575697b  node-v0.12.8-darwin-x64.tar.gz
+2ec14c53fa69836caf79822b2de071659fadb2c105b1344371b404df398bad39  node-v0.12.8-darwin-x86.tar.gz
+9ad0c77d0c5c2236ba42519dbd7375e9462412e812b6c60e776fcc129ef97084  node-v0.12.8-headers.tar.gz
+99f9f8792850867a21caeaf12b1f84da9f64d0cf0ac602920facc0fc4b81e8b4  node-v0.12.8-linux-x64.tar.gz
+b82e3b4a01f9be1f130d97cf6a8534ae727396448fb1bfeb7eb74ec58592bd88  node-v0.12.8-linux-x86.tar.gz
+94c46f6418175d43b47229b57d54c25d2ed9bb9a6cd51331de0c3b7df86be1e2  node-v0.12.8.pkg
+c8ca60698f99b7dc7722b94c5b4110636d08d3a20cb3df80807bd420e2c34376  node-v0.12.8-sunos-x64.tar.gz
+8d9553a684b6717f0f0f2f5dcc8ed78139db50129e1402ce6033e2494c06cfd3  node-v0.12.8-sunos-x86.tar.gz
+e0c96a6702978e2ed7f031315bebeb86b042e2c80e66d99af8ad864dc0e56436  node-v0.12.8.tar.gz
+d9c97de01f95bd99fcb9a21dc36db1916c46db6a4b1992f235c01acc1dba8b0c  node-v0.12.8-x86.msi
+4ce3651ccb4c0c3ffc968d2580ea9cd219a4697b0bd3e3c18b3e478d80402cfe  openssl-cli.exe
+745e656d36508a38ec307a81f540425d3e0befa1c8614d86cdc3dcb38de2cd3c  openssl-cli.pdb
+5d0455af75857a96d53593f23defb38e55706697cd638e0b442f6d7208864256  x64/node.exe
+c546e1e8f21ac580c30b8ca7d1653b180b6dd9ba07cca0fd661fa5c0c432f4f4  x64/node.exp
+44173c6b7b0978e28bb78b865954ec8d68a9b8843daf8586c67b520bc4f0c0a6  x64/node.lib
+f5f0ba7d83ff186fed1bae22700218d406335f8a668975993c0a94ec6fc4a959  x64/node.pdb
+d0b235299d85527b30f5901e059b4f56cf289b1f99d49d404b7776aa53f873f1  x64/node-v0.12.8-x64.msi
+2dc5b7ceaa8ae58d77c00701d97c5d52c2d369410f94a1b3f43b4e6aa7e01c3d  x64/openssl-cli.exe
+8bbc2c70d4afa149b58f60aa8ca5d835540a46bb92759b950a9d18c626db329f  x64/openssl-cli.pdb
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQEcBAEBAgAGBQJWVPhlAAoJEMJzeS99g1RdJlsIAN9VwrQTaxTbUcenm2KPUMPA
+1Va6Fj3BBERCTPuHxLf+XJIAz9qlMsJLRU1y7tqdzjUKDWBf5007RYY5KGmc0m0H
+oKKu1lnT+jc87IAYveBD/QldXibPwCc9e0rou7iO3OUPtttXRHlSMw/tYSkzg2ba
+x3E/wCQlNQmrAOrRdBd0Qzi3nlnosIWAoCMp8Hbw0TkjUD4LOq0zFCl/5AK+qnB6
+jiXpSWNXTciOhRb779NmF7UHYbrdjeEhOxcLE8ODq9U4PsBZXVZKaU2rQ4Lp/CAk
+wabJBZ3RQKT6okzbhlz0TbgbsjZ4VeVCpDJWVA4gBlEboXDoF9IWJ37hu+qqEaE=
+=vHgI
+-----END PGP SIGNATURE-----
+```


### PR DESCRIPTION
had to craft this by hand, so much is different with the <=0.12 release process & files that the release-post.js script breaks at multiple places, we should probably fix that so these old releases aren't quite so painful
