### PR TITLE
locale: add translation to German

### DIFF
--- a/locale/de/404.md
+++ b/locale/de/404.md
@@ -1,0 +1,7 @@
+---
+layout: page.hbs
+permalink: false
+title: 404
+---
+## 404: Seite wurde nicht gefunden
+### ENOENT: Datei oder Ordner nicht gefunden

--- a/locale/de/about/index.md
+++ b/locale/de/about/index.md
@@ -1,0 +1,74 @@
+---
+layout: about.hbs
+title: Über Node.js
+trademark: Trademark
+---
+# Über Node.js&reg;
+
+Als asynchrone, Event-basierte Laufzeitumgebung wurde Node speziell für die
+Entwicklung von skalierbaren Netzwerkanwendungen entworfen. Im nachfolgenden
+"Hallo Welt"-Beispiel können viele Verbindungen gleichzeitig bearbeitet werden.
+Bei jeder neuen Anfrage wird die Callback-Funktion ausgeführt. Gibt es jedoch
+nichts zu tun, befindet sich Node im Ruhezustand.
+
+```javascript
+const http = require('http');
+
+const hostname = '127.0.0.1';
+const port = 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hallo Welt\n');
+});
+
+server.listen(port, hostname, () => {
+  console.log(`Server läuft unter http://${hostname}:${port}/`);
+});
+```
+
+Dies steht im Gegensatz zu den heutzutage üblichen Modellen für Nebenläufigkeit,
+bei denen Threads des Betriebssystems genutzt werden. Thread-basiertes
+Networking is vergleichsweise ineffizent and sehr schwer umzusetzen.
+Zudem müssen sich Node-Nutzer nicht um Deadlocks im Prozess sorgen, da es
+keine Blockierung gibt. Fast keine Funktion in Node.js führt direkt I/O-Operationen aus, daher wird der Prozess nie blockiert. Da nichts blockiert,
+können mit Node sinnvoll skalierbare Systeme entwickelt werden.
+
+Wenn einige dieser Konzepte unbekannt sind, gibt es hier einen Artikel zum Thema
+[blockierend vs. blockierungsfrei][] (auf Englisch).
+
+---
+
+Node ähnelt im Design und ist beeinflusst von Systemen wie Rubys
+"[Event Machine][]" oder Pythons "[Twisted][]". Node führt das Event-Modell noch
+etwas weiter. Die [Ereignisschleife][] ist ein Konstrukt direkt in der
+Laufzeitumgebung und wird nicht über eine Bibliothek eingebunden.
+In anderen Systemen ist immer ein blockierender
+Aufruf notwendig, um die Ereignisschleife zu starten. Üblicherweise wird das
+Verhalten in Callback-Funktionen am Anfang des Skripts definiert und am Ende wird
+mit einem blockierenden Aufruf wie `EventMachine::run()` ein Server gestartet.
+In Node gibt es keinen solchen Aufruf, um die Ereignisschleife zu starten.
+Node beginnt einfach mit der Ereignisschleife, nachdem das Eingabe-Skript
+ausgeführt wurde. Node verlässt die Ereignisschleife, wenn keine
+Callback-Funktionen mehr auszuführen sind. Dieses Verhalten ist wie bei
+Browser-Javascript - die Ereignisschleife ist vor dem Nutzer versteckt.
+
+HTTP ist ein Basiselement in Node, entworfen mit Fokus auf Streaming und
+geringe Latenz. Dadurch ist Node sehr gut als Grundlage für Web-Bibliotheken
+oder Frameworks geeignet.
+
+Dass Node ohne Threads entworfen ist, bedeutet nicht, dass man die Vorteile von
+mehreren Kernen auf einer Maschine nicht ausnutzen kann. Untergeordnete Prozesse
+können mit der [`child_process.fork()`][] API gestartet werden und sie wurden so
+entworfen, dass man leicht mit ihnen kommunizieren kann. Auf der gleichen
+Schnittstelle setzt das [`Cluster`][] Modul auf, dass es Prozessen erlaubt
+Sockets gemeinsam zu nutzen, um Lastverteilung über Kerne hinweg zu
+ermöglichen.
+
+[blockierend vs. blockierungsfrei]: https://github.com/nodejs/node/blob/master/doc/topics/blocking-vs-non-blocking.md
+[`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
+[`Cluster`]: https://nodejs.org/api/cluster.html
+[Ereignisschleife]: https://github.com/nodejs/node/blob/master/doc/topics/event-loop-timers-and-nexttick.md
+[Event Machine]: http://rubyeventmachine.com/
+[Twisted]: http://twistedmatrix.com/

--- a/locale/de/docs/index.md
+++ b/locale/de/docs/index.md
@@ -1,0 +1,55 @@
+---
+title: Dokumentation
+layout: docs.hbs
+labels:
+  lts: LTS
+---
+
+# Über die Dokumentationen
+
+Auf dieser Webseite gibt es verschiedene Arten von Dokumentationen:
+
+* API-Referenz
+* ES6 Funktionalitäten
+* FAQ - Häufig gefragt
+* Anleitungen
+
+### API-Referenz
+
+Die [API-Referenz](/api/) stellt detaillierte Informationen über Funktionen und
+Objekte in Node.js bereit. Diese Dokumentation zeigt, welche Argumente die
+Methoden erlauben, den Rückgabewert der Methode und welche Fehler im
+Zusammenhang mit der Methode stehen. Die Dokumentation zeigt auch, welche
+Methoden in den verschiedenen Node.js-Versionen verfügbar sind.
+
+Die API-Referenz beschreibt Module, die in Node.js integriert sind. Module, die
+von der Community zur Verfügung gestellt werden, sind dort nicht dokumentiert.
+
+<div class="highlight-box">
+    <h4>Du suchst nach API Referenzen für ältere Versionen?</h4>
+
+    <ul>
+        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+        <li><a href="https://nodejs.org/docs/">Alle Versionen</a></li>
+    </ul>
+</div>
+
+### ES6 Funktionalitäten
+
+Der [ES6-Bereich](/en/docs/es6/) beschreibt die drei Gruppen von ES6-Funktionalitäten und gibt Detailinformation dazu, welche Funktionalitäten
+standardmäßig in Node.js eingeschaltet sind. Zudem gibt es Links zu weiteren
+Erklärungen. Dort finden sich auch Informationen, welche Version von V8 in
+welcher Node.js-Version enthalten ist.
+
+### FAQ - Häufig gefragt
+
+Der [FAQ-Bereich](/en/docs/faq/) beschreibt, wie man an Node.js mitwirken kann,
+den Verhaltenskodex und das Governance-Modell, wie man über GitHub und IRC Kontakt
+aufnehmen kann und wie man helfen kann Fehler ausfindig zu machen.
+
+### Anleitungen
+
+Unter Anleitungen finden sich ausführliche Artikel über technische
+Funktionalitäten und Leistungsfähigkeit von Node.js.

--- a/locale/de/download/index.md
+++ b/locale/de/download/index.md
@@ -1,0 +1,24 @@
+---
+layout: download.hbs
+title: Download
+download: Download
+downloads:
+    headline: Downloads
+    lts: LTS
+    current: Aktuell
+    tagline-current: Neueste Funktionalitäten
+    tagline-lts: Für die meisten Nutzer empfohlen
+    display-hint: Downloads anzeigen für
+    intro: >
+        Lade den Node.js-Quellcode oder ein bestehendes Installationsprogramm für deine Plattform herunter und beginne gleich mit der Entwicklung.
+    currentVersion: Aktuellste LTS-Version
+    buildDisclaimer: "Hinweis: Um den von den Quelldateien (tarball) zu bauen, wird Python 2.6 oder 2.7 benötigt."
+additional:
+    headline: Weitere Plattformen
+    intro: >
+        Mitglieder der Node.js Community pflegen inoffizielle, gebaute Versionen von Node.js für weitere Plattformen. Beachte, dass
+        solche Versionen nicht vom Node.js-Kernteam unterstützt werden und daher eventuell noch nicht auf dem selben Level wie die
+        aktuelle Node.js-Version sind.
+    platform: Plattform
+    provider: Anbieter
+---

--- a/locale/de/index.md
+++ b/locale/de/index.md
@@ -1,0 +1,21 @@
+---
+layout: index.hbs
+labels:
+  current-version: Aktuelle Version
+  download: Download
+  download-for: Herunterladen für
+  other-downloads: Andere Downloads
+  other-lts-downloads: Andere LTS Downloads
+  other-current-downloads: Andere aktuelle Downloads
+  current: Aktuell
+  lts: LTS
+  tagline-current: Neueste Funktionalitäten
+  tagline-lts: Für die meisten Nutzer empfohlen
+  changelog: Änderungshistorie
+  api: API Doku
+  version-schedule-prompt: Oder wirf einen Blick auf den
+  version-schedule-prompt-link-text: LTS Release Plan
+---
+
+Node.js® ist eine JavaScript-Laufzeitumgebung, die auf  [Chromes V8 JavaScript-Engine](https://developers.google.com/v8/) basiert.
+Durch ein Event-basiertes, blockierungsfreies I/O-Modell ist Node.js schlank und effizient. Mit [npm](https://www.npmjs.com/) hat Node.js das größte Ökosystem für Open Source Bibliotheken der Welt.

--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -1,0 +1,177 @@
+{
+    "title": "Node.js",
+    "author": "Node.js Foundation",
+    "url": "https://nodejs.org/de/",
+    "locale": "de",
+    "scrollToTop": "Zum Seitenanfang",
+    "reportNodeIssue": "Node.js-Fehler melden",
+    "reportWebsiteIssue": "Webseitenfehler melden",
+    "getHelpIssue": "Hilfe",
+    "by": "von",
+    "all-downloads": "Alle Download-Optionen",
+    "nightly": "Nightly Builds",
+    "feeds": [
+        {
+            "link": "feed/blog.xml",
+            "text": "Node.js-Blog"
+        },
+        {
+            "link": "feed/releases.xml",
+            "text": "Node.js-Blog: Versionen"
+        },
+        {
+            "link": "feed/vulnerability.xml",
+            "text": "Node.js-Blog: Berichte über Sicherheitslücken"
+        },
+        {
+            "link": "feed/tsc-minutes.xml",
+            "text": "Node.js TSC-Sitzungsprotokoll"
+        }
+    ],
+    "home": { "text": "Startseite" },
+    "about": {
+        "link": "about",
+        "text": "Über Node.js",
+        "governance": {
+            "link": "about/governance",
+            "text": "Governance"
+        },
+        "workinggroups": {
+            "link": "about/working-groups",
+            "text": "Arbeitskreise"
+        },
+        "releases": {
+            "link": "about/releases",
+            "text": "Versionen"
+        },
+        "resources": {
+            "link": "about/resources",
+            "text": "Ressourcen"
+        },
+        "foundation": {
+            "link": "foundation",
+            "text": "Foundation"
+        },
+        "security": {
+            "link": "security",
+            "text": "Sicherheit"
+        },
+        "trademark": {
+            "link": "about/trademark",
+            "text": "Trademark"
+        }
+    },
+    "download": {
+        "link": "download",
+        "text": "Downloads",
+        "releases": {
+            "link": "download/releases",
+            "text": "Alle Versionen"
+        },
+        "package-manager": {
+            "link": "download/package-manager",
+            "text": "Node.js mit Paketmanagern installieren"
+        },
+        "shasums":{
+          "link": "SHASUMS256.txt.asc",
+          "text": "Signierte SHASUMS für die Versionsdateien"
+        }
+    },
+    "docs": {
+        "link": "docs",
+        "text": "Dokumentation",
+        "es6": {
+            "link": "docs/es6",
+            "text": "ES6 und darüber hinaus"
+        },
+        "faq": {
+            "link": "docs/faq",
+            "text": "FAQ"
+        },
+        "api-lts": {
+            "link": "/dist/latest-v4.x/docs/api",
+            "subtext": "LTS",
+            "text": "%ver% API"
+        },
+        "api-current": {
+            "link": "/dist/latest-v6.x/docs/api",
+            "text": "%ver% API"
+        },
+        "guides": {
+            "link": "docs/guides",
+            "text": "Anleitungen"
+        }
+    },
+    "foundation": {
+        "link": "foundation",
+        "text": "Foundation",
+        "casestudies": {
+            "link": "foundation/case-studies",
+            "text": "Einsatzgebiete"
+        },
+        "members": {
+            "link": "foundation/members",
+            "text": "Mitglieder"
+        },
+        "board": {
+            "link": "foundation/board",
+            "text": "Vorstand"
+        },
+        "tsc": {
+            "link": "foundation/tsc",
+            "text": "Technische Leitung"
+        },
+        "itn": {
+             "link": "foundation/in-the-news",
+             "text": "In der Presse"
+        },
+        "announce": {
+            "link": "foundation/announcements",
+            "text": "Ankündigungen"
+        },
+        "education": {
+            "link": "foundation/education",
+            "text": "Bildungsinitiativen"
+        },
+        "outreachy": {
+            "link": "foundation/outreachy",
+            "text": "Outreachy + Node.js"
+        }
+    },
+    "getinvolved": {
+        "link": "get-involved",
+        "text": "Mitmachen",
+        "code-and-learn": {
+            "link": "get-involved/code-and-learn",
+            "text": "Programmiere + Lerne"
+        },
+        "contribute": {
+            "link": "get-involved/contribute",
+            "text": "Mitwirken"
+        },
+        "development": {
+            "link": "get-involved/development",
+            "text": "Entwicklung"
+        },
+        "events": {
+          "link": "get-involved/events",
+          "text": "Veranstaltungen"
+        },
+        "conduct": {
+            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+            "text": "Verhaltenskodex"
+        }
+    },
+    "security"   : { "link": "security",        "text": "Sicherheit" },
+    "blog"       : { "link": "blog",            "text": "Neuigkeiten" },
+
+    "releases": {
+        "title": "Versionshistorie",
+        "downloads": "Downloads"
+    },
+    "links": {
+        "pages": {
+            "changelog": "Änderungshistorie"
+        }
+    }
+}


### PR DESCRIPTION
This PR is related to #807  and https://github.com/nodejs/nodejs-de/issues/27.
I created the "minimal set" for the translation to German. Following the advice in #807 this includes
- site.json
- index
- about/index
- docs/index
- download/index
- 404

For one of these pages (docs/index) @juliangruber started a translation end of last year. Since the text seemed not in sync any more and he never made a PR I just made a new translation based on the current English version.

For discussion:
- I used the casual not the formal version of addressing someone ("du", not "Sie").
  Example: "Oder wirf einen Blick auf den LTS Release Plan."
- If possible I gave German words (as used in some universities) precedence over the also used English words. My train of thought here was that if someone understands all the English terms the person might nearly be able to read the English version anyway. 
  Examples: Event Loop -> Ereignisschleife, callback function -> Rückruffunktion

Please help with pinging the right people who can review this.
