### PR TITLE
add `google-site-verification` meta tag

### DIFF
--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -9,6 +9,7 @@
   <meta name="author" content="{{ site.author }}">
   <meta name="robots" content="{{#if robots}}{{ robots }}{{else}}index, follow{{/if}}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="google-site-verification" content="qFRqSS3YabaM02Yfi-rWfttSH1QBVeh2F0GlB4Fp0JI" />
 
   <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
   <link rel="icon" sizes="32x32" type="image/png" href="/static/favicon.png">


### PR DESCRIPTION
To enable us to link from one of the YouTube videos to the website- we need to make get the nodejs.org site approved.

Adding this meta tag will do the trick!