### PR TITLE
Take advantage of the request dependency

### DIFF
--- a/scripts/tasks/download.js
+++ b/scripts/tasks/download.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const github = require('octonode')
-const https = require('https')
+const request = require('request')
 const path = require('path')
 const fs = require('fs')
 
@@ -27,14 +27,26 @@ function checkOrFetchFile (file) {
     }
 
     console.log(`Weekly Update ${filePath} does not exist. Downloading.`)
+    const uri = file.download_url
 
-    https.get(file.download_url, (response) => {
-      const ws = fs.createWriteStream(filePath)
-      ws.on('error', (err) => console.error(err.stack))
+    request
+      .get(uri)
+      .on('error', (err) => console.error(err.stack))
+      .on('response', function (response) {
+        if (response.statusCode !== 200) {
+          this.emit('error', new Error(
+            `Invalid status code (!= 200) while retrieving ${uri}: ${response.statusCode}`
+          ))
+          return
+        }
 
-      response.on('end', () => console.log(`Weekly Update ${filePath} downloaded.`))
-      response.pipe(ws)
-    }).on('error', (err) => console.error(err.stack))
+        const ws = fs.createWriteStream(filePath)
+
+        ws.on('error', this.emit.bind(this, 'error'))
+        ws.on('finish', () => console.log(`Weekly Update ${filePath} downloaded.`))
+
+        response.pipe(ws)
+      })
   })
 }
 


### PR DESCRIPTION
With #378 we added the `request` dependency. Now that we have it I think that it makes sense to use it to make the code easier to read.
