### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,9 @@
     "test:snyk": "snyk test",
     "postinstall": "snyk protect"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nodejs/nodejs.org.git"
-  },
+  "repository": "nodejs/nodejs.org",
   "author": "Node.js Website Working Group",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/nodejs/nodejs.org/issues"
-  },
   "engines": {
     "node": ">=4.0.0"
   },


### PR DESCRIPTION
1. There's a shorter `owner/repository` syntax for GitHub repositories according to [npm docs](https://docs.npmjs.com/files/package.json#repository).
2. [normalize-package-data](https://github.com/npm/normalize-package-data#what-normalization-currently-entails) says bugs are needless if you've specified the repository.
