### PR TITLE
Update security banner for September releases

### DIFF
--- a/build.js
+++ b/build.js
@@ -247,7 +247,7 @@ function getSource (callback) {
         },
         banner: {
           visible: true,
-          content: 'Important <a href="/en/blog/vulnerability/june-2016-security-releases/">security upgrades</a> for recent V8 vulnerability'
+          content: 'Important <a href="/en/blog/vulnerability/september-2016-security-releases/">security upgrades</a> for recent OpenSSL and Node.js vulnerabilities'
         }
       }
     }


### PR DESCRIPTION
This updates the security banner on the front page for September releases.
It probably supersedes #910. 
