### PR TITLE
Blog: fix CVE ID for writeHead() bug / CVE-2016-5326

### DIFF
--- a/locale/en/blog/vulnerability/september-2016-security-releases.md
+++ b/locale/en/blog/vulnerability/september-2016-security-releases.md
@@ -35,7 +35,9 @@ Originally reported by Alexander Minozhenko and James Bunton (Atlassian).
 
 All versions of Node.js are **affected**.
 
-### CVE-2016-5325: `reason` argument in `ServerResponse#writeHead()` not properly validated
+### CVE-2016-5326: `reason` argument in `ServerResponse#writeHead()` not properly validated
+
+***Update 1-Oct-2016: this was originally reported as CVE-2016-5325, it has been updated with the correct ID, CVE-2016-5326***
 
 This is a low severity security defect that that may make [HTTP response splitting](https://en.wikipedia.org/wiki/HTTP_response_splitting) possible under certain circumstances. If user-input is passed to the `reason` argument to `writeHead()` on an HTTP response, a new-line character may be used to inject additional responses.
 


### PR DESCRIPTION
/cc @nodejs/security 
