### PR TITLE
Typo fix

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -351,7 +351,7 @@ cd pkgsrc/lang/nodejs && bmake install
 Void Linux ships node.js stable in the main repository.
 
 ```bash
-xbps-install -Sy node.js
+xbps-install -Sy nodejs
 ```
 
 


### PR DESCRIPTION
Installed void linux distro and tried the package manager and it fails to download the given file. The actual package name is nodejs.
