### PR TITLE
Make position of "Edit on GitHub" link consistent

### DIFF
--- a/build.js
+++ b/build.js
@@ -222,7 +222,7 @@ function githubLinks (options) {
       var url = 'https://github.com/nodejs/nodejs.org/edit/master/locale/' + options.locale + '/' + path.replace('.html', '.md')
 
       var contents = file.contents.toString().replace(/\<h1\>(.+)\<\/h1\>/, function ($1, $2) {
-        return `<h1><a class="edit-link" href="${url}">Edit on GitHub</a> ${$2}</h1>`
+        return `<a class="edit-link" href="${url}">Edit on GitHub</a> <h1>${$2}</h1>`
       })
 
       file.contents = new Buffer(contents)

--- a/build.js
+++ b/build.js
@@ -222,7 +222,7 @@ function githubLinks (options) {
       var url = 'https://github.com/nodejs/nodejs.org/edit/master/locale/' + options.locale + '/' + path.replace('.html', '.md')
 
       var contents = file.contents.toString().replace(/\<h1\>(.+)\<\/h1\>/, function ($1, $2) {
-        return '<h1>' + $2 + ' <a class="edit-link" href="' + url + '">Edit on GitHub</a></h1>'
+        return `<h1><a class="edit-link" href="${url}">Edit on GitHub</a> ${$2}</h1>`
       })
 
       file.contents = new Buffer(contents)

--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -135,7 +135,7 @@ pre
 
 .edit-link
     float right
-    font-size 0.6em
+    font-size 0.9em
     margin 0.5em 0
 
 @media screen and (max-width: 480px)


### PR DESCRIPTION
Currently if the headline is long, it will push the "Edit on GitHub" link down as can be seen on the "Get Involved" page:
![screen shot 2016-01-04 at 20 02 49](https://cloud.githubusercontent.com/assets/2499332/12107427/cd8c2184-b31f-11e5-9210-c01e4fb8de03.png)

This commit moves the link before the headline so that it is always in the top right:
![screen shot 2016-01-04 at 20 03 33](https://cloud.githubusercontent.com/assets/2499332/12107432/e82238bc-b31f-11e5-9d1f-ffb98dca573a.png)
