### PR TITLE
Remove Strongloop from member logos

### DIFF
--- a/locale/en/foundation/members.md
+++ b/locale/en/foundation/members.md
@@ -103,9 +103,6 @@ Individual membership costs [$100 a year, or $25 for students](https://identity.
 <a target="_new" class="imagelink" href="http://sphinx.sg/">
   <img alt="Sphinx" class="memberlogo" src="/static/images/foundation/sphinx.png" />
 </a>
-<a target="_new" class="imagelink" href="//strongloop.com">
-  <img alt="StrongLoop" class="memberlogo" src="/static/images/foundation/strongloopLogo.png" />
-</a>
 <a target="_new" class="imagelink" href="//yahoo.com">
   <img alt="Yahoo!" class="memberlogo" src="/static/images/foundation/yahoo.png" />
 </a>


### PR DESCRIPTION
Strongloop has made a home at IBM. They will now be one membership, as IBM. This removes Strongloop's logo.