### PR TITLE
docs: fixes broken link in debugging guide

### DIFF
--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -156,7 +156,7 @@ couple popular ones are listed below.
 
 The V8 Debugging Protocol is no longer maintained or documented.
 
-#### [Built-in Debugger](https://github.com/nodejs/node/blob/master/lib/_debugger.js)
+#### [Built-in Debugger](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with

--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -156,7 +156,7 @@ couple popular ones are listed below.
 
 The V8 Debugging Protocol is no longer maintained or documented.
 
-#### [Built-in Debugger](https://nodejs.org/dist/latest/docs/api/debugger.html)
+#### [Built-in Debugger](https://nodejs.org/dist/latest-v6.x/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with


### PR DESCRIPTION
There is a link in the [debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#legacy-debugger) that is supposed to lead to the legacy debugging documentation but is currently giving a 404. This pr will fix that by linking to to latest version of the debugger docs.

fixes: https://github.com/nodejs/node/issues/12928