### PR TITLE
add bash on Windows to download instructions

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -35,7 +35,7 @@ pacman -S nodejs npm
 
 ## Debian and Ubuntu based Linux distributions
 
-Also including: **Linux Mint**, **Linux Mint Debian Edition (LMDE)**, **elementaryOS** and others.
+Also including: **Linux Mint**, **Linux Mint Debian Edition (LMDE)**, **elementaryOS**, **bash on Windows** and others.
 
 Node.js is available from the [NodeSource](https://nodesource.com) Debian and Ubuntu binary distributions repository (formerly [Chris Lea's](https://github.com/chrislea) Launchpad PPA). Support for this repository, along with its scripts, can be found on GitHub at [nodesource/distributions](https://github.com/nodesource/distributions).
 


### PR DESCRIPTION
Sorry, forgot to create a new branch as was editing the docs in the browser.
I added 'bash on Windows' to the Ubuntu install instructions, as they apply there too.