### PR TITLE
Fix css hack for "Edit on GitHub" link

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -137,7 +137,7 @@ pre
 .edit-link
     float right
     font-size 0.6em
-    transform translateY(30%)
+    margin 0.5em 0
 
 @media screen and (max-width: 480px)
     .has-side-nav


### PR DESCRIPTION
This is a quick followup to #400, fixes a small css hack for vertically aligning "Edit on GitHub" link relatively to the headline.
