### PR TITLE
fix(locale): add missing styles.styl file for de

### DIFF
--- a/locale/de/styles.styl
+++ b/locale/de/styles.styl
@@ -1,0 +1,1 @@
+@import 'base'


### PR DESCRIPTION
Currently the styling of https://nodejs.org/de/ is broken. I think the reason is that I did not copy the styles.styl into the translation folder "locale/de" when working on #971. Unfortunately the bug did not appear when testing everything locally. Fixing the issue in this PR. Sorry for the inconvenience. 
