### PR TITLE
Make the event-geo script work on Windows

### DIFF
--- a/scripts/event-geo.js
+++ b/scripts/event-geo.js
@@ -1,17 +1,16 @@
 'use strict'
+
+const htmlToText = require('html-to-text')
 const yaml = require('js-yaml')
 const fs = require('fs')
 const path = require('path')
-let p = path.join(__dirname, '..', 'locale', 'en', 'get-involved', 'events.md')
-let htmlToText = require('html-to-text')
+
+const p = path.join(__dirname, '..', 'locale', 'en', 'get-involved', 'events.md')
 
 function load () {
-  let buf = fs.readFileSync(p)
-  let lines = buf.toString().split('\n')
-  let str = lines.slice(lines.indexOf('---') + 1, lines.indexOf('---', lines.indexOf('---') + 1)).join('\n')
-  let store = yaml.safeLoad(str)
-
-  return store
+  // Slice the file contents to get the YAML source code.
+  const contents = fs.readFileSync(p, { encoding: 'utf8' }).trim().slice(3, -3)
+  return yaml.safeLoad(contents)
 }
 
 // { type: 'Feature',


### PR DESCRIPTION
We are now [`splitting`](https://github.com/nodejs/nodejs.org/blob/c32b2b37fc703f881d98a36e010609a896669a55/scripts/event-geo.js#L10) the `events.md` file contents using the `\n` end-of-line marker.
This doesn't work as expected on Windows because lines are terminated with `\r\n`. As result [`lines.indexOf('---')`](https://github.com/nodejs/nodejs.org/blob/c32b2b37fc703f881d98a36e010609a896669a55/scripts/event-geo.js#L11) returns `-1` making the `load()` function fail.

This patch fixes the issue.
