### PR TITLE
change label for download to no longer say Current

### DIFF
--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -11,7 +11,7 @@ downloads:
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: Current version
+    currentVersion: Latest Current Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -11,7 +11,7 @@ downloads:
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: Current version
+    currentVersion: Latest LTS Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms


### PR DESCRIPTION
This made sense prior to Stable being change to Current, now it is
just confusing.

Fixes: https://github.com/nodejs/nodejs.org/issues/944

Before: 

<img width="487" alt="c3c4de02-8d94-11e6-86b0-d66d0bb9ea68" src="https://cloud.githubusercontent.com/assets/498775/19222192/af6d380a-8e20-11e6-91e0-c9d3748bb0fa.png">

After:

<img width="1015" alt="screen shot 2016-10-09 at 1 01 15 pm" src="https://cloud.githubusercontent.com/assets/498775/19222193/b4eba866-8e20-11e6-80c3-28afe093c90a.png">

<img width="1002" alt="screen shot 2016-10-09 at 1 03 07 pm" src="https://cloud.githubusercontent.com/assets/498775/19222198/c0735940-8e20-11e6-929e-474eace301c0.png">
