### PR TITLE
Update links for AIX and Linux on Z downloads

### DIFF
--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -25,11 +25,11 @@
 
       <tr>
         <th>Linux on System z</th>
-        <td colspan="6"><a href="http://www.ibm.com/developerworks/web/nodesdk/">Download (Unofficial, provided by IBM)</a></td>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-s390x.tar.xz">64-bit</a></td>
       </tr>
       <tr>
         <th>AIX on Power Systems</th>
-        <td colspan="6"><a href="http://www.ibm.com/developerworks/web/nodesdk/">Download (Unofficial, provided by IBM)</a></td>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-aix-ppc64.tar.gz">64-bit</a></td>
       </tr>
     </tbody>
   </table>

--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -40,6 +40,18 @@ const postMergeDownloads = [
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-ppc64le.tar.xz'
   },
   {
+    'title': 'Linux PPC BE 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-ppc64.tar.xz'
+  },
+  {
+    'title': 'Linux s390x 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-linux-s390x.tar.xz'
+  },
+  {
+    'title': 'AIX 64-bit Binary',
+    'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-aix-ppc64.tar.gz'
+  },
+  {
     'title': 'SunOS 32-bit Binary',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-sunos-x86.tar.xz'
   },


### PR DESCRIPTION
**NOTE:** This should not land until 6.X becomes LTS.  This is because binaries exist only for 6.X and later and I've not special cases LTS or Current.  Once 6.X becomes LTS then binaries will be available for both LTS and Current.

I'd like to get this reviewed in advance so that ideally it can land on the same day that 6.X becomes LTS.

Now that binaries are being built as part of release:
- Update the links for AIX and Linux on Z on the download
  page so that they point to the binaries available on
  the community download site instead of the
  external IBM download page.
- Add AIX, Linux s390x and Linux PPC BE to the helper
  used to generate release announcements.
