### PR TITLE
remove banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -246,7 +246,7 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: true,
+          visible: false,
           content: 'Important <a href="/en/blog/vulnerability/june-2016-security-releases/">security upgrades</a> for recent V8 vulnerability'
         }
       }


### PR DESCRIPTION
The security banner is 3 months old. While it's nice to leave it up for
a good while, we risk people not seeing it (because they're used to it
always being there) when we change it for a new security update banner.

(I hope I did this correctly!)
