### PR TITLE
Remove 'Security' and 'Foundation' from About nav

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -48,14 +48,6 @@
             "link": "about/resources",
             "text": "Resources"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "Foundation"
-        },
-        "security": {
-            "link": "security",
-            "text": "Security"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "Trademark"

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -48,14 +48,6 @@
             "link": "about/resources",
             "text": "Recursos"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "Fundación"
-        },
-        "security": {
-            "link": "security",
-            "text": "Seguridad"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "Marca"

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -50,14 +50,6 @@
             "link": "about/resources",
             "text": "Risorse"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "Fondazione"
-        },
-        "security": {
-            "link": "security",
-            "text": "Sicurezza"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "Marchio Registrato"

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -48,14 +48,6 @@
             "link": "about/resources",
             "text": "リソース"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "財団"
-        },
-        "security": {
-            "link": "security",
-            "text": "セキュリティ"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "トレードマーク"

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -48,14 +48,6 @@
             "link": "about/resources",
             "text": "관련 자료"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "재단"
-        },
-        "security": {
-            "link": "security",
-            "text": "보안"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "트레이드마크"

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -48,14 +48,6 @@
             "link": "about/resources",
             "text": "Ресурси"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "Фундація"
-        },
-        "security": {
-            "link": "security",
-            "text": "Безпека"
-        },
         "trademark": {
             "link": "about/trademark",
             "text": "Товарний знак"

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -44,14 +44,6 @@
             "link": "about/releases",
             "text": "发布"
         },
-        "foundation": {
-            "link": "foundation",
-            "text": "基金会"
-        },
-        "security": {
-            "link": "security",
-            "text": "安全"
-        },
         "resources": {
             "link": "about/resources",
             "text": "资源"


### PR DESCRIPTION
Fixes #914. It's really confusing to have those sections in two navbars.
