### PR TITLE
Openssl may 2016 updates

### DIFF
--- a/build.js
+++ b/build.js
@@ -252,7 +252,7 @@ function getSource (callback) {
         },
         banner: {
           visible: true,
-          content: 'Important <a href="https://nodejs.org/en/blog/vulnerability/npm-tokens-leak-march-2016/">security notification</a> regarding npm'
+          content: 'Important <a href="/en/blog/vulnerability/openssl-may-2016/">security upgrades</a> for recent OpenSSL vulnerabilities'
         }
       }
     }

--- a/locale/en/blog/vulnerability/openssl-may-2016.md
+++ b/locale/en/blog/vulnerability/openssl-may-2016.md
@@ -7,6 +7,16 @@ layout: blog-post.hbs
 author: Rod Vagg
 ---
 
+## _(Update 6-May-2016)_ New Node.js Releases
+
+* **Node v6.1.0 (Current)**: http://nodejs.org/en/blog/release/v6.1.0/
+* **Node v4.4.4 (LTS)**: http://nodejs.org/en/blog/release/v4.4.4/
+* **Node v5.11.1**: http://nodejs.org/en/blog/release/v5.11.1/
+* **Node v0.10.45 (Maintenance)**: http://nodejs.org/en/blog/release/v0.10.45/
+
+
+***Further updates to this post, including a risk assessment, are included below***
+
 The OpenSSL project has [announced](https://mta.openssl.org/pipermail/openssl-announce/2016-April/000069.html) that that they will be releasing versions 1.0.1t and 1.0.2h this week, on **Tuesday the 3rd of May, UTC**. The releases will fix _"several security defects"_ that are labelled as _"high"_ severity under their security policy, meaning they are:
 
 > ... issues that are of a lower risk than critical, perhaps due to affecting less common configurations, or which are less likely to be exploitable.

--- a/locale/en/blog/vulnerability/openssl-may-2016.md
+++ b/locale/en/blog/vulnerability/openssl-may-2016.md
@@ -9,13 +9,15 @@ author: Rod Vagg
 
 ## _(Update 6-May-2016)_ New Node.js Releases
 
+The following releases have been made available to include the security updates to OpenSSL discussed in the post below. Please upgrade your Node.js installation as soon as possible in order to be protected against the disclosed vulnerabilities.
+
 * **Node v6.1.0 (Current)**: http://nodejs.org/en/blog/release/v6.1.0/
-* **Node v4.4.4 (LTS)**: http://nodejs.org/en/blog/release/v4.4.4/
 * **Node v5.11.1**: http://nodejs.org/en/blog/release/v5.11.1/
+* **Node v4.4.4 (LTS)**: http://nodejs.org/en/blog/release/v4.4.4/
+* **Node v0.12.14 (Maintenance)**: http://nodejs.org/en/blog/release/v0.12.14/
 * **Node v0.10.45 (Maintenance)**: http://nodejs.org/en/blog/release/v0.10.45/
 
-
-***Further updates to this post, including a risk assessment, are included below***
+***Original post is included below, along with an update containing a risk assessment***
 
 The OpenSSL project has [announced](https://mta.openssl.org/pipermail/openssl-announce/2016-April/000069.html) that that they will be releasing versions 1.0.1t and 1.0.2h this week, on **Tuesday the 3rd of May, UTC**. The releases will fix _"several security defects"_ that are labelled as _"high"_ severity under their security policy, meaning they are:
 


### PR DESCRIPTION
also includes a change to the frontpage banner to point to the security update
