### PR TITLE
Add v4.x branch to releases page

### DIFF
--- a/locale/en/download/releases.md
+++ b/locale/en/download/releases.md
@@ -12,10 +12,9 @@ Releases 1.x through 3.x were called "io.js" as they were part of the io.js fork
 
     <ul class="list-divider-pipe">
         <li><a href="https://nodejs.org/dist/latest-v6.x/">Node.js 6.x</a></li>
-        <li><a href="https://nodejs.org/dist/latest-v5.x/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/dist/latest-v4.x/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.12.x/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.10.x/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/dist/">all versions</a></li>
     </ul>
 </div>
-


### PR DESCRIPTION
I noticed that the v4.x branch is not listed in the "Looking for latest release of a version branch?" box.

![screen shot 2016-10-24 at 15 12 36](https://cloud.githubusercontent.com/assets/1443911/19646993/54095b96-99fc-11e6-96fd-e8d5309c9959.png)

This patch removes the no longer supported v5.x branch in favor of v4.x.
