### PR TITLE
Releases: Rename "Modules" to "NODE_MODULE_VERSION"

### DIFF
--- a/layouts/css/page-modules/_download.styl
+++ b/layouts/css/page-modules/_download.styl
@@ -128,9 +128,6 @@ td.download-table-last
     > a
         padding 0 10px
 
-#modules-description
-    font-size: small
-
 @media (max-width: 700px)
     .download-hero ul
         width auto

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -26,7 +26,7 @@
                                 <td>Date</td>
                                 <td>V8</td>
                                 <td>npm</td>
-                                <td>Modules</td>
+                                <td>NODE_MODULE_VERSION<a href="#ref-1">[1]</a><span id="backref-1"></span></td>
                                 <td></td>
                             </tr>
                         </thead>
@@ -38,7 +38,7 @@
                                     <td data-label="Date"><time>{{date}}</time></td>
                                     <td data-label="V8">{{v8}}</td>
                                     <td data-label="npm">{{npm}}</td>
-                                    <td data-label="Modules">{{modules}}</td>
+                                    <td data-label="NODE_MODULE_VERSION">{{modules}}</td>
                                     <td class="download-table-last">
                                         <a href="{{url}}">
                                             {{i18n 'releases.downloads'}}
@@ -54,7 +54,7 @@
                             {{/project.versions}}
                         </tbody>
                     </table>
-                    <p id="modules-description">{{{modules}}}</p>
+                    <p><small id="ref-1">[<a href="#backref-1">1</a>]: {{{modules}}}</small></p>
                 </section>
             </article>
 

--- a/locale/en/download/releases.md
+++ b/locale/en/download/releases.md
@@ -3,5 +3,5 @@ layout: download-releases.hbs
 title: Previous Releases
 iojs:
   intro: "Releases 1.x through 3.x were called \"io.js\" as they were part of the io.js fork. As of Node.js 4.0.0 the former release lines of io.js converged with Node.js 0.12.x into unified Node.js releases."
-modules: "\"Modules\" refers to the ABI (application binary interface) version number of Node.js, used to determine which versions of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled. This version number is also referred to as <code>NODE_MODULE_VERSION</code>."
+modules: "<code>NODE_MODULE_VERSION</code> refers to the ABI (application binary interface) version number of Node.js, used to determine which versions of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled. It used to be stored as hex value in earlier versions, but is now represented as an integer."
 ---


### PR DESCRIPTION
Clarifies "NODE_MODULE_VERSION", see #419 and https://github.com/nodejs/build/issues/219.

/cc @charleswhchan @rvagg 
