### PR TITLE
Make the download script follow the standard style

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "standard": {
     "ignore": [
-      "static/"
+      "static/js/modernizr.custom.js",
+      "static/legacy/*"
     ]
   },
   "dependencies": {

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -1,79 +1,82 @@
 ;
 (function (d, n) {
-  'use strict';
+  'use strict'
 
   // document.querySelectorAll polyfill for ancient IEs
   // https://gist.github.com/chrisjlee/8960575
   if (!document.querySelectorAll) {
     document.querySelectorAll = function (selectors) {
-      var style = document.createElement('style'), elements = [], element;
-      document.documentElement.firstChild.appendChild(style);
-      document._qsa = [];
+      var style = document.createElement('style')
+      var elements = []
+      var element
 
-      style.styleSheet.cssText = selectors + '{x-qsa:expression(document._qsa && document._qsa.push(this))}';
-      window.scrollBy(0, 0);
-      style.parentNode.removeChild(style);
+      document.documentElement.firstChild.appendChild(style)
+      document._qsa = []
+
+      style.styleSheet.cssText = selectors + '{x-qsa:expression(document._qsa && document._qsa.push(this))}'
+      window.scrollBy(0, 0)
+      style.parentNode.removeChild(style)
 
       while (document._qsa.length) {
-        element = document._qsa.shift();
-        element.style.removeAttribute('x-qsa');
-        elements.push(element);
+        element = document._qsa.shift()
+        element.style.removeAttribute('x-qsa')
+        elements.push(element)
       }
-      document._qsa = null;
-      return elements;
-    };
+      document._qsa = null
+      return elements
+    }
   }
 
-  var osMatch = n.platform.match(/(Win|Mac|Linux)/);
-  var os = (osMatch && osMatch[1]) || '';
+  var osMatch = n.platform.match(/(Win|Mac|Linux)/)
+  var os = (osMatch && osMatch[1]) || ''
   var arch = n.userAgent.match(/x86_64|Win64|WOW64/) ||
-    n.cpuClass === 'x64' ? 'x64' : 'x86';
-  var text = 'textContent' in d ? 'textContent' : 'innerText';
-  var buttons = d.querySelectorAll('.home-downloadbutton');
-  var downloadHead = d.getElementById('home-downloadhead');
-  var dlLocal;
+    n.cpuClass === 'x64' ? 'x64' : 'x86'
+  var text = 'textContent' in d ? 'textContent' : 'innerText'
+  var buttons = d.querySelectorAll('.home-downloadbutton')
+  var downloadHead = d.getElementById('home-downloadhead')
+  var dlLocal
 
-  function versionIntoHref(nodeList, filename) {
-    var linkEls = Array.prototype.slice.call(nodeList);
-    var version;
-    var el;
+  function versionIntoHref (nodeList, filename) {
+    var linkEls = Array.prototype.slice.call(nodeList)
+    var version
+    var el
 
     for (var i = 0; i < linkEls.length; i++) {
-      version = linkEls[i].getAttribute('data-version');
+      version = linkEls[i].getAttribute('data-version')
       el = linkEls[i]
 
       // Windows 64-bit files for 0.x.x need to be prefixed with 'x64/'
       if (os === 'Win' && (version[1] === '0' && arch === 'x64')) {
-        el.href += arch + '/';
+        el.href += arch + '/'
       }
 
-      el.href += filename.replace('%version%', version);
+      el.href += filename.replace('%version%', version)
     }
   }
 
   if (downloadHead && buttons) {
-    dlLocal = downloadHead.getAttribute('data-dl-local');
+    dlLocal = downloadHead.getAttribute('data-dl-local')
     switch (os) {
       case 'Mac':
-        versionIntoHref(buttons, 'node-%version%.pkg');
-        downloadHead[text] = dlLocal + ' OS X (x64)';
-        break;
+        versionIntoHref(buttons, 'node-%version%.pkg')
+        downloadHead[text] = dlLocal + ' OS X (x64)'
+        break
       case 'Win':
-        versionIntoHref(buttons, 'node-%version%-' + arch + '.msi');
-        downloadHead[text] = dlLocal + ' Windows (' + arch +')';
-        break;
+        versionIntoHref(buttons, 'node-%version%-' + arch + '.msi')
+        downloadHead[text] = dlLocal + ' Windows (' + arch + ')'
+        break
       case 'Linux':
-        versionIntoHref(buttons, 'node-%version%-linux-' + arch + '.tar.xz');
-        downloadHead[text] = dlLocal + ' Linux (' + arch + ')';
-        break;
+        versionIntoHref(buttons, 'node-%version%-linux-' + arch + '.tar.xz')
+        downloadHead[text] = dlLocal + ' Linux (' + arch + ')'
+        break
     }
   }
 
   // Windows button on download page
-  var winButton = d.getElementById('windows-downloadbutton');
+  var winButton = d.getElementById('windows-downloadbutton')
   if (winButton && os === 'Win') {
-    var winText = winButton.getElementsByTagName('p')[0];
-    winButton.href = winButton.href.replace(/x(86|64)/, arch);
-    winText[text] = winText[text].replace(/x(86|64)/, arch);
+    var winText = winButton.getElementsByTagName('p')[0]
+    winButton.href = winButton.href.replace(/x(86|64)/, arch)
+    winText[text] = winText[text].replace(/x(86|64)/, arch)
   }
-})(document, navigator);
+})(document, navigator)


### PR DESCRIPTION
This fixes the style of [`download.js`](https://github.com/nodejs/nodejs.org/blob/e0fe46531491965579da53e21e4c70c40cbdd716/static/js/download.js) as suggested in #851.
I've run `standard --fix static/js/download.js` to fix it.
