### PR TITLE
Add direct link to SHASUMS file in download page

### DIFF
--- a/layouts/partials/download-list.hbs
+++ b/layouts/partials/download-list.hbs
@@ -1,5 +1,6 @@
 <section>
   <ul>
+    <li><a href="https://nodejs.org/dist/{{version.node}}/SHASUMS256.txt.asc">{{site.shasums}}</a></li>
     <li><a href="https://nodejs.org/dist/{{version.node}}">{{site.all-downloads}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}">{{site.download.package-manager.text}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.releases.link}}/">{{site.download.releases.text}}</a></li>

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -9,6 +9,7 @@
     "getHelpIssue": "Get Help",
     "by": "by",
     "all-downloads": "All download options",
+    "shasums": "Signed SHASUMS for release files",
     "nightly": "Nightly builds",
     "feeds": [
         {


### PR DESCRIPTION
As discussed in #742 it would be nice to have the shasums of the release files directly in the download page to improve the UX.

Before merging please read this [comment](https://github.com/nodejs/nodejs.org/issues/742#issuecomment-231024561) and share your thoughts.
