### PR TITLE
Change 'library' translation

### DIFF
--- a/locale/es/index.md
+++ b/locale/es/index.md
@@ -20,4 +20,4 @@ labels:
 Node.js® es una entorno de ejecución para JavaScript construido con el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
 Node.js usa un modelo de operaciones E/S sin bloqueo y orientado a eventos, que lo hace liviano y eficiente.
 El ecosistema de paquetes de Node.js, [npm](https://www.npmjs.com/), es el ecosistema mas grande de
-librerías de código abierto en el mundo.
+bibliotecas de código abierto en el mundo.


### PR DESCRIPTION
- 'librería' is a bad translation when we are talking about code in Spanish. We use the word 'biblioteca' instead, which refers to the place were we store, catalog and go to request/consult books.