### PR TITLE
fix: update LTS-schedule link on main page

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -64,7 +64,7 @@
           </div>
         {{/if}}
         <p>
-          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#lts_schedule">{{ labels.version-schedule-prompt-link-text }}.</a>
+          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#lts-schedule">{{ labels.version-schedule-prompt-link-text }}.</a>
         </p>
       </div>
 


### PR DESCRIPTION
current link is borked
