### PR TITLE
fix indentation of pre code elements

### DIFF
--- a/layouts/css/_base.styl
+++ b/layouts/css/_base.styl
@@ -71,3 +71,4 @@ pre
   code
     color $light-gray3
     background-color inherit
+    padding 0


### PR DESCRIPTION
Currently there are a number of the guides that have code examples which
have the first code line indented slightly more than the others. This
commit attempts to fix this.