### PR TITLE
Added support for v0.12.x releases in release blog post script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "autoprefixer-stylus": "0.8.1",
+    "changelog-url": "1.0.0",
     "chokidar": "1.2.0",
     "handlebars": "4.0.4",
     "html-to-text": "^1.5.0",

--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -1,6 +1,9 @@
-const extend = require('util')._extend
+'use strict'
 
-const downloads = [
+const extend = require('util')._extend
+const semver = require('semver')
+
+const postMergeDownloads = [
   {
     'title': 'Windows 32-bit Installer',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-x86.msi'
@@ -59,11 +62,64 @@ const downloads = [
   }
 ]
 
+// v0.x of Node.js
+const legacyDownloads = [
+  {
+    'title': 'Windows 32-bit Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-x86.msi'
+  },
+  {
+    'title': 'Windows 64-bit Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/x64/node-v%version%-x64.msi'
+  },
+  {
+    'title': 'Windows 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node.exe'
+  },
+  {
+    'title': 'Windows 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/x64/node.exe'
+  },
+  {
+    'title': 'Mac OS X Universal Installer',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.pkg'
+  },
+  {
+    'title': 'Mac OS X 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x64.tar.gz'
+  },
+  {
+    'title': 'Mac OS X 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x86.tar.gz'
+  },
+  {
+    'title': 'Linux 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-x86.tar.gz'
+  },
+  {
+    'title': 'Linux 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-x64.tar.gz'
+  },
+  {
+    'title': 'SunOS 32-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-sunos-x86.tar.gz'
+  },
+  {
+    'title': 'SunOS 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-sunos-x64.tar.gz'
+  },
+  {
+    'title': 'Source Code',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.tar.gz'
+  }
+]
+
 function resolveUrl (item, version) {
   const url = item.templateUrl.replace(/%version%/g, version)
-  return extend({url}, item)
+  return extend({ url }, item)
 }
 
 module.exports = (version) => {
+  const downloads = semver.satisfies(version, '>= 1.0.0') ? postMergeDownloads : legacyDownloads
   return downloads.map((item) => resolveUrl(item, version))
 }

--- a/tests/scripts/CHANGELOG.fixture.legacy.md
+++ b/tests/scripts/CHANGELOG.fixture.legacy.md
@@ -1,0 +1,87 @@
+2015-12-04, Version 0.12.9 (LTS), @rvagg
+
+Security Update
+
+Notable items:
+
+* http: Fix a bug where an HTTP socket may no longer have a socket but a pipelined request triggers a pause or resume, a potential denial-of-service vector. (Fedor Indutny)
+* openssl: Upgrade to 1.0.1q, containing fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
+
+Commits:
+
+* [8d24a14f2c] - deps: upgrade to openssl 1.0.1q (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
+* [dfc6f4a9af] - http: fix pipeline regression (Fedor Indutny)
+
+2015.11.25, Version 0.12.8 (LTS)
+
+* [d9399569bd] - build: backport tools/release.sh (Rod Vagg) https://github.com/nodejs/node/pull/3642
+* [78c5b4c8bd] - build: backport config for new CI infrastructure (Rod Vagg) https://github.com/nodejs/node/pull/3642
+* [83441616a5] - build: fix --without-ssl compile time error (Ben Noordhuis) https://github.com/nodejs/node/pull/3825
+* [8887666b0b] - build: update manifest to include Windows 10 (Lucien Greathouse) https://github.com/nodejs/node/pull/2843
+* [08afe4ec8e] - build: add MSVS 2015 support (Rod Vagg) https://github.com/nodejs/node/pull/2843
+* [4f2456369c] - build: work around VS2015 issue in ICU <56 (Steven R. Loomis) https://github.com/nodejs/node-v0.x-archive/pull/25804
+* [15030f26fd] - build: Intl: bump ICU4C from 54 to 55 (backport) (Steven R. Loomis) https://github.com/nodejs/node-v0.x-archive/pull/25856
+* [1083fa70f0] - build: run-ci makefile rule (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [2d2494cf14] - build: support flaky tests in test-ci (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [b25d26f2ef] - build: support Jenkins via test-ci (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [7e4b47f38a] - build,win: fix node.exe resource version (João Reis) https://github.com/nodejs/node/pull/3053
+* [e07c86e240] - build,win: try next MSVS version on failure (João Reis) https://github.com/nodejs/node/pull/2843
+* [b5a0abcfdf] - child_process: clone spawn options argument (cjihrig) https://github.com/nodejs/node-v0.x-archive/pull/9159
+* [8b81f98c41] - configure: add --without-mdb flag (cgalibern) https://github.com/nodejs/node-v0.x-archive/pull/25707
+* [071c860c2b] - crypto: replace rwlocks with simple mutexes (Ben Noordhuis) https://github.com/nodejs/node/pull/2723
+* [ca97fb6be3] - deps: upgrade npm to 2.14.9 (Forrest L Norvell) https://github.com/nodejs/node/pull/3684
+* [583734342e] - deps: fix openssl for MSVS 2015 (Andy Polyakov) https://github.com/nodejs/node/pull/2843
+* [02c262a4c6] - deps: fix gyp to work on MacOSX without XCode (Shigeki Ohtsu) https://github.com/nodejs/node/pull/2843
+* [f0fba0bce8] - deps: update gyp to 25ed9ac (João Reis) https://github.com/nodejs/node/pull/2843
+* [f693565813] - deps: upgrade to npm 2.13.4 (Kat Marchán) https://github.com/nodejs/node-v0.x-archive/pull/25825
+* [618b142679] - deps,v8: fix compilation in VS2015 (João Reis) https://github.com/nodejs/node/pull/2843
+* [49b4f0d54e] - doc: backport README.md (Rod Vagg) https://github.com/nodejs/node/pull/3642
+* [2860c53562] - doc: fixed child_process.exec doc (Tyler Anton) https://github.com/nodejs/node-v0.x-archive/pull/14088
+* [4a91fa11a3] - doc: Update docs for os.platform() (George Kotchlamazashvili) https://github.com/nodejs/node-v0.x-archive/pull/25777
+* [b03ab02fe8] - doc: Change the link for v8 docs to v8dox.com (Chad Walker) https://github.com/nodejs/node-v0.x-archive/pull/25811
+* [1fd8f37efd] - doc: buffer, adding missing backtick (Dyana Rose) https://github.com/nodejs/node-v0.x-archive/pull/25811
+* [162d0db3bb] - doc: tls.markdown, adjust version from v0.10.39 to v0.10.x (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [eda2560cdc] - doc: additional refinement to readable event (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [881d9bea01] - doc: readable event clarification (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [b6378f0c75] - doc: stream.unshift does not reset reading state (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [4952e2b4d2] - doc: clarify Readable._read and Readable.push (fresheneesz) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [14000b97d4] - doc: two minor stream doc improvements (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [6b6bd21497] - doc: Clarified read method with specified size argument. (Philippe Laferriere) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [16f547600a] - doc: Document http.request protocol option (Ville Skyttä) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [618e4ecda9] - doc: add a note about readable in flowing mode (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [0b165be37b] - doc: fix line wrapping in buffer.markdown (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [70dd13f88d] - doc: add CleartextStream deprecation notice (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [418cde0765] - doc: mention that mode is ignored if file exists (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [85bcb281e4] - doc: improve http.abort description (James M Snell) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [5ccb429ee8] - doc, comments: Grammar and spelling fixes (Ville Skyttä) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [a24db43101] - docs: event emitter behavior notice (Samuel Mills (Henchman)) https://github.com/nodejs/node-v0.x-archive/pull/25467
+* [8cbf7cb021] - docs: events clarify emitter.listener() behavior (Benjamin Steephenson) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [b7229debbe] - docs: Fix default options for fs.createWriteStream() (Chris Neave) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [f0453caea2] - domains: port caeb677 from v0.10 to v0.12 (Jeremy Whitlock) https://github.com/nodejs/node-v0.x-archive/pull/25835
+* [261fa3620f] - src: fix intermittent SIGSEGV in resolveTxt (Evan Lucas) https://github.com/nodejs/node-v0.x-archive/pull/9300
+* [1f7257b02d] - test: mark test-https-aws-ssl flaky on linux (João Reis) https://github.com/nodejs/node-v0.x-archive/pull/25893
+* [cf435d55db] - test: mark test-signal-unregister as flaky (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25750
+* [ceb6a8c131] - test: fix test-debug-port-from-cmdline (João Reis) https://github.com/nodejs/node-v0.x-archive/pull/25748
+* [22997731e6] - test: add regression test for #25735 (Fedor Indutny) https://github.com/nodejs/node-v0.x-archive/pull/25739
+* [39e05639f4] - test: mark http-pipeline-flood flaky on win32 (Julien Gilli) https://github.com/nodejs/node-v0.x-archive/pull/25707
+* [78d256e7f5] - test: unmark tests that are no longer flaky (João Reis) https://github.com/nodejs/node-v0.x-archive/pull/25676
+* [a9b642cf5b] - test: runner should return 0 on flaky tests (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [b48639befd] - test: support writing test output to file (Alexis Campailla) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [caa16b41d6] - (SEMVER-MINOR) tls: prevent server from using dhe keys < 768 (Michael Dawson) https://github.com/nodejs/node/pull/3890
+* [0363cf4a80] - tls: Closing parent socket also closes the tls sock (Devin Nakamura) https://github.com/nodejs/node-v0.x-archive/pull/25642
+* [75697112e8] - tls: do not hang without `newSession` handler (Fedor Indutny) https://github.com/nodejs/node-v0.x-archive/pull/25739
+* [d998a65058] - tools: pass constant to logger instead of string (Johan Bergström) https://github.com/nodejs/node-v0.x-archive/pull/25653
+* [1982ed6e63] - v8: port fbff705 from v0.10 to v0.12 (Jeremy Whitlock) https://github.com/nodejs/node-v0.x-archive/pull/25835
+* [44d7054252] - win: fix custom actions for WiX older than 3.9 (João Reis) https://github.com/nodejs/node/pull/2843
+* [586c4d8b8e] - win: fix custom actions on Visual Studio != 2013 (Julien Gilli) https://github.com/nodejs/node/pull/2843
+* [14db629497] - win,msi: correct installation path registry keys (João Reis) https://github.com/nodejs/node-v0.x-archive/pull/25640
+* [8e80528453] - win,msi: change InstallScope to perMachine (João Reis) https://github.com/nodejs/node-v0.x-archive/pull/25640
+* [35bbe98401] - Update addons.markdown (Max Deepfield) https://github.com/nodejs/node-v0.x-archive/pull/25885
+* [9a6f1ce416] - comma (Julien Valéry) https://github.com/nodejs/node-v0.x-archive/pull/25811
+* [d384bf8f84] - Update assert.markdown (daveboivin) https://github.com/nodejs/node-v0.x-archive/pull/25811
+* [89b22ccbe1] - Fixed typo (Andrew Murray) https://github.com/nodejs/node-v0.x-archive/pull/25811
+* [5ad05af380] - Update util.markdown (Daniel Rentz) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [cb660ab3d3] - Update child_process.markdown, spelling (Jared Fox) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [59c67fe3cd] - updated documentation for fs.createReadStream (Michele Caini) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [53b6a615a5] - Documentation update about Buffer initialization (Sarath) https://github.com/nodejs/node-v0.x-archive/pull/25591
+* [b8d47a7b6f] - fix (Fedor Indutny) https://github.com/nodejs/node-v0.x-archive/pull/25739

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -109,6 +109,7 @@ test('fetchChangelog(<version>)', (t) => {
   const releasePost = require('../../scripts/release-post')
 
   const changelogFixture = path.resolve(__dirname, 'CHANGELOG.fixture.md')
+  const changelogLegacyFixture = path.resolve(__dirname, 'CHANGELOG.fixture.legacy.md')
 
   t.test('resolves with section of changelog related to specified version', (t) => {
     const github = nock('https://raw.githubusercontent.com')
@@ -123,13 +124,26 @@ test('fetchChangelog(<version>)', (t) => {
     }, t.fail)
   })
 
+  t.test('can fetch changelog of legacy versions of Node.js', (t) => {
+    const github = nock('https://raw.githubusercontent.com')
+      .get('/nodejs/node/v0.12.9/ChangeLog')
+      .replyWithFile(200, changelogLegacyFixture)
+
+    releasePost.fetchChangelog('0.12.9').then((changelog) => {
+      t.true(changelog.includes('Security Update'))
+      t.true(github.isDone(), 'githubusercontent.com was requested')
+
+      t.end()
+    }, t.fail)
+  })
+
   t.test('rejects when a matching version section could not be found in changelog', (t) => {
     const github = nock('https://raw.githubusercontent.com')
-      .get('/nodejs/node/v0.14.0/CHANGELOG.md')
+      .get('/nodejs/node/v0.9999999.0/ChangeLog')
       .reply(200, 'A changelog without version sections...')
 
-    releasePost.fetchChangelog('0.14.0').then(t.fail, (err) => {
-      t.equal(err.message, "Couldn't find matching changelog for 0.14.0")
+    releasePost.fetchChangelog('0.9999999.0').then(t.fail, (err) => {
+      t.equal(err.message, "Couldn't find matching changelog for 0.9999999.0")
       t.true(github.isDone(), 'githubusercontent.com was requested')
 
       t.end()
@@ -164,6 +178,7 @@ test('fetchVersionPolicy(<version>)', (t) => {
   const releasePost = require('../../scripts/release-post')
 
   const changelogFixture = path.resolve(__dirname, 'CHANGELOG.fixture.md')
+  const changelogLegacyFixture = path.resolve(__dirname, 'CHANGELOG.fixture.legacy.md')
 
   t.test('finds "Stable" version policy', (t) => {
     const github = nock('https://raw.githubusercontent.com')
@@ -184,6 +199,19 @@ test('fetchVersionPolicy(<version>)', (t) => {
       .replyWithFile(200, changelogFixture)
 
     releasePost.fetchVersionPolicy('4.2.0').then((policy) => {
+      t.equal(policy, 'LTS')
+      t.true(github.isDone(), 'githubusercontent.com was requested')
+
+      t.end()
+    }, t.fail)
+  })
+
+  t.test('finds "LTS" version policy in legacy changelogs', (t) => {
+    const github = nock('https://raw.githubusercontent.com')
+      .get('/nodejs/node/v0.12.9/ChangeLog')
+      .replyWithFile(200, changelogLegacyFixture)
+
+    releasePost.fetchVersionPolicy('0.12.9').then((policy) => {
       t.equal(policy, 'LTS')
       t.true(github.isDone(), 'githubusercontent.com was requested')
 


### PR DESCRIPTION
This adds support for creating release blog posts for v0.12.x releases. Addresses the issues in #380, plus:
- The list of download URLs aren't the same for v0.12.x, legacy releases had to get their own list of URLs in `./scripts/helpers/downloads.js`
- Handle different header formats

Closes #380

/cc @nodejs/release 
