### PR TITLE
Document how harmony flags relate to v8

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -10,7 +10,7 @@ All ECMAScript 2015 (ES6) features are split into three groups for **shipping**,
 
 * All **shipping** features, which V8 considers stable, are turned **on by default on Node.js** and do **NOT** require any kind of runtime flag.
 * **Staged** features, which are almost-completed features that are not considered stable by the V8 team, require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
-* **In progress** features can be activated individually by their respective harmony flag, although this is highly discouraged unless for testing purposes.
+* **In progress** features can be activated individually by their respective harmony flag, although this is highly discouraged unless for testing purposes. Note: these flags are exposed by V8 and will potentially change without any deprecation notice.
 
 ## Which features ship with which Node.js version by default?
 


### PR DESCRIPTION
`es_` / `harmony` flags are deprecated by v8 without notice, which
potentially can cause errors to be thrown. Users should be informed
about this behavior.
- Original issue:
  https://github.com/nodejs/node/issues/6489
