### PR TITLE
Disable current release line when not yet cut

### DIFF
--- a/build.js
+++ b/build.js
@@ -242,7 +242,8 @@ function getSource (callback) {
       project: {
         versions,
         latestVersions: {
-          current: latestVersion.current(versions),
+          current: latestVersion.current(versions), // might be undefined!
+          upcomingCurrent: latestVersion.upcomingCurrent(versions), // might be undefined!
           lts: latestVersion.lts(versions)
         },
         banner: {

--- a/layouts/css/page-modules/_download.styl
+++ b/layouts/css/page-modules/_download.styl
@@ -85,6 +85,11 @@
   .tag
     font-size 0.8em
 
+  .upcoming-release
+    color $light-gray
+    width 100%
+    margin 2px
+
 .download-matrix
   margin-bottom 1.5rem
 

--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -20,7 +20,6 @@
 .home-secondary-links
   $home-secondary-links-color = saturation($node-green, 20%)
 
-  color $home-secondary-links-color
   font-size 0.9rem
 
   a
@@ -58,6 +57,9 @@
 
   &:hover
     background-color $node-green
+
+  &.upcoming
+    background-color $light-gray
 
   small
     display block

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -68,7 +68,7 @@
           <div class="home-downloadblock">
             <span class="home-downloadbutton upcoming">
               {{ project.latestVersions.upcomingCurrent.node }}
-              <small>Coming soon</small>
+              <small>{{ labels.tagline-upcoming-current }}</small>
             </span>
             <ul class="list-divider-pipe home-secondary-links">
               <li>

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -63,6 +63,26 @@
 
           </div>
         {{/if}}
+
+        {{#if project.latestVersions.upcomingCurrent.node}}
+          <div class="home-downloadblock">
+            <span class="home-downloadbutton upcoming">
+              {{ project.latestVersions.upcomingCurrent.node }}
+              <small>Coming soon</small>
+            </span>
+            <ul class="list-divider-pipe home-secondary-links">
+              <li>
+                <span>{{ labels.other-downloads }}</span>
+              </li>
+              <li>
+                <span>{{ labels.changelog }}</span>
+              </li>
+              <li>
+                <span>{{ labels.api }}</span>
+              </li>
+            </ul>
+          </div>
+        {{/if}}
         <p>
           {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#lts-schedule">{{ labels.version-schedule-prompt-link-text }}.</a>
         </p>

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -1,3 +1,4 @@
+{{#if version.node}}
 <section>
   <p class="color-lightgray">{{downloads.currentVersion}}: <strong>{{version.node}}</strong> (includes npm {{version.npm}})</p>
   <p>{{downloads.intro}}</p>
@@ -95,3 +96,13 @@
     </tbody>
   </table>
 </section>
+{{else}}
+<section>
+  <p class="color-lightgray">
+    {{downloads.currentVersion}}: -
+  </p>
+  <p>
+    {{downloads.noCurrentLine}}
+  </p>
+</section>
+{{/if}}

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -6,13 +6,23 @@
       <li>
         <div class="download-version-toggle">
           <a {{#if versionTypeLts}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}" title="{{downloads.display-hint}} {{downloads.lts}}">
-            <div class="title">{{downloads.lts}}</div>
+            <div class="title">{{downloads.lts}} {{project.latestVersions.lts.nodeMajor}}</div>
             <div class="tag">{{downloads.tagline-lts}}</div>
           </a>
-          <a {{#if versionTypeCurrent}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}/current" title="{{downloads.display-hint}} {{downloads.current}}">
-            <div class="title">{{downloads.current}}</div>
-            <div class="tag">{{downloads.tagline-current}}</div>
-          </a>
+
+          {{#if project.latestVersions.current}}
+            <a {{#if versionTypeCurrent}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}/current" title="{{downloads.display-hint}} {{downloads.current}}">
+              <div class="title">{{downloads.current}} {{project.latestVersions.current.nodeMajor}}</div>
+              <div class="tag">{{downloads.tagline-current}}</div>
+            </a>
+          {{/if}}
+
+          {{#if project.latestVersions.upcomingCurrent}}
+            <div class="upcoming-release">
+              <div class="title">{{downloads.current}} {{project.latestVersions.upcomingCurrent.nodeMajor}}</div>
+              <div class="tag">{{downloads.tagline-upcoming-current}}</div>
+            </div>
+          {{/if}}
         </div>
       </li>
       <li>

--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -1,3 +1,4 @@
+{{#if node.version}}
 <section>
   <h2>{{additional.headline}}</h2>
   <table class="download-matrix full-width">
@@ -35,3 +36,4 @@
   </table>
   {{> download-list }}
 </section>
+{{/if}}

--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -89,12 +89,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -4,14 +4,14 @@ title: Download
 download: Download
 downloads:
     headline: Downloads
-    lts: LTS v4.x
-    current: LTS v6.x
+    lts: LTS
+    current: Current
     tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: LTS Version
+    currentVersion: Latest Current Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -13,6 +13,10 @@ downloads:
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
     currentVersion: Latest Current Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
+    noCurrentLine: >
+        Node.js does not have a current release line at the moment. This is temporary
+        for a week or two. In the meantime we encourage you to use the latest LTS release
+        or wait until the new current release line is available.
 additional:
     headline: Additional Platforms
     intro: >

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -4,14 +4,14 @@ title: Download
 download: Download
 downloads:
     headline: Downloads
-    lts: LTS v4.x
-    current: LTS v6.x
+    lts: LTS
+    current: Current
     tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: LTS Version
+    currentVersion: Latest LTS Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -8,6 +8,7 @@ downloads:
     current: Current
     tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
+    tagline-upcoming-current: Coming soon
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -1,13 +1,13 @@
 ---
 layout: index.hbs
 labels:
-  current-version: LTS
+  current-version: Current Version
   download: Download
   download-for: Download for
   other-downloads: Other Downloads
   other-lts-downloads: Other LTS Downloads
   other-current-downloads: Other Current Downloads
-  current: LTS
+  current: Current
   lts: LTS
   tagline-current: Latest Features
   tagline-lts: Recommended For Most Users

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -10,6 +10,7 @@ labels:
   current: Current
   lts: LTS
   tagline-current: Latest Features
+  tagline-upcoming-current: Coming soon
   tagline-lts: Recommended For Most Users
   changelog: Changelog
   api: API Docs

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -89,12 +89,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -89,12 +89,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -87,12 +87,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -89,12 +89,12 @@
             "text": "よくある質問"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -89,12 +89,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -85,12 +85,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -89,12 +89,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -9,9 +9,9 @@ const map = (release) => release && {
   openssl: release.openssl
 }
 
-exports.lts = (releases) => {
-  const match = releases.find((release) => release.lts && semver.lte(release.version, '5.0.0'))
+exports.current = (releases) => {
+  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
   return map(match)
 }
 
-exports.current = (releases) => map(releases.find((release) => release.lts))
+exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -9,7 +9,7 @@ const map = (release) => release && {
   openssl: release.openssl
 }
 
-// might we undefined if the current release line has not been cut yet
+// might be undefined if the current release line has not been cut yet
 exports.current = (releases) => {
   const ltsVersion = exports.lts(releases).node
   const match = releases.find((release) => !release.lts && semver.gte(release.version, ltsVersion))
@@ -20,10 +20,14 @@ exports.current = (releases) => {
 // has not yet been cut
 exports.upcomingCurrent = (releases) => {
   const isCurrentReleased = exports.current(releases) !== undefined
+  if (isCurrentReleased) {
+    return undefined
+  }
+
   const ltsMajor = semver.major(exports.lts(releases).node)
   const nextCurrentVersion = `v${ltsMajor + 1}.0.0`
 
-  return !isCurrentReleased ? { node: nextCurrentVersion } : undefined
+  return { node: nextCurrentVersion }
 }
 
 exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -9,9 +9,21 @@ const map = (release) => release && {
   openssl: release.openssl
 }
 
+// might we undefined if the current release line has not been cut yet
 exports.current = (releases) => {
-  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
+  const ltsVersion = exports.lts(releases).node
+  const match = releases.find((release) => !release.lts && semver.gte(release.version, ltsVersion))
   return map(match)
+}
+
+// calculates the next upcoming major release version when the current release line
+// has not yet been cut
+exports.upcomingCurrent = (releases) => {
+  const isCurrentReleased = exports.current(releases) !== undefined
+  const ltsMajor = semver.major(exports.lts(releases).node)
+  const nextCurrentVersion = `v${ltsMajor + 1}.0.0`
+
+  return !isCurrentReleased ? { node: nextCurrentVersion } : undefined
 }
 
 exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -4,6 +4,7 @@ const semver = require('semver')
 
 const map = (release) => release && {
   node: release.version,
+  nodeMajor: `v${semver.major(release.version)}.x`,
   npm: release.npm,
   v8: release.v8,
   openssl: release.openssl
@@ -25,9 +26,13 @@ exports.upcomingCurrent = (releases) => {
   }
 
   const ltsMajor = semver.major(exports.lts(releases).node)
-  const nextCurrentVersion = `v${ltsMajor + 1}.0.0`
+  const upcomingMajor = ltsMajor + 1
+  const nextCurrentVersion = `v${upcomingMajor}.0.0`
 
-  return { node: nextCurrentVersion }
+  return {
+    node: nextCurrentVersion,
+    nodeMajor: `v${upcomingMajor}.x`
+  }
 }
 
 exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/plugins/navigation.js
+++ b/scripts/plugins/navigation.js
@@ -17,7 +17,7 @@ module.exports = function buildNavigation (latestVersions) {
       Object.keys(obj).forEach(function (key) {
         if (obj[key].link && obj[key].text) {
           // Insert latest versions for API docs
-          if (key === 'api-current') {
+          if (key === 'api-current' && latestVersions.current) {
             obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.current.node)
           }
           if (key === 'api-lts') {

--- a/scripts/plugins/navigation.js
+++ b/scripts/plugins/navigation.js
@@ -17,11 +17,19 @@ module.exports = function buildNavigation (latestVersions) {
       Object.keys(obj).forEach(function (key) {
         if (obj[key].link && obj[key].text) {
           // Insert latest versions for API docs
-          if (key === 'api-current' && latestVersions.current) {
+          if (key === 'api-current') {
+            // dont add a navigation item when link is supposed to be for
+            // the current release line, but that release line isn't present
+            if (!latestVersions.current) {
+              return
+            }
+
             obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.current.node)
+            obj[key].link = obj[key].link.replace(/%ver-major%/, latestVersions.current.nodeMajor)
           }
           if (key === 'api-lts') {
             obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.lts.node)
+            obj[key].link = obj[key].link.replace(/%ver-major%/, latestVersions.lts.nodeMajor)
           }
 
           meta.nav[level] = meta.nav[level] || parent

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('tape')
+
+const latestversion = require('../../scripts/helpers/latestversion')
+
+test('latestversion.current()', (t) => {
+  t.test('should be greater equal/greater than v5.0.0', (t) => {
+    const currentVersion = latestversion.current([
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(currentVersion, undefined)
+    t.end()
+  })
+
+  t.test('should not be an LTS release', (t) => {
+    const currentVersion = latestversion.current([
+      { version: 'v5.0.0', lts: false },
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(currentVersion.node, 'v5.0.0')
+    t.end()
+  })
+
+  t.end()
+})
+
+test('latestversion.lts()', (t) => {
+  t.test('should be an LTS release', (t) => {
+    const ltsVersion = latestversion.lts([
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(ltsVersion.node, 'v4.2.1')
+    t.end()
+  })
+
+  t.test('should pick latest LTS release', (t) => {
+    const ltsVersion = latestversion.lts([
+      { version: 'v5.0.0', lts: false },
+      { version: 'v4.2.1', lts: true },
+      { version: 'v4.2.0', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(ltsVersion.node, 'v4.2.1')
+    t.end()
+  })
+
+  t.end()
+})

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -5,17 +5,17 @@ const test = require('tape')
 const latestversion = require('../../scripts/helpers/latestversion')
 
 test('latestversion.current()', (t) => {
-  t.test('should be greater equal/greater than v5.0.0', (t) => {
+  t.test('should be undefined when latest LTS is v6 and v7 has not been released', (t) => {
     const currentVersion = latestversion.current([
-      { version: 'v4.2.1', lts: true },
-      { version: 'v0.12.7', lts: false }
+      { version: 'v6.8.1', lts: true },
+      { version: 'v5.7.1', lts: false }
     ])
 
     t.equal(currentVersion, undefined)
     t.end()
   })
 
-  t.test('should not be an LTS release', (t) => {
+  t.test('should be latest current release greather than latest LTS major', (t) => {
     const currentVersion = latestversion.current([
       { version: 'v5.0.0', lts: false },
       { version: 'v4.2.1', lts: true },
@@ -23,6 +23,30 @@ test('latestversion.current()', (t) => {
     ])
 
     t.equal(currentVersion.node, 'v5.0.0')
+    t.end()
+  })
+
+  t.end()
+})
+
+test('latestversion.upcomingCurrent()', (t) => {
+  t.test('should be undefined when there is an active current release', (t) => {
+    const upcoming = latestversion.upcomingCurrent([
+      { version: 'v4.2.1', lts: true },
+      { version: 'v5.0.0', lts: false }
+    ])
+
+    t.equal(upcoming, undefined)
+    t.end()
+  })
+
+  t.test('should be v7.0.0 when latest LTS is v6.x', (t) => {
+    const upcoming = latestversion.upcomingCurrent([
+      { version: 'v6.8.1', lts: true },
+      { version: 'v5.7.1', lts: false }
+    ])
+
+    t.same(upcoming, { node: 'v7.0.0' })
     t.end()
   })
 

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -46,7 +46,10 @@ test('latestversion.upcomingCurrent()', (t) => {
       { version: 'v5.7.1', lts: false }
     ])
 
-    t.same(upcoming, { node: 'v7.0.0' })
+    t.same(upcoming, {
+      node: 'v7.0.0',
+      nodeMajor: 'v7.x'
+    })
     t.end()
   })
 


### PR DESCRIPTION
These changes makes the website handle periodes where a current release line has not been cut yet, automatically. As discussed in https://github.com/nodejs/nodejs.org/issues/982, we could grey out the "current" option, instead of two LTS options, in periodes where we don't have a current release line.

Rationale behind handling this automatically is to prevent us having to land a big PR, which we probably haven't tested much, asap after v7 has been cut. This would _just work_ whenever v7 is out.

The main logic around this, is found in `scripts/helpers/latestversion.js` which picks which version should be displayed as LTS and current, plus "upcoming current" introduced with these changes. That logic is based around the list of releases in https://nodejs.org/download/release/index.json. In summary the logical rules are:
- **LTS**: latest version in with `.lts === true`
- **Current**: latest version with `.lts !== true` and version number greater than the latest **LTS**
- **Upcoming current**: whenever **current** doesn't exists, calculate upcoming current to be major of LTS + 1, e.g. `v6 + 1`

Download page should probably have something similar implemented. Would appreciate any thoughts about how that might look. Tried simply greying out the background for "current" in the download matrix, but that _really_ didn't look good, so I'm skipped that part for now.

Examples of how the frontpage looks depending on the versions found in https://nodejs.org/download/release/index.json.
#### Previously when LTS and current existed

<img width="591" alt="screen shot 2016-10-23 at 20 06 19" src="https://cloud.githubusercontent.com/assets/1231635/19628372/a3df3974-995c-11e6-8265-b925858a5f76.png">
#### When no current release is found (like now)

<img width="563" alt="screen shot 2016-10-23 at 20 06 34" src="https://cloud.githubusercontent.com/assets/1231635/19628374/a6208846-995c-11e6-99fc-fbf4b3c75717.png">
#### As soon as current exists again

<img width="569" alt="screen shot 2016-10-23 at 20 07 28" src="https://cloud.githubusercontent.com/assets/1231635/19628376/a85b3890-995c-11e6-827c-bb7399e6d497.png">
## Tasks
- [x] Frontpage
- [x] Download page
- [ ] Download page for current when current don't exist
