### PR TITLE
Use same style for "In the News" and "Announcements"

### DIFF
--- a/layouts/announcements.hbs
+++ b/layouts/announcements.hbs
@@ -29,9 +29,9 @@
             </aside>
 
             <article>
-                <div class="container">
+                <div class="container no-headline">
 
-                    <ul class="blog-index">
+                    <ul class="news-list">
                         {{#each collections.blogAnnounce}}
                             {{#if title}}
                                 <li>

--- a/layouts/css/layout/_grid.styl
+++ b/layouts/css/layout/_grid.styl
@@ -4,6 +4,9 @@
     margin 0 auto
     overflow hidden
 
+    &.no-headline
+        margin-top 0.5em
+
 .row
     display flex
     flex-direction row

--- a/layouts/css/page-modules/_in-the-news.styl
+++ b/layouts/css/page-modules/_in-the-news.styl
@@ -1,5 +1,21 @@
-#news-container
-    margin-top 50px
+.news-list
+    @media screen and (max-width: 480px)
+        margin-left -2.5em
+        margin-right 1em
 
-    .news-row
-        padding 5px
+    li
+        display flex
+
+        @media screen and (max-width: 799px)
+            display block
+            margin-bottom 0.5em
+
+    time
+        margin-right 1em
+        color $light-gray
+        white-space nowrap
+        // Fix min-width in Safari
+        flex-shrink 0
+
+        @media screen and (max-width: 799px)
+            display block

--- a/layouts/css/page-modules/_in-the-news.styl
+++ b/layouts/css/page-modules/_in-the-news.styl
@@ -11,7 +11,7 @@
             margin-bottom 0.5em
 
     time
-        margin-right 1em
+        width 5.5em
         color $light-gray
         white-space nowrap
         // Fix min-width in Safari

--- a/layouts/in-the-news.hbs
+++ b/layouts/in-the-news.hbs
@@ -45,13 +45,29 @@
                                  callback: showInfo,
                                  simpleSheet: true } )
 
+                function pad(str) { return ("0"+str).substr(-2) }
+
+                function parseDate(date) {
+                  try {
+                    var parsedDate = date.split('.')
+                    return new Date('20' + parsedDate[2], parsedDate[0] - 1, parsedDate[1])
+                  } catch(_){
+                    return date
+                  }
+                }
+
+                function formatDate(date) {
+                  return date == "Invalid Date" ? '' : date.getFullYear()+'-'+pad(date.getMonth()+1)+'-'+pad(date.getDate())
+                }
+
                 function showInfo(data, tabletop) {
                   data.reverse()
                   var html = ''
                   var list = document.getElementsByClassName('news-list')
 
                   data.forEach(function (row) {
-                    html += '<li><a href="'+row.Link+'">'+row.Title+'</a></li>'
+                    var date = parseDate(row.Date)
+                    html += '<li><time datetime="'+date+'">'+formatDate(date)+'</time><a href="'+row.Link+'">'+row.Title+'</a></li>'
                   })
                   if (list && list[0]) list[0].innerHTML = html
                 }

--- a/layouts/in-the-news.hbs
+++ b/layouts/in-the-news.hbs
@@ -31,8 +31,10 @@
             {{{ contents }}}
 
             <article>
-              <div id="news-container">
-              </div>
+                <div class="container no-headline">
+                    <ul class="news-list">
+                    </ul>
+                </div>
             </article>
 
             <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.4.2/tabletop.min.js"></script>
@@ -45,12 +47,13 @@
 
                 function showInfo(data, tabletop) {
                   data.reverse()
-                  var html = '<div id="news-list">'
+                  var html = ''
+                  var list = document.getElementsByClassName('news-list')
+
                   data.forEach(function (row) {
-                    html += '<div class="news-row"><a href="'+row.Link+'">'+row.Title+'</a></div>'
+                    html += '<li><a href="'+row.Link+'">'+row.Title+'</a></li>'
                   })
-                  html += '</div>'
-                  document.getElementById('news-container').innerHTML = html
+                  if (list && list[0]) list[0].innerHTML = html
                 }
               }
             </script>


### PR DESCRIPTION
As mentioned in #636, "In the News" and "Announcements" should use the same listing style. I also added date parsing for the spreadsheet data.

Tested on Chrome, Firefox and Safari on OS X.

**Small width:**
![small width](https://cloud.githubusercontent.com/assets/153481/14352732/46312de6-fcd6-11e5-8dc9-9e7e20ecae66.png)

**Medium width:**
![medium width](https://cloud.githubusercontent.com/assets/153481/14352733/46323a2e-fcd6-11e5-94b7-c6f2b1988fc7.png)

**Desktop width:**
![desktop width](https://cloud.githubusercontent.com/assets/153481/14352734/4632ed66-fcd6-11e5-99b9-f96d0029eb72.png)

/cc @nodejs/website @abouthiroppy @lpinca 
