### PR TITLE
Update ARM related wording on download page

### DIFF
--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -64,9 +64,16 @@
       </tr>
 
       <tr>
-        <th>Linux Binaries (.tar.xz)</th>
+        <th>Linux Binaries (x86/x64)</th>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x86.tar.xz">32-bit</a></td>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x64.tar.xz">64-bit</a></td>
+      </tr>
+
+      <tr>
+        <th>Linux Binaries (ARM)</th>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv6l.tar.xz">ARMv6</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv7l.tar.xz">ARMv7</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-arm64.tar.xz">ARMv8</a></td>
       </tr>
 
       <tr>

--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -3,14 +3,7 @@
   <table class="download-matrix full-width">
     <tbody>
       <tr>
-        <th>ARM Binaries (.tar.xz)</th>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv6l.tar.xz">ARMv6</a></td>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv7l.tar.xz">ARMv7</a></td>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-arm64.tar.xz">ARMv8</a></td>
-      </tr>
-
-      <tr>
-        <th>SunOS Binaries (.tar.xz)</th>
+        <th>SunOS Binaries</th>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x86.tar.xz">32-bit</a></td>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x64.tar.xz">64-bit</a></td>
       </tr>


### PR DESCRIPTION
- Renames "ARM binaries" to "Linux binaries (ARM)"
- Moves Linux ARM binaries to primary downloads
- Remove archive file extension where only one type is provided

Fixes #899
