### PR TITLE
remove dechartered working group

### DIFF
--- a/locale/en/about/working-groups.md
+++ b/locale/en/about/working-groups.md
@@ -2,42 +2,6 @@
 layout: about.hbs
 title: Working Groups
 ---
-# Working Groups
-There are 2 types of Working Groups:
-* [Top-Level Working Groups](#top-level-working-groups)
-* [Core Working Groups](#core-working-groups)
-
-# Top-Level Working Groups
-<!-- Information here should mostly mirror: https://github.com/nodejs/TSC/blob/master/WORKING_GROUPS.md -->
-
-Top-Level Working Groups are created by the
-[Technical Steering Committee (TSC)](https://github.com/nodejs/TSC#top-level-wgs-and-tlps).
-
-## Current Top-Level Working Groups
-* [Inclusivity](#inclusivity)
-
-### [Inclusivity](https://github.com/nodejs/inclusivity)
-The Inclusivity Working Group seeks to increase inclusivity and diversity for
-the Node.js project:
-
-* Increasing inclusivity means making the Node.js project a safe and friendly
-place for people from diverse backgrounds.
-* Increasing diversity means actively onboarding people from diverse backgrounds
-to the Node.js project and maintaining their participation.
-
-Responsibilities include:
-* Fostering a welcoming environment that ensures participants are valued and can
-feel confident contributing or joining discussions, regardless of any [aspect of
-their identity](https://github.com/nodejs/inclusivity/#list-of-responsibilities).
-* Proactively seeking and proposing concrete steps the project can take to increase
-inclusivity.
-* Serving as a resource for the development and enforcement of workflows that
-protect community members and projects from harassment and abuse.
-* Acknowledging and celebrating existing diversity accomplishments within the project
-while seeking to build upon them.
-* Identifying ways to measure diversity and inclusivity within the project and report
-them at regular intervals.
-
 # Core Working Groups
 <!-- Information here should mostly mirror: https://github.com/nodejs/node/blob/master/WORKING_GROUPS.md -->
 


### PR DESCRIPTION
The only top-level working group has been dechartered <strike>and superseded by
the Community Committee</strike>. Remove information about the dechartered
working group. For that matter, since there aren't any top-level
working groups, remove text identifying that there are two different
types of working groups (since, at the current time anyway, there is
only one type of working group that actually exists).