### PR TITLE
Fix JavaScript error related to case study tracking

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -52,27 +52,29 @@
 
 <script src="/static/js/dnt_helper.js"></script>
 <script>
-  if (!_dntEnabled()) {
-    !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
-    (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
-    s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
-    s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
+  (function(){
+    if (!_dntEnabled()) {
+      !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
+      (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
+      s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
+      s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
 
-    if (!ga) return;
+      if (!ga) return;
 
-    ga('create', 'UA-67020396-1', 'auto');
-    ga('send', 'pageview');
+      ga('create', 'UA-67020396-1', 'auto');
+      ga('send', 'pageview');
 
-    document.documentElement.addEventListener('click', function(e) {
+      document.documentElement.addEventListener('click', function(e) {
 
-      // Track case studies
-      if(!e.target || !e.target.dataset || !e.target.dataset.casestudy) return;
-      ga('send', 'event', {
-        eventCategory: 'casestudy',
-        eventAction: 'click',
-        eventLabel: e.target.dataset.casestudy,
-        eventValue: 0
+        // Track case studies
+        if(!e.target || !e.target.dataset || !e.target.dataset.casestudy) return;
+        ga('send', 'event', {
+          eventCategory: 'casestudy',
+          eventAction: 'click',
+          eventLabel: e.target.dataset.casestudy,
+          eventValue: 0
+        });
       });
-    });
-  }
+    }
+  })();
 </script>


### PR DESCRIPTION
For the tracking code just merged to work properly, we need to wrap it into an [IIFE](http://benalman.com/news/2010/11/immediately-invoked-function-expression/) because of a `return` statement which is only valid inside a function. This is what's visible in the console on nodejs.org ATM:

![screenshot1](https://cloud.githubusercontent.com/assets/1231635/23232895/351bb44e-f94d-11e6-9de6-ecc07816e8c4.png)

That error prevents the case study tracking scripts from attaching its click listeners, resulting in the case study tracking not being invoked at all.

Refs https://github.com/nodejs/nodejs.org/pull/1148