### PR TITLE
Uppercase Node.js in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The original contents of the nodejs.org repo are licensed for use as follows:
 
 """
-Copyright node.js Website WG contributors. All rights reserved.
+Copyright Node.js Website WG contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
There has been an initiative to unify how we write "Node.js", this minor change fixes that in our LICENSE file.

..this also serves as a test to check if the @nodejs-github-bot webhook still works after being moved to a new server.
