### PR TITLE
es6 => beyond_es5

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -64,7 +64,7 @@ would like to contribute to the translation of nodejs.org, please refer to the f
     nodejs-de: Add files - index.md, faq.md
     nodejs-ro: Add files - 15 files
 
-    nodejs-fr: Update files - es6.md
+    nodejs-fr: Update files - es2015.md
     nodejs-ja: Update files - all files
 ```
 

--- a/layouts/partials/docs-menu.hbs
+++ b/layouts/partials/docs-menu.hbs
@@ -3,8 +3,8 @@
         <li{{#equals path site.docs.link}} class="active"{{/equals}}>
             <a href="/{{site.locale}}/{{site.docs.link}}/">{{site.docs.text}}</a>
         </li>
-        <li{{#equals path site.docs.es6.link}} class="active"{{/equals}}>
-            <a href="/{{site.locale}}/{{site.docs.es6.link}}/">{{site.docs.es6.text}}</a>
+        <li{{#equals path site.docs.es2015.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.docs.es2015.link}}/">{{site.docs.es2015.text}}</a>
         </li>
         <li{{#equals path site.docs.faq.link}} class="active"{{/equals}}>
             <a href="/{{site.locale}}/{{site.docs.faq.link}}/">{{site.docs.faq.text}}</a>

--- a/locale/en/docs/es2015.md
+++ b/locale/en/docs/es2015.md
@@ -1,12 +1,12 @@
 ---
-title: ECMAScript 2015 (ES6)
+title: ECMAScript 2015
 layout: docs.hbs
 ---
-# ECMAScript 2015 (ES6) in Node.js
+# ECMAScript 2015 in Node.js
 
-Node.js is built against modern versions of [V8](https://developers.google.com/v8/). By keeping up-to-date with the latest releases of this engine, we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to Node.js developers in a timely manner, as well as continued performance and stability improvements.
+ECMASCcript 2015 is the 6th Edition of ECMA-262 (ES6). Node.js is built against modern versions of [V8](https://developers.google.com/v8/). By keeping up-to-date with the latest releases of this engine, we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to Node.js developers in a timely manner, as well as continued performance and stability improvements.
 
-All ECMAScript 2015 (ES6) features are split into three groups for **shipping**, **staged**, and **in progress** features:
+All ECMAScript 2015 features are split into three groups for **shipping**, **staged**, and **in progress** features:
 
 * All **shipping** features, which V8 considers stable, are turned **on by default on Node.js** and do **NOT** require any kind of runtime flag.
 * **Staged** features, which are almost-completed features that are not considered stable by the V8 team, require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
@@ -39,7 +39,7 @@ All ECMAScript 2015 (ES6) features are split into three groups for **shipping**,
 
 You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
 
-<small id="ref-1">[[1](#backref-1)]: As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES6 specification compliance.</small><br>
+<small id="ref-1">[[1](#backref-1)]: As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES2015 specification compliance.</small><br>
 <small id="ref-2">[[2](#backref-2)]: Only available in Node.js >= 5.x.x
 
 ## Which features are behind the --es_staging flag?

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -7,7 +7,7 @@ labels:
 
 # About Docs
 
-It's important for Node.js to provide documentation to its users, but documentation means different things to different people. Here, on nodejs.org, you will find three types of documentation, reference documentation, ES6 features, and frequently asked questions.
+It's important for Node.js to provide documentation to its users, but documentation means different things to different people. Here, on nodejs.org, you will find three types of documentation, reference documentation, ES2015 features, and frequently asked questions.
 
 Our [API reference documentation](/api/) is meant to provide detailed version information about a given method or pattern in Node.js. From this documentation you should be able to identify what input a method has, the return value of that method, and what, if any, errors may be related to that method. You should also be able to identify which methods are available for different versions of Node.js.
 
@@ -21,7 +21,7 @@ Our [API reference documentation](/api/) is meant to provide detailed version in
     </ul>
 </div>
 
-The [ES6 section](/en/docs/es6/) describes the three different features groups and which ones are enabled by default in Node.js. It lists out all the different features enabled by default, alongside explanatory links. Also, it shows how to find the exact version of V8 a Node.js release has.
+The [ES2015 section](/en/docs/es2015/) describes the three different features groups and which ones are enabled by default in Node.js. It lists out all the different features enabled by default, alongside explanatory links. Also, it shows how to find the exact version of V8 a Node.js release has.
 
 Our [FAQ](/en/docs/faq/) shows how everyone can contribute to Node.js, our code of conduct,
 governance model, how to get in touch on github and IRC, and helping out triaging issues.

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -63,9 +63,9 @@
     "docs": {
         "link": "docs",
         "text": "Docs",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 in Node.js"
+        "es2015": {
+            "link": "docs/es2015",
+            "text": "ES2015 in Node.js"
         },
         "faq": {
             "link": "docs/faq",

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -63,9 +63,9 @@
     "docs": {
         "link": "docs",
         "text": "Documentazione",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 in Node.js"
+        "es2015": {
+            "link": "docs/es2015",
+            "text": "ES2015 in Node.js"
         },
         "faq": {
             "link": "docs/faq",

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -62,9 +62,9 @@
     "docs": {
         "link": "docs",
         "text": "문서",
-        "es6": {
-            "link": "docs/es6",
-            "text": "Node.js의 ES6"
+        "es2015": {
+            "link": "docs/es2015",
+            "text": "Node.js의 ES2015"
         },
         "faq": {
             "link": "docs/faq",


### PR DESCRIPTION
Also tweak some of the wording to best fit the name change.

Edit:
After discussion, Here is the task list:
- [ ] The tab name needs to be generic (beyond_es5?).
- [ ] We need a redirect from docs/es6 to docs/beyond_es5.
- [ ] On that single page, we need something like #434 (comment)
