### PR TITLE
Update chokidar to version 1.5.1 and octonode to version 0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "autoprefixer-stylus": "0.9.3",
     "cheerio": "0.20.0",
-    "chokidar": "1.5.0",
+    "chokidar": "1.5.1",
     "handlebars": "4.0.5",
     "html-to-text": "2.1.0",
     "js-yaml": "3.6.1",
@@ -55,7 +55,7 @@
     "ncp": "2.0.0",
     "node-geocoder": "3.10.0",
     "node-version-data": "1.0.1",
-    "octonode": "0.7.5",
+    "octonode": "0.7.6",
     "request": "2.72.0",
     "require-dir": "0.3.0",
     "semver": "5.1.0",


### PR DESCRIPTION
- [`chokidar@1.5.1`](https://github.com/paulmillr/chokidar/compare/1.5.0...1.5.1)
- [`octonode@0.7.6`](https://github.com/pksunkara/octonode/compare/e56e8cca71e52f651352785cfa69bcdf57e29c06...95ce8e61f71216359ab34440ce3dc1dc9bc323af)
