### PR TITLE
Link to the old nodejs.org repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [nodejs.org](https://nodejs.org) by the [Node.js Foundation](https://nodejs.org/foundation/) builds on the merged community's past website projects to form a self-publishing, community-managed version of the previous site.
 
-On a technical level inspiration has been taken from the `iojs.org` repo while design and content has been migrated from the old `nodejs.org` repo. These technical changes have helped to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
+On a technical level inspiration has been taken from the `iojs.org` repo while design and content has been migrated from the old [nodejs.org repo](https://github.com/nodejs/nodejs.org-archive). These technical changes have helped to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
 
 This repo's issues section has become the primary home for the Website WG's coordination efforts (meeting planning, minute approval, etc.)
 


### PR DESCRIPTION
Added link to the old repo for `nodejs.org` in the readme, there are occasions where going through that repo for old are needed - e.g. for old blog articles and URLs.

And lets see if we're lucky enough to get a newly born bot commenting here.. *fingers crossed*
