### PR TITLE
Adding shasum links for release files to download page (#742)

### DIFF
--- a/layouts/partials/download-list.hbs
+++ b/layouts/partials/download-list.hbs
@@ -1,5 +1,6 @@
 <section>
   <ul>
+    <li><a href="https://nodejs.org/dist/{{version.node}}/{{site.download.shasums.link}}">{{site.download.shasums.text}}</a></li>
     <li><a href="https://nodejs.org/dist/{{version.node}}">{{site.all-downloads}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}">{{site.download.package-manager.text}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.releases.link}}/">{{site.download.releases.text}}</a></li>

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -71,6 +71,10 @@
         "package-manager": {
             "link": "download/package-manager",
             "text": "Installing Node.js via package manager"
+        },
+        "shasums":{
+          "link": "SHASUMS256.txt.asc",
+          "text": "Signed SHASUMS for release files"
         }
     },
     "docs": {


### PR DESCRIPTION
I opened #742 to improve the usability regarding retrieving SHASUM for the releases (something I do quite frequently). As discussed there this adds the link to the SHASUMs on the /download page. There is already another PR. The main difference is: I included the shamus text in the `download` section of `locale/en/site.json` (and this one is from 20 May but I forgot to push it :-) ) 
