### PR TITLE
Fix Spain world region

### DIFF
--- a/events/country-map.js
+++ b/events/country-map.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   EG: 'Africa',
-  ES: 'Africa',
   KE: 'Africa',
   MA: 'Africa',
   MU: 'Africa',
@@ -34,6 +33,7 @@ module.exports = {
   DE: 'Europe',
   DK: 'Europe',
   EE: 'Europe',
+  ES: 'Europe',
   FI: 'Europe',
   FR: 'Europe',
   GB: 'Europe',


### PR DESCRIPTION
I was browsing the list of events in Africa when I noticed something strange:

![screen shot 2016-03-30 at 17 31 23](https://cloud.githubusercontent.com/assets/1443911/14147829/5142ef56-f69d-11e5-8e03-08fafc0ceda8.png)

Madrid, Barcelona, Sevilla, Valencia are in Africa? This is new...
I guess we should rebuild `events.md` but I don't have the required API keys.
