### PR TITLE
Delete `background-repeat`

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -76,7 +76,6 @@
         width: 100%;
         height: 220px;
         background-image: url("/static/images/interactive/background.png");
-        background-repeat: repeat-y;
         text-align: center;
         display: flex;
         flex-wrap: nowrap;


### PR DESCRIPTION
Because background is disappear if the screen is large(more than 1850px)
## before

![2016-03-25 16 36 35](https://cloud.githubusercontent.com/assets/3367801/14040329/9d50580e-f2a9-11e5-9ef4-e9354b8d1b08.png)
## after

![2016-03-25 16 37 21](https://cloud.githubusercontent.com/assets/3367801/14040334/a4ab50e0-f2a9-11e5-9038-cc109ebe66cf.png)
## check browsers
- chrome
- chromium
- firefox
- safari
### safari(v8.0.4)

![2016-03-25 16 53 05](https://cloud.githubusercontent.com/assets/3367801/14040389/191b7856-f2aa-11e5-9b44-09e43f943cd4.png)

CSS of other parts are broken :cry: 

ps. Sorry, my Safari version is too low...:(
http://caniuse.com/#search=flex
