### PR TITLE
Fix typo on nodejs-certified-developer-program

### DIFF
--- a/locale/en/blog/announcements/nodejs-certified-developer-program.md
+++ b/locale/en/blog/announcements/nodejs-certified-developer-program.md
@@ -29,8 +29,7 @@ developer, possessing skills that are in high demand,” said Tracy Hinds,
 education community manager for the Node.js Foundation.
 
 The Node.js Certified Developer program, which is being developed with input from
-leading Node.js experts and contributors, is expected to be available in Q2 of
-2017. The program will provide a framework for general Node.js competency,
+leading Node.js experts and contributors, is expected to be available in Q2 of 2017. The program will provide a framework for general Node.js competency,
 helping enterprises quickly identify qualified Node.js engineers, while
 providing developers, contractors and consultants with a way to differentiate
 themselves in the market.


### PR DESCRIPTION
I fixed this issue, #1124. Here is a preview below:

**Before:**
<img width="985" alt="screen shot 2017-02-04 at 14 06 54" src="https://cloud.githubusercontent.com/assets/1587053/22615887/42362b8c-eae3-11e6-8a7c-eda953366e7c.png">

**After:**
<img width="883" alt="screen shot 2017-02-04 at 14 07 02" src="https://cloud.githubusercontent.com/assets/1587053/22615903/9b8e8b3e-eae3-11e6-847c-6b875d787d33.png">

Please review cc: @nodejs/website 