### PR TITLE
Simplify CSS for Node.js interactive banner

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -72,96 +72,53 @@
     </div>
 
     <style>
-      div.interactive {
-        width: 100%;
-        height: 220px;
+      #interactive-wrapper {
+        flex: none;
+      }
+
+      #interactive {
         background-image: url("/static/images/interactive/background.png");
-        text-align: center;
         display: flex;
-        flex-wrap: nowrap;
         align-items: center;
         justify-content: space-around;
       }
-      div.interactive a, div.interactive span {
-         border: 20px solid transparent;
-      }
 
-      #interactive-left,
-      #interactive-center,
-      #interactive-right {
-        /* Fix Flexbox inconsistency of items not shrinking to parent size.
-           https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored */
-        min-width: 0;
+      .interactive-item {
+        border: 20px solid transparent;
+        min-width: 1px;
       }
 
       @media (max-width: 480px) {
-        #interactive-center {
+        #logo-center {
           display:none;
         }
-        div.interactive {
+        #interactive {
           flex-wrap: wrap;
-          height: 556px;
-        }
-        div.interactive a, div.interactive span {
-          max-height:150px;
         }
       }
-      @media (min-width: 480px) {
-        #interactive-first {
+
+      @media (min-width: 481px) {
+        #logo-first {
           display:none;
-        }
-      }
-      @media (min-width: 480px) and (max-width: 580px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 100px;
-        }
-      }
-      @media (min-width: 580px) and (max-width: 680px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 120px;
-        }
-      }
-      @media (min-width: 680px) and (max-width: 780px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 140px;
-        }
-      }
-      @media (min-width: 780px) and (max-width: 880px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 160px;
-        }
-      }
-      @media (min-width: 880px) and (max-width: 980px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 180px;
-        }
-      }
-      @media (min-width: 980px) and (max-width: 1180px) {
-        div.interactive {
-          background-repeat: no-repeat;
-          height: 200px;
         }
       }
     </style>
 
-    <div class="interactive">
-      <span id="interactive-first">
-        <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
-      </span>
-      <a id="interactive-left" href="http://events.linuxfoundation.org/events/node-interactive-europe">
-        <img id="interactive-link" src="/static/images/interactive/nodejs-interactive-hero-banner-left-eu.png" />
-      </a>
-      <span id="interactive-center">
-        <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
-      </span>
-      <a id="interactive-right" href="http://events.linuxfoundation.org/events/node-interactive">
-        <img id="interactive-link" src="/static/images/interactive/nodejs-interactive-hero-banner-right-na.png" />
-      </a>
+    <div id="interactive-wrapper">
+      <div id="interactive">
+        <span id="logo-first" class="interactive-item">
+          <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
+        </span>
+        <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive-europe">
+          <img src="/static/images/interactive/nodejs-interactive-hero-banner-left-eu.png" />
+        </a>
+        <span id="logo-center" class="interactive-item">
+          <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
+        </span>
+        <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive">
+          <img src="/static/images/interactive/nodejs-interactive-hero-banner-right-na.png" />
+        </a>
+      </div>
     </div>
 
     {{> footer className="no-margin-top" }}


### PR DESCRIPTION
This patch brings the following changes:
- Banner height no longer have a fixed value. This value is computed automatically.
- Removed `background-repeat: no-repeat;` (background image is 1852px wide).
- Fixed a bug that could make the Node.js logo disappear (when the screen was exactly 480px wide).
- Cleaned up fix (#611) for Flexbox bug.

Screenshots:

**320**

![320](https://cloud.githubusercontent.com/assets/1443911/14209071/bb742490-f822-11e5-8601-a311a98a3673.png)

**375**

![375](https://cloud.githubusercontent.com/assets/1443911/14209108/d835c912-f822-11e5-9b7b-0955a34d6241.png)

**425**

![425](https://cloud.githubusercontent.com/assets/1443911/14209111/dd7b3718-f822-11e5-886f-76decb7a6e9d.png)

**768**

![768](https://cloud.githubusercontent.com/assets/1443911/14209122/e403cef6-f822-11e5-9b33-1d17e25d4644.png)

**1024**

![1024](https://cloud.githubusercontent.com/assets/1443911/14209133/ed0550ba-f822-11e5-8ec1-70b28ccf4b4e.png)

**1440**

![1440](https://cloud.githubusercontent.com/assets/1443911/14209138/f385b09c-f822-11e5-94b5-e087283a9b30.png)

Tested on:
- Firefox
- Chrome
- Safari
- iPhone 5 (Safari)
