### PR TITLE
Rephrase mature and dependable to recommended for most users

### DIFF
--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Recommended for most users
+    tagline-lts: Recommended for Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Mature and Dependable
+    tagline-lts: Recommended for most users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Recommended for Most Users
+    tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/download/stable.md
+++ b/locale/en/download/stable.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Recommended for most users
+    tagline-lts: Recommended for Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/download/stable.md
+++ b/locale/en/download/stable.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Mature and Dependable    
+    tagline-lts: Recommended for most users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/download/stable.md
+++ b/locale/en/download/stable.md
@@ -7,7 +7,7 @@ downloads:
     lts: LTS
     stable: Stable
     tagline-stable: Latest Features
-    tagline-lts: Recommended for Most Users
+    tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -10,7 +10,7 @@ labels:
   stable: Stable
   lts: LTS
   tagline-stable: Latest Features
-  tagline-lts: Recommended for Most Users
+  tagline-lts: Recommended For Most Users
   changelog: Changelog
   api: API Docs
   version-schedule-prompt: Or have a look at the

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -10,7 +10,7 @@ labels:
   stable: Stable
   lts: LTS
   tagline-stable: Latest Features
-  tagline-lts: Mature and Dependable
+  tagline-lts: Recommended for most users
   changelog: Changelog
   api: API Docs
   version-schedule-prompt: Or have a look at the

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -10,7 +10,7 @@ labels:
   stable: Stable
   lts: LTS
   tagline-stable: Latest Features
-  tagline-lts: Recommended for most users
+  tagline-lts: Recommended for Most Users
   changelog: Changelog
   api: API Docs
   version-schedule-prompt: Or have a look at the


### PR DESCRIPTION
Based on real world feedback from many nodeschool attendees I believe the choice between 'LTS' and 'Stable' is too nuanced and difficult to reason about for many first-time node users.

I like the way Ubuntu does it:

<img width="990" alt="screen shot 2016-03-09 at 2 22 07 pm" src="https://cloud.githubusercontent.com/assets/39759/13652670/58d0b5a6-e602-11e5-98d7-4300971db283.png">

This PR changes the wording on LTS to say 'Recommended for most users':

<img width="599" alt="screen shot 2016-03-09 at 2 23 20 pm" src="https://cloud.githubusercontent.com/assets/39759/13652701/85164504-e602-11e5-9776-2f025a72b96b.png">

I think this will help people not aware of what 'LTS' stands for have a better experience getting started with node.
