### PR TITLE
Use Object.assign instead of util._extend

### DIFF
--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const extend = require('util')._extend
 const semver = require('semver')
 
 const postMergeDownloads = [
@@ -120,7 +119,7 @@ const legacyDownloads = [
 
 function resolveUrl (item, version) {
   const url = item.templateUrl.replace(/%version%/g, version)
-  return extend({ url }, item)
+  return Object.assign({ url }, item)
 }
 
 module.exports = (version) => {

--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -22,7 +22,6 @@
 
 const fs = require('fs')
 const path = require('path')
-const extend = require('util')._extend
 const Handlebars = require('handlebars')
 const request = require('request')
 const changelogUrl = require('changelog-url')
@@ -179,12 +178,12 @@ function urlOrComingSoon (binary) {
 function renderPost (results) {
   const templateStr = fs.readFileSync(path.resolve(__dirname, 'release.hbs')).toString('utf8')
   const template = Handlebars.compile(templateStr, { noEscape: true })
-  const view = extend({
+  const view = Object.assign({
     date: new Date().toISOString(),
     versionSlug: slugify(results.version)
   }, results)
 
-  return extend({
+  return Object.assign({
     content: template(view)
   }, results)
 }


### PR DESCRIPTION
`util._extend` has been deprecated. This patch replaces it with `Object.assign`.
