### PR TITLE
nodejs-ca: Add Catalan language

### DIFF
--- a/locale/ca/404.md
+++ b/locale/ca/404.md
@@ -1,0 +1,7 @@
+---
+layout: page.hbs
+permalink: false
+title: 404
+---
+## 404: Pàgina no trobada
+### ENOENT: El arxiu o directori no existeix

--- a/locale/ca/404.md
+++ b/locale/ca/404.md
@@ -4,4 +4,4 @@ permalink: false
 title: 404
 ---
 ## 404: Pàgina no trobada
-### ENOENT: El arxiu o directori no existeix
+### ENOENT: L'arxiu o directori no existeix

--- a/locale/ca/index.md
+++ b/locale/ca/index.md
@@ -1,0 +1,23 @@
+---
+layout: index.hbs
+labels:
+  current-version: Versió actual
+  download: Descarregar
+  download-for: Descarregar per
+  other-downloads: Altres Descàrregues
+  other-lts-downloads: Altres Descàrregues LTS
+  other-current-downloads: Altres Descàrregues Actuals
+  current: Actual
+  lts: LTS
+  tagline-current: Últimes característiques
+  tagline-lts: Recomenat per a la majoria
+  changelog: Canvis
+  api: Documentació del API
+  version-schedule-prompt: O revisi la
+  version-schedule-prompt-link-text: Agenda de LTS
+---
+
+Node.js® és un entorn d'execució per a JavaScript constrüit amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
+Node.js fa servir un model d'operacions E/S sense bloqueig i orientat a esdeveniments, que el fa lleuger i eficient.
+L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més grand de
+llibreries de codi obert al món.

--- a/locale/ca/index.md
+++ b/locale/ca/index.md
@@ -10,7 +10,7 @@ labels:
   current: Actual
   lts: LTS
   tagline-current: Últimes característiques
-  tagline-lts: Recomenat per a la majoria
+  tagline-lts: Recomanat per a la majoria
   changelog: Canvis
   api: Documentació del API
   version-schedule-prompt: O revisi la
@@ -19,5 +19,5 @@ labels:
 
 Node.js® és un entorn d'execució per a JavaScript constrüit amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
 Node.js fa servir un model d'operacions E/S sense bloqueig i orientat a esdeveniments, que el fa lleuger i eficient.
-L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més grand de
+L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més gran de
 llibreries de codi obert al món.

--- a/locale/ca/index.md
+++ b/locale/ca/index.md
@@ -12,12 +12,11 @@ labels:
   tagline-current: Últimes característiques
   tagline-lts: Recomanat per a la majoria
   changelog: Canvis
-  api: Documentació del API
+  api: Documentació de l'API
   version-schedule-prompt: O revisi la
   version-schedule-prompt-link-text: Agenda de LTS
 ---
 
-Node.js® és un entorn d'execució per a JavaScript constrüit amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
+Node.js® és un entorn d'execució per a JavaScript construït amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
 Node.js fa servir un model d'operacions E/S sense bloqueig i orientat a esdeveniments, que el fa lleuger i eficient.
-L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més gran de
-llibreries de codi obert al món.
+L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més gran de llibreries de codi obert del món.

--- a/locale/ca/index.md
+++ b/locale/ca/index.md
@@ -18,5 +18,5 @@ labels:
 ---
 
 Node.js® és un entorn d'execució per a JavaScript construït amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).
-Node.js fa servir un model d'operacions E/S sense bloqueig i orientat a esdeveniments, que el fa lleuger i eficient.
+Node.js fa servir un model d'operacions E/S sense bloqueig i orientat a esdeveniments, cosa que el fa lleuger i eficient.
 L'ecosistema de paquets de Node.js, [npm](https://www.npmjs.com/), és l'ecosistema més gran de llibreries de codi obert del món.

--- a/locale/ca/security.md
+++ b/locale/ca/security.md
@@ -36,7 +36,7 @@ Aquestes solucions no són enviades al repositori públic, en canvi són retingu
 
 - A la data d'embargament, se li envia una còpia de l'anunci a la llista de correu de seguretat de Node.js. Els canvis són pujats al repositori públic i noves versions són desplegades en nodejs.org. En les següents 6 hores de la notificació a la llista de correu, una còpia de l'anunci es publicarà al blog de Node.js.
 
-- Normalment la data d'embargament s'establirà 72 hores des de la creació del CVE. Però, això pot variar depenent de
+- Normalment la data d'embargament s'establirà 72 hores des de la creació del CVE. Però això pot variar depenent de
 la severitat de l'error o la dificultat a aplicar la solució.
 
 - Aquest procés pot trigar algun temps, especialment quan es requereix coordinació amb els encarregats del manteniment d'altres projectes. 

--- a/locale/ca/security.md
+++ b/locale/ca/security.md
@@ -1,0 +1,56 @@
+---
+layout: security.hbs
+title: Seguretat
+---
+# Seguretat
+
+## Informe d'errors
+
+Tots els problemes de seguretat en Node.js es tracten seriosament i han de ser reportats enviant un correu a [security@nodejs.org]
+(mailto: security@nodejs.org).
+Aquest serà rebut per un subgrup de l'equip central encarregat dels problemes de seguretat.
+
+El seu correu serà revisat en 24 hores, i vostè rebrà una resposta detallada al seu missatge en les següents 48 hores indicant els passos a seguir en el procés del seu informe.
+
+Després de la resposta inicial al seu informe, l'equip de seguretat s'esforçarà a mantenir-lo informat del progrés fet en
+direcció a la solució i l'anunci públic, també poden demanar informació addicional o instruccions sobre l'error reportat.
+Aquestes actualitzacions seran enviades com a mínim cada cinc dies, a la pràctica serà aproximadament cada 24-48 hores.
+
+Errors de seguretat en mòduls de tercers han de ser reportats als seus respectius encarregats i també han de ser coordinats
+a través de [Node Security Project](https://nodesecurity.io).
+
+Gràcies per millorar la seguretat de Node.js. Els seus esforços i la seva confidencialitat responsable són gratament apreciats
+i han de ser reconeguts.
+
+## Política de divulgació
+
+Aquesta és la política de divulgació de Node.js
+
+- El informe de seguretat és rebut i assignat a un responsable inicial. Aquesta persona coordinarà la solució i el procés
+de publicació. Un cop el problema és confirmat es determina una llista de totes les versions afectades. El codi és auditat
+per trobar potencials problemes similars. Es preparen les solucions per a totes les versions que estan en manteniment.
+Aquestes solucions no són enviades al repositori públic, en canvi són retingudes localment fins a l'anunci públic.
+
+- Una data d'embargament per a aquesta vulnerabilitat és seleccionada i un CVE (Common Vulnerabilities and  Exposures (CVE®))
+és sol·licitat per la vulnerabilitat.
+
+- A la data d'embargament, se li envia una còpia de l'anunci a la llista de correu de seguretat de Node.js. Els canvis són pujats al repositori públic i noves versions són desplegades en nodejs.org. En les següents 6 hores de la notificació a la llista de correu, una còpia de l'anunci es publicarà al blog de Node.js.
+
+- Normalment la data d'embargament s'establirà 72 hores des de la creació del CVE. Però, això pot variar depenent de
+la severitat de l'error o la dificultat a aplicar la solució.
+
+- Aquest procés pot trigar algun temps, especialment quan es requereix coordinació amb els encarregats del manteniment d'altres projectes. 
+Es farà tot el possible per manejar l'error en la forma més oportuna possible, però, és important que seguim el procés descrit a dalt per assegurar que la divulgació es maneja d'una manera consistent.
+
+## Rebi actualitzacions de seguretat
+
+Les notificacions de seguretat seran distribuïdes usant els següents mitjans.
+
+- [https://groups.google.com/group/nodejs-sec](https://groups.google.com/group/nodejs-sec)
+- [https://nodejs.org/en/blog](https://nodejs.org/en/blog)
+
+
+## Comentaris sobre aquesta política
+
+Si vostè té suggeriments sobre com pot ser millorat aquest procés, si us plau enviï un [pull request](https://github.com/nodejs/nodejs.org)
+o un mitssage a [security@nodejs.org](mailto:security@nodejs.org) per discutir-ho.

--- a/locale/ca/security.md
+++ b/locale/ca/security.md
@@ -26,7 +26,7 @@ i han de ser reconeguts.
 
 Aquesta és la política de divulgació de Node.js
 
-- El informe de seguretat és rebut i assignat a un responsable inicial. Aquesta persona coordinarà la solució i el procés
+- L'informe de seguretat és rebut i assignat a un responsable inicial. Aquesta persona coordinarà la solució i el procés
 de publicació. Un cop el problema és confirmat es determina una llista de totes les versions afectades. El codi és auditat
 per trobar potencials problemes similars. Es preparen les solucions per a totes les versions que estan en manteniment.
 Aquestes solucions no són enviades al repositori públic, en canvi són retingudes localment fins a l'anunci públic.
@@ -40,7 +40,7 @@ Aquestes solucions no són enviades al repositori públic, en canvi són retingu
 la severitat de l'error o la dificultat a aplicar la solució.
 
 - Aquest procés pot trigar algun temps, especialment quan es requereix coordinació amb els encarregats del manteniment d'altres projectes. 
-Es farà tot el possible per manejar l'error en la forma més oportuna possible, però, és important que seguim el procés descrit a dalt per assegurar que la divulgació es maneja d'una manera consistent.
+Es farà tot el possible per gestionar l'error en la forma més oportuna possible, però, és important que seguim el procés descrit a dalt per assegurar que la divulgació es gestiona d'una manera consistent.
 
 ## Rebi actualitzacions de seguretat
 

--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -166,7 +166,7 @@
   "blog": { "link": "blog", "text": "Notícies" },
 
   "releases": {
-    "title": "Release History",
+    "title": "Històric de Versions",
     "downloads": "Descarrègues"
   },
   "links": {

--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -140,7 +140,7 @@
   },
   "getinvolved": {
     "link": "get-involved",
-    "text": "Get Involved",
+    "text": "Implica't",
     "code-and-learn": {
       "link": "get-involved/code-and-learn",
       "text": "Programa i Aprèn"

--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -1,0 +1,177 @@
+{
+  "title": "Node.js",
+  "author": "Fundació Node.js",
+  "url": "https://nodejs.org/ca/",
+  "locale": "ca",
+  "scrollToTop": "Torna al començament",
+  "reportNodeIssue": "Informe d'un problema de Node.js",
+  "reportWebsiteIssue": "Informe d'un problema al lloc web",
+  "getHelpIssue": "Aconseguir ajuda",
+  "by": "per",
+  "all-downloads": "Totes les opcions de descàrrega",
+  "nightly": "Versions Nightly",
+  "chakracore-nightly": "Versions Node-ChakraCore Nightly",
+  "feeds": [{
+      "link": "feed/blog.xml",
+      "text": "Node.js Blog"
+    },
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js Blog: Versions"
+    },
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js Blog: Informes de vulnerabilitat"
+    },
+    {
+      "link": "feed/tsc-minutes.xml",
+      "text": "Minutes de les reunions del TSC de Node.js"
+    }
+  ],
+  "home": { "text": "Inici" },
+  "about": {
+    "link": "about",
+    "text": "Quant a",
+    "governance": {
+      "link": "about/governance",
+      "text": "Govern"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Grups de treball"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Versions"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Recursos"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Marca"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "Política de privacitat"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Descàrregues",
+    "releases": {
+      "link": "download/releases",
+      "text": "Versions anteriors"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "instal·lar Node.js amb gestor de paquets"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "Signatures SHASUMS per arxius de versions"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Documentació",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 i més enllà"
+    },
+    "faq": {
+      "link": "docs/faq",
+      "text": "FAQ"
+    },
+    "inspector": {
+      "link": "docs/inspector",
+      "text": "Inspector"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guies"
+    }
+  },
+  "foundation": {
+    "link": "foundation",
+    "text": "Fundació",
+    "casestudies": {
+      "link": "foundation/case-studies",
+      "text": "Recursos"
+    },
+    "members": {
+      "link": "foundation/members",
+      "text": "Membres"
+    },
+    "board": {
+      "link": "foundation/board",
+      "text": "Consell directiu"
+    },
+    "tsc": {
+      "link": "foundation/tsc",
+      "text": "Govern tècnic"
+    },
+    "itn": {
+      "link": "foundation/in-the-news",
+      "text": "En les notícies"
+    },
+    "announce": {
+      "link": "foundation/announcements",
+      "text": "Anuncis"
+    },
+    "education": {
+      "link": "foundation/education",
+      "text": "iniciatives d'Educació"
+    },
+    "outreachy": {
+      "link": "foundation/outreachy",
+      "text": "Outreachy + Node.js"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Get Involved",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Programa i Aprèn"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribueix"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Desenvolupament"
+    },
+    "events": {
+      "link": "get-involved/events",
+      "text": "Esdeveniments"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Conducta"
+    }
+  },
+  "security": { "link": "security", "text": "Seguretat" },
+  "blog": { "link": "blog", "text": "Notícies" },
+
+  "releases": {
+    "title": "Release History",
+    "downloads": "Descarrègues"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Canvis"
+    }
+  }
+}


### PR DESCRIPTION
This PR is related to #1197 

I created the minimal set of files according [Node.js Website Translation Policy](https://github.com/nodejs/nodejs.org/blob/master/TRANSLATION.md#for-localization-groups) indications.

* nodejs-ca: Add files - `index.md`, `404.md`, `security.md`, ` site.json`