### PR TITLE
add link to Node-ChakraCore nightlies

### DIFF
--- a/layouts/partials/download-list.hbs
+++ b/layouts/partials/download-list.hbs
@@ -5,6 +5,7 @@
     <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}">{{site.download.package-manager.text}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.releases.link}}/">{{site.download.releases.text}}</a></li>
     <li><a href="https://nodejs.org/download/nightly/">{{site.nightly}}</a></li>
+    <li><a href="https://nodejs.org/download/chakracore-nightly/">{{site.chakracore-nightly}}</a></li>
   </ul>
   <p>{{downloads.buildDisclaimer}}</p>
 </section>

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -10,6 +10,7 @@
     "by": "by",
     "all-downloads": "All download options",
     "nightly": "Nightly builds",
+    "chakracore-nightly": "Node-ChakraCore Nightly builds",
     "feeds": [
         {
             "link": "feed/blog.xml",


### PR DESCRIPTION
We now provide Node-ChakraCore nightlies at https://nodejs.org/download/chakracore-nightly/ per @joaocgreis's work in https://github.com/nodejs/build/issues/527. This adds a link for these to the Downloads page.

//cc @nodejs/build @nodejs/chakracore 