### PR TITLE
Updating Amazon Linux Version

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -176,7 +176,7 @@ yum install gcc-c++ make
 **Other distributions known to be supported:**
 
 * **Oracle Linux** (mirrors RHEL very closely)
-* **Amazon Linux** (tested on 2014.03)
+* **Amazon Linux** (tested on 2016.03)
 
 ### Alternatives
 


### PR DESCRIPTION
I just verified that the package manager install steps work on the newest version of Amazon Linux (2016.3.3), so I'm updating the version on the package manager page.
