### PR TITLE
Make use of `overflow-x: scroll` in release page

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -71,6 +71,7 @@ pre
     font-size 0.8em
     white-space pre-wrap
     color $light-gray3
+    overflow-x scroll
 
     code
         color $light-gray3
@@ -153,9 +154,6 @@ pre
             float none
         article
             margin-left 0px
-
-            pre
-              overflow-x scroll
 
 .full-width
     width 100%


### PR DESCRIPTION
Hello :)
## before

<img width="412" alt="2016-03-28 22 23 00" src="https://cloud.githubusercontent.com/assets/3367801/14078812/b93cb06c-f533-11e5-8960-97e34a007ee8.png">
## after

<img width="411" alt="2016-03-28 22 22 39" src="https://cloud.githubusercontent.com/assets/3367801/14078815/bfea7106-f533-11e5-8897-4656b9779e02.png">

---

I deleted this line([layouts/css/base.styl#L158](https://github.com/nodejs/nodejs.org/blob/master/layouts/css/base.styl#L158)) and then global `pre` has `overflow-x: scroll`.
I feel that I don't have any problem even if `pre` has the `overflow-x: scroll` at global.

in `about` page(IE11)
![2016-03-28 18 06 46](https://cloud.githubusercontent.com/assets/3367801/14075291/b49b4a12-f512-11e5-84d8-3ec85baa410e.png)
## check browsers
- chrome
- chromium
- firefox
- safari
- IE11

Cheers!
