### PR TITLE
Point to Node.js v4 as a first choice for Red Hat installs

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -97,7 +97,19 @@ Node.js is available from the [NodeSource](https://nodesource.com) Enterprise Li
 
 Note that the Node.js packages for EL 5 (RHEL5 and CentOS 5) depend on the **[EPEL](https://fedoraproject.org/wiki/EPEL)** repository being available. The setup script will check and provide instructions if it is not installed.
 
-Run as root on RHEL, CentOS or Fedora:
+Run as root on RHEL, CentOS or Fedora, for Node.js v4 LTS Argon:
+
+```bash
+curl --silent --location https://rpm.nodesource.com/setup_4.x | bash -
+```
+
+Alternatevely for Node.js v5:
+
+```bash
+curl --silent --location https://rpm.nodesource.com/setup_5.x | bash -
+```
+
+Alternatevely for Node.js 0.10:
 
 ```bash
 curl --silent --location https://rpm.nodesource.com/setup | bash -
@@ -106,7 +118,7 @@ curl --silent --location https://rpm.nodesource.com/setup | bash -
 Then install, as root:
 
 ```bash
-yum -y install nodejs 
+yum -y install nodejs
 ```
 
 ***Optional***: install build tools


### PR DESCRIPTION
As titled.

Possibly a different solution might be found, but at least this is a quick fix. We want everybody on Node 4 asap :D.
