### PR TITLE
Error in build.js/copystatic()  `ENOENT: no such file or directory, open '.../nodejs.org/build/static/event-geo.json'`

### DIFF
--- a/build.js
+++ b/build.js
@@ -172,13 +172,11 @@ function buildlocale (source, locale) {
 
 function copystatic () {
   console.time('[metalsmith] build/static finished')
-  fs.mkdir(path.join(__dirname, 'build'), function () {
-    fs.mkdir(path.join(__dirname, 'build', 'static'), function () {
-      ncp(path.join(__dirname, 'static'), path.join(__dirname, 'build', 'static'), function (err) {
-        if (err) { return console.error(err) }
-        console.timeEnd('[metalsmith] build/static finished')
-      })
-    })
+  fs.mkdirSync(path.join(__dirname, 'build'))
+  fs.mkdirSync(path.join(__dirname, 'build', 'static'))
+  ncp(path.join(__dirname, 'static'), path.join(__dirname, 'build', 'static'), function (err) {
+    if (err) { return console.error(err) }
+    console.timeEnd('[metalsmith] build/static finished')
   })
   fs.writeFileSync(path.join(__dirname, 'build', 'static', 'event-geo.json'), JSON.stringify(eventGeo()))
 }


### PR DESCRIPTION
After I switched to nodejs v5.0, running a clean build no longer worked.
It doesn't seem to be creating the directories before the `fs.mkdir` callback(s)??

It's a build script, so hopefully a synchronous fix isn't the worst...
