### PR TITLE
Correct 2015-04-16 meeting title Fixes #592

### DIFF
--- a/locale/en/foundation/tsc/minutes/2015-04-16.md
+++ b/locale/en/foundation/tsc/minutes/2015-04-16.md
@@ -1,5 +1,5 @@
 ---
-title: Minutes for the Node.js core team meeting of 2015-04-17
+title: Minutes for the Node.js core team meeting of 2015-04-16
 date: 2015-04-16
 layout: foundation-tsc-minutes-post.hbs
 ---


### PR DESCRIPTION
According to the Foundation's By-Laws:

> Section 9.1 Books and Records
> The Foundation shall keep adequate and correct books and records of account, minutes of the proceedings of the Members, the Board and Board Committees ...

@phillipj These meetings were held on Thursdays, the `date` property in the yaml and the other changes [in the original PR](https://github.com/nodejs/nodejs.org-archive/pull/107) have the 16th (a Thursday). I feel confident `17` in the title was the error.
