### PR TITLE
remove invalid video link from meeting minutes

### DIFF
--- a/locale/en/foundation/tsc/minutes/2014-12-10.md
+++ b/locale/en/foundation/tsc/minutes/2014-12-10.md
@@ -3,8 +3,6 @@ title: Minutes for the Node.js core team meeting of 12/10/2014
 date: 2014-12-10
 layout: foundation-tsc-minutes-post.hbs
 ---
-A [video recording](https://bluejeans.com/s/7_j@/) of this meeting is also
-available.
 
 ## Team announcements
 


### PR DESCRIPTION
The URL no long works and a new video link has not been found. Removing.

Fixes #591 
