### PR TITLE
Remove "Planet Node" link from page.

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -24,8 +24,6 @@ right place. Explore our community resources to find out how you can help:
 
 - [Node Weekly](http://nodeweekly.com) is an email list that gathers up the latest events and news from around the Node.js community.
 
-- [Planet Node](http://planetnodejs.com) is an aggregator of Node developer blogs.
-
 - [NodeUp](http://nodeup.com) is a podcast covering the latest Node news in the community.
 
 - [NodeJS Reactions](http://nodejsreactions.tumblr.com) captures the Node.js experience in the form of animated GIFs.


### PR DESCRIPTION
Remove "Planet Node" link from page since it does not exist anymore.

Solves issue #1045 