### PR TITLE
Remove border-radius from hovered links on frontpage

### DIFF
--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -29,6 +29,7 @@
     &:hover
       background-color transparent
       border-bottom 1px solid $home-secondary-links-color
+      border-radius 0
 
 #home-intro
   max-width $body-max-width * 0.75


### PR DESCRIPTION
I think these look better without a radius.

##### Before
<img width="144" src="https://cloud.githubusercontent.com/assets/115237/20940697/00e5ce6c-bbf4-11e6-8c7f-755cf94bcf99.png">

##### After

<img width="145" src="https://cloud.githubusercontent.com/assets/115237/20940715/0d3769a0-bbf4-11e6-9581-7791946b6dad.png">
