### PR TITLE
Add ES5/ESnext switcher on about page

### DIFF
--- a/layouts/about.hbs
+++ b/layouts/about.hbs
@@ -44,6 +44,84 @@
         </div>
     </div>
 
+    <style>
+        .es-switcher > p.active, .es-switcher > p:hover {
+            color: #FFF;
+            background-color: rgb(51, 51, 51);
+            border-color: rgb(51, 51, 51);
+        }
+        .es-switcher > p {
+            display: inline-block;
+            margin: 0px;
+            cursor: pointer;
+            padding: 0em 21px;
+            border-style: solid;
+            border-color: rgb(255, 255, 255);
+            border-width: 3px;
+            background-color: rgb(238, 238, 238);
+            border-top-right-radius: 3px;
+            border-top-left-radius: 3px;
+        }
+        .es-switcher > pre {
+            border-top-left-radius: 0px !important;
+            margin: 0px;
+        }
+    </style>
+
+    <script>
+var esNextText = 'Modern JavaScript:'
+var es5Text = 'ES5:'
+
+function nextSiblingMatch (e, name, text) {
+  var sib = e.nextSibling
+  while (sib) {
+    if (sib.nodeType == 1) {
+      if (sib.nodeName == name && (!text || sib.textContent == text))
+        return sib
+      return null
+    }
+    sib = sib.nextSibling
+  }
+}
+
+Array.prototype.slice.call(document.querySelectorAll('p'))
+  .filter(function (p) { return p.textContent == esNextText })
+  .map(function (esNextP) {
+    var esNextPre = nextSiblingMatch(esNextP, 'PRE')
+    if (!esNextPre) return null
+    var es5P = nextSiblingMatch(esNextPre, 'P')
+    if (!es5P) return null
+    var es5Pre = nextSiblingMatch(es5P, 'PRE')
+    if (!es5Pre) return null
+    return { esNextP: esNextP, esNextPre: esNextPre, es5P: es5P, es5Pre: es5Pre }
+  })
+  .filter(Boolean)
+  .forEach(function (block) {
+    var div = document.createElement('div')
+    div.className = 'es-switcher'
+    block.esNextP.parentElement.insertBefore(div, block.esNextP)
+    block.esNextP.textContent = esNextText.replace(/:$/, '')
+    block.es5P.textContent = es5Text.replace(/:$/, '')
+    block.esNextP.className = 'active'
+    div.appendChild(block.esNextP)
+    div.appendChild(block.es5P)
+    div.appendChild(block.esNextPre)
+    div.appendChild(block.es5Pre)
+    block.es5Pre.style.display = 'none'
+    block.esNextP.addEventListener('click', function () {
+      block.esNextPre.style.display = 'block'
+      block.es5Pre.style.display = 'none'
+      block.esNextP.className = 'active'
+      block.es5P.className = ''
+    })
+    block.es5P.addEventListener('click', function () {
+      block.esNextPre.style.display = 'none'
+      block.es5Pre.style.display = 'block'
+      block.esNextP.className = ''
+      block.es5P.className = 'active'
+    })
+  })
+    </script>
     {{> footer }}
 </body>
 </html>

--- a/locale/en/about/index.md
+++ b/locale/en/about/index.md
@@ -10,7 +10,9 @@ scalable network applications. In the following "hello world" example, many
 connections can be handled concurrently. Upon each connection the callback is
 fired, but if there is no work to be done Node is sleeping.
 
-```javascript
+Modern JavaScript:
+
+```js
 const http = require('http');
 
 const hostname = '127.0.0.1';
@@ -21,6 +23,22 @@ http.createServer((req, res) => {
   res.end('Hello World\n');
 }).listen(port, hostname, () => {
   console.log(`Server running at http://${hostname}:${port}/`);
+});
+```
+
+ES5:
+
+```js
+var http = require('http');
+
+var hostname = '127.0.0.1';
+var port = 1337;
+
+http.createServer(function(req, res) {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello World\n');
+}).listen(port, hostname, function() {
+  console.log('Server running at http://%s:%d/', hostname, port);
 });
 ```
 


### PR DESCRIPTION
This is a proof of concept, my frontend JS is super-rusty so this will likely need a more skilled hand if we go with it. My styling skills also leave a lot to be desired. The purpose of this is for discussion and a possible way to address the growing concern and confusion about the increasing use of ES6+ in docs. Specifically being discussed here: https://github.com/nodejs/docs/issues/55 (and perhaps elsewhere?).

Here's what my PR adds:

![eswut?](https://cloud.githubusercontent.com/assets/495647/12319103/da080078-baf3-11e5-9a7b-bb9c1405d430.gif)

The markdown only needs to have `Modern JavaScript:` added before a code block, then `ES5:` followed by a code block with ES5. The work of putting it together is done in the browser, if for some reason that can't be done the fall back just displays the two blocks with titles above them so it gracefully degrades. This approach could be used across all docs, API docs included.
