### PR TITLE
change Korean term for Current

### DIFF
--- a/locale/ko/about/index.md
+++ b/locale/ko/about/index.md
@@ -102,7 +102,7 @@ Node는 스레드를 사용하지 않도록 설계되지만 멀티 코어 환경
 [Blocking vs Non-Blocking]: https://github.com/nodejs/node/blob/master/doc/topics/blocking-vs-non-blocking.md
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
-[event loop]: https://github.com/nodejs/node/blob/master/doc/topics/the-event-loop-timers-and-nexttick.md
+[event loop]: https://github.com/nodejs/node/blob/master/doc/topics/event-loop-timers-and-nexttick.md
 [Event Machine]: http://rubyeventmachine.com/
 [Twisted]: http://twistedmatrix.com/
 -->
@@ -110,6 +110,6 @@ Node는 스레드를 사용하지 않도록 설계되지만 멀티 코어 환경
 [Blocking vs Non-Blocking]: https://github.com/nodejs/node/blob/master/doc/topics/blocking-vs-non-blocking.md
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
-[event loop]: https://github.com/nodejs/node/blob/master/doc/topics/the-event-loop-timers-and-nexttick.md
+[event loop]: https://github.com/nodejs/node/blob/master/doc/topics/event-loop-timers-and-nexttick.md
 [Event Machine]: http://rubyeventmachine.com/
 [Twisted]: http://twistedmatrix.com/

--- a/locale/ko/docs/index.md
+++ b/locale/ko/docs/index.md
@@ -8,20 +8,22 @@ labels:
 <!--
 # About Docs
 
-There are three types of documentation available on this website:
+There are several types of documentation available on this website:
 
 * API reference documentation
 * ES6 features
 * Frequently asked questions
+* Guides
 -->
 
 # 문서에 관해서
 
-이 웹사이트에는 세 가지 종류의 문서가 있습니다.
+이 웹사이트에는 여러 종류의 문서가 있습니다.
 
 * API 레퍼런스 문서
 * ES6 기능
 * 자주 묻는 질문
+* 안내
 
 <!--
 ### API Reference Documentation
@@ -83,3 +85,13 @@ The [FAQ](/en/docs/faq/) covers how everyone can contribute to Node.js, our code
 
 [FAQ](/ko/docs/faq/)에서는 Node.js에 기여하는 방법, 행동강령과 거버넌스 모델,
 GitHub과 IRC에서 연락을 취하는 방법, 선별된 이슈로 돕는 방법 등을 다룹니다.
+
+<!--
+### Guides
+
+Long-form, in-depth articles about Node.js technical features and capabilities.
+-->
+
+### 안내
+
+Node.js의 기술적인 기능에 대한 길고 상세한 글

--- a/locale/ko/download/current.md
+++ b/locale/ko/download/current.md
@@ -5,13 +5,13 @@ download: 다운로드
 downloads:
     headline: 다운로드
     lts: LTS
-    current: 최신 버전
+    current: 현재 버전
     tagline-current: 최신 기능
     tagline-lts: 대다수 사용자에게 추천
     display-hint: "다음 버전을 표시:"
     intro: >
         플랫폼에 맞게 미리 빌드된 Node.js 인스톨러나 소스코드를 다운받아서 바로 개발을 시작하세요.
-    currentVersion: 최신 버전
+    currentVersion: 최신 현재 버전
     buildDisclaimer: "Note: 소스 tarball을 빌드하려면 Python 2.6이나 2.7이 필요합니다."
 additional:
     headline: 그 밖의 플랫폼

--- a/locale/ko/download/index.md
+++ b/locale/ko/download/index.md
@@ -5,13 +5,13 @@ download: 다운로드
 downloads:
     headline: 다운로드
     lts: LTS
-    current: 최신 버전
+    current: 현재 버전
     tagline-current: 최신 기능
     tagline-lts: 대다수 사용자에게 추천
     display-hint: "다음 버전을 표시:"
     intro: >
         플랫폼에 맞게 미리 빌드된 Node.js 인스톨러나 소스코드를 다운받아서 바로 개발을 시작하세요.
-    currentVersion: 최신 버전
+    currentVersion: 최신 LTS 버전
     buildDisclaimer: "Note: 소스 tarball을 빌드하려면 Python 2.6이나 2.7이 필요합니다."
 additional:
     headline: 그 밖의 플랫폼

--- a/locale/ko/download/releases.md
+++ b/locale/ko/download/releases.md
@@ -19,7 +19,7 @@ Node.js 4.0.0에서 io.js의 이전 릴리스 라인과 Node.js 0.12.x가 합쳐
 
     <ul class="list-divider-pipe">
         <li><a href="https://nodejs.org/dist/latest-v6.x/">Node.js 6.x</a></li>
-        <li><a href="https://nodejs.org/dist/latest-v5.x/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/dist/latest-v4.x/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.12.x/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.10.x/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/dist/">all versions</a></li>
@@ -31,7 +31,7 @@ Node.js 4.0.0에서 io.js의 이전 릴리스 라인과 Node.js 0.12.x가 합쳐
 
     <ul class="list-divider-pipe">
         <li><a href="https://nodejs.org/dist/latest-v6.x/">Node.js 6.x</a></li>
-        <li><a href="https://nodejs.org/dist/latest-v5.x/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/dist/latest-v4.x/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.12.x/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/dist/latest-v0.10.x/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/dist/">모든 버전</a></li>

--- a/locale/ko/index.md
+++ b/locale/ko/index.md
@@ -3,7 +3,7 @@ layout: index.hbs
 labels:
   current-version: 현재 버전
   download: 다운로드
-  download-for: Download for
+  download-for: 다운로드 -
   other-downloads: 다른 운영 체제
   other-lts-downloads: 다른 LTS 다운로드
   other-current-downloads: 다른 현재 버전 다운로드
@@ -13,8 +13,8 @@ labels:
   tagline-lts: 안정적, 신뢰도 높음
   changelog: 변경사항
   api: API 문서
-  version-schedule-prompt: Or have a look at the
-  version-schedule-prompt-link-text: LTS schedule
+  version-schedule-prompt: LTS 일정은
+  version-schedule-prompt-link-text: 여기서 확인하세요
 ---
 
 Node.js®는 [Chrome V8 JavaScript 엔진](https://developers.google.com/v8/)으로 빌드된 JavaScript 런타임입니다.


### PR DESCRIPTION
There was some confusion between `latest` and `current` in Korean. We discussed it in [here](https://github.com/nodejs/nodejs-ko/issues/436). To clarify, we want to change a term for `Current`. @nodejs/nodejs-ko 

Additionally, I updated Korean documents to follow English documents, see [changes](https://github.com/nodejs/nodejs.org/compare/6f24cea...d86dcff) for more details.
