### PR TITLE
Fix  Korean for nodejs-ko

### DIFF
--- a/locale/en/about/working-groups.md
+++ b/locale/en/about/working-groups.md
@@ -160,7 +160,7 @@ Each language community maintains its own membership.
 * [nodejs-it - Italian (Italiano)](https://github.com/nodejs/nodejs-it)
 * [nodejs-ja - Japanese (日本語)](https://github.com/nodejs/nodejs-ja)
 * [nodejs-ka - Georgian (ქართული)](https://github.com/nodejs/nodejs-ka)
-* [nodejs-ko - Korean (조선말)](https://github.com/nodejs/nodejs-ko)
+* [nodejs-ko - Korean (한국어)](https://github.com/nodejs/nodejs-ko)
 * [nodejs-mk - Macedonian (Mакедонски)](https://github.com/nodejs/nodejs-mk)
 * [nodejs-ms - Malay (بهاس ملايو)](https://github.com/nodejs/nodejs-ms)
 * [nodejs-nl - Dutch (Nederlands)](https://github.com/nodejs/nodejs-nl)


### PR DESCRIPTION
This was changed in https://github.com/nodejs/nodejs.org/commit/41fe898c4e6a24dd0620e12519504d4545e7dda9 . I don't know why it was changed in the commit. But we use it "한국어" not "조선말". So, I revert it.(related with https://github.com/nodejs/nodejs-ko/issues/344 ) @nodejs-ko
