### PR TITLE
blog-index: some extra styling for pagination links

### DIFF
--- a/build.js
+++ b/build.js
@@ -191,7 +191,8 @@ function buildlocale (source, locale) {
         strftime: require('./scripts/helpers/strftime.js'),
         apidocslink: require('./scripts/helpers/apidocslink.js'),
         majorapidocslink: require('./scripts/helpers/majorapidocslink.js'),
-        summary: require('./scripts/helpers/summary.js')
+        summary: require('./scripts/helpers/summary.js'),
+        and: require('./scripts/helpers/and.js')
       }
     }))
     // Pipes the generated files into their respective subdirectory in the build

--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -27,11 +27,13 @@
             {{#if pagination}}
                 <nav class="pagination">
                     {{#if pagination.prev.path}}
-                        <a href="/{{ site.locale }}/{{ pagination.prev.path }}">&lt; Newer</a>
+                        <a href="/{{ site.locale }}/{{ pagination.prev.path }}">&nbsp;&lt; Newer&nbsp;</a>
                     {{/if}}
-
+                    {{#if (and pagination.next.path pagination.prev.path)}}
+                        |
+                    {{/if}}
                     {{#if pagination.next.path}}
-                        <a href="/{{ site.locale }}/{{ pagination.next.path }}">Older &gt;</a>
+                        <a href="/{{ site.locale }}/{{ pagination.next.path }}">&nbsp;Older &gt;&nbsp;</a>
                     {{/if}}
                 </nav>
             {{/if}}

--- a/scripts/helpers/and.js
+++ b/scripts/helpers/and.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function and (v1, v2) {
+  return v1 && v2
+}


### PR DESCRIPTION
1. Add some space around the links so the highlighting works better.
2. Add a divider for when both links are displayed.

May be better done in CSS, but I'm not exactly sure where the relevant CSS is if it exists?

Screenshots:
<img width="874" alt="screen shot 2016-01-04 at 1 25 25 pm" src="https://cloud.githubusercontent.com/assets/1093990/12096920/ad6ec228-b2e6-11e5-86ce-556c167bcc65.png">
<img width="571" alt="screen shot 2016-01-04 at 1 25 38 pm" src="https://cloud.githubusercontent.com/assets/1093990/12096929/bee24372-b2e6-11e5-8bdb-2fcf254f0677.png">
