### PR TITLE
Replace `scroll` with `auto`

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -71,7 +71,7 @@ pre
     font-size 0.8em
     white-space pre-wrap
     color $light-gray3
-    overflow-x scroll
+    overflow-x auto
 
     code
         color $light-gray3


### PR DESCRIPTION
I modified this PR(https://github.com/nodejs/nodejs.org/pull/609) because a scroll bar is always displayed on Windows.
#### When screen size is small(on IE11)

![2016-04-01 12 20 52](https://cloud.githubusercontent.com/assets/3367801/14197278/839c6ed0-f807-11e5-9cbf-6f77486f8503.png)
#### Generally

![2016-04-01 12 21 04](https://cloud.githubusercontent.com/assets/3367801/14197285/a6812666-f807-11e5-98c9-af5fbbf06729.png)
## Check the browsers
#### OS X(el capitan and yosemite)
- Safari
- Firefox
- Chrome
- Chromium
#### Windows
- IE11
  - win7
  - win8.1
  - win10
- Edge
  - win10
#### iOS(8.3 and 9.3)
- Safari

Cheers!
