### PR TITLE
Display security announcement for december security releases

### DIFF
--- a/build.js
+++ b/build.js
@@ -194,8 +194,8 @@ function fullbuild () {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: false,
-          content: '<a href="https://nodejs.org/en/blog/release/v4.2.1/">Long Term Support Release</a>'
+          visible: true,
+          content: 'Important <a href="https://nodejs.org/en/blog/vulnerability/december-2015-security-releases/">security releases</a>, please update now!'
         }
       }
     }

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -14,7 +14,6 @@
 
                 {{#if project.banner.visible}}
                     <p class="home-version home-version-banner">
-                        {{ labels.current-version }}: {{ project.currentVersion }}<br>
                         {{{ project.banner.content }}}
                     </p>
                 {{/if}}


### PR DESCRIPTION
Should we display an announcement about the recent security releases? It links to the [December Security Release Summary](https://nodejs.org/en/blog/vulnerability/december-2015-security-releases/) post.

/cc @rvagg 

<img width="774" alt="screen shot 2015-12-04 at 08 41 06" src="https://cloud.githubusercontent.com/assets/1231635/11584291/093e60e6-9a63-11e5-9241-2df45f22ff57.png">
