### PR TITLE
Fix undefined stylus variable

### DIFF
--- a/layouts/css/page-modules/_scrollToTop.styl
+++ b/layouts/css/page-modules/_scrollToTop.styl
@@ -6,7 +6,7 @@ html
     font-size 1rem
     color $node-gray
     background-color $light-gray3
-    border 1px solid $gray2
+    border 1px solid $light-gray2
     border-radius 2px
     position fixed
     bottom 10%


### PR DESCRIPTION
This fixes a leftover from da396786512e19d432a79bb86f83961241ffed93.

Before:

![before](https://cloud.githubusercontent.com/assets/1443911/14040004/1baaef76-f263-11e5-81e4-3aa8962794cb.png)

After:

![after](https://cloud.githubusercontent.com/assets/1443911/14040005/1cfabb86-f263-11e5-8fd2-3e90d1dfeacb.png)

cc: @rnsloan 
