### PR TITLE
Add back semicolons to the HTTP server example in about page

### DIFF
--- a/locale/en/about/index.md
+++ b/locale/en/about/index.md
@@ -11,20 +11,20 @@ connections can be handled concurrently. Upon each connection the callback is
 fired, but if there is no work to be done Node is sleeping.
 
 ```javascript
-const http = require('http')
+const http = require('http');
 
-const hostname = '127.0.0.1'
-const port = 3000
+const hostname = '127.0.0.1';
+const port = 3000;
 
 const server = http.createServer((req, res) => {
-  res.statusCode = 200
-  res.setHeader('Content-Type', 'text/plain')
-  res.end('Hello World\n')
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello World\n');
 })
 
 server.listen(port, hostname, () => {
-  console.log(`Server running at http://${hostname}:${port}/`)
-})
+  console.log(`Server running at http://${hostname}:${port}/`);
+});
 ```
 
 This is in contrast to today's more common concurrency model where OS threads


### PR DESCRIPTION
Reverts nodejs/nodejs.org#641

Not sure what are the better practices there, I guess the purpose was to test the bot.
Anyway I'm filing this pr because semicolons have been removed and this makes the example inconsistent with all the others (guides, API docs, etc).

cc: @Fishrock123 
