### PR TITLE
Replace Object.assign with lodash.defaultsDeep

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,6 +14,7 @@ const prism = require('metalsmith-prism')
 const stylus = require('metalsmith-stylus')
 const permalinks = require('metalsmith-permalinks')
 const pagination = require('metalsmith-yearly-pagination')
+const defaultsDeep = require('lodash.defaultsdeep')
 const marked = require('marked')
 const path = require('path')
 const fs = require('fs')
@@ -48,7 +49,7 @@ function i18nJSON (lang) {
   const defaultJSON = require(`./locale/${DEFAULT_LANG}/site.json`)
   const templateJSON = require(`./locale/${lang}/site.json`)
 
-  return Object.assign({}, defaultJSON, templateJSON)
+  return defaultsDeep({}, templateJSON, defaultJSON)
 }
 
 // This is the function where the actual magic happens. This contains the main

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "html-to-text": "2.1.3",
     "js-yaml": "3.6.1",
     "junk": "1.0.3",
+    "lodash.defaultsdeep": "4.5.1",
     "map-async": "0.1.1",
     "marked": "0.3.5",
     "metalsmith": "2.1.0",


### PR DESCRIPTION
`Object.assign` does not work recursively so it's not suitable to merge the localization [data](https://github.com/nodejs/nodejs.org/blob/557f1e7f0bad5b26a66e0b2327ea270349397902/build.js#L48-L49).
If a nested item is missing from [`templateJSON`](https://github.com/nodejs/nodejs.org/blob/557f1e7f0bad5b26a66e0b2327ea270349397902/build.js#L49) that item will not be included in the final object, despite it being available in [`defaultJSON`](https://github.com/nodejs/nodejs.org/blob/557f1e7f0bad5b26a66e0b2327ea270349397902/build.js#L48).

This patch should fix the issue.

Ref: https://github.com/nodejs/nodejs.org/pull/847
