### PR TITLE
Created smoke test for the build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "serve": "node server.js",
     "load-versions": "node scripts/load-versions.js",
     "start": "npm run serve",
-    "test": "standard *.js scripts/*.js scripts/**/*.js tests/**/*.js && tape tests/**/*.test.js | faucet"
+    "test": "npm run test:lint && npm run test:unit && npm run test:smoke",
+    "test:lint": "standard *.js scripts/*.js scripts/**/*.js tests/*.js tests/**/*.js",
+    "test:unit": "tape tests/**/*.test.js | faucet",
+    "test:smoke": "tape tests/*.smoketest.js | faucet"
   },
   "repository": {
     "type": "git",

--- a/tests/build.smoketest.js
+++ b/tests/build.smoketest.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const path = require('path')
+const exec = require('child_process').exec
+const test = require('tape')
+
+const pathToBuild = path.resolve(__dirname, '../build.js')
+
+test('build.js', (t) => {
+  t.plan(1)
+
+  t.test('should not generate error', (t) => {
+    exec(`node ${pathToBuild}`, (err) => {
+      t.equal(err, null)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
This smoke test will verify there's no errors being generated when running the build process. The test simply executes `build.js` and asserts there were no errors raised from the child process. As most of the current code base lacks test coverage atm, this will hopefully provide some confidence that the build process will not explode - that has happened with more than once with incoming PRs.

Also did some minor package.json test script refactoring for better readability.

What it would look like when running the tests and some bad SASS syntax error got introduced by accident:

``` bash
➜ npm run test:smoke

> nodejs.org@1.0.0 test:smoke /nodejs.org
> tape tests/*.smoketest.js | faucet

✓ build.js
⨯ should not generate error
  not ok 1 should be equal
    ---
      operator: equal
      expected: |-
        null
      actual: |-
        { [Error: Command failed: /bin/sh -c node /nodejs.org/build.js

  /nodejs.org/build.js:203
      if (err) { throw err }
                 ^
  CssSyntaxError: /nodejs.org/styles.styl:1:144: Unknown word
      at Input.error (/nodejs.org/node_modules/autoprefixer-stylus/node_modules/postcss/lib/input.js:61:21)
      at Parser.unknownWord (/nodejs.org/node_modules/autoprefixer-stylus/node_modules/postcss/lib/parser.js:479:26)
      ...
```

Closes #225
