### PR TITLE
Terminate ubuntu installation commands with semicolons

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -42,14 +42,14 @@ Node.js is available from the [NodeSource](https://nodesource.com) Debian and Ub
 **NOTE:** If you are using Ubuntu Precise or Debian Wheezy, you might want to read about [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md).
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash;
 sudo apt-get install -y nodejs
 ```
 
 Alternatively, for Node.js v7:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash;
 sudo apt-get install -y nodejs
 ```
 


### PR DESCRIPTION
If a user tried to copy these commands---with the trailing dashes on
lines 45 and 52---and paste them to a terminal, the commands would most likely
fail.

I wasn't sure whether to just delete the dashes entirely, so I replaced them with semicolons to make it clearer that these are separate statements, not a wrapped line.