### PR TITLE
default to .xz files for all Linux downloads

### DIFF
--- a/layouts/partials/download-matrix.hbs
+++ b/layouts/partials/download-matrix.hbs
@@ -64,22 +64,22 @@
             </tr>
 
             <tr>
-                <th>Linux Binaries (.tar.gz)</th>
-                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x86.tar.gz">32-bit</a></td>
-                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x64.tar.gz">64-bit</a></td>
+                <th>Linux Binaries (.tar.xz)</th>
+                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x86.tar.xz">32-bit</a></td>
+                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x64.tar.xz">64-bit</a></td>
             </tr>
 
             <tr>
-                <th>SunOS Binaries (.tar.gz)</th>
-                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x86.tar.gz">32-bit</a></td>
-                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x64.tar.gz">64-bit</a></td>
+                <th>SunOS Binaries (.tar.xz)</th>
+                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x86.tar.xz">32-bit</a></td>
+                <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x64.tar.xz">64-bit</a></td>
             </tr>
 
             <tr>
-                <th>ARM Binaries (.tar.gz)</th>
-                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv6l.tar.gz">ARMv6</a></td>
-                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv7l.tar.gz">ARMv7</a></td>
-                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-arm64.tar.gz">ARMv8</a></td>
+                <th>ARM Binaries (.tar.xz)</th>
+                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv6l.tar.xz">ARMv6</a></td>
+                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv7l.tar.xz">ARMv7</a></td>
+                <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-arm64.tar.xz">ARMv8</a></td>
             </tr>
 
             <tr>


### PR DESCRIPTION
I reckon it's time for this. Any objections from @nodejs/build?

Leaving source tarball alone for now for portability, OSX doesn't have xz installed by default.
