### PR TITLE
Fix missing link on some foundation pages

### DIFF
--- a/layouts/announcements.hbs
+++ b/layouts/announcements.hbs
@@ -8,25 +8,7 @@
     <div id="main">
         <div class="container has-side-nav">
 
-            <aside>
-                <ul>
-                    <li{{#equals path site.foundation.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.link}}/">{{site.foundation.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.members.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.members.link}}/">{{site.foundation.members.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.tsc.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.tsc.link}}/">{{site.foundation.tsc.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.itn.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.itn.link}}/">{{site.foundation.itn.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.announce.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.announce.link}}/">{{site.foundation.announce.text}}</a>
-                    </li>
-                </ul>
-            </aside>
+            {{> foundation-menu }}
 
             <article>
                 <div class="container">

--- a/layouts/foundation.hbs
+++ b/layouts/foundation.hbs
@@ -8,28 +8,7 @@
     <div id="main">
         <div class="container has-side-nav">
 
-            <aside>
-                <ul>
-                    <li{{#equals path site.foundation.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.link}}/">{{site.foundation.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.members.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.members.link}}/">{{site.foundation.members.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.board.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.board.link}}/">{{site.foundation.board.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.tsc.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.tsc.link}}/">{{site.foundation.tsc.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.itn.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.itn.link}}/">{{site.foundation.itn.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.announce.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.announce.link}}/">{{site.foundation.announce.text}}</a>
-                    </li>
-                </ul>
-            </aside>
+            {{> foundation-menu }}
 
             <article>
                 {{{ contents }}}

--- a/layouts/in-the-news.hbs
+++ b/layouts/in-the-news.hbs
@@ -8,25 +8,7 @@
     <div id="main">
         <div class="container has-side-nav">
 
-            <aside>
-                <ul>
-                    <li{{#equals path site.foundation.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.link}}/">{{site.foundation.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.members.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.members.link}}/">{{site.foundation.members.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.tsc.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.tsc.link}}/">{{site.foundation.tsc.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.itn.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.itn.link}}/">{{site.foundation.itn.text}}</a>
-                    </li>
-                    <li{{#equals path site.foundation.announce.link}} class="active"{{/equals}}>
-                        <a href="/{{site.locale}}/{{site.foundation.announce.link}}/">{{site.foundation.announce.text}}</a>
-                    </li>
-                </ul>
-            </aside>
+            {{> foundation-menu }}
 
             {{{ contents }}}
 

--- a/layouts/partials/foundation-menu.hbs
+++ b/layouts/partials/foundation-menu.hbs
@@ -1,0 +1,22 @@
+<aside>
+    <ul>
+        <li{{#equals path site.foundation.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.link}}/">{{site.foundation.text}}</a>
+        </li>
+        <li{{#equals path site.foundation.members.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.members.link}}/">{{site.foundation.members.text}}</a>
+        </li>
+        <li{{#equals path site.foundation.board.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.board.link}}/">{{site.foundation.board.text}}</a>
+        </li>
+        <li{{#equals path site.foundation.tsc.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.tsc.link}}/">{{site.foundation.tsc.text}}</a>
+        </li>
+        <li{{#equals path site.foundation.itn.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.itn.link}}/">{{site.foundation.itn.text}}</a>
+        </li>
+        <li{{#equals path site.foundation.announce.link}} class="active"{{/equals}}>
+            <a href="/{{site.locale}}/{{site.foundation.announce.link}}/">{{site.foundation.announce.text}}</a>
+        </li>
+    </ul>
+</aside>


### PR DESCRIPTION
The "Board" link is not present on the "Announcements" or "In the News" pages because they have separate templates whose menus don't include it. I moved the foundation menu into a partial and included it in the three foundation templates to fix it.
