### PR TITLE
Make the release-post script more tolerant

### DIFF
--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -103,7 +103,7 @@ function fetchChangelog (version) {
     const rxSection = new RegExp(`<a id="${version}"></a>\\n([\\s\\S]+?)(?:\\n<a id="|$)`)
     const matches = rxSection.exec(data)
     return matches
-      ? matches[1]
+      ? matches[1].trim()
       : Promise.reject(new Error(`Couldn't find matching changelog for ${version}`))
   })
 }

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -117,6 +117,8 @@ test('fetchChangelog(<version>)', (t) => {
       .replyWithFile(200, changelogFixture)
 
     releasePost.fetchChangelog('4.1.1').then((changelog) => {
+      t.true(changelog.charAt(changelog.length - 1) !== '\n')
+      t.true(changelog.charAt(0) !== '\n')
       t.true(changelog.includes('Fixed a bug introduced in v4.1.0'))
       t.true(github.isDone(), 'githubusercontent.com was requested')
 


### PR DESCRIPTION
Right now the release script does not work if a release section starts with a new line.
This patch fixes the issue by removing any leading or trailing new line.
