### PR TITLE
v0.10.43

### DIFF
--- a/locale/en/blog/release/v0.10.43.md
+++ b/locale/en/blog/release/v0.10.43.md
@@ -1,0 +1,99 @@
+---
+date: 2016-03-04T01:47:40.622Z
+version: 0.10.43
+category: release
+title: Node v0.10.43 (Maintenance)
+slug: node-v0-10-43
+layout: blog-post.hbs
+author: Rod Vagg
+---
+
+This release contains security updates. OpenSSL 1.0.1s fixes some low-severity defects that impact Node.js. See our [impact assessment](http://nodejs.org/en/blog/vulnerability/openssl-and-low-severity-fixes-jan-2016/#_-update-29-jan-2016-_-openssl-impact-assessment) for full details.
+
+### Notable changes:
+
+* **http_parser**: Update to http-parser 1.2 to fix an unintentionally strict limitation of allowable header characters. (James M Snell) [nodejs/node#5242](https://github.com/nodejs/node/pull/5242)
+* **domains**:
+  - Prevent an exit due to an exception being thrown rather than emitting an `'uncaughtException'` event on the `process` object when no error handler is set on the domain within which an error is thrown and an `'uncaughtException'` event listener is set on `process`. (Julien Gilli) [nodejs/node#3887](https://github.com/nodejs/node/pull/3887)
+  - Fix an issue where the process would not abort in the proper function call if an error is thrown within a domain with no error handler and `--abort-on-uncaught-exception` is used. (Julien Gilli) [nodejs/node#3887](https://github.com/nodejs/node/pull/3887)
+* **openssl**: Upgrade from 1.0.1r to 1.0.1s (Ben Noordhuis) [nodejs/node#5508](https://github.com/nodejs/node/pull/5508)
+  - Fix a double-free defect in parsing malformed DSA keys that may potentially be used for DoS or memory corruption attacks. It is likely to be very difficult to use this defect for a practical attack and is therefore considered low severity for Node.js users. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0705
+  - Fix a defect that can cause memory corruption in certain very rare cases relating to the internal `BN_hex2bn()` and `BN_dec2bn()` functions. It is believed that Node.js is not invoking the code paths that use these functions so practical attacks via Node.js using this defect are _unlikely_ to be possible. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0797
+  - Fix a defect that makes the CacheBleed Attack (https://ssrg.nicta.com.au/projects/TS/cachebleed/) possible. This defect enables attackers to execute side-channel attacks leading to the potential recovery of entire RSA private keys. It only affects the Intel Sandy Bridge (and possibly older) microarchitecture when using hyper-threading. Newer microarchitectures, including Haswell, are unaffected. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0702
+  - Remove SSLv2 support, the `--enable-ssl2` command line argument will now produce an error. The DROWN Attack (https://drownattack.com/) creates a vulnerability where SSLv2 is enabled by a server, even if a client connection is not using SSLv2. The SSLv2 protocol is widely considered unacceptably broken and should not be supported. More information is available at https://www.openssl.org/news/vulnerabilities.html#2016-0800
+
+Commits:
+
+* [[`3123e9a6df`](https://github.com/nodejs/node/commit/3123e9a6df)] - 2016-03-04 Version 0.10.43 (Maintenance) Release (Rod Vagg) [#5404](https://github.com/nodejs/node/pull/5404)
+* [[`164157abbb`](https://github.com/nodejs/node/commit/164157abbb)] - **build**: update Node.js logo on OSX installer (Rod Vagg) [#5401](https://github.com/nodejs/node/pull/5401)
+* [[`f8cb0dcf67`](https://github.com/nodejs/node/commit/f8cb0dcf67)] - **crypto,tls**: remove SSLv2 support (Ben Noordhuis) [#5529](https://github.com/nodejs/node/pull/5529)
+* [[`42ded2a590`](https://github.com/nodejs/node/commit/42ded2a590)] - **deps**: upgrade openssl to 1.0.1s (Ben Noordhuis) [#5508](https://github.com/nodejs/node/pull/5508)
+* [[`1e45a6111c`](https://github.com/nodejs/node/commit/1e45a6111c)] - **deps**: update http-parser to version 1.2 (James M Snell) [#5242](https://github.com/nodejs/node/pull/5242)
+* [[`6db377b2f4`](https://github.com/nodejs/node/commit/6db377b2f4)] - **doc**: remove SSLv2 descriptions (Shigeki Ohtsu) [#5541](https://github.com/nodejs/node/pull/5541)
+* [[`563c359f5c`](https://github.com/nodejs/node/commit/563c359f5c)] - **domains**: fix handling of uncaught exceptions (Julien Gilli) [#3887](https://github.com/nodejs/node/pull/3887)
+* [[`e483f3fd26`](https://github.com/nodejs/node/commit/e483f3fd26)] - **test**: fix hanging http obstext test (Ben Noordhuis) [#5511](https://github.com/nodejs/node/pull/5511)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43-x86.msi<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.43/x64/node-v0.10.43-x64.msi<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.43/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.43/x64/node.exe<br>
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43.pkg<br>
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x64.tar.gz<br>
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x86.tar.gz<br>
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x64.tar.gz<br>
+SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz<br>
+SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz<br>
+Source Code: https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz<br>
+Other release files: https://nodejs.org/dist/v0.10.43/<br>
+Documentation: https://nodejs.org/docs/v0.10.43/api/
+
+Shasums (GPG signing hash: SHA512, file hash: SHA256):
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+d08256e94e7f0006495f48f04bfde0f08fe57bb3d6f881ffd5d3e7382a437379  node.exe
+89582528585db5cd105165d2bd839fa2475a651ef9deafc540cfdea4044e83d1  node.exp
+3485a706ccc62694872f7cb78101cc62ce29ab1128281b9942da6b166edd51a5  node.lib
+7aefcedfb06e629decc774cf7a9b1c4684d59f58fbab8f95a746b674add99901  node.pdb
+c7fb30129206fa2d74d72d3c1a86fa5cb768a1165c41be9f7c724e35c3b53ca9  node-v0.10.43-darwin-x64.tar.gz
+00457f6102e70c696baf375a48a4299d5d065a2e2f78c08545a1983ba674c398  node-v0.10.43-darwin-x64.tar.xz
+a62a819832db4d6a1e9c10d286faa74c2917288a011dc7aca0476725b85cc0ae  node-v0.10.43-darwin-x86.tar.gz
+fd1ccdce22c88ac673eec684a9aab1ffafb75873b52591913f9dc8262488a329  node-v0.10.43-darwin-x86.tar.xz
+5c6f56f2230e9ef64a443d45dd66526e2614fce4d11a711a5bc89ecc31be05f2  node-v0.10.43-headers.tar.gz
+4fbe1416a85e5bf0685eb8c4dadd3c8fa222d987eaf312861b74fa35a039ed6a  node-v0.10.43-headers.tar.xz
+8a439e17af1971432798ec79a70abf8fa21e03e2aa994bb7150bc088bfa482f2  node-v0.10.43-linux-x64.tar.gz
+1f704fd493a4b8747227f5e1966d4a56192a07036357e1165bd1140760ca919e  node-v0.10.43-linux-x64.tar.xz
+142bdf1cb8793bd7c7da7974c73bd2d466933f8d5b496d9a28d3b1e343b62bd0  node-v0.10.43-linux-x86.tar.gz
+75b33151e4ad29aff26d210d772d683d4ef69a83a1a1b38cdbe8856a0a2ebfc6  node-v0.10.43-linux-x86.tar.xz
+cd16c330369500c9f3225f20bf8a5d2a644d059c407804067bd52b6d91a6cc49  node-v0.10.43.pkg
+f6cf66e77e1def7fa854ddb83a176d89f9a5b349fbb1e0bcdb742778c31e1510  node-v0.10.43-sunos-x64.tar.gz
+5feaa499d5a5ff6ed5922d9ce02809151115a2ec3c06e23d1544e8c62badbd8b  node-v0.10.43-sunos-x64.tar.xz
+b3badbc35d085723a2ad30847c5109398363b13649e199db6d22fe5f56e74c52  node-v0.10.43-sunos-x86.tar.gz
+94bdc514b30d32cfb362186bc89a9b818c616f540a9b28556e15f0819d3257eb  node-v0.10.43-sunos-x86.tar.xz
+c672452a61dd37cf2779bc158b65a5a22af343da19fec1cddf9bced382a2595a  node-v0.10.43.tar.gz
+6c5185cbfad3538484c9d97eec0110b5cd5826126f15b776015dfee1f51cd32a  node-v0.10.43.tar.xz
+d961a479d01f0fb145b77a6abf62f66e33b75383dc99ac7bed94c8bd75d854fd  node-v0.10.43-x86.msi
+77755d041c76dd2c8bc277916dea5ee269efaa784671aa068c15164a30d9f351  openssl-cli.exe
+04235831f2699980489a760063754adc54acb0eace4cafc2e552a6f2efe62c3e  openssl-cli.pdb
+4648414b546844ddf329d497ca10e7bce3abd63bf6b4995c1318cb2a4c33229d  x64/node.exe
+73d9783523050e8e450220568743da6300cfa0f5f45fb04501b77dfa1c1f8360  x64/node.exp
+5ef4d9d80f2e79d94ad69386e72d027a75c727f8736ac6221cb5702b09e4ae6b  x64/node.lib
+6acf585f3d1cb1116649c3bc18e2764b3d05cb8e21f349cd2704e5d21536e46c  x64/node.pdb
+e9216efaf78d63ed9eaf6eb31ae166845847886717dc5d3ef98e647032290b8f  x64/node-v0.10.43-x64.msi
+d042372ccedff1b5a20847f535d0835b520c08dd3cbc9505752cc3b7122b168d  x64/openssl-cli.exe
+fd5aeebfb38888f3e0d1d85fd2cc2bddca47be1c5f721d33edc876e9315f6ffc  x64/openssl-cli.pdb
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQEcBAEBAgAGBQJW2OiLAAoJEMJzeS99g1RdjM4H/1VPMHeLCmkUupVP3s0FKtEs
+bmoIPabUlRXW0JZRL9q1LRk7AhAc9SQjVwpYYCnjYEQhDzsYC4RKs8R19YEcIC/E
+N8r7r6hZ7k9Tqh6gA67Mh9Hc6CswfjYp46yAMtC7C6aYHYPDPJPU4/KML+Rsg4WI
+sBfsAWcDxWVtbh+Ef00PAadWeHEXzFd4hXdk2DNVonvTQZFW9JrN6/qEp3u75rz1
+Z6ilBto4Wr80IFrCKfvUCO7ChKx4SXHxkMtJYzDUo0F0mVTEL6f9n9PdiDd8Pwrf
+3NTlOdnFUoLTVKQFKRlkQyjx5Ud+0ve0+5capSZ6jMDSXHS/enfY8BUvNZUqWAU=
+=Dong
+-----END PGP SIGNATURE-----
+
+```


### PR DESCRIPTION
@nodejs/website `./scripts/release-post.js 0.10.43` is trying to fetch the ChangeLog from nodejs/node-v0.x-archive rather than nodejs/node, it looks like the changelog-url library needs to be updated to know when to start looking at nodejs/node for v0.10 releases.
