### PR TITLE
Added a 3rd option to debugging with node --inspect via Chrome DevTools.

### DIFF
--- a/locale/en/docs/guides/debugging_getting_started.md
+++ b/locale/en/docs/guides/debugging_getting_started.md
@@ -66,6 +66,8 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
+* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):
+  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
 #### [VS Code](https://github.com/microsoft/vscode) 1.10+
 


### PR DESCRIPTION
This extension has been very well received by the Node community and I think it should be made available (ie known) to more Node developers.

https://twitter.com/wesbos/status/839871649738555393
https://twitter.com/paul_irish/status/824807215202656256