### PR TITLE
Add shortcut link for v4.x API docs

### DIFF
--- a/locale/de/docs/index.md
+++ b/locale/de/docs/index.md
@@ -30,6 +30,7 @@ von der Community zur Verfügung gestellt werden, sind dort nicht dokumentiert.
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/docs/">Alle Versionen</a></li>

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -25,6 +25,7 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/docs/">all versions</a></li>

--- a/locale/es/docs/index.md
+++ b/locale/es/docs/index.md
@@ -26,6 +26,7 @@ También describe los módulos incluidos que proporciona Node.js, mas no documen
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/docs/">Todas las versiones</a></li>

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -33,6 +33,7 @@ labels:
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <!-- <li><a href="https://nodejs.org/docs/">all versions</a></li> -->

--- a/locale/ko/docs/index.md
+++ b/locale/ko/docs/index.md
@@ -57,6 +57,7 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/docs/">모든 버전</a></li>

--- a/locale/uk/docs/index.md
+++ b/locale/uk/docs/index.md
@@ -24,6 +24,7 @@ labels:
 
     <ul>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
         <li><a href="https://nodejs.org/docs/">всі версії</a></li>


### PR DESCRIPTION
This adds a shortcut link for the v4.x API docs.