### PR TITLE
Fix inconsistent headings and some typos

### DIFF
--- a/locale/en/blog/community/individual-membership.md
+++ b/locale/en/blog/community/individual-membership.md
@@ -28,7 +28,7 @@ Keep in mind that every meeting of the Board must reach quorum in order to pass 
 
 ## What does the Board of Directors do?
 
-The Board meets every month to approve resolutions and discuss Node.js Foundation administrative matters. This includes legal considerations, budgetting and approving Foundation-led conferences and other initiatives. Technical governance is overseen by the TSC, not the Board of Directors.
+The Board meets every month to approve resolutions and discuss Node.js Foundation administrative matters. This includes legal considerations, budgeting and approving Foundation-led conferences and other initiatives. Technical governance is overseen by the TSC, not the Board of Directors.
 
 The current board members are listed [here](../../../foundation/board).
 

--- a/locale/en/foundation/tsc/index.md
+++ b/locale/en/foundation/tsc/index.md
@@ -1,9 +1,9 @@
 ---
-title: Technical Steering Commitee
+title: Technical Steering Committee
 layout: foundation.hbs
 ---
 
-## Collaborators and the Technical Steering Committee
+# Collaborators and the Technical Steering Committee
 
 The Node.js project is sponsored by the Node.js Foundation and maintained by
 individual Collaborators. The Technical Steering Committee (TSC) membership
@@ -14,13 +14,13 @@ term commitment to driving the project and community forward.
 You can read more about how to become a collaborator and a TSC member in [the
 contributing section](/en/get-involved/contribute/).
 
-### Current collaborators
+## Current collaborators
 
 The Node.js Project currently has well over 300 contributors actively
 working on different areas of the project. The current list of contributors
 can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/people).
 
-### Current members of the Technical Steering Committee
+## Current members of the Technical Steering Committee
 
 * Alexis Campailla ([orangemocha](https://github.com/orangemocha))
 * Ben Noordhuis ([bnoordhuis](https://github.com/bnoordhuis))
@@ -36,6 +36,6 @@ can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/pe
 * Shigeki Ohtsu ([shigeki](https://github.com/shigeki))
 * Trevor Norris ([trevnorris](https://github.com/trevnorris))
 
-### Technical Steering Commitee Meetings
+## Technical Steering Committee Meetings
 
 [Meeting minutes](minutes/)

--- a/locale/en/get-involved/code-and-learn.md
+++ b/locale/en/get-involved/code-and-learn.md
@@ -3,7 +3,7 @@ title: Code + Learn
 layout: contribute.hbs
 ---
 
-## Code + Learn
+# Code + Learn
 
 Code + Learn is a worldwide initiative of workshop sprints to introduce new developers to working on Node.js.  Supportive, hands-on sessions are mentored by existing contributors and tackle real problems.
 


### PR DESCRIPTION
Change headings on two pages to h1 and h2 for consistency with other pages and fixed typos in "committee" and "budgeting"
