### PR TITLE
Falling back to english when page hasn't been translated locally

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,8 @@ const chokidar = require('chokidar')
 const mount = st({
   path: path.join(__dirname, 'build'),
   cache: false,
-  index: 'index.html'
+  index: 'index.html',
+  passthrough: true
 })
 
 const build = require('./build')
@@ -33,6 +34,28 @@ const opts = {
 const locales = chokidar.watch(path.join(__dirname, 'locale'), opts)
 const layouts = chokidar.watch(path.join(__dirname, 'layouts'), opts)
 const statics = chokidar.watch(path.join(__dirname, 'static'), opts)
+
+// Redirect mechanism meant as a fix for languages where some pages
+// has not translated yet, therefore redirect to the english equivalent,
+// which ofc isn't the correct language, but better than a 404-page
+function redirectToEnglishUrl (req, res) {
+  return () => {
+    const isAlreadyEnglish = req.url.startsWith('/en')
+    const urlContainsLanguage = req.url.split('/').length > 2
+
+    if (isAlreadyEnglish || !urlContainsLanguage) {
+      res.writeHead(404, 'Not found')
+      return res.end()
+    }
+
+    let englishUrl = req.url.replace(/^\/\w+\//, '/en/')
+
+    res.writeHead(302, {
+      location: englishUrl
+    })
+    res.end()
+  }
+}
 
 // Gets the locale name by path.
 function getLocale (filePath) {
@@ -61,7 +84,9 @@ statics.on('add', (filePath) => {
 })
 
 // Initializes the server and mounts it in the generated build directory.
-http.createServer(mount).listen(port, () => console.log(`http://localhost:${port}/en/`))
+http.createServer((req, res) => {
+  mount(req, res, redirectToEnglishUrl(req, res))
+}).listen(port, () => console.log(`http://localhost:${port}/en/`))
 
 // Start the initial build of static HTML pages
 build.fullBuild()


### PR DESCRIPTION
Currently translation working groups will have to translate _all_ pages to their respective
language, if not most pages would end in displaying a (english) 404 page. That's a massive
requirement on translation groups, and keeping up with future changes are probably near impossible.

Lowering the barrier and letting translation groups start on the frontpage and work their way
down a couple of page depths, should be alot simpler and more rewarding.

NB! This only affects local development as nodejs.org runs nginx serving strictly static content.
Getting the same behaviour in production requires changes to the nginx config.

Example of the current 404 issue; navigate any of the headers links in the current Korean translation: https://nodejs.org/ko/. I haven't done my dues when it comes to translating (yet), this is one of the main reasons I've decided not to.

Any thoughts? Should we do this, and roll it out in production aswell?
