### PR TITLE
Blog listing pages for "categories"

### DIFF
--- a/layouts/category-index.hbs
+++ b/layouts/category-index.hbs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ site.locale }}">
+{{> html-head }}
+
+<body>
+    {{> header }}
+
+    <div id="main">
+        <div class="container">
+            {{#if title}}
+                <h2>{{ title }}</h2>
+            {{/if}}
+
+            <ul class="blog-index">
+                {{#each collections.blog}}
+                    {{#unless listing}}
+                        {{#startswith path ../path}}
+                            {{#if title}}
+                                <li>
+                                    <time datetime="{{ date }}">{{ strftime date "%d %b %y" }}</time>
+                                    <a href="/{{../site.locale}}/{{ path }}/">{{ title }}</a>
+                                </li>
+                            {{/if}}
+                        {{/startswith}}
+                    {{/unless}}
+                {{/each}}
+            </ul>
+
+        </div>
+    </div>
+
+    {{> footer }}
+</body>
+</html>

--- a/locale/en/blog/advisory-board/index.md
+++ b/locale/en/blog/advisory-board/index.md
@@ -1,0 +1,6 @@
+---
+title: Advisory Board
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/announcements/index.md
+++ b/locale/en/blog/announcements/index.md
@@ -1,0 +1,6 @@
+---
+title: Announcements
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/community/index.md
+++ b/locale/en/blog/community/index.md
@@ -1,0 +1,6 @@
+---
+title: Community
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/feature/index.md
+++ b/locale/en/blog/feature/index.md
@@ -1,0 +1,6 @@
+---
+title: Features
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/module/index.md
+++ b/locale/en/blog/module/index.md
@@ -1,0 +1,6 @@
+---
+title: Modules
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/npm/index.md
+++ b/locale/en/blog/npm/index.md
@@ -1,0 +1,6 @@
+---
+title: NPM
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/release/index.md
+++ b/locale/en/blog/release/index.md
@@ -1,0 +1,6 @@
+---
+title: Releases
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/uncategorized/index.md
+++ b/locale/en/blog/uncategorized/index.md
@@ -1,0 +1,6 @@
+---
+title: Uncategorized
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/video/index.md
+++ b/locale/en/blog/video/index.md
@@ -1,0 +1,6 @@
+---
+title: Videos
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/vulnerability/index.md
+++ b/locale/en/blog/vulnerability/index.md
@@ -1,0 +1,6 @@
+---
+title: Vulnerabilities
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---

--- a/locale/en/blog/weekly-updates/index.md
+++ b/locale/en/blog/weekly-updates/index.md
@@ -1,0 +1,6 @@
+---
+title: Weekly Updates
+layout: category-index.hbs
+listing: true
+robots: noindex, follow
+---


### PR DESCRIPTION
Currently navigating up the pathname from one of the blog pages, you encounter a 404 or 403. This adds support for these intermediate "categories" providing a filtered list of entries.

https://nodejs.org/en/blog/release/ (403)
https://nodejs.org/en/blog/announcement/ (404)

<img width="1082" alt="category-listing-pages" src="https://cloud.githubusercontent.com/assets/2323810/11609803/32b4e71a-9b99-11e5-8288-1ca94cd30c85.png">

Firstly, is this a good addition? 

Secondly, are there any suggestion of changes that need to be made?
