### PR TITLE
Respect visitor's Do-Not-Track setting

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -126,6 +126,18 @@
 
   {{> footer className="no-margin-top" }}
   <script src="/static/js/download.js" async defer></script>
+  <script src="/static/js/dnt_helper.js"></script>
+  <script>
+    if (!_dntEnabled()) {
+      !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
+      (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
+      s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
+      s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
+
+      ga('create', 'UA-67020396-1', 'auto');
+      ga('send', 'pageview');
+    }
+    </script>
 
 </body>
 </html>

--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -21,13 +21,5 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600">
   <script>
   document.querySelector('html').className += " has-js";
-
-  !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
-    (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
-    s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
-    s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
-
-    ga('create', 'UA-67020396-1', 'auto');
-    ga('send', 'pageview');
     </script>
   </head>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "standard": {
     "ignore": [
       "static/js/modernizr.custom.js",
+      "static/js/dnt_helper.js",
       "static/legacy/*"
     ]
   },

--- a/static/js/dnt_helper.js
+++ b/static/js/dnt_helper.js
@@ -1,0 +1,49 @@
+/**
+ * http://schalkneethling.github.io/blog/2015/11/06/respect-user-choice-do-not-track/
+ * https://github.com/schalkneethling/dnt-helper/blob/master/js/dnt-helper.js
+ *
+ * Returns true or false based on whether doNotTack is enabled. It also takes into account the
+ * anomalies, such as !bugzilla 887703, which effect versions of Fx 31 and lower. It also handles
+ * IE versions on Windows 7, 8 and 8.1, where the DNT implementation does not honor the spec.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+ * @params {string} [dnt] - An optional mock doNotTrack string to ease unit testing.
+ * @params {string} [userAgent] - An optional mock userAgent string to ease unit testing.
+ * @returns {boolean} true if enabled else false
+ */
+function _dntEnabled(dnt, userAgent) {
+
+    'use strict';
+
+    // for old version of IE we need to use the msDoNotTrack property of navigator
+    // on newer versions, and newer platforms, this is doNotTrack but, on the window object
+    // Safari also exposes the property on the window object.
+    var dntStatus = dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+    var ua = userAgent || navigator.userAgent;
+
+    // List of Windows versions known to not implement DNT according to the standard.
+    var anomalousWinVersions = ['Windows NT 6.1', 'Windows NT 6.2', 'Windows NT 6.3'];
+
+    var fxMatch = ua.match(/Firefox\/(\d+)/);
+    var ieRegEx = /MSIE|Trident/i;
+    var isIE = ieRegEx.test(ua);
+    // Matches from Windows up to the first occurance of ; un-greedily
+    // http://www.regexr.com/3c2el
+    var platform = ua.match(/Windows.+?(?=;)/g);
+
+    // With old versions of IE, DNT did not exist so we simply return false;
+    if (isIE && typeof Array.prototype.indexOf !== 'function') {
+        return false;
+    } else if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
+        // Can't say for sure if it is 1 or 0, due to Fx bug 887703
+        dntStatus = 'Unspecified';
+    } else if (isIE && platform && anomalousWinVersions.indexOf(platform.toString()) !== -1) {
+        // default is on, which does not honor the specification
+        dntStatus = 'Unspecified';
+    } else {
+        // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
+        // If dntStatus is undefined, it will be set to Unspecified
+        dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
+    }
+
+    return dntStatus === 'Enabled' ? true : false;
+}


### PR DESCRIPTION
There's been raised some concern about our use of external web tracking/analytics service. In that discussion, there has been agreement that we at least should respect the visitor's Do-Not-Track setting in their browser.

Also moves the Google Analytics script to the bottom of the page, as tracking is _not_ top priority IMO, even though GA-scripts are async.

**SHOULD BE MERGED ON A SATURDAY**

Refs: https://github.com/nodejs/node/pull/6601#issuecomment-243876849
