### PR TITLE
ES6: Highlight difference between '--es_staging' and '--harmony' flag

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -9,7 +9,7 @@ Node.js is built against modern versions of [V8](https://developers.google.com/v
 All ECMAScript 2015 (ES6) features are split into three groups for **shipping**, **staged**, and **in progress** features:
 
 * All **shipping** features, which V8 considers stable, are turned **on by default on Node.js** and do **NOT** require any kind of runtime flag.
-* **Staged** features, which are almost-completed features that are not considered stable by the V8 team, require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
+* **Staged** features, which are almost-completed features that are not considered stable by the V8 team, require a runtime flag: `--es_staging` (or `--harmony` for staged ES6 features only).
 * **In progress** features can be activated individually by their respective harmony flag, although this is highly discouraged unless for testing purposes. Note: these flags are exposed by V8 and will potentially change without any deprecation notice.
 
 ## Which features ship with which Node.js version by default?


### PR DESCRIPTION
Both flags are not exact synonyms, as '--harmony' includes only staged ES6
features, while '--es_staging' also covers first features from ES7.

Refs:
- #705
- #694
