### PR TITLE
Add information that ab is ApacheBench

### DIFF
--- a/locale/en/docs/guides/simple-profiling.md
+++ b/locale/en/docs/guides/simple-profiling.md
@@ -88,7 +88,7 @@ high latency on requests. We can easily run the app with the built in profiler:
 NODE_ENV=production node --prof app.js
 ```
 
-and put some load on the server using ab:
+and put some load on the server using ab (ApacheBench):
 
 ```
 curl -X GET "http://localhost:8080/newUser?username=matt&password=password"


### PR DESCRIPTION
I had trouble figuring out what ab referred to, as the term is not SEO-friendly. It is useful to add information that ab is ApacheBench.