### PR TITLE
Revert "Blog: fix CVE ID for writeHead() bug / CVE-2016-5326"

### DIFF
--- a/locale/en/blog/vulnerability/september-2016-security-releases.md
+++ b/locale/en/blog/vulnerability/september-2016-security-releases.md
@@ -35,9 +35,7 @@ Originally reported by Alexander Minozhenko and James Bunton (Atlassian).
 
 All versions of Node.js are **affected**.
 
-### CVE-2016-5326: `reason` argument in `ServerResponse#writeHead()` not properly validated
-
-***Update 1-Oct-2016: this was originally reported as CVE-2016-5325, it has been updated with the correct ID, CVE-2016-5326***
+### CVE-2016-5325: `reason` argument in `ServerResponse#writeHead()` not properly validated
 
 This is a low severity security defect that that may make [HTTP response splitting](https://en.wikipedia.org/wiki/HTTP_response_splitting) possible under certain circumstances. If user-input is passed to the `reason` argument to `writeHead()` on an HTTP response, a new-line character may be used to inject additional responses.
 


### PR DESCRIPTION
Reverts nodejs/nodejs.org#930

@nodejs/security darn it, digging further I've realised that it was actually correct as is! CVE-2016-5326 is for a separate issue that we have decided not to handle as a security problem afterall and CVE-2016-5325 is the one we were going to fix in June but deferred and are now releasing, so it was right all along! Sorry for the confusion!
