### PR TITLE
Fix 'Other Downloads' link for Stable

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -51,7 +51,7 @@
 
                     <ul class="list-divider-pipe home-secondary-links">
                         <li>
-                          <a href="https://nodejs.org/{{site.locale}}/download/">{{ labels.other-downloads }}</a>
+                          <a href="https://nodejs.org/{{site.locale}}/download/stable/">{{ labels.other-downloads }}</a>
                         </li>
                         <li>
                             <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.changelog }}</a>


### PR DESCRIPTION
The 'Other Downloads' of the Stable section on the frontpage did wrongly lead the the LTS downloads.

cc: @mikemaccana
