### PR TITLE
fix standard.js lint error

### DIFF
--- a/build.js
+++ b/build.js
@@ -199,7 +199,7 @@ function githubLinks (options) {
   return (files, m, next) => {
     // add suffix (".html" or "/") to each part of regex
     // to ignore possible occurrences in titles (e.g. blog posts)
-    const isEditable = /security\.html|about\/|docs\/|foundation\/|get\-involved\/|knowledge\//
+    const isEditable = /security\.html|about\/|docs\/|foundation\/|get-involved\/|knowledge\//
 
     Object.keys(files).forEach((path) => {
       if (!isEditable.test(path)) {

--- a/scripts/event-geo.js
+++ b/scripts/event-geo.js
@@ -42,66 +42,66 @@ function _meetup (ev) {
     if (ev.description[0] !== '<') {
       ev.description = `<p>${ev.description}</p>`
     }
-    const regex = /<br\s*[\/]?>/gi
+    const regex = /<br\s*[/]?>/gi
     desc = htmlToText.fromString(ev.description).replace(regex, '\n')
   }
 
   const ret =
-  { type: 'Feature',
-    geometry:
-    { type: 'Point',
-      coordinates: [ev.lon, ev.lat]
-    },
-    properties:
-    { title: ev.name,
-      description: desc,
-      link: ev.link,
-      image: ev.group_photo ? ev.group_photo.photo_link : '',
-      'marker-size': 'medium',
-      'marker-symbol': 'star',
-      'marker-color': '#80bd01'
+    { type: 'Feature',
+      geometry:
+      { type: 'Point',
+        coordinates: [ev.lon, ev.lat]
+      },
+      properties:
+      { title: ev.name,
+        description: desc,
+        link: ev.link,
+        image: ev.group_photo ? ev.group_photo.photo_link : '',
+        'marker-size': 'medium',
+        'marker-symbol': 'star',
+        'marker-color': '#80bd01'
+      }
     }
-  }
   return ret
 }
 function _conference (ev) {
   if (!ev.lat) return
   const ret =
-  { type: 'Feature',
-    geometry:
-    { type: 'Point',
-      coordinates: [ev.lon, ev.lat]
-    },
-    properties:
-    { title: ev.name,
-      description: ev.desc,
-      link: ev.link,
-      image: ev.image,
-      'marker-size': 'medium',
-      'marker-symbol': 'triangle',
-      'marker-color': '#3887be'
+    { type: 'Feature',
+      geometry:
+      { type: 'Point',
+        coordinates: [ev.lon, ev.lat]
+      },
+      properties:
+      { title: ev.name,
+        description: ev.desc,
+        link: ev.link,
+        image: ev.image,
+        'marker-size': 'medium',
+        'marker-symbol': 'triangle',
+        'marker-color': '#3887be'
+      }
     }
-  }
   return ret
 }
 function _nodeschool (ev) {
   if (!ev.lat) return
   const ret =
-  { type: 'Feature',
-    geometry:
-    { type: 'Point',
-      coordinates: [ev.lon, ev.lat]
-    },
-     properties:
-     { title: ev.name,
-       link: ev.website || ev.repo,
-       image: ev.image,
-       description: `${ev.name} ${ev.repo || ''} ${ev.website || ''}`,
-       'marker-size': 'medium',
-       'marker-symbol': 'star-stroked',
-       'marker-color': '#f7da03'
+    { type: 'Feature',
+      geometry:
+      { type: 'Point',
+        coordinates: [ev.lon, ev.lat]
+      },
+      properties:
+      { title: ev.name,
+        link: ev.website || ev.repo,
+        image: ev.image,
+        description: `${ev.name} ${ev.repo || ''} ${ev.website || ''}`,
+        'marker-size': 'medium',
+        'marker-symbol': 'star-stroked',
+        'marker-color': '#f7da03'
+      }
     }
-  }
   return ret
 }
 

--- a/scripts/plugins/anchor-markdown-headings.js
+++ b/scripts/plugins/anchor-markdown-headings.js
@@ -2,7 +2,7 @@
 
 module.exports = function anchorMarkdownHeadings (text, level, raw) {
   const escapedText = raw
-    .replace(/(\[([^\]]+)\]\([^)]+\))/g, '$2')
+    .replace(/(\[([^\]]+)]\([^)]+\))/g, '$2')
     .replace(/[^\w]+/g, '-')
     .replace(/-{2,}/g, '-')
     .replace(/(^-|-$)/g, '')

--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -123,7 +123,7 @@ function fetchVersionPolicy (version) {
     // matches the policy for a given version (Stable, LTS etc) in the changelog
     // ## 2015-10-07, Version 4.2.0 'Argon' (LTS), @jasnell
     // ## 2015-12-04, Version 0.12.9 (LTS), @rvagg
-    const rxPolicy = /^## ?\d{4}-\d{2}-\d{2}, Version [^(].*\(([^\)]+)\)/
+    const rxPolicy = /^## ?\d{4}-\d{2}-\d{2}, Version [^(].*\(([^)]+)\)/
     const matches = rxPolicy.exec(section)
     return matches
       ? matches[1]


### PR DESCRIPTION
[Latest build on Travis failed](https://travis-ci.org/nodejs/nodejs.org/builds/178625472).

```
standard: Use JavaScript Standard Style (http://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
  /home/travis/build/nodejs/nodejs.org/build.js:202:71: Unnecessary escape character: \-.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:45:27: Unnecessary escape character: \/.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:50:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:51:5: Expected indentation of 6 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:55:5: Expected indentation of 6 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:64:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:70:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:71:5: Expected indentation of 6 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:75:5: Expected indentation of 6 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:84:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:90:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:91:5: Expected indentation of 6 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:95:6: Expected indentation of 6 spaces but found 5.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:103:5: Expected indentation of 5 spaces but found 4.
  /home/travis/build/nodejs/nodejs.org/scripts/event-geo.js:104:3: Expected indentation of 4 spaces but found 2.
  /home/travis/build/nodejs/nodejs.org/scripts/plugins/anchor-markdown-headings.js:5:26: Unnecessary escape character: \].
  /home/travis/build/nodejs/nodejs.org/scripts/release-post.js:126:66: Unnecessary escape character: \).
```

I'm not sure the reason, but I found [standard is v8.6.0](https://github.com/feross/standard/releases/tag/v8.6.0). The latest build that is passed used standard@v8.5.0.