### PR TITLE
Rename 'Stable' release to 'Current'

### DIFF
--- a/build.js
+++ b/build.js
@@ -240,14 +240,9 @@ function copyStatic () {
   })
 }
 
-// This is where the build is orchestrated from, as indicated by the function
-// name. It brings together all build steps and dependencies and executes them.
-function fullBuild () {
-  // Copies static files.
-  copyStatic()
+function getSource (callback) {
   // Loads all node/io.js versions.
   loadVersions((err, versions) => {
-    if (err) { throw err }
     const source = {
       project: {
         versions,
@@ -261,6 +256,18 @@ function fullBuild () {
         }
       }
     }
+
+    callback(err, source)
+  })
+}
+
+// This is where the build is orchestrated from, as indicated by the function
+// name. It brings together all build steps and dependencies and executes them.
+function fullBuild () {
+  // Copies static files.
+  copyStatic()
+  getSource((err, source) => {
+    if (err) { throw err }
 
     // Executes the build cycle for every locale.
     fs.readdir(path.join(__dirname, 'locale'), (e, locales) => {
@@ -276,6 +283,7 @@ if (require.main === module) {
   fullBuild()
 }
 
+exports.getSource = getSource
 exports.fullBuild = fullBuild
 exports.buildLocale = buildLocale
 exports.copyStatic = copyStatic

--- a/build.js
+++ b/build.js
@@ -252,7 +252,7 @@ function fullBuild () {
       project: {
         versions,
         currentVersions: {
-          stable: latestVersion.stable(versions),
+          current: latestVersion.current(versions),
           lts: latestVersion.lts(versions)
         },
         banner: {

--- a/layouts/download-current.hbs
+++ b/layouts/download-current.hbs
@@ -12,8 +12,8 @@
                     <h1>{{downloads.headline}}</h1>
                 </div>
 
-                {{> primary-download-matrix version=project.currentVersions.stable versionTypeStable="true"}}
-                {{> secondary-download-matrix version=project.currentVersions.stable versionTypeStable="true"}}
+                {{> primary-download-matrix version=project.currentVersions.current versionTypeCurrent="true"}}
+                {{> secondary-download-matrix version=project.currentVersions.current versionTypeCurrent="true"}}
 
             </article>
 

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -41,23 +41,23 @@
 
                 </div>
 
-                {{#if project.currentVersions.stable}}
+                {{#if project.currentVersions.current}}
                   <div class="home-downloadblock">
 
-                    <a href="https://nodejs.org/dist/{{ project.currentVersions.stable }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.currentVersions.stable }} {{ labels.stable }}"  data-version="{{ project.currentVersions.stable }}">
-                        {{ project.currentVersions.stable }} {{ labels.stable }}
-                        <small>{{ labels.tagline-stable }}</small>
+                    <a href="https://nodejs.org/dist/{{ project.currentVersions.current }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.currentVersions.current }} {{ labels.current }}"  data-version="{{ project.currentVersions.current }}">
+                        {{ project.currentVersions.current }} {{ labels.current }}
+                        <small>{{ labels.tagline-current }}</small>
                     </a>
 
                     <ul class="list-divider-pipe home-secondary-links">
                         <li>
-                          <a href="https://nodejs.org/{{site.locale}}/download/stable/">{{ labels.other-downloads }}</a>
+                          <a href="https://nodejs.org/{{site.locale}}/download/current/">{{ labels.other-downloads }}</a>
                         </li>
                         <li>
-                            <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.stable }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                            <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.current }}/CHANGELOG.md">{{ labels.changelog }}</a>
                         </li>
                         <li>
-                          <a href="{{majorapidocslink project.currentVersions.stable}}">{{ labels.api }}</a>
+                          <a href="{{majorapidocslink project.currentVersions.current}}">{{ labels.api }}</a>
                         </li>
                     </ul>
 

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -9,9 +9,9 @@
                     <div class="title">{{downloads.lts}}</div>
                     <div class="tag">{{downloads.tagline-lts}}</div>
                 </a>
-                <a {{#if versionTypeStable}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}/stable" title="{{downloads.display-hint}} {{downloads.stable}}">
-                    <div class="title">{{downloads.stable}}</div>
-                    <div class="tag">{{downloads.tagline-stable}}</div>
+                <a {{#if versionTypeCurrent}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}/current" title="{{downloads.display-hint}} {{downloads.current}}">
+                    <div class="title">{{downloads.current}}</div>
+                    <div class="tag">{{downloads.tagline-current}}</div>
                 </a>
               </div>
             </li>

--- a/locale/en/blog/community/node-v5.md
+++ b/locale/en/blog/community/node-v5.md
@@ -13,7 +13,7 @@ We just released [Node.js v5.0.0](https://nodejs.org/en/blog/release/v5.0.0/). Y
 
 Node.js is growing, and growing fast. As we continue to innovate quickly, we will focus on two different release lines. One release line will fall under our **LTS** plan. All release lines that have LTS support will be even numbers, and (most importantly) focus on stability and security. These release lines are for organizations with complex environments that find it cumbersome to continually upgrade. We recently released the first in this line: [Node.js v4.2.1](https://nodejs.org/en/blog/release/v4.2.1/) “Argon.”
 
-The other release line is called **Stable**. All release lines will be odd numbers, and have a shorter lifespan and more frequent updates to the code. The Stable release line will focus on active development of necessary features and refinement of existing APIs. Node.js version 5 is this type of release.
+The other release line is called **Current**. All release lines will be odd numbers, and have a shorter lifespan and more frequent updates to the code. The Current release line will focus on active development of necessary features and refinement of existing APIs. Node.js version 5 is this type of release.
 
 We want to make sure that you are adopting the release that best meets your Node.js needs, so to break it down:
 
@@ -47,7 +47,7 @@ First and foremost, if you haven’t read the [Essential Steps: Long Term Suppor
 
 * There will be no more than two active LTS release lines at any given time. Overlap is intended to help ease migration planning.
 
-* Once a Stable release line becomes LTS, no new features or breaking changes will be added to that release. Changes are limited to bug fixes for stability, security updates, possible npm updates, documentation updates and certain performance improvements that can be demonstrated to not break existing applications.
+* Once a Current release line becomes LTS, no new features or breaking changes will be added to that release. Changes are limited to bug fixes for stability, security updates, possible npm updates, documentation updates and certain performance improvements that can be demonstrated to not break existing applications.
 
 ## Questions?
 

--- a/locale/en/blog/release/v4.0.0.md
+++ b/locale/en/blog/release/v4.0.0.md
@@ -2,7 +2,7 @@
 date: 2015-09-08T12:10:06.000Z
 version: 4.0.0
 category: release
-title: Node v4.0.0 (Stable)
+title: Node v4.0.0 (Current)
 slug: node-v4-0-0-stable
 layout: blog-post.hbs
 ---

--- a/locale/en/blog/release/v4.1.0.md
+++ b/locale/en/blog/release/v4.1.0.md
@@ -2,12 +2,12 @@
 date: 2015-09-17T05:30:00.969Z
 version: 4.1.0
 category: release
-title: Node v4.1.0 (Stable)
+title: Node v4.1.0 (Current)
 slug: node-v4-1-0-stable
 layout: blog-post.hbs
 ---
 
-## 2015-09-17, Version 4.1.0 (Stable), @Fishrock123
+## 2015-09-17, Version 4.1.0 (Current), @Fishrock123
 
 ### Notable changes
 
@@ -36,7 +36,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 ### Commits
 
 * [[`b1abe812cd`](https://github.com/nodejs/node/commit/b1abe812cd)] - Working on 4.0.1 (Rod Vagg)
-* [[`f9f8378853`](https://github.com/nodejs/node/commit/f9f8378853)] - 2015-09-08, Version 4.0.0 (Stable) Release (Rod Vagg)
+* [[`f9f8378853`](https://github.com/nodejs/node/commit/f9f8378853)] - 2015-09-08, Version 4.0.0 (Current) Release (Rod Vagg)
 * [[`9683e5df51`](https://github.com/nodejs/node/commit/9683e5df51)] - **bindings**: close after reading module struct (Fedor Indutny) [#2792](https://github.com/nodejs/node/pull/2792)
 * [[`4b4cfa2d44`](https://github.com/nodejs/node/commit/4b4cfa2d44)] - **buffer**: always allocate typed arrays outside heap (Trevor Norris) [#2893](https://github.com/nodejs/node/pull/2893)
 * [[`7df018a29b`](https://github.com/nodejs/node/commit/7df018a29b)] - **buffer**: construct Uint8Array in JS (Trevor Norris) [#2866](https://github.com/nodejs/node/pull/2866)

--- a/locale/en/blog/release/v4.1.1.md
+++ b/locale/en/blog/release/v4.1.1.md
@@ -2,7 +2,7 @@
 date: 2015-09-23T02:01:38.545Z
 version: 4.1.1
 category: release
-title: Node v4.1.1 (Stable)
+title: Node v4.1.1 (Current)
 slug: node-v4-1-1-stable
 layout: blog-post.hbs
 author: Rod Vagg

--- a/locale/en/blog/release/v4.1.2.md
+++ b/locale/en/blog/release/v4.1.2.md
@@ -2,12 +2,12 @@
 date: 2015-10-05T20:05:01.925Z
 version: 4.1.2
 category: release
-title: Node v4.1.2 (Stable)
+title: Node v4.1.2 (Current)
 slug: node-v4-1-2-stable
 layout: blog-post.hbs
 ---
 
-## 2015-10-05, Version 4.1.2 (Stable), @rvagg
+## 2015-10-05, Version 4.1.2 (Current), @rvagg
 
 This release includes a fix for [CVE-2015-7384](https://github.com/nodejs/node/issues/3138), a Denial of Service (DoS) bug. Details of the bug can be found on the [nodejs-sec](https://groups.google.com/forum/#!topic/nodejs-sec/fSNEQiuof6I) group. Please subscribe to [nodejs-sec](https://groups.google.com/forum/#!forum/nodejs-sec) to receive future notifications of security releases.
 

--- a/locale/en/blog/release/v5.0.0.md
+++ b/locale/en/blog/release/v5.0.0.md
@@ -2,7 +2,7 @@
 date: 2015-10-29T12:33:38.068Z
 version: 5.0.0
 category: release
-title: Node v5.0.0 (Stable)
+title: Node v5.0.0 (Current)
 slug: node-v5-0-0
 layout: blog-post.hbs
 author: Rod Vagg

--- a/locale/en/blog/release/v5.1.0.md
+++ b/locale/en/blog/release/v5.1.0.md
@@ -2,7 +2,7 @@
 date: 2015-11-17T21:47:36.127Z
 version: 5.1.0
 category: release
-title: Node v5.1.0 (Stable)
+title: Node v5.1.0 (Current)
 slug: node-v5-1-0
 layout: blog-post.hbs
 author: Jeremiah Senkpiel

--- a/locale/en/blog/release/v5.1.1.md
+++ b/locale/en/blog/release/v5.1.1.md
@@ -2,7 +2,7 @@
 date: 2015-12-04T03:04:00.000Z
 version: 5.1.1
 category: release
-title: Node v5.1.1 (Stable)
+title: Node v5.1.1 (Current)
 slug: node-v5-1-1
 layout: blog-post.hbs
 author: Rod Vagg

--- a/locale/en/blog/release/v5.10.0.md
+++ b/locale/en/blog/release/v5.10.0.md
@@ -2,7 +2,7 @@
 date: 2016-04-01T03:31:50.474Z
 version: 5.10.0
 category: release
-title: Node v5.10.0 (Stable)
+title: Node v5.10.0 (Current)
 slug: node-v5-10-0
 layout: blog-post.hbs
 author: Evan Lucas

--- a/locale/en/blog/release/v5.10.1.md
+++ b/locale/en/blog/release/v5.10.1.md
@@ -2,7 +2,7 @@
 date: 2016-04-05T23:33:44.892Z
 version: 5.10.1
 category: release
-title: Node v5.10.1 (Stable)
+title: Node v5.10.1 (Current)
 slug: node-v5-10-1
 layout: blog-post.hbs
 author: Myles Borins

--- a/locale/en/blog/release/v5.2.0.md
+++ b/locale/en/blog/release/v5.2.0.md
@@ -2,7 +2,7 @@
 date: 2015-12-09T05:24:54.976Z
 version: 5.2.0
 category: release
-title: Node v5.2.0 (Stable)
+title: Node v5.2.0 (Current)
 slug: node-v5-2-0
 layout: blog-post.hbs
 author: Rod Vagg

--- a/locale/en/blog/release/v5.3.0.md
+++ b/locale/en/blog/release/v5.3.0.md
@@ -2,7 +2,7 @@
 date: 2015-12-16T20:23:07.363Z
 version: 5.3.0
 category: release
-title: Node v5.3.0 (Stable)
+title: Node v5.3.0 (Current)
 slug: node-v5-3-0
 layout: blog-post.hbs
 author: Colin Ihrig
@@ -31,7 +31,7 @@ author: Colin Ihrig
 
 ### Commits
 
-* [[`6ca5ea3860`](https://github.com/nodejs/node/commit/6ca5ea3860)] - 2015-12-09, Version 5.2.0 (Stable) (Rod Vagg) [#4181](https://github.com/nodejs/node/pull/4181)
+* [[`6ca5ea3860`](https://github.com/nodejs/node/commit/6ca5ea3860)] - 2015-12-09, Version 5.2.0 (Current) (Rod Vagg) [#4181](https://github.com/nodejs/node/pull/4181)
 * [[`da5cdc2207`](https://github.com/nodejs/node/commit/da5cdc2207)] - **assert**: accommodate ES6 classes that extend Error (Rich Trott) [#4166](https://github.com/nodejs/node/pull/4166)
 * [[`67e181986a`](https://github.com/nodejs/node/commit/67e181986a)] - **(SEMVER-MINOR)** **buffer**: add includes() for parity with TypedArray (Alexander Martin) [#3567](https://github.com/nodejs/node/pull/3567)
 * [[`84dea1bd0c`](https://github.com/nodejs/node/commit/84dea1bd0c)] - **configure**: fix arm vfpv2 (Jörg Krause) [#4203](https://github.com/nodejs/node/pull/4203)

--- a/locale/en/blog/release/v5.4.0.md
+++ b/locale/en/blog/release/v5.4.0.md
@@ -2,7 +2,7 @@
 date: 2016-01-06T22:41:09.455Z
 version: 5.4.0
 category: release
-title: Node v5.4.0 (Stable)
+title: Node v5.4.0 (Current)
 slug: node-v5-4-0
 layout: blog-post.hbs
 author: Jeremiah Senkpiel

--- a/locale/en/blog/release/v5.4.1.md
+++ b/locale/en/blog/release/v5.4.1.md
@@ -2,7 +2,7 @@
 date: 2016-01-12T23:59:28.459Z
 version: 5.4.1
 category: release
-title: Node v5.4.1 (Stable)
+title: Node v5.4.1 (Current)
 slug: node-v5-4-1
 layout: blog-post.hbs
 author: Myles Borins

--- a/locale/en/blog/release/v5.5.0.md
+++ b/locale/en/blog/release/v5.5.0.md
@@ -2,7 +2,7 @@
 date: 2016-01-21T02:26:55.519Z
 version: 5.5.0
 category: release
-title: Node v5.5.0 (Stable)
+title: Node v5.5.0 (Current)
 slug: node-v5-5-0
 layout: blog-post.hbs
 author: Evan Lucas

--- a/locale/en/blog/release/v5.6.0.md
+++ b/locale/en/blog/release/v5.6.0.md
@@ -2,7 +2,7 @@
 date: 2016-02-09T17:32:46.793Z
 version: 5.6.0
 category: release
-title: Node v5.6.0 (Stable)
+title: Node v5.6.0 (Current)
 slug: node-v5-6-0
 layout: blog-post.hbs
 author: James M Snell

--- a/locale/en/blog/release/v5.7.0.md
+++ b/locale/en/blog/release/v5.7.0.md
@@ -2,7 +2,7 @@
 date: 2016-02-23T05:37:34.766Z
 version: 5.7.0
 category: release
-title: Node v5.7.0 (Stable)
+title: Node v5.7.0 (Current)
 slug: node-v5-7-0
 layout: blog-post.hbs
 author: Rod Vagg

--- a/locale/en/blog/release/v5.7.1.md
+++ b/locale/en/blog/release/v5.7.1.md
@@ -2,7 +2,7 @@
 date: 2016-03-02T23:23:06.216Z
 version: 5.7.1
 category: release
-title: Node v5.7.1 (Stable)
+title: Node v5.7.1 (Current)
 slug: node-v5-7-1
 layout: blog-post.hbs
 author: Jeremiah Senkpiel

--- a/locale/en/blog/release/v5.8.0.md
+++ b/locale/en/blog/release/v5.8.0.md
@@ -2,7 +2,7 @@
 date: 2016-03-09T15:57:36.574Z
 version: 5.8.0
 category: release
-title: Node v5.8.0 (Stable)
+title: Node v5.8.0 (Current)
 slug: node-v5-8-0
 layout: blog-post.hbs
 author: Jeremiah Senkpiel

--- a/locale/en/blog/release/v5.9.0.md
+++ b/locale/en/blog/release/v5.9.0.md
@@ -2,7 +2,7 @@
 date: 2016-03-16T21:34:26.150Z
 version: 5.9.0
 category: release
-title: Node v5.9.0 (Stable)
+title: Node v5.9.0 (Current)
 slug: node-v5-9-0
 layout: blog-post.hbs
 author: Evan Lucas

--- a/locale/en/blog/release/v5.9.1.md
+++ b/locale/en/blog/release/v5.9.1.md
@@ -2,7 +2,7 @@
 date: 2016-03-23T17:40:02.432Z
 version: 5.9.1
 category: release
-title: Node v5.9.1 (Stable)
+title: Node v5.9.1 (Current)
 slug: node-v5-9-1
 layout: blog-post.hbs
 author: Jeremiah Senkpiel

--- a/locale/en/blog/weekly-updates/weekly-update.2015-10-30.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2015-10-30.md
@@ -9,13 +9,13 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News — October 30th
-Node.js v5.0.0 (Stable) is released
+Node.js v5.0.0 (Current) is released
 
-### Node.js v5.0.0 (Stable) Releases
+### Node.js v5.0.0 (Current) Releases
 
-This week we have one release: [Node.js v5.0.0 (Stable)](https://nodejs.org/en/blog/release/v5.0.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+This week we have one release: [Node.js v5.0.0 (Current)](https://nodejs.org/en/blog/release/v5.0.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
-### Notable changes : v5.0.0 (Stable)
+### Notable changes : v5.0.0 (Current)
 
 * **v8**: _(Breaking)_ Upgraded to 4.6.85.25 from 4.5.103.35  (Ali Ijaz Sheikh) [#3351](https://github.com/nodejs/node/pull/3351).
   - Implements the spread operator, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator for further information.

--- a/locale/en/blog/weekly-updates/weekly-update.2015-11-20.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2015-11-20.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News — November 20th
-Node.js v5.1.0 (Stable) is released
+Node.js v5.1.0 (Current) is released
 
-### Node.js v5.1.0 (Stable) Releases
+### Node.js v5.1.0 (Current) Releases
 
-This week we have one release: [Node.js v5.1.0 (Stable)](https://nodejs.org/en/blog/release/v5.1.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+This week we have one release: [Node.js v5.1.0 (Current)](https://nodejs.org/en/blog/release/v5.1.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### Notable changes
 

--- a/locale/en/blog/weekly-updates/weekly-update.2015-12-04.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2015-12-04.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News — December 4th
-Node v5.1.1 (Stable), v4.2.3 "Argon" (LTS), v0.12.9 (LTS) and v0.10.41 (Maintenance) are released
+Node v5.1.1 (Current), v4.2.3 "Argon" (LTS), v0.12.9 (LTS) and v0.10.41 (Maintenance) are released
 
 ### December Security Release Summary
 * This is an important security release. Please update your Node.js installation.
-* We have released Node.js [v0.10.41 (Maintenance)](/en/blog/release/v0.10.41/), [v0.12.9 (LTS)](/en/blog/release/v0.12.9/), [v4.2.3 "Argon" (LTS)](/en/blog/release/v4.2.3/) and [v5.1.1 (Stable)](/en/blog/release/v5.1.1/) with fixes for the announced vulnerabilities and updates to OpenSSL.
+* We have released Node.js [v0.10.41 (Maintenance)](/en/blog/release/v0.10.41/), [v0.12.9 (LTS)](/en/blog/release/v0.12.9/), [v4.2.3 "Argon" (LTS)](/en/blog/release/v4.2.3/) and [v5.1.1 (Current)](/en/blog/release/v5.1.1/) with fixes for the announced vulnerabilities and updates to OpenSSL.
 * All Node.js users should consult our December Security Release Summary for details on patched vulnerabilities.
 
 See https://nodejs.org/en/blog/vulnerability/december-2015-security-releases/ for more information.

--- a/locale/en/blog/weekly-updates/weekly-update.2015-12-11.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2015-12-11.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News — December 11st
-Node v5.2.0 (Stable) is released
+Node v5.2.0 (Current) is released
 
-### Node.js v5.2.0 (Stable) Releases
+### Node.js v5.2.0 (Current) Releases
 
-This week we have one release: [Node.js v5.2.0 (Stable)](https://nodejs.org/en/blog/release/v5.2.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+This week we have one release: [Node.js v5.2.0 (Current)](https://nodejs.org/en/blog/release/v5.2.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### Notable changes
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-01-11.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-01-11.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v5.4.0 (Stable) is released
+Node v5.4.0 (Current) is released
 
-### Node v5.4.0 (Stable) Releases
+### Node v5.4.0 (Current) Releases
 
-Last week we had one release: [Node v5.4.0 (Stable)](https://nodejs.org/en/blog/release/v5.4.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+Last week we had one release: [Node v5.4.0 (Current)](https://nodejs.org/en/blog/release/v5.4.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### Notable changes
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-01-18.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-01-18.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v5.4.1 (Stable) is released
+Node v5.4.1 (Current) is released
 
-### Node v5.4.1 (Stable) Releases
+### Node v5.4.1 (Current) Releases
 
-Last week we had one release: [Node v5.4.1 (Stable)](https://nodejs.org/en/blog/release/v5.4.1/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+Last week we had one release: [Node v5.4.1 (Current)](https://nodejs.org/en/blog/release/v5.4.1/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### Notable Changes
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-01-22.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-01-22.md
@@ -9,7 +9,7 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v4.2.6 (LTS), Node v5.5.0 (Stable), Node v4.2.5 (LTS) are released
+Node v4.2.6 (LTS), Node v5.5.0 (Current), Node v4.2.5 (LTS) are released
 
 ### Nominations for the 2016 election
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-02-15.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-02-15.md
@@ -9,10 +9,10 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v0.10.42 (LTS), Node v0.12.10 (LTS), Node v4.3.0 (LTS) and Node v5.6.0 (Stable) are released.
+Node v0.10.42 (LTS), Node v0.12.10 (LTS), Node v4.3.0 (LTS) and Node v5.6.0 (Current) are released.
 
 ### February 2016 Security Release Summary
-We had released Node.js [v0.10.42 (Maintenance)](/en/blog/release/v0.10.42/), [v0.12.10 (LTS)](/en/blog/release/v0.12.10/), [v4.3.0 "Argon" (LTS)](/en/blog/release/v4.3.0/) and [v5.6.0 (Stable)](/en/blog/release/v5.6.0/) with fixes for the announced vulnerabilities and updates to OpenSSL.
+We had released Node.js [v0.10.42 (Maintenance)](/en/blog/release/v0.10.42/), [v0.12.10 (LTS)](/en/blog/release/v0.12.10/), [v4.3.0 "Argon" (LTS)](/en/blog/release/v4.3.0/) and [v5.6.0 (Current)](/en/blog/release/v5.6.0/) with fixes for the announced vulnerabilities and updates to OpenSSL.
 
 **Please note that our LTS "Argon" release line has moved from v4.2.x to v4.3.x due to the security fixes enclosed. There will be no further updates to v4.2.x.** Users are advised to upgrade to v4.3.0 as soon as possible.
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-02-22.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-02-22.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v4.3.1 (LTS), Node v4.4.0 (RC) and Node v5.7.0 (Stable) are released.
+Node v4.3.1 (LTS), Node v4.4.0 (RC) and Node v5.7.0 (Current) are released.
 
-### Node v4.3.1 (LTS), Node v4.4.0 (RC) and Node v5.7.0 (Stable) Releases
+### Node v4.3.1 (LTS), Node v4.4.0 (RC) and Node v5.7.0 (Current) Releases
 
-We have three releases: [Node v4.3.1 (LTS)](https://nodejs.org/en/blog/release/v4.3.1/), [Node v4.4.0 (RC)](https://github.com/nodejs/node/pull/5301) and [Node v5.7.0 (Stable)](https://nodejs.org/en/blog/release/v5.7.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+We have three releases: [Node v4.3.1 (LTS)](https://nodejs.org/en/blog/release/v4.3.1/), [Node v4.4.0 (RC)](https://github.com/nodejs/node/pull/5301) and [Node v5.7.0 (Current)](https://nodejs.org/en/blog/release/v5.7.0/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### New official Node.js logo
 As a result of an iteration on the official logo, we are proud to introduce and unveil our new logo

--- a/locale/en/blog/weekly-updates/weekly-update.2016-03-07.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-03-07.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node v0.10.43 (Maintenance), Node v0.12.11 (LTS), Node v5.7.1 (Stable) and Node v4.3.2 (LTS) are released.
+Node v0.10.43 (Maintenance), Node v0.12.11 (LTS), Node v5.7.1 (Current) and Node v4.3.2 (LTS) are released.
 
-### Node v0.10.43 (Maintenance), Node v0.12.11 (LTS), Node v5.7.1 (Stable) and Node v4.3.2 (LTS) Releases
+### Node v0.10.43 (Maintenance), Node v0.12.11 (LTS), Node v5.7.1 (Current) and Node v4.3.2 (LTS) Releases
 
-We have four releases: [Node v0.10.43 (Maintenance)](https://nodejs.org/en/blog/release/v0.10.43/), [Node v0.12.11 (LTS)](https://nodejs.org/en/blog/release/v0.12.11/), [Node v5.7.1 (Stable)](https://nodejs.org/en/blog/release/v5.7.1/) and [Node v4.3.2 (LTS)](https://nodejs.org/en/blog/release/v4.3.2/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+We have four releases: [Node v0.10.43 (Maintenance)](https://nodejs.org/en/blog/release/v0.10.43/), [Node v0.12.11 (LTS)](https://nodejs.org/en/blog/release/v0.12.11/), [Node v5.7.1 (Current)](https://nodejs.org/en/blog/release/v5.7.1/) and [Node v4.3.2 (LTS)](https://nodejs.org/en/blog/release/v4.3.2/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### Initial benchmark data
 

--- a/locale/en/blog/weekly-updates/weekly-update.2016-03-14.md
+++ b/locale/en/blog/weekly-updates/weekly-update.2016-03-14.md
@@ -9,11 +9,11 @@ layout: blog-post.hbs
 ---
 
 ### Node.js News
-Node Node v4.4.0 (LTS), Node v5.8.0 (Stable) and Node v0.12.12 (LTS) are released.
+Node Node v4.4.0 (LTS), Node v5.8.0 (Current) and Node v0.12.12 (LTS) are released.
 
-### Node Node v4.4.0 (LTS), Node v5.8.0 (Stable) and Node v0.12.12 (LTS) Releases
+### Node Node v4.4.0 (LTS), Node v5.8.0 (Current) and Node v0.12.12 (LTS) Releases
 
-We have three releases: [Node v4.4.0 (LTS)](https://nodejs.org/en/blog/release/v4.4.0/), [Node v5.8.0 (Stable)](https://nodejs.org/en/blog/release/v5.8.0/) and [Node v0.12.12 (LTS)](https://nodejs.org/en/blog/release/v0.12.12/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
+We have three releases: [Node v4.4.0 (LTS)](https://nodejs.org/en/blog/release/v4.4.0/), [Node v5.8.0 (Current)](https://nodejs.org/en/blog/release/v5.8.0/) and [Node v0.12.12 (LTS)](https://nodejs.org/en/blog/release/v0.12.12/). Complete changelog from previous releases can be found [on GitHub](https://github.com/nodejs/node/blob/master/CHANGELOG.md).
 
 ### AppDynamics, New Relic, Opbeat and Sphinx Join the Node.js Foundation as Silver Members
 

--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -1,17 +1,17 @@
 ---
-layout: download-stable.hbs
+layout: download-current.hbs
 title: Download
 download: Download
 downloads:
     headline: Downloads
     lts: LTS
-    stable: Stable
-    tagline-stable: Latest Features
+    current: Current
+    tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: Current stable version
+    currentVersion: Current version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -5,8 +5,8 @@ download: Download
 downloads:
     headline: Downloads
     lts: LTS
-    stable: Stable
-    tagline-stable: Latest Features
+    current: Current
+    tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -6,10 +6,10 @@ labels:
   download-for: Download for
   other-downloads: Other Downloads
   other-lts-downloads: Other LTS Downloads
-  other-stable-downloads: Other Stable Downloads
-  stable: Stable
+  other-current-downloads: Other Current Downloads
+  current: Current
   lts: LTS
-  tagline-stable: Latest Features
+  tagline-current: Latest Features
   tagline-lts: Recommended For Most Users
   changelog: Changelog
   api: API Docs

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -89,7 +89,7 @@
             "subtext": "LTS",
             "text": "v4.4.2 API"
         },
-        "api-stable": {
+        "api-current": {
             "link": "/dist/latest-v5.x/docs/api",
             "text": "v5.10.1 API"
         },

--- a/locale/it/index.md
+++ b/locale/it/index.md
@@ -6,10 +6,10 @@ labels:
   download-for: Download per
   other-downloads: Altri Downloads
   other-lts-downloads: Altri Download LTS
-  other-stable-downloads: Altri Download Stabili
-  stable: Stabile
+  other-current-downloads: Altri Download Stabili
+  current: Corrente
   lts: LTS
-  tagline-stable: Ultime funzionalità
+  tagline-current: Ultime funzionalità
   tagline-lts: Maturo e affidabile
   changelog: Changelog
   api: Documentazione API

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -80,7 +80,7 @@
             "subtext": "LTS",
             "text": "v4.4.2 API"
         },
-        "api-stable": {
+        "api-current": {
             "link": "/dist/latest-v5.x/docs/api",
             "text": "v5.10.1 API"
         },

--- a/locale/ko/index.md
+++ b/locale/ko/index.md
@@ -6,10 +6,10 @@ labels:
   download-for: Download for
   other-downloads: 다른 운영 체제
   other-lts-downloads: 다른 LTS 다운로드
-  other-stable-downloads: 다른 안정 버전 다운로드
-  stable: 안정 버전
+  other-current-downloads: 다른 안정 버전 다운로드
+  current: 안정 버전
   lts: LTS
-  tagline-stable: 최신 기능
+  tagline-current: 최신 기능
   tagline-lts: 안정적, 신뢰도 높음
   changelog: 변경사항
   api: API 문서

--- a/locale/ko/index.md
+++ b/locale/ko/index.md
@@ -6,8 +6,8 @@ labels:
   download-for: Download for
   other-downloads: 다른 운영 체제
   other-lts-downloads: 다른 LTS 다운로드
-  other-current-downloads: 다른 안정 버전 다운로드
-  current: 안정 버전
+  other-current-downloads: 다른 현재 버전 다운로드
+  current: 현재 버전
   lts: LTS
   tagline-current: 최신 기능
   tagline-lts: 안정적, 신뢰도 높음

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -81,7 +81,7 @@
             "subtext": "LTS",
             "text": "v4.4.2 API"
         },
-        "api-stable": {
+        "api-current": {
             "link": "/dist/latest-v5.x/docs/api",
             "text": "v5.10.1 API"
         },

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 
-exports.stable = (releases) => {
+exports.current = (releases) => {
   const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
   return match && match.version
 }

--- a/server.js
+++ b/server.js
@@ -40,12 +40,16 @@ function getLocale (filePath) {
   return filePath.slice(pre.length + 1, filePath.indexOf('/', pre.length + 1))
 }
 
-locales.on('change', (filePath) => {
-  build.buildLocale(filePath, getLocale(filePath))
-})
-locales.on('add', (filePath) => {
-  build.buildLocale(filePath, getLocale(filePath))
-  locales.add(filePath)
+build.getSource((err, source) => {
+  if (err) { throw err }
+
+  locales.on('change', (filePath) => {
+    build.buildLocale(source, getLocale(filePath))
+  })
+  locales.on('add', (filePath) => {
+    build.buildLocale(source, getLocale(filePath))
+    locales.add(filePath)
+  })
 })
 
 layouts.on('change', build.fullBuild)

--- a/tests/scripts/CHANGELOG.fixture.md
+++ b/tests/scripts/CHANGELOG.fixture.md
@@ -1,6 +1,6 @@
 # Node.js ChangeLog
 
-## 2015-10-13, Version 4.2.1 'Argon' (Stable), @jasnell
+## 2015-10-13, Version 4.2.1 'Argon' (Current), @jasnell
 
 ### Notable changes
 
@@ -107,7 +107,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`8dfdee3733`](https://github.com/nodejs/node/commit/8dfdee3733)] - **util**: correctly inspect Map/Set Iterators (Evan Lucas) [#3119](https://github.com/nodejs/node/pull/3119)
 * [[`b5c51fdba0`](https://github.com/nodejs/node/commit/b5c51fdba0)] - **util**: fix check for Array constructor (Evan Lucas) [#3119](https://github.com/nodejs/node/pull/3119)
 
-## 2015-09-22, Version 4.1.1 (Stable), @rvagg
+## 2015-09-22, Version 4.1.1 (Current), @rvagg
 
 ### Notable changes
 
@@ -159,7 +159,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`3e09dcfc32`](https://github.com/nodejs/node/commit/3e09dcfc32)] - **test**: update cwd-enoent tests for AIX (Imran Iqbal) [#2909](https://github.com/nodejs/node/pull/2909)
 * [[`6ea8ec1c59`](https://github.com/nodejs/node/commit/6ea8ec1c59)] - **tools**: single, cross-platform tick processor (Matt Loring) [#2868](https://github.com/nodejs/node/pull/2868)
 
-## 2015-09-17, Version 4.1.0 (Stable), @Fishrock123
+## 2015-09-17, Version 4.1.0 (Current), @Fishrock123
 
 ### Notable changes
 
@@ -188,7 +188,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 ### Commits
 
 * [[`b1abe812cd`](https://github.com/nodejs/node/commit/b1abe812cd)] - Working on 4.0.1 (Rod Vagg)
-* [[`f9f8378853`](https://github.com/nodejs/node/commit/f9f8378853)] - 2015-09-08, Version 4.0.0 (Stable) Release (Rod Vagg)
+* [[`f9f8378853`](https://github.com/nodejs/node/commit/f9f8378853)] - 2015-09-08, Version 4.0.0 (Current) Release (Rod Vagg)
 * [[`9683e5df51`](https://github.com/nodejs/node/commit/9683e5df51)] - **bindings**: close after reading module struct (Fedor Indutny) [#2792](https://github.com/nodejs/node/pull/2792)
 * [[`4b4cfa2d44`](https://github.com/nodejs/node/commit/4b4cfa2d44)] - **buffer**: always allocate typed arrays outside heap (Trevor Norris) [#2893](https://github.com/nodejs/node/pull/2893)
 * [[`7df018a29b`](https://github.com/nodejs/node/commit/7df018a29b)] - **buffer**: construct Uint8Array in JS (Trevor Norris) [#2866](https://github.com/nodejs/node/pull/2866)
@@ -243,7 +243,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`ba47511976`](https://github.com/nodejs/node/commit/ba47511976)] - **tsc**: adjust TSC membership for IBM+StrongLoop (James M Snell) [#2858](https://github.com/nodejs/node/pull/2858)
 * [[`e035266805`](https://github.com/nodejs/node/commit/e035266805)] - **win,msi**: fix documentation shortcut url (Brian White) [#2781](https://github.com/nodejs/node/pull/2781)
 
-## 2015-09-08, Version 4.0.0 (Stable), @rvagg
+## 2015-09-08, Version 4.0.0 (Current), @rvagg
 
 ### Notable changes
 

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -4,25 +4,25 @@ const test = require('tape')
 
 const latestversion = require('../../scripts/helpers/latestversion')
 
-test('latestversion.stable()', (t) => {
+test('latestversion.current()', (t) => {
   t.test('should be greater equal/greater than v5.0.0', (t) => {
-    const stableVersion = latestversion.stable([
+    const currentVersion = latestversion.current([
       { version: 'v4.2.1', lts: true },
       { version: 'v0.12.7', lts: false }
     ])
 
-    t.equal(stableVersion, undefined)
+    t.equal(currentVersion, undefined)
     t.end()
   })
 
   t.test('should not be an LTS release', (t) => {
-    const stableVersion = latestversion.stable([
+    const currentVersion = latestversion.current([
       { version: 'v5.0.0', lts: false },
       { version: 'v4.2.1', lts: true },
       { version: 'v0.12.7', lts: false }
     ])
 
-    t.equal(stableVersion, 'v5.0.0')
+    t.equal(currentVersion, 'v5.0.0')
     t.end()
   })
 

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -194,13 +194,13 @@ test('fetchVersionPolicy(<version>)', (t) => {
   const changelogFixture = path.resolve(__dirname, 'CHANGELOG.fixture.md')
   const changelogLegacyFixture = path.resolve(__dirname, 'CHANGELOG.fixture.legacy.md')
 
-  t.test('finds "Stable" version policy', (t) => {
+  t.test('finds "Current" version policy', (t) => {
     const github = nock('https://raw.githubusercontent.com')
       .get('/nodejs/node/v4.1.0/CHANGELOG.md')
       .replyWithFile(200, changelogFixture)
 
     releasePost.fetchVersionPolicy('4.1.0').then((policy) => {
-      t.equal(policy, 'Stable')
+      t.equal(policy, 'Current')
       t.true(github.isDone(), 'githubusercontent.com was requested')
 
       t.end()


### PR DESCRIPTION
PR for #669:
- I haven't changed any release blog posts _prior 4.0_. The old Node.js version numbers used the terms stable/unstable.
- We will need a redirect from `/<lang>/downloads/stable` to `/<lang>/downloads/current`: https://github.com/nodejs/build/pull/399
- ~~Changing markdown files while running `npm run serve` crashes the process:~~ Fixed (cherry-picked to `master`)
- ~~Some tests are failing for release blogpost generation, @phillipj can you please take a look?~~
