### PR TITLE
Revert "meta: switch v6.x to LTS (#973)"

### DIFF
--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -81,12 +81,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -4,14 +4,14 @@ title: Download
 download: Download
 downloads:
     headline: Downloads
-    lts: LTS v4.x
-    current: LTS v6.x
+    lts: LTS
+    current: Current
     tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: LTS Version
+    currentVersion: Latest Current Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -4,14 +4,14 @@ title: Download
 download: Download
 downloads:
     headline: Downloads
-    lts: LTS v4.x
-    current: LTS v6.x
+    lts: LTS
+    current: Current
     tagline-current: Latest Features
     tagline-lts: Recommended For Most Users
     display-hint: Display downloads for
     intro: >
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
-    currentVersion: LTS Version
+    currentVersion: Latest LTS Version
     buildDisclaimer: "Note: Python 2.6 or 2.7 is required to build from source tarballs."
 additional:
     headline: Additional Platforms

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -1,13 +1,13 @@
 ---
 layout: index.hbs
 labels:
-  current-version: LTS
+  current-version: Current Version
   download: Download
   download-for: Download for
   other-downloads: Other Downloads
   other-lts-downloads: Other LTS Downloads
   other-current-downloads: Other Current Downloads
-  current: LTS
+  current: Current
   lts: LTS
   tagline-current: Latest Features
   tagline-lts: Recommended For Most Users

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -81,12 +81,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -81,12 +81,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -79,12 +79,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -81,12 +81,12 @@
             "text": "よくある質問"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -81,12 +81,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -77,12 +77,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -81,12 +81,12 @@
             "text": "FAQ"
         },
         "api-lts": {
-            "link": "/dist/latest-v4.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "subtext": "LTS",
             "text": "%ver% API"
         },
         "api-current": {
-            "link": "/dist/latest-v6.x/docs/api",
+            "link": "/dist/latest-%ver-major%/docs/api",
             "text": "%ver% API"
         },
         "guides": {

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -4,6 +4,7 @@ const semver = require('semver')
 
 const map = (release) => release && {
   node: release.version,
+  nodeMajor: majorStr(release),
   npm: release.npm,
   v8: release.v8,
   openssl: release.openssl
@@ -15,3 +16,7 @@ exports.current = (releases) => {
 }
 
 exports.lts = (releases) => map(releases.find((release) => release.lts))
+
+function majorStr (release) {
+  return `v${semver.major(release.version)}.x`
+}

--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -9,9 +9,9 @@ const map = (release) => release && {
   openssl: release.openssl
 }
 
-exports.lts = (releases) => {
-  const match = releases.find((release) => release.lts && semver.lte(release.version, '5.0.0'))
+exports.current = (releases) => {
+  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
   return map(match)
 }
 
-exports.current = (releases) => map(releases.find((release) => release.lts))
+exports.lts = (releases) => map(releases.find((release) => release.lts))

--- a/scripts/plugins/navigation.js
+++ b/scripts/plugins/navigation.js
@@ -19,9 +19,11 @@ module.exports = function buildNavigation (latestVersions) {
           // Insert latest versions for API docs
           if (key === 'api-current') {
             obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.current.node)
+            obj[key].link = obj[key].link.replace(/%ver-major%/, latestVersions.current.nodeMajor)
           }
           if (key === 'api-lts') {
             obj[key].text = obj[key].text.replace(/%ver%/, latestVersions.lts.node)
+            obj[key].link = obj[key].link.replace(/%ver-major%/, latestVersions.lts.nodeMajor)
           }
 
           meta.nav[level] = meta.nav[level] || parent

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('tape')
+
+const latestversion = require('../../scripts/helpers/latestversion')
+
+test('latestversion.current()', (t) => {
+  t.test('should be greater equal/greater than v5.0.0', (t) => {
+    const currentVersion = latestversion.current([
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(currentVersion, undefined)
+    t.end()
+  })
+
+  t.test('should not be an LTS release', (t) => {
+    const currentVersion = latestversion.current([
+      { version: 'v5.0.0', lts: false },
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(currentVersion.node, 'v5.0.0')
+    t.end()
+  })
+
+  t.end()
+})
+
+test('latestversion.lts()', (t) => {
+  t.test('should be an LTS release', (t) => {
+    const ltsVersion = latestversion.lts([
+      { version: 'v4.2.1', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(ltsVersion.node, 'v4.2.1')
+    t.end()
+  })
+
+  t.test('should pick latest LTS release', (t) => {
+    const ltsVersion = latestversion.lts([
+      { version: 'v5.0.0', lts: false },
+      { version: 'v4.2.1', lts: true },
+      { version: 'v4.2.0', lts: true },
+      { version: 'v0.12.7', lts: false }
+    ])
+
+    t.equal(ltsVersion.node, 'v4.2.1')
+    t.end()
+  })
+
+  t.end()
+})

--- a/tests/scripts/latestversion.test.js
+++ b/tests/scripts/latestversion.test.js
@@ -5,7 +5,7 @@ const test = require('tape')
 const latestversion = require('../../scripts/helpers/latestversion')
 
 test('latestversion.current()', (t) => {
-  t.test('should be greater equal/greater than v5.0.0', (t) => {
+  t.test('should be equal/greater than v5.0.0', (t) => {
     const currentVersion = latestversion.current([
       { version: 'v4.2.1', lts: true },
       { version: 'v0.12.7', lts: false }
@@ -23,6 +23,15 @@ test('latestversion.current()', (t) => {
     ])
 
     t.equal(currentVersion.node, 'v5.0.0')
+    t.end()
+  })
+
+  t.test('should generate major version string', (t) => {
+    const currentVersion = latestversion.current([
+      { version: 'v7.0.0', lts: false }
+    ])
+
+    t.equal(currentVersion.nodeMajor, 'v7.x')
     t.end()
   })
 


### PR DESCRIPTION
For the release of v7.0 we should revert commit 8c53b4b0a0a

This can be trumped by #990 if it is ready for release before v7 is cut
