### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Thanks for wanting to report an issue you've found on the nodejs.org website.
+
+For issues regarding the Node.js API docs, please head over to:
+https://github.com/nodejs/node/issues/ (prefix your issue name with "doc")
+
+For general questions about Node.js:
+https://github.com/nodejs/help/issues/
+
+Please fill in the template below by replacing the HTML comments with an
+appropriate answer. If unsure about something, just do as best as you're able.
+If you are reporting a visual glitch, it will be much easier for us to fix it
+when you attach a screenshot as well.
+
+Thank you!
+-->
+
+* **URL**:
+* **Browser version**:
+* **Operating system**:
+
+<!-- Enter your issue details below this comment. -->


### PR DESCRIPTION
As general questions about Node.js and issues regarding the API docs often land here instead, I created a GitHub issue template based on the template in `nodejs/node`.
