### PR TITLE
update older docs paths

### DIFF
--- a/scripts/helpers/apidocslink.js
+++ b/scripts/helpers/apidocslink.js
@@ -4,6 +4,14 @@ const semver = require('semver')
 
 module.exports = function (version) {
   if (!version) { return '' }
+  
+  if (semver.satisfies(version, '>=0.3.1 <0.5.1')) {
+    return `https://nodejs.org/docs/${version}/api/`
+  }
+
+  if (semver.satisfies(version, '>=0.1.14 <0.3.1')) {
+    return `https://nodejs.org/docs/${version}/api.html`
+  }
 
   return semver.satisfies(version, '>=1.0.0 <4.0.0')
     ? `https://iojs.org/dist/${version}/docs/api/`


### PR DESCRIPTION
currently on the releases page here https://nodejs.org/en/download/releases/
we have many 404 errors if you try clicking on the 'docs' for releases previous to v0.5.1
This fixes the paths accordingly to access the older docs.
