### PR TITLE
Change dev policy URL on page about core contribution

### DIFF
--- a/locale/en/get-involved/contribute.md
+++ b/locale/en/get-involved/contribute.md
@@ -24,10 +24,10 @@ The Node.js project is currently managed across a number of separate GitHub repo
 
 ## Code contributions
 
-If you'd like to fix bugs or add a new feature to Node.js, please make sure you consult the [Node.js Development Policy](https://github.com/nodejs/dev-policy).
+If you'd like to fix bugs or add a new feature to Node.js, please make sure you consult the [Node.js Development Policy](/en/get-involved/development/).
 
-Before any contribution can be accepted and be part of the project, it needs to be reviewed by existing collaborators in accordance to the guidelines established by the [Node.js Development Policy](https://github.com/nodejs/dev-policy).
+Before any contribution can be accepted and be part of the project, it needs to be reviewed by existing collaborators in accordance to the guidelines established by the [Node.js Development Policy](/en/get-involved/development/).
 
 ## Becoming a collaborator
 
-By becoming a collaborator, contributors can have even more impact on the project. They can help other contributors by reviewing their contributions, triage issues and take an even bigger part in shaping the project's future. The Node.js project is always looking for people who are interested in becoming collaborators. If you're interested, make sure you familiarize yourself with the [Node.js Development Policy](https://github.com/nodejs/dev-policy).
+By becoming a collaborator, contributors can have even more impact on the project. They can help other contributors by reviewing their contributions, triage issues and take an even bigger part in shaping the project's future. The Node.js project is always looking for people who are interested in becoming collaborators. If you're interested, make sure you familiarize yourself with the [Node.js Development Policy](/en/get-involved/development/).


### PR DESCRIPTION
This changes the three dev policy links displayed in the [Contribute](https://nodejs.org/en/get-involved/contribute/) page, to what's the updated and future dev policy / workflow documentation: https://nodejs.org/en/get-involved/development/ as mentioned in https://github.com/nodejs/nodejs.org/issues/468#issuecomment-172612818

Refs #468.

/cc @nodejs/documentation 
