### PR TITLE
Fix Google Analytics tracking across the site

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -73,18 +73,6 @@
 
   {{> footer className="no-margin-top" }}
   <script src="/static/js/download.js" async defer></script>
-  <script src="/static/js/dnt_helper.js"></script>
-  <script>
-    if (!_dntEnabled()) {
-      !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
-      (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
-      s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
-      s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
-
-      ga('create', 'UA-67020396-1', 'auto');
-      ga('send', 'pageview');
-    }
-    </script>
 
 </body>
 </html>

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -49,3 +49,16 @@
     s.parentNode.insertBefore(m,s);
   })(document,'script');
 </script>
+
+<script src="/static/js/dnt_helper.js"></script>
+<script>
+  if (!_dntEnabled()) {
+    !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
+    (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
+    s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
+    s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
+
+    ga('create', 'UA-67020396-1', 'auto');
+    ga('send', 'pageview');
+  }
+</script>


### PR DESCRIPTION
With https://github.com/nodejs/nodejs.org/pull/885 site wide Google Analytics tracking got moved from the `layouts/partials/footer.hbs` -> `layouts/index.hbs`.
That was a huge mistake (by me), which made the index / frontpage be the only page left with Google Analytics tracking, all other pages lost the tracking scripts.

This fixes that blooper by moving the tracking scripts back into `layouts/partials/footer.hbs`, but still ensuring we respect our visitor's Do-Not-Track setting.

Closes https://github.com/nodejs/nodejs.org/issues/1028

/cc @mikeal 