### PR TITLE
Fix a Flexbox issue in NodeJS Interactive images in Firefox. Closes #610.

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -70,7 +70,7 @@
 
         </div>
     </div>
-    
+
     <style>
       div.interactive {
         width: 100%;
@@ -85,7 +85,15 @@
       div.interactive a, div.interactive span {
          border: 20px solid transparent;
       }
-      
+
+      #interactive-left,
+      #interactive-center,
+      #interactive-right {
+        /* Fix Flexbox inconsistency of items not shrinking to parent size.
+           https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored */
+        min-width: 0;
+      }
+
       @media (max-width: 480px) {
         #interactive-center {
           display:none;
@@ -140,18 +148,18 @@
         }
       }
     </style>
-    
+
     <div class="interactive">
       <span id="interactive-first">
         <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
       </span>
-      <a href="http://events.linuxfoundation.org/events/node-interactive-europe">
+      <a id="interactive-left" href="http://events.linuxfoundation.org/events/node-interactive-europe">
         <img id="interactive-link" src="/static/images/interactive/nodejs-interactive-hero-banner-left-eu.png" />
       </a>
       <span id="interactive-center">
         <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
       </span>
-      <a href="http://events.linuxfoundation.org/events/node-interactive">
+      <a id="interactive-right" href="http://events.linuxfoundation.org/events/node-interactive">
         <img id="interactive-link" src="/static/images/interactive/nodejs-interactive-hero-banner-right-na.png" />
       </a>
     </div>


### PR DESCRIPTION
As documented in #610, this fixes it. It's a flexbox issue documented in Philip Walton's flexbugs [here](https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored). Firefox got omitted from the list of   browsers with the issue in philipwalton/flexbugs#103.

I have to admit, I don't like how the CSS is written or injected to the document as an inline style, but this is what I can do for a quick fix.
