### PR TITLE
Remove unused CSS rules

### DIFF
--- a/layouts/css/page-modules/_footer.styl
+++ b/layouts/css/page-modules/_footer.styl
@@ -14,17 +14,3 @@ footer
 
   &.no-margin-top
     margin-top 0px
-
-.footer-nav
-  display flex
-  justify-content space-between
-  font-size 16px
-  margin 1em 0
-
-  ul
-    list-style-type none
-    margin 0
-    padding 0
-
-    li:first-child
-      font-weight bold


### PR DESCRIPTION
It seems that these rules are no longer used. I think they have been replaced by the rules in `_linuxfoundation.styl`.

Please correct me if I'm wrong.
