### PR TITLE
Fix events map link color

### DIFF
--- a/layouts/css/page-modules/_events.styl
+++ b/layouts/css/page-modules/_events.styl
@@ -4,8 +4,17 @@
     margin-top 20px
 
     .marker-image img
+        width 100%
         max-width 320px
         max-height 100px
+
+    .marker-title a
+        color $node-green
+        text-decoration none
+        &:hover
+            color $white
+            background $node-green
+
 
 .events-map-key
     padding 8px 0


### PR DESCRIPTION
fixes #390
- fix map link color
- make images not overflow map marker box

Before:
![1](https://cloud.githubusercontent.com/assets/2513462/11456248/9516645e-96d7-11e5-9454-47ad6d3a2e06.png)

After:
![2](https://cloud.githubusercontent.com/assets/2513462/11456249/9518f66a-96d7-11e5-9398-b6d2f9bfa752.png)
