### PR TITLE
Remove unused `count` variable

### DIFF
--- a/events/pull-nodeschool.js
+++ b/events/pull-nodeschool.js
@@ -20,7 +20,6 @@ request({
     throw (err || new Error(`Invalid status code (${resp.statusCode})`))
   }
 
-  let count = 0
   const chapters = []
 
   list.regions.forEach((reg) => {
@@ -34,7 +33,6 @@ request({
       chapter.location = `${chapter.location}, ${chapter.country}`
       delete chapter.country
       yml.replace(store.nodeschools, 'name', chapter.name, chapter)
-      count += 1
       chapters.push(chapter)
     })
   })


### PR DESCRIPTION
This patch removes the unused `count` variable from `pull-nodeschool.js`.
