### PR TITLE
Update standard to version 7.x.x

### DIFF
--- a/build.js
+++ b/build.js
@@ -214,7 +214,7 @@ function githubLinks (options) {
       const file = files[path]
       const url = `https://github.com/nodejs/nodejs.org/edit/master/locale/${options.locale}/${path.replace('.html', '.md')}`
 
-      const contents = file.contents.toString().replace(/\<h1\>(.+)\<\/h1\>/, ($1, $2) => {
+      const contents = file.contents.toString().replace(/<h1>(.+)<\/h1>/, ($1, $2) => {
         return `<a class="edit-link" href="${url}">Edit on GitHub</a> <h1>${$2}</h1>`
       })
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "nock": "^8.0.0",
     "pre-commit": "^1.1.2",
     "proxyquire": "^1.7.4",
-    "standard": "^6.0.8",
+    "standard": "^7.0.0",
     "stylint": "^1.3.8",
     "tape": "^4.5.1"
   }


### PR DESCRIPTION
This updates `standard` to the latest version.
Here is the changelog for version `7.0.0`: https://github.com/feross/standard/blob/master/CHANGELOG.md#700---2016-05-02
