### PR TITLE
Show shipped npm version on download page, fixes #731

### DIFF
--- a/build.js
+++ b/build.js
@@ -69,7 +69,7 @@ function buildLocale (source, locale) {
     .source(path.join(__dirname, 'locale', locale))
     // Extracts the main menu and sub-menu links form locale's site.json and
     // adds them to the metadata. This data is used in the navigation template
-    .use(navigation(source.project.currentVersions))
+    .use(navigation(source.project.latestVersions))
     // Defines the blog post/guide collections used to internally group them for
     // easier future handling and feed generation.
     .use(collections({
@@ -246,7 +246,7 @@ function getSource (callback) {
     const source = {
       project: {
         versions,
-        currentVersions: {
+        latestVersions: {
           current: latestVersion.current(versions),
           lts: latestVersion.lts(versions)
         },

--- a/layouts/download-current.hbs
+++ b/layouts/download-current.hbs
@@ -12,8 +12,8 @@
           <h1>{{downloads.headline}}</h1>
         </div>
 
-        {{> primary-download-matrix version=project.currentVersions.current versionTypeCurrent="true"}}
-        {{> secondary-download-matrix version=project.currentVersions.current versionTypeCurrent="true"}}
+        {{> primary-download-matrix version=project.latestVersions.current versionTypeCurrent="true"}}
+        {{> secondary-download-matrix version=project.latestVersions.current versionTypeCurrent="true"}}
 
       </article>
 

--- a/layouts/download.hbs
+++ b/layouts/download.hbs
@@ -12,8 +12,8 @@
           <h1>{{downloads.headline}}</h1>
         </div>
 
-        {{> primary-download-matrix version=project.currentVersions.lts versionTypeLts="true"}}
-        {{> secondary-download-matrix version=project.currentVersions.lts versionTypeLts="true"}}
+        {{> primary-download-matrix version=project.latestVersions.lts versionTypeLts="true"}}
+        {{> secondary-download-matrix version=project.latestVersions.lts versionTypeLts="true"}}
 
       </article>
 

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -22,8 +22,8 @@
 
         <div class="home-downloadblock">
 
-          <a href="https://nodejs.org/dist/{{ project.currentVersions.lts }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.currentVersions.lts }} {{ labels.lts }}" data-version="{{ project.currentVersions.lts }}">
-            {{ project.currentVersions.lts }} {{ labels.lts }}
+          <a href="https://nodejs.org/dist/{{ project.latestVersions.lts.node }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.latestVersions.lts.node }} {{ labels.lts }}" data-version="{{ project.latestVersions.lts.node }}">
+            {{ project.latestVersions.lts.node }} {{ labels.lts }}
             <small>{{ labels.tagline-lts }}</small>
           </a>
 
@@ -32,20 +32,20 @@
               <a href="https://nodejs.org/{{site.locale}}/download/">{{ labels.other-downloads }}</a>
             </li>
             <li>
-              <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.lts }}/CHANGELOG.md">{{ labels.changelog }}</a>
+              <a href="https://github.com/nodejs/node/blob/{{ project.latestVersions.lts.node }}/CHANGELOG.md">{{ labels.changelog }}</a>
             </li>
             <li>
-              <a href="{{majorapidocslink project.currentVersions.lts}}">{{ labels.api }}</a>
+              <a href="{{majorapidocslink project.latestVersions.lts.node}}">{{ labels.api }}</a>
             </li>
           </ul>
 
         </div>
 
-        {{#if project.currentVersions.current}}
+        {{#if project.latestVersions.current.node}}
           <div class="home-downloadblock">
 
-            <a href="https://nodejs.org/dist/{{ project.currentVersions.current }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.currentVersions.current }} {{ labels.current }}"  data-version="{{ project.currentVersions.current }}">
-              {{ project.currentVersions.current }} {{ labels.current }}
+            <a href="https://nodejs.org/dist/{{ project.latestVersions.current.node }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.latestVersions.current.node }} {{ labels.current }}"  data-version="{{ project.latestVersions.current.node }}">
+              {{ project.latestVersions.current.node }} {{ labels.current }}
               <small>{{ labels.tagline-current }}</small>
             </a>
 
@@ -54,10 +54,10 @@
                 <a href="https://nodejs.org/{{site.locale}}/download/current/">{{ labels.other-downloads }}</a>
               </li>
               <li>
-                <a href="https://github.com/nodejs/node/blob/{{ project.currentVersions.current }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                <a href="https://github.com/nodejs/node/blob/{{ project.latestVersions.current.node }}/CHANGELOG.md">{{ labels.changelog }}</a>
               </li>
               <li>
-                <a href="{{majorapidocslink project.currentVersions.current}}">{{ labels.api }}</a>
+                <a href="{{majorapidocslink project.latestVersions.current.node}}">{{ labels.api }}</a>
               </li>
             </ul>
 

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -1,5 +1,5 @@
 <section>
-  <p class="color-lightgray">{{downloads.currentVersion}}: <strong>{{version}}</strong></p>
+  <p class="color-lightgray">{{downloads.currentVersion}}: <strong>{{version.node}}</strong> (includes npm {{version.npm}})</p>
   <p>{{downloads.intro}}</p>
   <div class="download-hero full-width">
     <ul class="no-padding">
@@ -16,24 +16,24 @@
         </div>
       </li>
       <li>
-        <a href="https://nodejs.org/dist/{{version}}/node-{{version}}-x86.msi" id="windows-downloadbutton" data-version="{{version}}">
+        <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x86.msi" id="windows-downloadbutton" data-version="{{version.node}}">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M1.589 23.55l-0.017-15.31 18.839-2.558v17.868zM23.55 5.225l25.112-3.654v21.979h-25.112zM48.669 26.69l-0.006 21.979-25.112-3.533v-18.446zM20.41 44.736l-18.824-2.58-0.001-15.466h18.825z"></path></svg>
           Windows Installer
-          <p class="small color-lightgray">node-{{version}}-x86.msi</p>
+          <p class="small color-lightgray">node-{{version.node}}-x86.msi</p>
         </a>
       </li>
       <li>
-        <a href="https://nodejs.org/dist/{{version}}/node-{{version}}.pkg">
+        <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M39.054 34.065q-1.093 3.504-3.448 7.009-3.617 5.495-7.205 5.495-1.374 0-3.925-0.897-2.411-0.897-4.233-0.897-1.71 0-3.981 0.925-2.271 0.953-3.701 0.953-4.261 0-8.439-7.261-4.121-7.317-4.121-14.102 0-6.392 3.168-10.485 3.14-4.037 7.962-4.037 2.019 0 4.962 0.841 2.916 0.841 3.869 0.841 1.262 0 4.009-0.953 2.86-0.953 4.85-0.953 3.336 0 5.972 1.822 1.458 1.009 2.916 2.804-2.215 1.878-3.196 3.308-1.822 2.635-1.822 5.803 0 3.476 1.934 6.252t4.43 3.533zM28.512 1.179q0 1.71-0.813 3.813-0.841 2.103-2.607 3.869-1.514 1.514-3.028 2.019-1.037 0.308-2.916 0.477 0.084-4.177 2.187-7.205 2.075-3 7.009-4.149 0.028 0.084 0.070 0.308t0.070 0.308q0 0.112 0.014 0.28t0.014 0.28z"></path></svg>
           Macintosh Installer
-          <p class="small color-lightgray">node-{{version}}.pkg</p>
+          <p class="small color-lightgray">node-{{version.node}}.pkg</p>
         </a>
       </li>
       <li>
-        <a href="https://nodejs.org/dist/{{version}}/node-{{version}}.tar.gz">
+        <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.tar.gz">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M25.030 0.934l-24.871 10.716 24.895 10.632 25.152-10.656-25.176-10.691zM26.050 23.62v25.686l24.188-11.483v-24.478l-24.188 10.275zM0.001 37.824l24.27 11.483v-25.686l-24.27-10.275v24.478z"></path></svg>
           Source Code
-          <p class="small color-lightgray">node-{{version}}.tar.gz</p>
+          <p class="small color-lightgray">node-{{version.node}}.tar.gz</p>
         </a>
       </li>
     </ul>
@@ -43,36 +43,36 @@
     <tbody>
       <tr>
         <th>Windows Installer (.msi)</th>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-x86.msi">32-bit</a></td>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-x64.msi">64-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x86.msi">32-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x64.msi">64-bit</a></td>
       </tr>
 
       <tr>
         <th>Windows Binary (.exe)</th>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/win-x86/node.exe">32-bit</a></td>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/win-x64/node.exe">64-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/win-x86/node.exe">32-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/win-x64/node.exe">64-bit</a></td>
       </tr>
 
       <tr>
         <th>Mac OS X Installer (.pkg)</th>
-        <td colspan="6"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}.pkg">64-bit</a></td>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit</a></td>
       </tr>
 
       <tr>
         <th>Mac OS X Binaries (.tar.gz)</th>
-        <td colspan="6"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-darwin-x64.tar.gz">64-bit</a></td>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
       </tr>
 
       <tr>
         <th>Linux Binaries (.tar.xz)</th>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x86.tar.xz">32-bit</a></td>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-x64.tar.xz">64-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x86.tar.xz">32-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x64.tar.xz">64-bit</a></td>
       </tr>
 
       <tr>
         <th>Source Code</th>
         <td colspan="6">
-          <a href="https://nodejs.org/dist/{{version}}/node-{{version}}.tar.gz">node-{{version}}.tar.gz</a>
+          <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.tar.gz">node-{{version.node}}.tar.gz</a>
         </td>
       </tr>
     </tbody>

--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -4,15 +4,15 @@
     <tbody>
       <tr>
         <th>ARM Binaries (.tar.xz)</th>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv6l.tar.xz">ARMv6</a></td>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-armv7l.tar.xz">ARMv7</a></td>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-arm64.tar.xz">ARMv8</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv6l.tar.xz">ARMv6</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv7l.tar.xz">ARMv7</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-arm64.tar.xz">ARMv8</a></td>
       </tr>
 
       <tr>
         <th>SunOS Binaries (.tar.xz)</th>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x86.tar.xz">32-bit</a></td>
-        <td colspan="3"><a href="https://nodejs.org/dist/{{version}}/node-{{version}}-sunos-x64.tar.xz">64-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x86.tar.xz">32-bit</a></td>
+        <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x64.tar.xz">64-bit</a></td>
       </tr>
 
       <tr>
@@ -23,7 +23,7 @@
       <tr>
         <th>Linux on Power Systems</th>
         <td colspan="3">
-          <a href="https://nodejs.org/dist/{{version}}/node-{{version}}-linux-ppc64le.tar.xz">64-bit le</a>
+          <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit le</a>
           <span>Official Node.js release</span>
         </td>
         <td colspan="3">

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -2,9 +2,16 @@
 
 const semver = require('semver')
 
-exports.current = (releases) => {
-  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
-  return match && match.version
+const map = (release) => release && {
+  node: release.version,
+  npm: release.npm,
+  v8: release.v8,
+  openssl: release.openssl
 }
 
-exports.lts = (releases) => releases.find((release) => release.lts).version
+exports.current = (releases) => {
+  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
+  return map(match)
+}
+
+exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/plugins/navigation.js
+++ b/scripts/plugins/navigation.js
@@ -2,7 +2,7 @@
 
 // Extracts the main menu and sub-menu links form locale's site.json and
 // adds them to the metadata. This data is used in the navigation template
-module.exports = function buildNavigation (currentVersions) {
+module.exports = function buildNavigation (latestVersions) {
   return function (files, metalsmith, done) {
     const meta = metalsmith.metadata()
     meta.nav = {}
@@ -18,10 +18,10 @@ module.exports = function buildNavigation (currentVersions) {
         if (obj[key].link && obj[key].text) {
           // Insert latest versions for API docs
           if (key === 'api-current') {
-            obj[key].text = obj[key].text.replace(/%ver%/, currentVersions.current)
+            obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.current.node)
           }
           if (key === 'api-lts') {
-            obj[key].text = obj[key].text.replace(/%ver%/, currentVersions.lts)
+            obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.lts.node)
           }
 
           meta.nav[level] = meta.nav[level] || parent

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -22,7 +22,7 @@ test('latestversion.current()', (t) => {
       { version: 'v0.12.7', lts: false }
     ])
 
-    t.equal(currentVersion, 'v5.0.0')
+    t.equal(currentVersion.node, 'v5.0.0')
     t.end()
   })
 
@@ -36,7 +36,7 @@ test('latestversion.lts()', (t) => {
       { version: 'v0.12.7', lts: false }
     ])
 
-    t.equal(ltsVersion, 'v4.2.1')
+    t.equal(ltsVersion.node, 'v4.2.1')
     t.end()
   })
 
@@ -48,7 +48,7 @@ test('latestversion.lts()', (t) => {
       { version: 'v0.12.7', lts: false }
     ])
 
-    t.equal(ltsVersion, 'v4.2.1')
+    t.equal(ltsVersion.node, 'v4.2.1')
     t.end()
   })
 


### PR DESCRIPTION
Exposes versions of node, npm, v8 and openssl for templates.

![](https://cloud.githubusercontent.com/assets/153481/15207609/812e18e8-1827-11e6-823f-d486545263b2.png)
