### PR TITLE
doc: lint and modernize code examples in guides

### DIFF
--- a/locale/en/docs/guides/anatomy-of-an-http-transaction.md
+++ b/locale/en/docs/guides/anatomy-of-an-http-transaction.md
@@ -201,7 +201,7 @@ code and the headers to the stream.
 ```javascript
 response.writeHead(200, {
   'Content-Type': 'application/json',
-  'X-Powered-By': 'bacon',
+  'X-Powered-By': 'bacon'
 });
 ```
 

--- a/locale/en/docs/guides/anatomy-of-an-http-transaction.md
+++ b/locale/en/docs/guides/anatomy-of-an-http-transaction.md
@@ -18,9 +18,9 @@ Any node web server application will at some point have to create a web server
 object. This is done by using [`createServer`][].
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer((request, response) => {
   // magic happens here!
 });
 ```
@@ -32,8 +32,8 @@ handler. In fact, the [`Server`][] object returned by [`createServer`][] is an
 `server` object and then adding the listener later.
 
 ```javascript
-var server = http.createServer();
-server.on('request', function(request, response) {
+const server = http.createServer();
+server.on('request', (request, response) => {
   // the same kind of magic happens here!
 });
 ```
@@ -54,8 +54,7 @@ the method and URL, so that appropriate actions can be taken. Node makes this
 relatively painless by putting handy properties onto the `request` object.
 
 ```javascript
-var method = request.method;
-var url = request.url;
+const { method, url } = request;
 ```
 > **Note:** The `request` object is an instance of [`IncomingMessage`][].
 
@@ -67,8 +66,8 @@ Headers are also not far away. They're in their own object on `request` called
 `headers`.
 
 ```javascript
-var headers = request.headers;
-var userAgent = headers['user-agent'];
+const { headers } = request;
+const userAgent = headers['user-agent'];
 ```
 
 It's important to note here that all headers are represented in lower-case only,
@@ -93,10 +92,10 @@ going to be string data, the best thing to do is collect the data in an array,
 then at the `'end'`, concatenate and stringify it.
 
 ```javascript
-var body = [];
-request.on('data', function(chunk) {
+let body = [];
+request.on('data', (chunk) => {
   body.push(chunk);
-}).on('end', function() {
+}).on('end', () => {
   body = Buffer.concat(body).toString();
   // at this point, `body` has the entire request body stored in it as a string
 });
@@ -120,7 +119,7 @@ continue on your way. (Though it's probably best to send some kind of HTTP error
 response. More on that later.)
 
 ```javascript
-request.on('error', function(err) {
+request.on('error', (err) => {
   // This prints the error message and stack trace to `stderr`.
   console.error(err.stack);
 });
@@ -137,18 +136,16 @@ headers and body out of requests. When we put that all together, it might look
 something like this:
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // At this point, we have the headers, method, url and body, and can now
     // do whatever we need to in order to respond to this request.
@@ -204,7 +201,7 @@ code and the headers to the stream.
 ```javascript
 response.writeHead(200, {
   'Content-Type': 'application/json',
-  'X-Powered-By': 'bacon'
+  'X-Powered-By': 'bacon',
 });
 ```
 
@@ -250,23 +247,20 @@ all of the data that was sent to us by the user. We'll format that data as JSON
 using `JSON.stringify`.
 
 ```javascript
+const http = require('http');
 
-var http = require('http');
-
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // BEGINNING OF NEW STUFF
 
-    response.on('error', function(err) {
+    response.on('error', (err) => {
       console.error(err);
     });
 
@@ -275,12 +269,7 @@ http.createServer(function(request, response) {
     // Note: the 2 lines above could be replaced with this next one:
     // response.writeHead(200, {'Content-Type': 'application/json'})
 
-    var responseBody = {
-      headers: headers,
-      method: method,
-      url: url,
-      body: body
-    };
+    const responseBody = { headers, method, url, body };
 
     response.write(JSON.stringify(responseBody));
     response.end();
@@ -300,13 +289,13 @@ we need to do is grab the data from the request stream and write that data to
 the response stream, similar to what we did previously.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var body = [];
-  request.on('data', function(chunk) {
+http.createServer((request, response) => {
+  let body = [];
+  request.on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     response.end(body);
   });
@@ -322,17 +311,17 @@ conditions:
 In any other case, we want to simply respond with a 404.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
-    var body = [];
-    request.on('data', function(chunk) {
+    let body = [];
+    request.on('data', (chunk) => {
       body.push(chunk);
-    }).on('end', function() {
+    }).on('end', () => {
       body = Buffer.concat(body).toString();
       response.end(body);
-    })
+    });
   } else {
     response.statusCode = 404;
     response.end();
@@ -351,9 +340,9 @@ That means we can use [`pipe`][] to direct data from one to the other. That's
 exactly what we want for an echo server!
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
     request.pipe(response);
   } else {
@@ -377,15 +366,15 @@ and message would be. As usual with errors, you should consult the
 On the response, we'll just log the error to `stdout`.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  request.on('error', (err) => {
     console.error(err);
     response.statusCode = 400;
     response.end();
   });
-  response.on('error', function(err) {
+  response.on('error', (err) => {
     console.error(err);
   });
   if (request.method === 'GET' && request.url === '/echo') {

--- a/locale/en/docs/guides/backpressuring-in-streams.md
+++ b/locale/en/docs/guides/backpressuring-in-streams.md
@@ -6,9 +6,9 @@ layout: docs.hbs
 # Backpressuring in Streams
 
 There is a general problem that occurs during data handling called
-[`backpressure`][] and describes a buildup of data behind a buffer during data 
-transfer. When the recieving end of the transfer has complex operations, or is 
-slower for whatever reason, there is a tendency for data from the incoming 
+[`backpressure`][] and describes a buildup of data behind a buffer during data
+transfer. When the recieving end of the transfer has complex operations, or is
+slower for whatever reason, there is a tendency for data from the incoming
 source to accumulate, like a clog.
 
 To solve this problem, there must be a delegation system in place to ensure a
@@ -42,11 +42,10 @@ const readline = require('readline');
 // process.stdin and process.stdout are both instances of Streams
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 
 rl.question('Why should you use streams? ', (answer) => {
-
   console.log(`Maybe it's ${answer}, maybe it's because they are awesome! :)`);
 
   rl.close();
@@ -65,7 +64,7 @@ $ zip The.Matrix.1080p.mkv
 ```
 
 While that will take a few minutes to complete, in another shell we may run
-a script that takes Node.js' module [`zlib`][], that wraps around another 
+a script that takes Node.js' module [`zlib`][], that wraps around another
 compression tool, [`gzip(1)`][].
 
 ```javascript
@@ -79,14 +78,14 @@ inp.pipe(gzip).pipe(out);
 ```
 
 To test the results, try opening each compressed file. The file compressed by
-the [`zip(1)`][] tool will notify you the file is corrupt, whereas the 
+the [`zip(1)`][] tool will notify you the file is corrupt, whereas the
 compression finished by [`Stream`][] will decompress without error.
 
 Note: In this example, we use `.pipe()` to get the data source from one end
 to the other. However, notice there is no proper error handlers attached. If
-a chunk of data were to fail be properly recieved, the `Readable` source or 
-`gzip` stream will not be destroyed. [`pump`][] is a utility tool that would 
-properly destroy all the streams in a pipeline if one of them fails or closes, 
+a chunk of data were to fail be properly recieved, the `Readable` source or
+`gzip` stream will not be destroyed. [`pump`][] is a utility tool that would
+properly destroy all the streams in a pipeline if one of them fails or closes,
 and is a must have in this case!
 
 ## Too Much Data, Too Quickly
@@ -104,12 +103,12 @@ occur because the write disk will not be able to keep up with the speed from
 the read.
 
 ```javascript
-  // Secretly the stream is saying: "whoa, whoa! hang on, this is way too much!"
-  // Data will begin to build up on the read-side of the data buffer as
-  // `write` tries to keep up with the incoming data flow.
-  inp.pipe(gzip).pipe(outputFile);
+// Secretly the stream is saying: "whoa, whoa! hang on, this is way too much!"
+// Data will begin to build up on the read-side of the data buffer as
+// `write` tries to keep up with the incoming data flow.
+inp.pipe(gzip).pipe(outputFile);
 ```
-This is why a backpressure mechanism is important. If a backpressure system was 
+This is why a backpressure mechanism is important. If a backpressure system was
 not present, the process would use up your system's memory, effectively slowing
 down other processes, and monopolizing a large part of your system until
 completion.
@@ -123,7 +122,7 @@ This results in a few things:
 In the following examples we will take out the [return value][] of the
 `.write()` function and change it to `true`, which effectively disables
 backpressure support in Node.js core. In any reference to 'modified' binary,
-we are talking about running the `node` binary without the `return ret;` line, 
+we are talking about running the `node` binary without the `return ret;` line,
 and instead with the replaced `return true;`.
 
 ## Excess Drag on Garbage Collection
@@ -131,6 +130,7 @@ and instead with the replaced `return true;`.
 Let's take a look at a quick benchmark. Using the same example from above, we
 ran a few time trials to get a median time for both binaries.
 
+<!-- eslint-skip -->
 ```javascript
    trial (#)  | `node` binary (ms) | modified `node` binary (ms)
 =================================================================
@@ -148,9 +148,10 @@ but let's take a closer look to confirm whether our suspicions are correct. We
 use the linux tool [`dtrace`][] to evaluate what's happening with the V8 garbage
 collector.
 
-The GC (garbage collector) measured time indicates the intervals of a full cycle 
+The GC (garbage collector) measured time indicates the intervals of a full cycle
 of a single sweep done by the garbage collector:
 
+<!-- eslint-skip -->
 ```javascript
 approx. time (ms) | GC (ms) | modified GC (ms)
 =================================================
@@ -185,7 +186,7 @@ being used for each chunk transfer.
 
 The more memory that is being allocated, the more the GC has to take care of in
 one sweep. The bigger the sweep, the more the GC needs to decide what can be
-freed up, and scanning for detached pointers in a larger memory space will 
+freed up, and scanning for detached pointers in a larger memory space will
 consume more computing power.
 
 ## Memory Exhaustion
@@ -196,6 +197,7 @@ individually.
 
 This is the output on the normal binary:
 
+<!-- eslint-skip -->
 ```javascript
 Respecting the return value of .write()
 =============================================
@@ -223,6 +225,7 @@ The maximum byte size occupied by virtual memory turns out to be approximately
 
 And now changing the [return value][] of the [`.write()`][] function, we get:
 
+<!-- eslint-skip -->
 ```javascript
 Without respecting the return value of .write():
 ==================================================
@@ -247,12 +250,12 @@ user        53.15sys          7.43
 The maximum byte size occupied by virtual memory turns out to be approximately
 1.52 gb.
 
-Without streams in place to delegate the backpressure, there is an order of 
-magnitude greater of memory space being allocated - a huge margin of 
+Without streams in place to delegate the backpressure, there is an order of
+magnitude greater of memory space being allocated - a huge margin of
 difference between the same process!
 
 This experiment shows how optimized and cost-effective Node's backpressure
-mechanism is for your computing system. Now, let's do a break down on how it 
+mechanism is for your computing system. Now, let's do a break down on how it
 works!
 
 ## How Does Backpressure Resolve These Issues?
@@ -280,7 +283,7 @@ the write queue is currently busy, [`.write()`][] will return `false`.
 
 When a `false` value is returned, the backpressure system kicks in. It will
 pause the incoming [`Readable`][] stream from sending any data and wait until
-the consumer is ready again. Once the data buffer is emptied, a [`.drain()`][] 
+the consumer is ready again. Once the data buffer is emptied, a [`.drain()`][]
 event will be emitted and resume the incoming data flow.
 
 Once the the queue is finished, backpressure will allow data to be sent again.
@@ -310,6 +313,7 @@ To achieve a better understanding of backpressure, here is a flow-chart on the
 lifecycle of a [`Readable`][] stream being [piped][] into a [`Writable`][]
 stream:
 
+<!-- eslint-skip -->
 ```javascript
                                                      +===================+
                          x-->  Piping functions   +-->   src.pipe(dest)  |
@@ -324,8 +328,8 @@ stream:
 |  Readable Stream  +----+                           | .on('finish', cb) |
 +-^-------^-------^-+    |                           | .on('end', cb)    |
   ^       |       ^      |                           +-------------------+
-  |       |       |      |                           
-  |       ^       |      |                                              
+  |       |       |      |
+  |       ^       |      |
   ^       ^       ^      |    +-------------------+         +=================+
   ^       |       ^      +---->  Writable Stream  +--------->  .write(chunk)  |
   |       |       |           +-------------------+         +=======+=========+
@@ -354,11 +358,11 @@ stream:
                                        +============+
 ```
 
-Note: If you are setting up a pipeline to chain together a few streams to 
-manipulate your data, you will most likely be implementing [`Transform`][] 
-stream. 
+Note: If you are setting up a pipeline to chain together a few streams to
+manipulate your data, you will most likely be implementing [`Transform`][]
+stream.
 
-In this case, your output from your [`Readable`][] stream will enter in the 
+In this case, your output from your [`Readable`][] stream will enter in the
 [`Transform`][] and will pipe into the [`Writable`][].
 
 ```javascript
@@ -366,7 +370,7 @@ Readable.pipe(Transformable).pipe(Writable);
 ```
 
 Backpressure will be automatically applied, but note the both the incoming and
-outgoing `highWaterMark` of the [`Transform`][] stream may be manipulated and 
+outgoing `highWaterMark` of the [`Transform`][] stream may be manipulated and
 will effect the backpressure system.
 
 ## Backpressure Guidelines
@@ -382,41 +386,41 @@ the next section will go a little bit more in-depth.
 
 ## Rules to Abide By When Implementing Custom Streams
 
-The golden rule of streams is __to always respect backpressure__. What 
+The golden rule of streams is __to always respect backpressure__. What
 constitutes as best practice is non-contradictory practice. So long as you are
-careful to avoid behaviours that conflict with internal backpressure support, 
+careful to avoid behaviours that conflict with internal backpressure support,
 you can be sure you're following good practice.
 
 In general,
 
 1. Never `.push()` if you are not asked.
 2. Never call `.write()` after it returns false but wait for 'drain' instead.
-3. Streams changes between different node versions, and the library you use. 
+3. Streams changes between different node versions, and the library you use.
 Be careful and test things.
 
-Note: In regards to point 3, an incredibly useful package for building 
-browser streams is [`readable-stream`][]. Rodd Vagg has written a 
-[great blog post][] describing the utility of this library. In short, it 
-provides a type of automated graceful degradation for [`Readable`][] streams, 
+Note: In regards to point 3, an incredibly useful package for building
+browser streams is [`readable-stream`][]. Rodd Vagg has written a
+[great blog post][] describing the utility of this library. In short, it
+provides a type of automated graceful degradation for [`Readable`][] streams,
 and supports older versions of browsers and Node.js.
 
 ## Rules specific to Readable Streams
 
-So far, we have taken a look at how [`.write()`][] affects backpressure and have 
-focused much on the [`Writable`][] stream. Because of Node's functionality, 
-data is technically flowing downstream from [`Readable`][] to [`Writable`][]. 
-However, as we can observe in any transmission of data, matter, or energy, the 
-source is just as important as the destination and the [`Readable`][] stream 
+So far, we have taken a look at how [`.write()`][] affects backpressure and have
+focused much on the [`Writable`][] stream. Because of Node's functionality,
+data is technically flowing downstream from [`Readable`][] to [`Writable`][].
+However, as we can observe in any transmission of data, matter, or energy, the
+source is just as important as the destination and the [`Readable`][] stream
 is vital to how backpressure is handled.
 
-Both these processes rely on one another to communicate effectively, if 
-the [`Readable`][] ignores when the [`Writable`][] stream asks for it to stop 
-sending in data, it can be just as problematic to when the [`.write()`][]'s return 
+Both these processes rely on one another to communicate effectively, if
+the [`Readable`][] ignores when the [`Writable`][] stream asks for it to stop
+sending in data, it can be just as problematic to when the [`.write()`][]'s return
 value is incorrect.
 
-So, as well with respecting the [`.write()`][] return, we must also respect the 
-return value of [`.push()`][] used in the [`._read()`][] method. If 
-[`.push()`][] returns a `false` value, the stream will stop reading from the 
+So, as well with respecting the [`.write()`][] return, we must also respect the
+return value of [`.push()`][] used in the [`._read()`][] method. If
+[`.push()`][] returns a `false` value, the stream will stop reading from the
 source. Otherwise, it will continue without pause.
 
 Here is an example of bad practice using [`.push()`][]:
@@ -433,17 +437,17 @@ class MyReadable extends Readable {
 }
 ```
 
-Additionally, from outside the custom stream, there are pratfalls for ignoring 
+Additionally, from outside the custom stream, there are pratfalls for ignoring
 backpressure. In this counter-example of good practice, the application's code
-forces data through whenever it is available (signaled by the 
+forces data through whenever it is available (signaled by the
 [`.data` event][]):
 ```javascript
 // This ignores the backpressure mechanisms node has set in place,
-// and unconditionally pushes through data, regardless if the 
+// and unconditionally pushes through data, regardless if the
 // destination stream is ready for it or not.
-readable.on('data', data =>
-  writable.write(data)
-)
+readable.on('data', (data) => {
+  writable.write(data);
+});
 ```
 
 ## Rules specific to Writable Streams
@@ -460,6 +464,7 @@ However, when we want to use a [`Writable`][] directly, we must respect the
 * If the data chunk is too large, [`.write()`][] will return false (the limit
 is indicated by the variable, [`highWaterMark`][]).
 
+<!-- eslint-disable indent -->
 ```javascript
 // This writable is invalid because of the async nature of javascript callbacks.
 // Without a return statement for each callback prior to the last,
@@ -486,37 +491,37 @@ There are also some things to look out for when implementing [`._writev()`][].
 The function is coupled with [`.cork()`][], but there is a common mistake when
 writing:
 ```javascript
-  // Using .uncork() twice here makes two calls on the C++ layer, rendering the 
-  // cork/uncork technique useless.
-  ws.cork()
-  ws.write('hello ')
-  ws.write('world ')
-  ws.uncork()
+// Using .uncork() twice here makes two calls on the C++ layer, rendering the
+// cork/uncork technique useless.
+ws.cork();
+ws.write('hello ');
+ws.write('world ');
+ws.uncork();
 
-  ws.cork()
-  ws.write('from ')
-  ws.write('Matteo')
-  ws.uncork()
+ws.cork();
+ws.write('from ');
+ws.write('Matteo');
+ws.uncork();
 
-  // The correct way to write this is to utilize process.nextTick(), which fires
-  // on the next event loop.
-  ws.cork()
-  ws.write('hello ')
-  ws.write('world ')
-  process.nextTick(doUncork, ws)
+// The correct way to write this is to utilize process.nextTick(), which fires
+// on the next event loop.
+ws.cork();
+ws.write('hello ');
+ws.write('world ');
+process.nextTick(doUncork, ws);
 
-  ws.cork()
-  ws.write('from ')
-  ws.write('Matteo')
-  process.nextTick(doUncork, ws)
+ws.cork();
+ws.write('from ');
+ws.write('Matteo');
+process.nextTick(doUncork, ws);
 
-  // as a global function
-  function doUncork (stream) {
-    stream.uncork()
-  }
+// as a global function
+function doUncork(stream) {
+  stream.uncork();
+}
 ```
 
-[`.cork()`][] can be called as many times we want, we just need to be careful to 
+[`.cork()`][] can be called as many times we want, we just need to be careful to
 call [`.uncork()`][] the same amount of times to make it flow again.
 
 ## Conclusion
@@ -526,11 +531,11 @@ structure, and for developers, to expand and connect across the Node.js modules
 ecosystem.
 
 Hopefully, you will now be able to troubleshoot, safely code your own
-[`Writable`][] and [`Readable`][] streams with backpressure in mind, and share 
+[`Writable`][] and [`Readable`][] streams with backpressure in mind, and share
 your knowledge with colleagues and friends.
 
 Be sure to read up more on [`Stream`][] for other API functions to help
-improve unleash your streaming capabilities when building an applcation with 
+improve unleash your streaming capabilities when building an applcation with
 Node.js.
 
 

--- a/locale/en/docs/guides/backpressuring-in-streams.md
+++ b/locale/en/docs/guides/backpressuring-in-streams.md
@@ -445,9 +445,9 @@ forces data through whenever it is available (signaled by the
 // This ignores the backpressure mechanisms node has set in place,
 // and unconditionally pushes through data, regardless if the
 // destination stream is ready for it or not.
-readable.on('data', (data) => {
+readable.on('data', (data) =>
   writable.write(data);
-});
+);
 ```
 
 ## Rules specific to Writable Streams

--- a/locale/en/docs/guides/backpressuring-in-streams.md
+++ b/locale/en/docs/guides/backpressuring-in-streams.md
@@ -42,7 +42,7 @@ const readline = require('readline');
 // process.stdin and process.stdout are both instances of Streams
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout,
+  output: process.stdout
 });
 
 rl.question('Why should you use streams? ', (answer) => {

--- a/locale/en/docs/guides/blocking-vs-non-blocking.md
+++ b/locale/en/docs/guides/blocking-vs-non-blocking.md
@@ -129,11 +129,11 @@ execute in the correct order is:
 
 ```js
 const fs = require('fs');
-fs.readFile('/file.md', (err, data) => {
-  if (err) throw err;
+fs.readFile('/file.md', (readFileErr, data) => {
+  if (readFileErr) throw readFileErr;
   console.log(data);
-  fs.unlink('/file.md', (err) => {
-    if (err) throw err;
+  fs.unlink('/file.md', (unlinkErr) => {
+    if (unlinkErr) throw unlinkErr;
   });
 });
 ```

--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -27,6 +27,7 @@ by sending an HTTP request to `http://[host:port]/json/list`.  This returns a
 JSON object like the following; use the `webSocketDebuggerUrl` property as the
 URL to connect directly to Inspector.
 
+<!-- eslint-skip -->
 ```javascript
 {
   "description": "node.js instance",

--- a/locale/en/docs/guides/domain-postmortem.md
+++ b/locale/en/docs/guides/domain-postmortem.md
@@ -57,7 +57,7 @@ the active domain to hijack the error:
 const domain = require('domain');
 const net = require('net');
 const d = domain.create();
-d.on('error', (err) => { console.error(err.message); });
+d.on('error', (err) => console.error(err.message));
 
 d.run(() => net.createServer((c) => {
   c.end();
@@ -127,7 +127,7 @@ d1.on('error', (er) => { /* handle error */ });
 d1.run(() => setTimeout(() => {
   const d2 = domain.create();
   d2.bar = 43;
-  d2.on('error', (er) => { console.error(er.message, domain._stack); });
+  d2.on('error', (er) => console.error(er.message, domain._stack));
   d2.run(() => {
     setTimeout(() => {
       setTimeout(() => {
@@ -360,7 +360,7 @@ const server = net.createServer((c) => {
   // Mock class that does some useless async data transformation
   // for demonstration purposes.
   const ds = new DataStream(dataTransformed);
-  c.on('data', (chunk) => { ds.data(chunk); });
+  c.on('data', (chunk) => ds.data(chunk));
 }).listen(8080, () => console.log('listening on 8080'));
 
 function dataTransformed(chunk) {

--- a/locale/en/docs/guides/domain-postmortem.md
+++ b/locale/en/docs/guides/domain-postmortem.md
@@ -132,11 +132,11 @@ d1.run(() => setTimeout(() => {
     setTimeout(() => {
       setTimeout(() => {
         throw new Error('outer');
-      }, 1);
+      });
       throw new Error('inner');
-    }, 1);
+    });
   });
-}, 1));
+}));
 ```
 
 Even in the case that the domain instances are being used for local storage so

--- a/locale/en/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/en/docs/guides/event-loop-timers-and-nexttick.md
@@ -106,34 +106,30 @@ threshold, then your script starts asynchronously reading a file which
 takes 95 ms:
 
 ```js
+const fs = require('fs');
 
-var fs = require('fs');
-
-function someAsyncOperation (callback) {
+function someAsyncOperation(callback) {
   // Assume this takes 95ms to complete
   fs.readFile('/path/to/file', callback);
 }
 
-var timeoutScheduled = Date.now();
+const timeoutScheduled = Date.now();
 
-setTimeout(function () {
+setTimeout(() => {
+  const delay = Date.now() - timeoutScheduled;
 
-  var delay = Date.now() - timeoutScheduled;
-
-  console.log(delay + "ms have passed since I was scheduled");
+  console.log(`${delay}ms have passed since I was scheduled`);
 }, 100);
 
 
 // do someAsyncOperation which takes 95 ms to complete
-someAsyncOperation(function () {
-
-  var startCallback = Date.now();
+someAsyncOperation(() => {
+  const startCallback = Date.now();
 
   // do something that will take 10ms...
   while (Date.now() - startCallback < 10) {
-    ; // do nothing
+    // do nothing
   }
-
 });
 ```
 
@@ -238,11 +234,11 @@ process:
 
 ```js
 // timeout_vs_immediate.js
-setTimeout(function timeout () {
+setTimeout(() => {
   console.log('timeout');
-},0);
+}, 0);
 
-setImmediate(function immediate () {
+setImmediate(() => {
   console.log('immediate');
 });
 ```
@@ -262,16 +258,16 @@ callback is always executed first:
 
 ```js
 // timeout_vs_immediate.js
-var fs = require('fs')
+const fs = require('fs');
 
 fs.readFile(__filename, () => {
   setTimeout(() => {
-    console.log('timeout')
-  }, 0)
+    console.log('timeout');
+  }, 0);
   setImmediate(() => {
-    console.log('immediate')
-  })
-})
+    console.log('immediate');
+  });
+});
 ```
 
 ```
@@ -312,10 +308,10 @@ design philosophy where an API should always be asynchronous even where
 it doesn't have to be. Take this code snippet for example:
 
 ```js
-function apiCall (arg, callback) {
+function apiCall(arg, callback) {
   if (typeof arg !== 'string')
     return process.nextTick(callback,
-      new TypeError('argument should be string'));
+                            new TypeError('argument should be string'));
 }
 ```
 
@@ -338,18 +334,18 @@ This philosophy can lead to some potentially problematic situations.
 Take this snippet for example:
 
 ```js
+let bar;
+
 // this has an asynchronous signature, but calls callback synchronously
-function someAsyncApiCall (callback) { callback(); };
+function someAsyncApiCall(callback) { callback(); }
 
 // the callback is called before `someAsyncApiCall` completes.
 someAsyncApiCall(() => {
-
   // since someAsyncApiCall has completed, bar hasn't been assigned any value
   console.log('bar', bar); // undefined
-
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 The user defines `someAsyncApiCall()` to have an asynchronous signature,
@@ -368,15 +364,17 @@ useful for the user to be alerted to an error before the event loop is
 allowed to continue. Here is the previous example using `process.nextTick()`:
 
 ```js
-function someAsyncApiCall (callback) {
+let bar;
+
+function someAsyncApiCall(callback) {
   process.nextTick(callback);
-};
+}
 
 someAsyncApiCall(() => {
   console.log('bar', bar); // 1
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 Here's another real world example:
@@ -428,11 +426,11 @@ stack has unwound but before the event loop continues.
 One example is to match the user's expectations. Simple example:
 
 ```js
-var server = net.createServer();
-server.on('connection', function(conn) { });
+const server = net.createServer();
+server.on('connection', (conn) => { });
 
 server.listen(8080);
-server.on('listening', function() { });
+server.on('listening', () => { });
 ```
 
 Say that `listen()` is run at the beginning of the event loop, but the
@@ -457,7 +455,7 @@ function MyEmitter() {
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```
@@ -476,14 +474,14 @@ function MyEmitter() {
   EventEmitter.call(this);
 
   // use nextTick to emit the event once a handler is assigned
-  process.nextTick(function () {
+  process.nextTick(() => {
     this.emit('event');
-  }.bind(this));
+  });
 }
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```

--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -25,7 +25,7 @@ you load into a container.
 First, create a new directory where all the files would live. In this directory
 create a `package.json` file that describes your app and its dependencies:
 
-```javascript
+```json
 {
   "name": "docker_web_app",
   "version": "1.0.0",
@@ -55,12 +55,12 @@ const HOST = '0.0.0.0';
 
 // App
 const app = express();
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('Hello world\n');
 });
 
 app.listen(PORT, HOST);
-console.log('Running on http://' + HOST + ':' + PORT);
+console.log(`Running on http://${HOST}:${PORT}`);
 ```
 
 In the next steps, we'll look at how you can run this app inside a Docker
@@ -119,7 +119,7 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run 
+your runtime. Here we will use the basic `npm start` which will run
 `node server.js` to start your server:
 
 ```docker

--- a/locale/en/docs/guides/simple-profiling.md
+++ b/locale/en/docs/guides/simple-profiling.md
@@ -31,9 +31,9 @@ application. Our application will have two handlers, one for adding new users to
 our system:
 
 ```javascript
-app.get('/newUser', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/newUser', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -41,13 +41,10 @@ app.get('/newUser', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var salt = crypto.randomBytes(128).toString('base64');
-  var hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const salt = crypto.randomBytes(128).toString('base64');
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
 
-  users[username] = {
-    salt: salt,
-    hash: hash
-  };
+  users[username] = { salt, hash };
 
   res.sendStatus(200);
 });
@@ -56,9 +53,9 @@ app.get('/newUser', function (req, res) {
 and another for validating user authentication attempts:
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -66,7 +63,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
 
   if (users[username].hash.toString() === hash.toString()) {
     res.sendStatus(200);
@@ -220,9 +217,9 @@ To remedy this issue, you make a small modification to the above handlers to use
 the asynchronous version of the pbkdf2 function:
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -230,7 +227,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  crypto.pbkdf2(password, users[username].salt, 10000, 512, function(err, hash) {
+  crypto.pbkdf2(password, users[username].salt, 10000, 512, (err, hash) => {
     if (users[username].hash.toString() === hash.toString()) {
       res.sendStatus(200);
     } else {

--- a/locale/en/docs/guides/timers-in-node.md
+++ b/locale/en/docs/guides/timers-in-node.md
@@ -170,7 +170,7 @@ below for examples of both:
 ```js
 const timerObj = setTimeout(() => {
   console.log('will i run?');
-}, 1);
+});
 
 // if left alone, this statement will keep the above
 // timeout from running, since the timeout will be the only

--- a/locale/en/docs/guides/timers-in-node.md
+++ b/locale/en/docs/guides/timers-in-node.md
@@ -35,8 +35,8 @@ arguments may also be included and these will be passed on to the function. Here
 is an example of that:
 
 ```js
-function myFunc (arg) {
-  console.log('arg was => ' + arg);
+function myFunc(arg) {
+  console.log(`arg was => ${arg}`);
 }
 
 setTimeout(myFunc, 1500, 'funky');
@@ -111,7 +111,7 @@ that may hold on to the event loop, and therefore should be treated as an
 approximate delay. See the below example:
 
 ```js
-function intervalFunc () {
+function intervalFunc() {
   console.log('Cant stop me now!');
 }
 
@@ -134,15 +134,15 @@ that object will be halted completely. The respective functions are
 below for an example of each:
 
 ```js
-let timeoutObj = setTimeout(() => {
+const timeoutObj = setTimeout(() => {
   console.log('timeout beyond time');
 }, 1500);
 
-let immediateObj = setImmediate(() => {
+const immediateObj = setImmediate(() => {
   console.log('immediately executing immediate');
 });
 
-let intervalObj = setInterval(() => {
+const intervalObj = setInterval(() => {
   console.log('interviewing the interval');
 }, 500);
 
@@ -168,9 +168,9 @@ not *exactly* restore the initial behavior for performance reasons. See
 below for examples of both:
 
 ```js
-let timerObj = setTimeout(() => {
+const timerObj = setTimeout(() => {
   console.log('will i run?');
-});
+}, 1);
 
 // if left alone, this statement will keep the above
 // timeout from running, since the timeout will be the only


### PR DESCRIPTION
1. Lint code examples in guides according to the main repository rules (also add some `eslint-plugin-markdown` comments to ease possible future linting).

2. Modernize some fragments (arrow functions in callbacks, destructuring, template literals, object shorthand, `Buffer.alloc()` etc).

Some trailing spaces were deleted automatically.