### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/locale/en/about/organization.md
+++ b/locale/en/about/organization.md
@@ -19,7 +19,7 @@ contributing section](/contribute/).
 
 The Node.js Project currently has well over 300 contributors actively
 working on different areas of the project. The current list of contributors
-can be found on the project's [Github profile](https://github.com/orgs/nodejs/people).
+can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/people).
 
 ### Current members of the Technical steering committee
 

--- a/locale/en/foundation/tsc/index.md
+++ b/locale/en/foundation/tsc/index.md
@@ -18,7 +18,7 @@ contributing section](/en/get-involved/contribute/).
 
 The Node.js Project currently has well over 300 contributors actively
 working on different areas of the project. The current list of contributors
-can be found on the project's [Github profile](https://github.com/orgs/nodejs/people).
+can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/people).
 
 ### Current members of the Technical Steering Committee
 

--- a/locale/en/get-involved/contribute.md
+++ b/locale/en/get-involved/contribute.md
@@ -17,7 +17,7 @@ When reporting an issue we also need as much information about your environment 
 * Platform you're running on (OS X, SunOS, Linux, Windows)
 * Architecture you're running on (32bit or 64bit and x86 or ARM)
 
-The Node.js project is currently managed across a number of separate Github repositories, each with their own separate issues database. If possible, please direct any issues you are reporting to the appropriate repository but don't worry if things happen to get put in the wrong place, the community of contributors will be more than happy to help get you pointed in the right direction.
+The Node.js project is currently managed across a number of separate GitHub repositories, each with their own separate issues database. If possible, please direct any issues you are reporting to the appropriate repository but don't worry if things happen to get put in the wrong place, the community of contributors will be more than happy to help get you pointed in the right direction.
 
 * To report issues specific to Node.js, please use [nodejs/node](https://github.com/nodejs/node)
 * To report issues specific to this website, please use [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org/issues)

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -16,7 +16,7 @@ right place. Explore our community resources to find out how you can help:
 
 ## Discussion
 
-- The [Github issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
+- The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 
 - For real-time chat about Node development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](http://webchat.freenode.net/?channels=node.js).
 


### PR DESCRIPTION
This replaces some occurrences of "Github" with "GitHub".
