### PR TITLE
document npm inconsistency in v4.4.2 and v0.12.13

### DIFF
--- a/locale/en/blog/release/v0.12.13.md
+++ b/locale/en/blog/release/v0.12.13.md
@@ -12,6 +12,8 @@ author: Rod Vagg
 
 Node.js v0.12.13 will be the **final Active-LTS release for the v0.12 release line**, from next month, v0.12 moves in to Maintenance. This change impacts on the types of changes that will be accepted in to v0.12 releases, restricting them primarily to critical security and stability fixes. v0.12 will remain supported until the end of 2016 but it is important that you begin planning your move to a new release line as soon as possible. **v4 (LTS "Argon")** is recommended at this stage.
 
+*Update*: The version of npm included in this release did not have the correct version string. As such executing `npm -v` will report `2.15.0` rather than `2.15.1`, which is incorrect. The source code included in this release is in fact the source for `2.15.1`, including the security fix.
+
 ### Notable changes:
 
 * npm: Upgrade to v2.15.1. Fixes a security flaw in the use of authentication tokens in HTTP requests that would allow an attacker to set up a server that could collect tokens from users of the command-line interface. Authentication tokens have previously been sent with every request made by the CLI for logged-in users, regardless of the destination of the request. This update fixes this by only including those tokens for requests made against the registry or registries used for the current install. (Forrest L Norvell) https://github.com/nodejs/node/pull/5967

--- a/locale/en/blog/release/v4.4.2.md
+++ b/locale/en/blog/release/v4.4.2.md
@@ -10,6 +10,8 @@ author: Myles Borins
 
 This release includes a security update for npm. For more details you can read [this post on our blog](https://nodejs.org/en/blog/vulnerability/npm-tokens-leak-march-2016/) written by [Forrest L Norvell](https://github.com/othiym23) from npm.
 
+*Update*: The version of npm included in this release did not have the correct version string. As such executing `npm -v` will report `2.15.0` rather than `2.15.1`, which is incorrect. The source code included in this release is in fact the source for `2.15.1`, including the security fix.
+
 ### Notable Changes
 
 * **https**:


### PR DESCRIPTION
So it turns out that the version of npm included in v0.12.13 and v4.4.2 has the wrong version string... It has the correct code, and fixes the security problem... but will report `v2.15.0` not `v2.15.1`

This is an update to the blog posts to document this errata
