### PR TITLE
Improve styling of event listing

### DIFF
--- a/layouts/css/page-modules/_events.styl
+++ b/layouts/css/page-modules/_events.styl
@@ -49,10 +49,16 @@
         background $blue
 
 .region
+    border 1px solid $light-gray2
+    background $light-gray3
+    padding 0.75em 1em
     margin-bottom 2em
 
     h1
-        margin 0 0 0.5em
+        border-bottom 1px solid
+        text-transform uppercase
+        font-size 22px
+        margin 0 0 1em
 
     h2
         margin 0 0 0.5em
@@ -63,6 +69,9 @@
 
         .arrow
             display inline-block
+            font-size 0.5em
+            vertical-align middle
+            padding-bottom 0.25em
 
     h3
         margin 0 0 0.5em

--- a/layouts/events.hbs
+++ b/layouts/events.hbs
@@ -39,7 +39,7 @@
                 <span class="key-nodeschool" data-i18n="events-nodeschool">NodeSchool</span>
                 <span class="key-conference" data-i18n="events-conference">Conference</span>
               </div>
-              
+
               <div class="main-content">{{{contents}}}</div>
                 {{#each regions}}
                 <div class="region">
@@ -60,7 +60,7 @@
                   {{/each}}
                   </div>
                   <h2>
-                    <span class="arrow">&#62;</span>
+                    <span class="arrow">&#x25ba;</span>
                     <a class="js-list-toggle-link" href="#">NodeSchools <span class="events-number"></span></a>
                   </h2>
                   <ul class="events-list">
@@ -80,7 +80,7 @@
                   </ul>
 
                   <h2>
-                    <span class="arrow">&#62;</span>
+                    <span class="arrow">&#x25ba;</span>
                     <a class="js-list-toggle-link" href="#">Meetups <span class="events-number"></span></a>
                     </h2>
                   <ul class="events-list">
@@ -157,7 +157,7 @@
               return {lon: _lon, lat: _lat, dist: dist}
             })
             .sort(function (a, b) {
-              return a.dist > b.dist ? 1 : 
+              return a.dist > b.dist ? 1 :
                      a.dist < b.dist ? -1 : 0;
             })
             var nearest = []


### PR DESCRIPTION
The events page have little visual structure.
## Before:

![](https://cloud.githubusercontent.com/assets/153481/14059476/f1b63286-f341-11e5-9840-f7bf71cc6245.png)

---
## After:

![](https://cloud.githubusercontent.com/assets/153481/14059471/d62e3a90-f341-11e5-84a9-58eda9937404.png)
