### PR TITLE
Remove Roadmap Working Group

### DIFF
--- a/locale/en/about/working-groups.md
+++ b/locale/en/about/working-groups.md
@@ -52,7 +52,6 @@ Core Working Groups are created by the
 * [Diagnostics](#diagnostics)
 * [i18n](#i18n)
 * [Evangelism](#evangelism)
-* [Roadmap](#roadmap)
 * [Docker](#docker)
 * [Addon API](#addon-api)
 * [Benchmarking](#benchmarking)
@@ -218,19 +217,6 @@ Responsibilities include:
 * Messaging about the future of HTTP to give the community advance notice of
   changes.
 
-### [Roadmap](https://github.com/nodejs/roadmap)
-
-The Roadmap Working Group is responsible for user community outreach
-and the translation of their concerns into a plan of action for Node.js.
-
-The final [ROADMAP](https://github.com/nodejs/node/blob/master/ROADMAP.md) document is still
-owned by the TC and requires the same approval for changes as any other project asset.
-
-Responsibilities include:
-* Attracting and summarizing user community needs and feedback.
-* Finding or potentially creating tools that allow for broader participation.
-* Creating Pull Requests for relevant changes to
-[ROADMAP.md](https://github.com/nodejs/node/blob/master/ROADMAP.md)
 
 ### [Docker](https://github.com/nodejs/docker-node)
 


### PR DESCRIPTION
See:
https://github.com/nodejs/CTC/issues/16
https://github.com/nodejs/node/pull/9545

Since this page mirrors the legit info in the `node` repo, please do not merge before https://github.com/nodejs/node/pull/9545 is complete. I'll follow up with another comment to signal it is GTG.