### PR TITLE
improve accessibility for header anchors

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -109,19 +109,17 @@
       <span id="logo-first" class="interactive-item">
         <img src="/static/images/interactive/nodejs-interactive-logo-center.png" />
       </span>
-      <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive-europe"
-        title="Node.js Interactive Europe">
+      <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive-europe">
         <img src="/static/images/interactive/nodejs-interactive-hero-banner-left-eu.png"
-          alt="Amsterdam, Netherlands, September 15-16, 2016"/>
+          alt="Node.js Interactive Europe, Amsterdam, Netherlands, September 15-16, 2016"/>
       </a>
       <span id="logo-center" class="interactive-item">
         <img src="/static/images/interactive/nodejs-interactive-logo-center.png"
           alt="Node.js Interactive" />
       </span>
-      <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive"
-        title="Node.js Interactive North America">
+      <a class="interactive-item" href="http://events.linuxfoundation.org/events/node-interactive">
         <img src="/static/images/interactive/nodejs-interactive-hero-banner-right-na.png"
-          alt="Austin, Texas, November 29-30, 2016" />
+          alt="Node.js Interactive North America, Austin, Texas, November 29-30, 2016" />
       </a>
     </div>
   </div>

--- a/scripts/plugins/anchor-markdown-headings.js
+++ b/scripts/plugins/anchor-markdown-headings.js
@@ -7,7 +7,8 @@ module.exports = function anchorMarkdownHeadings (text, level, raw) {
     .replace(/-{2,}/g, '-')
     .replace(/(^-|-$)/g, '')
     .toLowerCase()
-  return '<h' + level + '>' + text + '<a name="' +
+  return '<h' + level + ' id="header-' + escapedText + '">' + text + '<a name="' +
     escapedText + '" class="anchor" href="#' +
+    escapedText + '" aria-labelledby="header-' +
     escapedText + '"></a></h' + level + '>'
 }

--- a/tests/scripts/anchor-mardown-headings.test.js
+++ b/tests/scripts/anchor-mardown-headings.test.js
@@ -11,8 +11,9 @@ test('anchorMarkdownHeadings', (t) => {
     const level = 1
     const raw = 'Simple title'
     const output = anchorMarkdownHeadings(text, level, raw)
-    const expected = '<h1>Simple title<a name="simple-title" class="anchor" ' +
-      'href="#simple-title"></a></h1>'
+    const expected = '<h1 id="header-simple-title">Simple title' +
+      '<a name="simple-title" class="anchor" ' +
+      'href="#simple-title" aria-labelledby="header-simple-title"></a></h1>'
 
     t.plan(1)
     t.equal(output, expected)
@@ -23,8 +24,10 @@ test('anchorMarkdownHeadings', (t) => {
     const level = 3
     const raw = 'Title with [link](#)'
     const output = anchorMarkdownHeadings(text, level, raw)
-    const expected = '<h3>Title with <a href="#">link</a>' +
-      '<a name="title-with-link" class="anchor" href="#title-with-link"></a></h3>'
+    const expected = '<h3 id="header-title-with-link">Title with ' +
+      '<a href="#">link</a>' +
+      '<a name="title-with-link" class="anchor" href="#title-with-link" ' +
+      'aria-labelledby="header-title-with-link"></a></h3>'
 
     t.plan(1)
     t.equal(output, expected)
@@ -35,8 +38,10 @@ test('anchorMarkdownHeadings', (t) => {
     const level = 2
     const raw = 'a [b](b) c[d](d)e'
     const output = anchorMarkdownHeadings(text, level, raw)
-    const expected = '<h2>a <a href="b">b</a> c<a href="d">d</a>e' +
-      '<a name="a-b-cde" class="anchor" href="#a-b-cde"></a></h2>'
+    const expected = '<h2 id="header-a-b-cde">a <a href="b">b</a> c' +
+      '<a href="d">d</a>e' +
+      '<a name="a-b-cde" class="anchor" href="#a-b-cde" ' +
+      'aria-labelledby="header-a-b-cde"></a></h2>'
 
     t.plan(1)
     t.equal(output, expected)
@@ -47,8 +52,9 @@ test('anchorMarkdownHeadings', (t) => {
     const level = 4
     const raw = '$$$ WIN BIG! $$$'
     const output = anchorMarkdownHeadings(text, level, raw)
-    const expected = '<h4>$$$ WIN BIG! $$$' +
-      '<a name="win-big" class="anchor" href="#win-big"></a></h4>'
+    const expected = '<h4 id="header-win-big">$$$ WIN BIG! $$$' +
+      '<a name="win-big" class="anchor" href="#win-big" ' +
+      'aria-labelledby="header-win-big"></a></h4>'
 
     t.plan(1)
     t.equal(output, expected)


### PR DESCRIPTION
Anchors shouldn't be without a label, so this uses aria-labelledby to associate the existing header text with the anchor. Also revised the text on the home page after further review of the resulting content calculation.

Is it correct that the API docs anchors would need to be updated separately on the /node repo?
