### PR TITLE
Translate about of docs section into Japanese

### DIFF
--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -9,7 +9,7 @@ labels:
 # ドキュメント
 
 <!-- There are three types of documentation available on this website: -->
-このサイトには 3 種類ののドキュメントがあります：
+ここには 3 種類のドキュメントがあります：
 
 <!-- * API reference documentation -->
 <!-- * ES6 features -->
@@ -22,15 +22,14 @@ labels:
 ### API リファレンス
 
 <!-- The [API reference documentation](/api/) provides detailed information about a function or object in Node.js. This documentation indicates what arguments a method accepts, the return value of that method, and what errors may be related to that method. It also indicates which methods are available for different versions of Node.js. -->
-[API リファレンス](/api/) では Node.js の関数やオブジェクトについての詳細を提供しています。
-ドキュメントではメソッドには何の引数を取るのか、そのメソッドでは何を返すのか、そしてメソッドに関連するエラーについて説明しています。また、Node.js の異なるバージョンでどのメソッドが使用可能かについても説明されています。
+[API リファレンス](/api/) では Node.js の関数やオブジェクトの詳細情報を提供しています。このドキュメントでは、メソッドで何の引数を取るのか、そのメソッドの返り値とそのメソッドに関連するエラーについても説明されています。また、異なる Node.js のバージョンでどのメソッドが使えるかについても説明されています。
 
 <!-- This documentation describes the built-in modules provided by Node.js. It does not document modules provided by the community. -->
-ドキュメントでは Node.js によって開発されたモジュールにについて説明しています。しかしコミュニティによって開発されたものには説明していません。
+ドキュメントでは Node.js によって開発された組み込みのモジュールについて説明しています。コミュニティによってつくられたものについては説明されていません。
 
 <div class="highlight-box">
     <!-- <h4>Looking for API docs of previous releases?</h4> -->
-    <h4>以前のバージョンの API ドキュメントをお探しですか？</h4>
+    <h4>以前のバージョンの API リファレンスをお探しですか？</h4>
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
@@ -45,12 +44,11 @@ labels:
 ### ES6 の機能
 
 <!-- The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find version of V8 shipped with a particular Node.js release. -->
-[ES6 セクション](/en/docs/es6) では 3 つの ES6 の機能グループについて説明しています。追加のリンクと一緒にどの機能が Node.js がデフォルトで使用可能なのか
-。V8 バージョン特定の Node.js のリリースをどのように見つけるのかについても説明しています。
+追加のリンクで Node.js でどの機能が標準で使えるの詳細が書かれた 3 つの ES6 の機能グループについて説明されています。また、どのように特定の Node.js のリリースに負づいするリリースされた V8 のバージョンについても説明されています。
+
 
 <!-- ### Frequently Asked Questions -->
 ### よくある質問
 
 <!-- The [FAQ](/en/docs/faq/) covers how everyone can contribute to Node.js, our code of conduct and governance model, how to get in touch on GitHub and IRC, and how to help out with triaging issues. -->
-
-[よくある質問](/en/docs/faq) はどのようにみんなが Node.js に貢献できるのか、行動規範とガバナンス体制、GitHub と IRC に参加する方法、問題を助ける方法。
+[よくある質問](/en/docs/faq)　では誰でもどのように Node.js に貢献できるのか、行動規範とガバナンス体制、GitHub と IRC でのやり取りの方法、どのように不具合を修正するのかなどの方法について網羅しています。

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -44,7 +44,7 @@ labels:
 ### ES6 の機能
 
 <!-- The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find version of V8 shipped with a particular Node.js release. -->
-[ES6 のセクション](/en/docs/es6/) では、ES6 の3つの機能について説明しており、それぞれの機能ごとのリンクと一緒に Node.js の標準で有効化されているかについて書いてあります。また、リリースされた Node.js のバージョンごとにバンドルされた V8 のバージョンを知るのにも利用することができます。
+[ES6 のセクション](/en/docs/es6/) では、ES6 の3つの機能について説明しており、それぞれの機能ごとのリンクと一緒に Node.js の標準で有効化されているかについて書いてあります。また、リリースされた Node.js のバージョンごとに組み込まれている V8 のバージョンを知るのにも利用することができます。
 
 <!-- ### Frequently Asked Questions -->
 ### よくある質問

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -25,7 +25,7 @@ labels:
 [API リファレンス](/api/) では Node.js の関数やオブジェクトの詳細情報を提供しています。このドキュメントでは、メソッドで何の引数を取るのか、そのメソッドの返り値とそのメソッドに関連するエラーについても説明されています。また、異なる Node.js のバージョンでどのメソッドが使えるかについても説明されています。
 
 <!-- This documentation describes the built-in modules provided by Node.js. It does not document modules provided by the community. -->
-ドキュメントでは Node.js によって開発された組み込みのモジュールについて説明しています。コミュニティによってつくられたものについては説明されていません。
+このドキュメントでは Node.js によって提供された組み込みのモジュールについて説明しています。コアに組み込まれていないモジュールは含みません。
 
 <div class="highlight-box">
     <!-- <h4>Looking for API docs of previous releases?</h4> -->
@@ -44,11 +44,11 @@ labels:
 ### ES6 の機能
 
 <!-- The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find version of V8 shipped with a particular Node.js release. -->
-追加のリンクで Node.js でどの機能が標準で使えるの詳細が書かれた 3 つの ES6 の機能グループについて説明されています。また、どのように特定の Node.js のリリースに負づいするリリースされた V8 のバージョンについても説明されています。
-
+[ES6 のセクション](/en/docs/es6/) では、ES6 の3つの機能について説明しており、それぞれの機能ごとのリンクと一緒に Node.js の標準で有効化されているかについて書いてあります。また、リリースされた Node.js のバージョンごとにバンドルされた V8 のバージョンを知るのにも利用することができます。
 
 <!-- ### Frequently Asked Questions -->
 ### よくある質問
 
 <!-- The [FAQ](/en/docs/faq/) covers how everyone can contribute to Node.js, our code of conduct and governance model, how to get in touch on GitHub and IRC, and how to help out with triaging issues. -->
-[よくある質問](/en/docs/faq)　では誰でもどのように Node.js に貢献できるのか、行動規範とガバナンス体制、GitHub と IRC でのやり取りの方法、どのように不具合を修正するのかなどの方法について網羅しています。
+[よくある質問](/en/docs/faq)　では、どなたでも参加ができる Node.js への貢献の仕方、行動規範、ガバナンス体制、GitHub や IRC でのやり取りの方法、不具合の修正の仕方などについて網羅しています。
+ 

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -1,0 +1,56 @@
+---
+title: ドキュメント
+layout: docs.hbs
+labels:
+  lts: LTS
+---
+
+<!-- # About Docs -->
+# ドキュメント
+
+<!-- There are three types of documentation available on this website: -->
+このサイトには 3 種類ののドキュメントがあります：
+
+<!-- * API reference documentation -->
+<!-- * ES6 features -->
+<!-- * Frequently asked questions -->
+* API リファレンス
+* ES6 の機能
+* よくある質問
+
+<!-- ### API Reference Documentation -->
+### API リファレンス
+
+<!-- The [API reference documentation](/api/) provides detailed information about a function or object in Node.js. This documentation indicates what arguments a method accepts, the return value of that method, and what errors may be related to that method. It also indicates which methods are available for different versions of Node.js. -->
+[API リファレンス](/api/) では Node.js の関数やオブジェクトについての詳細を提供しています。
+ドキュメントではメソッドには何の引数を取るのか、そのメソッドでは何を返すのか、そしてメソッドに関連するエラーについて説明しています。また、Node.js の異なるバージョンでどのメソッドが使用可能かについても説明されています。
+
+<!-- This documentation describes the built-in modules provided by Node.js. It does not document modules provided by the community. -->
+ドキュメントでは Node.js によって開発されたモジュールにについて説明しています。しかしコミュニティによって開発されたものには説明していません。
+
+<div class="highlight-box">
+    <!-- <h4>Looking for API docs of previous releases?</h4> -->
+    <h4>以前のバージョンの API ドキュメントをお探しですか？</h4>
+
+    <ul>
+        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+        <!-- <li><a href="https://nodejs.org/docs/">all versions</a></li> -->
+        <li><a href="https://nodejs.org/docs/">すべてのバージョン</a></li>
+    </ul>
+</div>
+
+<!-- ### ES6 Features -->
+### ES6 の機能
+
+<!-- The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find version of V8 shipped with a particular Node.js release. -->
+[ES6 セクション](/en/docs/es6) では 3 つの ES6 の機能グループについて説明しています。追加のリンクと一緒にどの機能が Node.js がデフォルトで使用可能なのか
+。V8 バージョン特定の Node.js のリリースをどのように見つけるのかについても説明しています。
+
+<!-- ### Frequently Asked Questions -->
+### よくある質問
+
+<!-- The [FAQ](/en/docs/faq/) covers how everyone can contribute to Node.js, our code of conduct and governance model, how to get in touch on GitHub and IRC, and how to help out with triaging issues. -->
+
+[よくある質問](/en/docs/faq) はどのようにみんなが Node.js に貢献できるのか、行動規範とガバナンス体制、GitHub と IRC に参加する方法、問題を助ける方法。


### PR DESCRIPTION
Translate about of docs section into Japanese :jp:
## Japanese Translation Note

It is written in Japanese below:

以下の英語は `API リファレンス` と統一して訳しています。
- API Reference Documentation
- API docs

Please review :bow:
