### PR TITLE
Remove double properties in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,12 +9,5 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.js]
-indent_size = 2
-
 [*.md]
 trim_trailing_whitespace = false
-
-[package.json]
-indent_style = space
-indent_size = 2


### PR DESCRIPTION
There's no reason to duplicate any property in editorconfig. :bulb:
