### PR TITLE
add Bryan Hughes @nebruis to the TSC list

### DIFF
--- a/locale/en/foundation/tsc/index.md
+++ b/locale/en/foundation/tsc/index.md
@@ -26,6 +26,7 @@ can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/pe
 * Ben Noordhuis ([bnoordhuis](https://github.com/bnoordhuis))
 * Bert Belder ([piscisaureus](https://github.com/piscisaureus))
 * Brian White ([mscdex](https://github.com/mscdex))
+* Bryan Hughes ([nebrius](https://github.com/nebrius))
 * Chris Dickinson ([chrisdickinson](https://github.com/chrisdickinson))
 * Colin Ihrig ([cjihrig](https://github.com/cjihrig))
 * Fedor Indutny ([indutny](https://github.com/indutny))


### PR DESCRIPTION
The TSC confirmed the addition of Bryan Hughes @nebrius to the TSC at their last meeting. The TSC repo was updated via https://github.com/nodejs/TSC/pull/108. This PR just syncs the change to the website's list.
