### PR TITLE
Docker: Add .dockerignore file in guide

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -145,6 +145,15 @@ EXPOSE 8080
 CMD [ "npm", "start" ]
 ```
 
+## .dockerignore file
+
+Prevent your local modules and debug log from being copied into your Docker image:
+
+```
+node_modules
+npm-debug.log
+```
+
 ## Building your image
 
 Go to the directory that has your `Dockerfile` and run the following command to

--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -147,12 +147,16 @@ CMD [ "npm", "start" ]
 
 ## .dockerignore file
 
-Prevent your local modules and debug log from being copied into your Docker image:
+Create a `.dockerignore` file in the same directory as your `Dockerfile`
+with following content:
 
 ```
 node_modules
 npm-debug.log
 ```
+
+This will prevent your local modules and debug logs from being copied onto your
+Docker image and possibly overwriting modules installed within your image.
 
 ## Building your image
 


### PR DESCRIPTION
Without the `.dockerignore` file the npm modules installed inside the image possibly get overwritten by your local modules.

The overwriting happens here:
```docker
COPY . /usr/src/app
```
Given you have a `node_modules` folder locally.
