### PR TITLE
doc: update current version in package-manager.md

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -46,10 +46,10 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
-Alternatively, for Node.js v7:
+Alternatively, for Node.js 8:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -121,10 +121,10 @@ Run as root on RHEL, CentOS or Fedora, for Node.js v6 LTS:
 curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
 ```
 
-Alternatively for Node.js v7:
+Alternatively for Node.js 8:
 
 ```bash
-curl --silent --location https://rpm.nodesource.com/setup_7.x | bash -
+curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
 ```
 
 Alternatively for Node.js 0.10:


### PR DESCRIPTION
Fixes: https://github.com/nodejs/nodejs.org/issues/1247

I've just formally replaced `(v)7` with `8` where it seemed concerning Node.js. Please, correct me where I am wrong, as I am not experienced in this area.