### PR TITLE
Add .eslintrc to ensure that editor plugins will use the correct config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}


### PR DESCRIPTION
I have a globally defined `.eslintrc` which is used by my editor plugin when a project specific `.eslintrc` is not found.
I don't use the `standard` style as my default so whenever I open a file in this project my editor turns into a Christmas tree with warnings and errors everywhere.

This adds a local `.eslintrc` which simply extends the `standard` config to fix the issue.
