### PR TITLE
Add Education initiatives and Outreachy to Foundation section of website

### DIFF
--- a/locale/en/foundation/education.md
+++ b/locale/en/foundation/education.md
@@ -1,0 +1,111 @@
+---
+title: Education Initiatives
+layout: foundation.hbs
+---
+
+## Education in Node.js
+
+Here we will ask fun questions like, 'what is education in [Node.js](https://nodejs.org/en/)?'
+
+Notice we didn't say 'answer'? Education initiatives from the Node.js Foundation explore what it means to be learning Node.js. Who uses it? How are folks learning it? How can we as a community make the experience better and inclusive for existing users and rad, diverse group of learners?
+
+A few people who are exploring this currently:
+
+- [Tracy Hinds](https://twitter.com/HackyGoLucky), Education Community Manager for the Node.js Foundation
+- Education Advisory Group for the Node.js Foundation
+- Lots of awesome community folks who have been doing cool stuff for a while in Node.js and deserve to be heard, like you!
+
+Please participate. [File issues, PRs, and create the community you'd like to be a part of](https://github.com/nodejs/education).
+
+
+### Roadmap
+
+This roadmap is a living document, and it is likely that priorities will change, but the items below should give some indication of education initiatives for this calendar year.
+
+**Certification**  
+
+The Node.js Foundation (in partnership with The Linux Foundation) will be performing the following tasks to build and ship the Node.js certification:
+
+- Define Certification(s), the number of levels (parallel or sequential), titles, program goals
+- Define Scope Statement of Certification
+- Define the in-browser hosted exam environment which will be provided to candidates. Must be exactly reproducible and consistent in function.
+- Conduct job task analysis(JTA) which is to define the Domains of work and corresponding Tasks within each domain a Certification Candidate should be able to perform
+- Define the exam blueprint containing the specific exam Domains and Tasks and their relevant weight within the exam(Domains and Tasks will be opensourced. Blueprint will be secure and not public facing, testrunner will also be opensourced).
+- Publish determined domains and tasks for ecosystem to prepare complementary trainings with ample notice.
+- Write performance-based exam items (problems to solve) based on the Domains and Tasks defined by the JTA
+    - Exam items must be written and formatted to comply with an auto-grade script that is run on answers provided (i.e. machine-gradeable)
+    - Consideration of non-English speaking users including items written in a way that they are translatable
+
+- Provide subject matter expert (SME) support and review to  
+    - Script and program the exam items
+    - Set-up Certification registration portal
+    - Deploy the exam
+
+- Conduct secure pilot testing (alpha, beta)
+- Determine the exam passing score via psychometrician-led standard setting process
+- Support the public launch of the exam including program marketing
+- Manage certification program including:
+    - Creation and documentation of program policies and procedures (Candidate Handbook, Candidate Agreement, etc.)
+    - Technical support and help desk
+    - Candidate appeals and sanctions considerations
+    - Regular SME advisory from cert advisory board and consultants
+    - Regular renewal of job analysis and item creation (example: every 3 years)
+
+
+Work may be organized into committees or subcommittees representing, but not limited to the following:
+
+- Job Analysis Committee--define the Domains of work and corresponding Tasks within each domain a Certification Candidate should be able to perform
+- Item Writing Committee--writing/developing the individual item tasks into problems for the exam.
+- Standard Setting Committee--will set the passing/cut score. This process is led by the psychometrician. Aggregation of scores weighted by the committee.
+- Certification Advisory Board--perspectives from industry experts for the cert lead(education community manager) for essential decisions related to standards, policies, and procedures of the certification.
+
+Work will be divided into collaborative group sessions and individual self-paced assignments in accordance with project schedule. Time commitments will vary.
+
+**Docs**  
+- Stay tuned and help your friends at the [Docs WG](https://github.com/nodejs/docs)
+
+**Resources for learning Node.js**  
+- Stay tuned and participate [in our convos](https://github.com/nodejs/education/issues/4)
+
+
+## Contact
+
+For questions about education initiatives or a little inspiration, please send an
+email to <a href="mailto:tracyhinds@linuxfoundation.org?subject=Education-questions">tracyhinds@linuxfoundation.org</a>.
+
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="//nodejs.us14.list-manage.com/subscribe/post?u=c7c2e114a827812354112c23b&amp;id=f5f8d4eddb" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+	<h2>Subscribe to get updates and give input for education initiatives</h2>
+<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+<div class="mc-field-group">
+	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+</label>
+	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div class="mc-field-group">
+	<label for="mce-FNAME">First Name </label>
+	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+</div>
+<div class="mc-field-group">
+	<label for="mce-LNAME">Last Name </label>
+	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+</div>
+	<div id="mce-responses" class="clear">
+		<div class="response" id="mce-error-response" style="display:none"></div>
+		<div class="response" id="mce-success-response" style="display:none"></div>
+	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c7c2e114a827812354112c23b_f5f8d4eddb" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->

--- a/locale/en/foundation/index.md
+++ b/locale/en/foundation/index.md
@@ -62,12 +62,9 @@ email to <a href="mailto:trademark@nodejs.org?subject=Trademark">trademark@nodej
 	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
 	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
 	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-    #mc_embed_signup form {
-     padding: 0px 0px 0px 0px;
-    }
 </style>
 <div id="mc_embed_signup">
-<form action="//nodejs.us14.list-manage.com/subscribe/post?u=c7c2e114a827812354112c23b&amp;id=e842100924" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<form action="//nodejs.us14.list-manage.com/subscribe/post?u=c7c2e114a827812354112c23b&amp;id=f006b61f29" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
 	<h2>Subscribe to our Node.js project newsletter mailing list</h2>
 <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
@@ -88,7 +85,7 @@ email to <a href="mailto:trademark@nodejs.org?subject=Trademark">trademark@nodej
 		<div class="response" id="mce-error-response" style="display:none"></div>
 		<div class="response" id="mce-success-response" style="display:none"></div>
 	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c7c2e114a827812354112c23b_e842100924" tabindex="-1" value=""></div>
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c7c2e114a827812354112c23b_f006b61f29" tabindex="-1" value=""></div>
     <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>
 </form>

--- a/locale/en/foundation/outreachy.md
+++ b/locale/en/foundation/outreachy.md
@@ -1,0 +1,100 @@
+---
+title: Outreachy + Node.js
+layout: foundation.hbs
+---
+
+### Outreachy
+
+**Welcome to Node.js + Outreachy**  
+Outreachy provides a collaborative environment in which newcomers from underrepresented backgrounds can get help working on their first contributions and a focused opportunity for them to dedicate a full-time effort to learning and contributing to FOSS. The program also assists people with finding mentors to help them with their projects. By participating in the program, interns develop a good understanding of the power of FOSS and skills necessary to continue contributing to it.  
+
+The Node.js project is excited to partner with Outreachy to invite newcomers with diverse perspectives into our community for the December 2016 cohort.  
+
+Participation is open internationally to all women (cis and trans), trans men, and genderqueer people. Additionally, it's open to residents and nationals of the United States of any gender who are Black/African American, Hispanic/Latin@, American Indian, Alaska Native, Native Hawaiian, or Pacific Islander. We are planning to expand the program to more participants from underrepresented backgrounds in the future.  
+
+**Quick links**
+
+- [The Node.js project on GitHub](https://github.com/nodejs/node)
+- [Getting started for applicants](https://wiki.gnome.org/Outreachy#Introduction)
+- [Mentor prep](https://wiki.gnome.org/Outreachy/Admin/InfoForMentors)
+
+**Schedule**
+
+- October 17: application deadline at 7pm UTC
+- October 17 - November 8: applicants are encouraged to continue making contributions for the project they applied for; submitted applications are open for editing
+- November 8: accepted participants announced on this page at 4pm UTC
+- December 6, 2016 - March 6, 2017: internship period
+
+**What is Node.js?**  
+From our guiding principles, "The goal of the Node.js project is to provide a JavaScript-based application development platform that is current, reliable, and stable.  
+
+Contributors to Node.js work on behalf of the community of users who build their applications and businesses with the Node.js platform. Accordingly, contributors must demonstrate an ongoing commitment, not only to the Project, but to the stability and vitality of the community as a whole...  
+
+The Node.js community is large, inclusive, and excited to enable as many users to contribute in whatever way they can. If you want to report an issue, help with documentation or contribute to the code base of the project, you’ve come to the right place."  
+
+**PARTICIPANTS**
+
+How can I familiarize myself with the community and project?
+
+- We’re on IRC! Connect to irc.freenode.net in the #node.js channel with an IRC client or connect in your web browser to the channel using [freenode's WebChat](http://webchat.freenode.net/?channels=node.js).
+
+- The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
+- Read more about our   [contributing](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md) and [collaborator](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md) guidelines  
+- Check out some of our [international communities](https://nodejs.org/en/get-involved/)  
+- Introduce yourself to the project's mentors and discuss what your tasks during the internship program would be.
+
+**How to apply and application tips**
+
+The application process is described in detail at https://wiki.gnome.org/OutreachProgramForWomen#Send_in_an_Application. A contribution is required and you answer questions when you apply. You are expected to work full-time on the internship although you can indicate any pre-planned time off in your application.  
+
+In order to make your application stronger, here are a few things you could consider including:
+
+- Previously worked projects/coding experience. If it is docs, related experience if any
+- What do you intend to learn from the selected project? Or rationale behind choosing the specific project
+- How do you think this internship is going to help you achieve what you wanted?
+- Your next choice of projects if your first choice is not available
+
+Also include information or link on your merged patch (which is a requirement to be considered for the internship). Please be available and responsive throughout the application period so we can work with you on improving your application.
+
+**Questions about the Node.js project?**
+
+With open source, just finding out where to ask your question can be intimidating. Email [Tracy Hinds](tracyhinds@linuxfoundation.org) if you have any questions during the application process and she’ll be happy to find the person most helpful, if she isn’t it.
+
+**MENTORS**
+
+For information about expectations for mentors and to volunteer to be a mentor, see [Outreachy mentors](https://wiki.gnome.org/Outreachy/Admin/InfoForMentors).
+
+The volunteer mentors are:
+
+- [Franziska Hinkelmann](https://plus.google.com/u/1/116713283748910059509?prsrc=4)
+- [Rich Trott](rtrott@gmail.com), IRC: Trott
+- [Dan Shaw](dshaw@nodesource.com), IRC: dshaw
+- [Myles Borins](mborins@us.ibm.com ), IRC: thealphanerd
+- [Priyanka Sulugodua Prakash Murthy](priyanka.sulugodu.prakash.murthy@intel.com)
+
+**Project administrator**
+
+- Tracy Hinds, Education Community Manager at the Node.js Foundation Reach her at [tracyhinds@linuxfoundation.org](tracyhinds@linuxfoundation.org) or on IRC: hackygolucky
+
+**PROJECTS**
+**Improve the vm module in Node.js core**  
+*Mentor:* [Franziska Hinkelmann](https://plus.google.com/u/1/116713283748910059509?prsrc=4)    
+The vm module is used in the Node.js command line and in DOM implementations, such as jsdom. Sadly, there are many open issues related to the module and it needs some love. Recent changes in V8, Node's JS engine, now make it possible to fix several of the issues and improve the vm code base significantly.    
+
+This project includes learning how to build and debug Node.js core, how the vm module is implemented, some Node internals about the global proxy, and how to use the V8 API. You will be coding in C++ and write tests in JavaScript. No worries if you're not too familiar with these languages, a desire to learn and curiosity are much more important than a fixed skill set.
+
+Mentor based in Europe.  
+https://github.com/nodejs/node/issues/6283
+
+
+**Project TBD**    
+[Rich Trott](rtrott@gmail.com)
+
+**Project TBD**  
+[Dan Shaw](dshaw@nodesource.com)
+
+**Project TBD**    
+[Myles Borins](mborins@us.ibm.com )
+
+**Project TBD**  
+[Priyanka Sulugodua Prakash Murthy](priyanka.sulugodu.prakash.murthy@intel.com)

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -128,6 +128,14 @@
         "announce": {
             "link": "foundation/announcements",
             "text": "Announcements"
+        },
+        "education": {
+            "link": "foundation/education",
+            "text": "Education Initiatives"
+        },
+        "outreachy": {
+            "link": "foundation/outreachy",
+            "text": "Outreachy + Node.js"
         }
     },
     "getinvolved": {


### PR DESCRIPTION
This adds two subsections to nodejs.org/foundation as discussed in [this thread](https://github.com/nodejs/nodejs.org/issues/908),
- Education initiatives: so more people can know what's up with things going on with my work and coordinating efforts across the community for learning Node.js.
- Outreachy(effort to get underrepresented groups contributing to core via an internship and the independent page is required as part of the Node.js project participation with Outreachy)

Separate PR forthcoming adding 'Learn' as top-level and rearranging where some things go, such as 'Foundation' as also mentioned in the above-linked thread.

Thanks!
