### PR TITLE
adding a --force flag to update a release blog post

### DIFF
--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -179,7 +179,7 @@ function writeToFile (results) {
 
   return new Promise((resolve, reject) => {
     fs.access(filepath, fs.F_OK, (err) => {
-      if (!err) {
+      if (!err && process.argv[3] !== '--force') {
         return reject(new Error(`Release post for ${results.version} already exists!`))
       }
 


### PR DESCRIPTION
Adding a flag to allow update a specific **release blog post** without the need of removing the file first

cc: @nodejs/release