### PR TITLE
blog: make shasums an h3, remove SHA512/SHA256 note

### DIFF
--- a/scripts/release.hbs
+++ b/scripts/release.hbs
@@ -16,7 +16,8 @@ author: {{author}}
 Other release files: https://nodejs.org/dist/v{{version}}/<br>
 Documentation: https://nodejs.org/docs/v{{version}}/api/
 
-Shasums (GPG signing hash: SHA512, file hash: SHA256):
+<h3 id="shasums">SHASUMS</h3>
+
 ```
 {{shasums}}
 ```


### PR DESCRIPTION
We should only have SHA256, both file and content hashes, to avoid confusion, so we don't need the note. Also making it a proper heading now. What think ye?
