### PR TITLE
Update changelog links

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -32,7 +32,7 @@
               <a href="https://nodejs.org/{{site.locale}}/download/">{{ labels.other-downloads }}</a>
             </li>
             <li>
-              <a href="https://github.com/nodejs/node/blob/{{ project.latestVersions.lts.node }}/CHANGELOG.md">{{ labels.changelog }}</a>
+              <a href="{{changeloglink project.latestVersions.lts.node}}">{{ labels.changelog }}</a>
             </li>
             <li>
               <a href="{{majorapidocslink project.latestVersions.lts.node}}">{{ labels.api }}</a>
@@ -54,7 +54,7 @@
                 <a href="https://nodejs.org/{{site.locale}}/download/current/">{{ labels.other-downloads }}</a>
               </li>
               <li>
-                <a href="https://github.com/nodejs/node/blob/{{ project.latestVersions.current.node }}/CHANGELOG.md">{{ labels.changelog }}</a>
+                <a href="{{changeloglink project.latestVersions.current.node}}">{{ labels.changelog }}</a>
               </li>
               <li>
                 <a href="{{majorapidocslink project.latestVersions.current.node}}">{{ labels.api }}</a>

--- a/scripts/helpers/changeloglink.js
+++ b/scripts/helpers/changeloglink.js
@@ -3,15 +3,17 @@
 const semver = require('semver')
 
 module.exports = (version) => {
-  if (!version) { return '' }
+  if (!semver.valid(version)) return ''
 
-  if (semver.satisfies(version, '>= 1.0.0')) {
-    return `https://github.com/nodejs/node/blob/${version}/CHANGELOG.md`
-  }
+  const changelogs = 'https://github.com/nodejs/node/blob/master/doc/changelogs'
+  const clean = semver.clean(version)
+  const major = semver.major(clean)
+  const minor = semver.minor(clean)
 
-  // 0.12.8+ and 0.10.41+ releases come from the new repo
-  if (semver.satisfies(version, '~0.12.8 || ~0.10.41')) {
-    return `https://github.com/nodejs/node/blob/${version}/ChangeLog`
+  if (major >= 4) return `${changelogs}/CHANGELOG_V${major}.md#${clean}`
+  if (major >= 1) return `${changelogs}/CHANGELOG_IOJS.md#${clean}`
+  if (minor === 12 || minor === 10) {
+    return `${changelogs}/CHANGELOG_V${major}${minor}.md#${clean}`
   }
 
   return `https://github.com/nodejs/node-v0.x-archive/blob/${version}/ChangeLog`


### PR DESCRIPTION
This updates the changelog links (#775) in accordance with the new changelog structure.
The affected pages are:
- https://nodejs.org/en/
- https://nodejs.org/en/download/releases/
