### PR TITLE
meta: temporarily use master for changelog

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -54,7 +54,9 @@
                           <a href="https://nodejs.org/{{site.locale}}/download/current/">{{ labels.other-downloads }}</a>
                         </li>
                         <li>
-                            <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.current }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                            <a href="https://github.com/nodejs/node/blob/master/CHANGELOG.md#2016-04-26-version-600-current-jasnell">{{ labels.changelog }}</a>
+                            {{!--TODO revert when v6.0.1 releases --}}
+                            {{!-- <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.current }}/CHANGELOG.md">{{ labels.changelog }}</a> --}}
                         </li>
                         <li>
                           <a href="{{majorapidocslink project.currentVersions.current}}">{{ labels.api }}</a>


### PR DESCRIPTION
Current changelog is not rendering on github due to filesize. No way to fix that right now

this should be reverted as soon as v6.0.1 is released
