### PR TITLE
Replace Mac OS X / OS X with macOS

### DIFF
--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -54,12 +54,12 @@
       </tr>
 
       <tr>
-        <th>Mac OS X Installer (.pkg)</th>
+        <th>macOS Installer (.pkg)</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>Mac OS X Binaries (.tar.gz)</th>
+        <th>macOS Binaries (.tar.gz)</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
       </tr>
 

--- a/locale/en/get-involved/contribute.md
+++ b/locale/en/get-involved/contribute.md
@@ -14,7 +14,7 @@ If you have found what you believe to be an issue with Node.js please do not hes
 When reporting an issue we also need as much information about your environment that you can include. We never know what information will be pertinent when trying narrow down the issue. Please include at least the following information:
 
 * Version of Node
-* Platform you're running on (OS X, SunOS, Linux, Windows)
+* Platform you're running on (macOS, SunOS, Linux, Windows)
 * Architecture you're running on (32bit or 64bit and x86 or ARM)
 
 The Node.js project is currently managed across a number of separate GitHub repositories, each with their own separate issues database. If possible, please direct any issues you are reporting to the appropriate repository but don't worry if things happen to get put in the wrong place, the community of contributors will be more than happy to help get you pointed in the right direction.

--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -20,11 +20,11 @@ const postMergeDownloads = [
     'templateUrl': 'https://nodejs.org/dist/v%version%/win-x64/node.exe'
   },
   {
-    'title': 'Mac OS X 64-bit Installer',
+    'title': 'macOS 64-bit Installer',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.pkg'
   },
   {
-    'title': 'Mac OS X 64-bit Binary',
+    'title': 'macOS 64-bit Binary',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x64.tar.gz'
   },
   {
@@ -84,15 +84,15 @@ const legacyDownloads = [
     'templateUrl': 'https://nodejs.org/dist/v%version%/x64/node.exe'
   },
   {
-    'title': 'Mac OS X Universal Installer',
+    'title': 'macOS Universal Installer',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%.pkg'
   },
   {
-    'title': 'Mac OS X 64-bit Binary',
+    'title': 'macOS 64-bit Binary',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x64.tar.gz'
   },
   {
-    'title': 'Mac OS X 32-bit Binary',
+    'title': 'macOS 32-bit Binary',
     'templateUrl': 'https://nodejs.org/dist/v%version%/node-v%version%-darwin-x86.tar.gz'
   },
   {

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -59,7 +59,7 @@
     switch (os) {
       case 'Mac':
         versionIntoHref(buttons, 'node-%version%.pkg')
-        downloadHead[text] = dlLocal + ' OS X (x64)'
+        downloadHead[text] = dlLocal + ' macOS (x64)'
         break
       case 'Win':
         versionIntoHref(buttons, 'node-%version%-' + arch + '.msi')


### PR DESCRIPTION
This replaces some occurrences of "Mac OS X" and "OS X" with the "macOS".

Refs: https://github.com/nodejs/nodejs.org/issues/951
