### PR TITLE
Release blog post improvements; @author parsing and notable header

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "autoprefixer-stylus": "0.8.1",
-    "changelog-url": "1.0.0",
+    "changelog-url": "1.0.2",
     "cheerio": "0.19.0",
     "chokidar": "1.2.0",
     "handlebars": "4.0.4",

--- a/tests/scripts/CHANGELOG.fixture.legacy.md
+++ b/tests/scripts/CHANGELOG.fixture.legacy.md
@@ -1,3 +1,27 @@
+2016-03-04, Version 0.10.43 (Maintenance), @rvagg
+
+Notable changes:
+
+* http_parser: Update to http-parser 1.2 to fix an unintentionally strict limitation of allowable header characters. (James M Snell) https://github.com/nodejs/node/pull/5242
+* domains:
+  - Prevent an exit due to an exception being thrown rather than emitting an `'uncaughtException'` event on the `process` object when no error handler is set on the domain within which an error is thrown and an `'uncaughtException'` event listener is set on `process`. (Julien Gilli) https://github.com/nodejs/node/pull/3887
+  - Fix an issue where the process would not abort in the proper function call if an error is thrown within a domain with no error handler and `--abort-on-uncaught-exception` is used. (Julien Gilli) https://github.com/nodejs/node/pull/3887
+* openssl: Upgrade from 1.0.1r to 1.0.1s (Ben Noordhuis) https://github.com/nodejs/node/pull/5508
+  - Fix a double-free defect in parsing malformed DSA keys that may potentially be used for DoS or memory corruption attacks. It is likely to be very difficult to use this defect for a practical attack and is therefore considered low severity for Node.js users. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0705
+  - Fix a defect that can cause memory corruption in certain very rare cases relating to the internal `BN_hex2bn()` and `BN_dec2bn()` functions. It is believed that Node.js is not invoking the code paths that use these functions so practical attacks via Node.js using this defect are _unlikely_ to be possible. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0797
+  - Fix a defect that makes the CacheBleed Attack (https://ssrg.nicta.com.au/projects/TS/cachebleed/) possible. This defect enables attackers to execute side-channel attacks leading to the potential recovery of entire RSA private keys. It only affects the Intel Sandy Bridge (and possibly older) microarchitecture when using hyper-threading. Newer microarchitectures, including Haswell, are unaffected. More info is available at https://www.openssl.org/news/vulnerabilities.html#2016-0702
+  - Remove SSLv2 support, the `--enable-ssl2` command line argument will now produce an error. The DROWN Attack (https://drownattack.com/) creates a vulnerability where SSLv2 is enabled by a server, even if a client connection is not using SSLv2. The SSLv2 protocol is widely considered unacceptably broken and should not be supported. More information is available at https://www.openssl.org/news/vulnerabilities.html#2016-0800
+
+Commits:
+
+* [164157abbb] - build: update Node.js logo on OSX installer (Rod Vagg) https://github.com/nodejs/node/pull/5401
+* [f8cb0dcf67] - crypto,tls: remove SSLv2 support (Ben Noordhuis) https://github.com/nodejs/node/pull/5529
+* [42ded2a590] - deps: upgrade openssl to 1.0.1s (Ben Noordhuis) https://github.com/nodejs/node/pull/5508
+* [1e45a6111c] - deps: update http-parser to version 1.2 (James M Snell) https://github.com/nodejs/node/pull/5242
+* [6db377b2f4] - doc: remove SSLv2 descriptions (Shigeki Ohtsu) https://github.com/nodejs/node/pull/5541
+* [563c359f5c] - domains: fix handling of uncaught exceptions (Julien Gilli) https://github.com/nodejs/node/pull/3887
+* [e483f3fd26] - test: fix hanging http obstext test (Ben Noordhuis) https://github.com/nodejs/node/pull/5511
+
 2015-12-04, Version 0.12.9 (LTS), @rvagg
 
 Security Update

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -139,7 +139,7 @@ test('fetchChangelog(<version>)', (t) => {
 
   t.test('rejects when a matching version section could not be found in changelog', (t) => {
     const github = nock('https://raw.githubusercontent.com')
-      .get('/nodejs/node/v0.9999999.0/ChangeLog')
+      .get('/nodejs/node-v0.x-archive/v0.9999999.0/ChangeLog')
       .reply(200, 'A changelog without version sections...')
 
     releasePost.fetchChangelog('0.9999999.0').then(t.fail, (err) => {
@@ -157,6 +157,7 @@ test('fetchChangelogBody(<version>)', (t) => {
   const releasePost = require('../../scripts/release-post')
 
   const changelogFixture = path.resolve(__dirname, 'CHANGELOG.fixture.md')
+  const changelogLegacyFixture = path.resolve(__dirname, 'CHANGELOG.fixture.legacy.md')
 
   t.test('does not include `## header` in matched version section', (t) => {
     const github = nock('https://raw.githubusercontent.com')
@@ -164,6 +165,19 @@ test('fetchChangelogBody(<version>)', (t) => {
       .replyWithFile(200, changelogFixture)
 
     releasePost.fetchChangelogBody('4.1.0').then((body) => {
+      t.true(body.startsWith('### Notable changes'))
+      t.true(github.isDone(), 'githubusercontent.com was requested')
+
+      t.end()
+    }, t.fail)
+  })
+
+  t.test('ensures notable changes header are prefix with `###`', (t) => {
+    const github = nock('https://raw.githubusercontent.com')
+      .get('/nodejs/node/v0.10.43/ChangeLog')
+      .replyWithFile(200, changelogLegacyFixture)
+
+    releasePost.fetchChangelogBody('0.10.43').then((body) => {
       t.true(body.startsWith('### Notable changes'))
       t.true(github.isDone(), 'githubusercontent.com was requested')
 


### PR DESCRIPTION
Some improvements to the release blog post script.
- handle @author parsing when using . instead of , in the release version header, which was the case with v5.8.0 release
- ensure ### prefixed Notable changes header
- bumped changelog-url version too handle new v0.10.x releases

Refs: https://github.com/nodejs/nodejs.org/pull/551#issue-138257829
Fixes: https://github.com/nodejs/nodejs.org/pull/553#issue-138350952

/cc @nodejs/release 
