### PR TITLE
Present tense + fix download links to include packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## What is this repo?
 
-[nodejs.org](https://nodejs.org) is an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version of the previous site.
+[nodejs.org](https://nodejs.org) by the [Node.js Foundation](https://nodejs.org/foundation/) builds on the merged community's past website projects to form a self-publishing, community-managed version of the previous site.
 
 On a technical level inspiration has been taken from the `iojs.org` repo while design and content has been migrated from the old `nodejs.org` repo. These technical changes have helped to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## What is this repo?
 
-`nodejs.org` represents an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version of the old [nodejs.org](https://nodejs.org).
+[nodejs.org](https://nodejs.org) is an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version of the previous site.
 
-On a technical level inspiration will be taken from the `iojs.org` repo while design and content will be migrated from the old `nodejs.org` repo. These technical changes will help to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
+On a technical level inspiration has been taken from the `iojs.org` repo while design and content has been migrated from the old `nodejs.org` repo. These technical changes have helped to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
 
-This repo's issues section will also become the primary home for the Website WG's coordination efforts (meeting planning, minute approval, etc.)
+This repo's issues section has become the primary home for the Website WG's coordination efforts (meeting planning, minute approval, etc.)
 
 ## Contributing
 

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -29,7 +29,7 @@
 
                   <ul class="list-divider-pipe home-secondary-links">
                       <li>
-                        <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/">{{ labels.other-downloads }}</a>
+                        <a href="https://nodejs.org/{{site.locale}}/download/">{{ labels.other-downloads }}</a>
                       </li>
                       <li>
                           <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.changelog }}</a>
@@ -51,7 +51,7 @@
 
                     <ul class="list-divider-pipe home-secondary-links">
                         <li>
-                          <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/">{{ labels.other-downloads }}</a>
+                          <a href="https://nodejs.org/{{site.locale}}/download/">{{ labels.other-downloads }}</a>
                         </li>
                         <li>
                             <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.changelog }}</a>


### PR DESCRIPTION
Currently 'other downloads' on the locale's home page just goes to a directory listing - if you're looking for packages you won't see them, even though they're included in the locale's 'downloads' section.

This makes 'other downloads' go to the locale's 'downloads' section which includes packages and other downloads not hosted on nodejs.org. 
