### PR TITLE
template: modify ppcbe to serve official tarball

### DIFF
--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -24,11 +24,9 @@
         <th>Linux on Power Systems</th>
         <td colspan="3">
           <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit le</a>
-          <span>Official Node.js release</span>
         </td>
         <td colspan="3">
-          <a href="http://www.ibm.com/developerworks/web/nodesdk/">64-bit be</a>
-          <span>Unofficial, provided by IBM</span>
+          <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64.tar.xz">64-bit be</a>
         </td>
       </tr>
 


### PR DESCRIPTION
We are now building ppcbe in production so we should be serving
that from the website

_note_: do not land this until a new version of v4.x is cut. The next
release will include ppcbe, and we can avoid a bunch of nasty custom
code in the meantime.

/cc @mhdawson
