### PR TITLE
doc: lint and modernize code examples in localized guides

### DIFF
--- a/locale/ko/docs/guides/anatomy-of-an-http-transaction.md
+++ b/locale/ko/docs/guides/anatomy-of-an-http-transaction.md
@@ -28,9 +28,9 @@ Any node web server application will at some point have to create a web server
 object. This is done by using [`createServer`][].
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer((request, response) => {
   // magic happens here!
 });
 ```
@@ -42,9 +42,9 @@ var server = http.createServer(function(request, response) {
 이 때 [`createServer`][]를 이용합니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer((request, response) => {
   // 여기서 작업이 진행됩니다!
 });
 ```
@@ -57,8 +57,8 @@ handler. In fact, the [`Server`][] object returned by [`createServer`][] is an
 `server` object and then adding the listener later.
 
 ```javascript
-var server = http.createServer();
-server.on('request', function(request, response) {
+const server = http.createServer();
+server.on('request', (request, response) => {
   // the same kind of magic happens here!
 });
 ```
@@ -69,8 +69,8 @@ server.on('request', function(request, response) {
 `server` 객체를 생성하고 리스너를 추가하는 축약 문법을 사용한 것입니다.
 
 ```javascript
-var server = http.createServer();
-server.on('request', function(request, response) {
+const server = http.createServer();
+server.on('request', (request, response) => {
   // 여기서 작업이 진행됩니다!
 });
 ```
@@ -101,8 +101,7 @@ the method and URL, so that appropriate actions can be taken. Node makes this
 relatively painless by putting handy properties onto the `request` object.
 
 ```javascript
-var method = request.method;
-var url = request.url;
+const { method, url } = request;
 ```
 > **Note:** The `request` object is an instance of [`IncomingMessage`][].
 -->
@@ -113,8 +112,7 @@ var url = request.url;
 Node가 `request` 객체에 유용한 프로퍼티를 넣어두었으므로 이 작업은 비교적 쉽게 할 수 있습니다.
 
 ```javascript
-var method = request.method;
-var url = request.url;
+const { method, url } = request;
 ```
 > **주의:** `request` 객체는 [`IncomingMessage`][]의 인스턴스입니다.
 
@@ -127,8 +125,8 @@ Headers are also not far away. They're in their own object on `request` called
 `headers`.
 
 ```javascript
-var headers = request.headers;
-var userAgent = headers['user-agent'];
+const { headers } = request;
+const userAgent = headers['user-agent'];
 ```
 -->
 
@@ -138,8 +136,8 @@ var userAgent = headers['user-agent'];
 헤더도 많이 다르지 않습니다. `request`에 `headers`라는 전용 객체가 있습니다.
 
 ```javascript
-var headers = request.headers;
-var userAgent = headers['user-agent'];
+const { headers } = request;
+const userAgent = headers['user-agent'];
 ```
 
 <!--
@@ -187,10 +185,10 @@ then at the `'end'`, concatenate and stringify it.
 
 <!--
 ```javascript
-var body = [];
-request.on('data', function(chunk) {
+let body = [];
+request.on('data', (chunk) => {
   body.push(chunk);
-}).on('end', function() {
+}).on('end', () => {
   body = Buffer.concat(body).toString();
   // at this point, `body` has the entire request body stored in it as a string
 });
@@ -203,10 +201,10 @@ of what's going on before going down that road, and that's why you're here!
 -->
 
 ```javascript
-var body = [];
-request.on('data', function(chunk) {
+let body = [];
+request.on('data', (chunk) => {
   body.push(chunk);
-}).on('end', function() {
+}).on('end', () => {
   body = Buffer.concat(body).toString();
   // 여기서 `body`에 전체 요청 바디가 문자열로 담겨있습니다.
 });
@@ -242,7 +240,7 @@ HTTP 오류 응답을 보내는 것이 좋을 겁니다. 이에 대해는 뒤에
 
 <!--
 ```javascript
-request.on('error', function(err) {
+request.on('error', (err) => {
   // This prints the error message and stack trace to `stderr`.
   console.error(err.stack);
 });
@@ -254,7 +252,7 @@ and you're going to have to deal with them.
 -->
 
 ```javascript
-request.on('error', function(err) {
+request.on('error', (err) => {
   // 여기서 `stderr`에 오류 메시지와 스택 트레이스를 출력합니다.
   console.error(err.stack);
 });
@@ -271,18 +269,16 @@ headers and body out of requests. When we put that all together, it might look
 something like this:
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // At this point, we have the headers, method, url and body, and can now
     // do whatever we need to in order to respond to this request.
@@ -297,18 +293,16 @@ http.createServer(function(request, response) {
 이를 모두 사용하면 다음과 같이 될 것입니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // 여기서 헤더, 메소드, url, 바디를 가지게 되었고
     // 이 요청에 응답하는 데 필요한 어떤 일이라도 할 수 있게 되었습니다.
@@ -500,22 +494,20 @@ using `JSON.stringify`.
 
 ```javascript
 
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // BEGINNING OF NEW STUFF
 
-    response.on('error', function(err) {
+    response.on('error', (err) => {
       console.error(err);
     });
 
@@ -524,12 +516,7 @@ http.createServer(function(request, response) {
     // Note: the 2 lines above could be replaced with this next one:
     // response.writeHead(200, {'Content-Type': 'application/json'})
 
-    var responseBody = {
-      headers: headers,
-      method: method,
-      url: url,
-      body: body
-    };
+    const responseBody = { headers, method, url, body };
 
     response.write(JSON.stringify(responseBody));
     response.end();
@@ -549,23 +536,20 @@ HTTP 응답 만드는 방법을 배웠으니 이제 모든 것을 함께 사용�
 JSON으로 포매팅할 것입니다.
 
 ```javascript
+const http = require('http');
 
-var http = require('http');
-
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // 여기서부터 새로운 부분입니다.
 
-    response.on('error', function(err) {
+    response.on('error', (err) => {
       console.error(err);
     });
 
@@ -574,12 +558,7 @@ http.createServer(function(request, response) {
     // 주의: 위 두 줄은 다음 한 줄로 대체할 수도 있습니다.
     // response.writeHead(200, {'Content-Type': 'application/json'})
 
-    var responseBody = {
-      headers: headers,
-      method: method,
-      url: url,
-      body: body
-    };
+    const responseBody = { headers, method, url, body };
 
     response.write(JSON.stringify(responseBody));
     response.end();
@@ -600,13 +579,13 @@ we need to do is grab the data from the request stream and write that data to
 the response stream, similar to what we did previously.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var body = [];
-  request.on('data', function(chunk) {
+http.createServer((request, response) => {
+  let body = [];
+  request.on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     response.end(body);
   });
@@ -621,13 +600,13 @@ http.createServer(function(request, response) {
 응답 스트림에 쓰기만 하면 됩니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var body = [];
-  request.on('data', function(chunk) {
+http.createServer((request, response) => {
+  let body = [];
+  request.on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     response.end(body);
   });
@@ -644,17 +623,17 @@ conditions:
 In any other case, we want to simply respond with a 404.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
-    var body = [];
-    request.on('data', function(chunk) {
+    let body = [];
+    request.on('data', (chunk) => {
       body.push(chunk);
-    }).on('end', function() {
+    }).on('end', () => {
       body = Buffer.concat(body).toString();
       response.end(body);
-    })
+    });
   } else {
     response.statusCode = 404;
     response.end();
@@ -671,17 +650,17 @@ http.createServer(function(request, response) {
 위 조건이 아닌 경우에는 404를 응답합니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
-    var body = [];
-    request.on('data', function(chunk) {
+    let body = [];
+    request.on('data', (chunk) => {
       body.push(chunk);
-    }).on('end', function() {
+    }).on('end', () => {
       body = Buffer.concat(body).toString();
       response.end(body);
-    })
+    });
   } else {
     response.statusCode = 404;
     response.end();
@@ -701,9 +680,9 @@ That means we can use [`pipe`][] to direct data from one to the other. That's
 exactly what we want for an echo server!
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
     request.pipe(response);
   } else {
@@ -724,9 +703,9 @@ http.createServer(function(request, response) {
 에코 서버에서 하려는 것이 바로 이것입니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
     request.pipe(response);
   } else {
@@ -751,15 +730,15 @@ and message would be. As usual with errors, you should consult the
 On the response, we'll just log the error to `stdout`.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  request.on('error', (err) => {
     console.error(err);
     response.statusCode = 400;
     response.end();
   });
-  response.on('error', function(err) {
+  response.on('error', (err) => {
     console.error(err);
   });
   if (request.method === 'GET' && request.url === '/echo') {
@@ -784,15 +763,15 @@ http.createServer(function(request, response) {
 응답에서는 `stdout`에 오류를 로깅 할 것입니다.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  request.on('error', (err) => {
     console.error(err);
     response.statusCode = 400;
     response.end();
   });
-  response.on('error', function(err) {
+  response.on('error', (err) => {
     console.error(err);
   });
   if (request.method === 'GET' && request.url === '/echo') {

--- a/locale/ko/docs/guides/blocking-vs-non-blocking.md
+++ b/locale/ko/docs/guides/blocking-vs-non-blocking.md
@@ -240,11 +240,11 @@ execute in the correct order is:
 
 ```js
 const fs = require('fs');
-fs.readFile('/file.md', (err, data) => {
-  if (err) throw err;
+fs.readFile('/file.md', (readFileErr, data) => {
+  if (readFileErr) throw readFileErr;
   console.log(data);
-  fs.unlink('/file.md', (err) => {
-    if (err) throw err;
+  fs.unlink('/file.md', (unlinkErr) => {
+    if (unlinkErr) throw unlinkErr;
   });
 });
 ```
@@ -256,11 +256,11 @@ fs.readFile('/file.md', (err, data) => {
 
 ```js
 const fs = require('fs');
-fs.readFile('/file.md', (err, data) => {
-  if (err) throw err;
+fs.readFile('/file.md', (readFileErr, data) => {
+  if (readFileErr) throw readFileErr;
   console.log(data);
-  fs.unlink('/file.md', (err) => {
-    if (err) throw err;
+  fs.unlink('/file.md', (unlinkErr) => {
+    if (unlinkErr) throw unlinkErr;
   });
 });
 ```

--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -71,6 +71,7 @@ it will activate the Inspector API.
 HTTP 요청을 보내서 이 메타데이터를 받을 수 있습니다. 이는 다음과 같은 JSON 객체를 반환합니다.
 인스펙터에 직접 접속하려면 URL로 `webSocketDebuggerUrl` 프로퍼티를 사용하세요.
 
+<!-- eslint-skip -->
 ```javascript
 {
   "description": "node.js instance",

--- a/locale/ko/docs/guides/domain-postmortem.md
+++ b/locale/ko/docs/guides/domain-postmortem.md
@@ -238,7 +238,7 @@ d1.run(() => setTimeout(() => {
       setTimeout(() => {
         throw new Error('outer');
       });
-      throw new Error('inner')
+      throw new Error('inner');
     });
   });
 }));
@@ -266,7 +266,7 @@ d1.run(() => setTimeout(() => {
       setTimeout(() => {
         throw new Error('outer');
       });
-      throw new Error('inner')
+      throw new Error('inner');
     });
   });
 }));
@@ -323,11 +323,11 @@ const pipeList = [];
 const FILENAME = '/tmp/tmp.tmp';
 const PIPENAME = '/tmp/node-domain-example-';
 const FILESIZE = 1024;
-var uid = 0;
+let uid = 0;
 
 // Setting up temporary resources
-const buf = Buffer(FILESIZE);
-for (var i = 0; i < buf.length; i++)
+const buf = Buffer.alloc(FILESIZE);
+for (let i = 0; i < buf.length; i++)
   buf[i] = ((Math.random() * 1e3) % 78) + 48;  // Basic ASCII
 fs.writeFileSync(FILENAME, buf);
 
@@ -380,12 +380,12 @@ net.createServer((c) => {
 
 function streamInParts(fd, cr, pos) {
   const d2 = domain.create();
-  var alive = true;
+  const alive = true;
   d2.on('error', (er) => {
-    print('d2 error:', er.message)
+    print('d2 error:', er.message);
     cr.end();
   });
-  fs.read(fd, new Buffer(10), 0, 10, pos, d2.intercept((bRead, buf) => {
+  fs.read(fd, Buffer.alloc(10), 0, 10, pos, d2.intercept((bRead, buf) => {
     if (!cr.isAlive()) {
       return fs.close(fd);
     }
@@ -423,12 +423,12 @@ function pipeData(cr) {
     });
   });
   cr.on('data', (chunk) => {
-    for (var i = 0; i < connectionList.length; i++) {
+    for (let i = 0; i < connectionList.length; i++) {
       connectionList[i].write(chunk);
     }
   });
   cr.on('end', () => {
-    for (var i = 0; i < connectionList.length; i++) {
+    for (let i = 0; i < connectionList.length; i++) {
       connectionList[i].end();
     }
     ps.close();
@@ -440,7 +440,7 @@ function pipeData(cr) {
 process.on('SIGINT', () => process.exit());
 process.on('exit', () => {
   try {
-    for (var i = 0; i < pipeList.length; i++) {
+    for (let i = 0; i < pipeList.length; i++) {
       fs.unlinkSync(pipeList[i]);
     }
     fs.unlinkSync(FILENAME);
@@ -469,11 +469,11 @@ const pipeList = [];
 const FILENAME = '/tmp/tmp.tmp';
 const PIPENAME = '/tmp/node-domain-example-';
 const FILESIZE = 1024;
-var uid = 0;
+let uid = 0;
 
 // 임시 자원을 설정합니다
-const buf = Buffer(FILESIZE);
-for (var i = 0; i < buf.length; i++)
+const buf = Buffer.alloc(FILESIZE);
+for (let i = 0; i < buf.length; i++)
   buf[i] = ((Math.random() * 1e3) % 78) + 48;  // Basic ASCII
 fs.writeFileSync(FILENAME, buf);
 
@@ -526,12 +526,12 @@ net.createServer((c) => {
 
 function streamInParts(fd, cr, pos) {
   const d2 = domain.create();
-  var alive = true;
+  const alive = true;
   d2.on('error', (er) => {
-    print('d2 error:', er.message)
+    print('d2 error:', er.message);
     cr.end();
   });
-  fs.read(fd, new Buffer(10), 0, 10, pos, d2.intercept((bRead, buf) => {
+  fs.read(fd, Buffer.alloc(10), 0, 10, pos, d2.intercept((bRead, buf) => {
     if (!cr.isAlive()) {
       return fs.close(fd);
     }
@@ -569,12 +569,12 @@ function pipeData(cr) {
     });
   });
   cr.on('data', (chunk) => {
-    for (var i = 0; i < connectionList.length; i++) {
+    for (let i = 0; i < connectionList.length; i++) {
       connectionList[i].write(chunk);
     }
   });
   cr.on('end', () => {
-    for (var i = 0; i < connectionList.length; i++) {
+    for (let i = 0; i < connectionList.length; i++) {
       connectionList[i].end();
     }
     ps.close();
@@ -586,7 +586,7 @@ function pipeData(cr) {
 process.on('SIGINT', () => process.exit());
 process.on('exit', () => {
   try {
-    for (var i = 0; i < pipeList.length; i++) {
+    for (let i = 0; i < pipeList.length; i++) {
       fs.unlinkSync(pipeList[i]);
     }
     fs.unlinkSync(FILENAME);
@@ -681,7 +681,7 @@ const server = net.createServer((c) => {
   // for demonstration purposes.
   const ds = new DataStream(dataTransformed);
   c.on('data', (chunk) => ds.data(chunk));
-}).listen(8080, () => console.log(`listening on 8080`));
+}).listen(8080, () => console.log('listening on 8080'));
 
 function dataTransformed(chunk) {
   // FAIL! Because the DataStream instance also created a
@@ -703,15 +703,15 @@ DataStream.prototype.data = function data(chunk) {
   // This code is self contained, but pretend it's a complex
   // operation that crosses at least one other module. So
   // passing along "this", etc., is not easy.
-  this.domain.run(function() {
+  this.domain.run(() => {
     // Simulate an async operation that does the data transform.
     setImmediate(() => {
-      for (var i = 0; i < chunk.length; i++)
+      for (let i = 0; i < chunk.length; i++)
         chunk[i] = ((chunk[i] + Math.random() * 100) % 96) + 33;
       // Grab the instance from the active domain and use that
       // to call the user's callback.
       const self = domain.active.data.inst;
-      self.cb.call(self, chunk);
+      self.cb(chunk);
     });
   });
 };
@@ -740,7 +740,7 @@ const server = net.createServer((c) => {
   // 데모용으로 쓸모없는 비동기 데이터 변환을 하는 Mock 클래스
   const ds = new DataStream(dataTransformed);
   c.on('data', (chunk) => ds.data(chunk));
-}).listen(8080, () => console.log(`listening on 8080`));
+}).listen(8080, () => console.log('listening on 8080'));
 
 function dataTransformed(chunk) {
   // 실패! DataStream 인스턴스도 도메인을 생성했으므로
@@ -759,14 +759,14 @@ function DataStream(cb) {
 DataStream.prototype.data = function data(chunk) {
   // 이 코드는 자기충족적이지만 최소한 하나의 다른 모듈과의 복잡한 작업인 척합니다.
   // 그러므로 "this"를 함께 전달하기는 쉽지 않습니다.
-  this.domain.run(function() {
+  this.domain.run(() => {
     // 데이터를 변환하는 비동기 작업을 시뮬레이트합니다.
     setImmediate(() => {
-      for (var i = 0; i < chunk.length; i++)
+      for (let i = 0; i < chunk.length; i++)
         chunk[i] = ((chunk[i] + Math.random() * 100) % 96) + 33;
       // 활성화된 도메인에서 인스턴스를 가져오고 사용자 콜백을 호출하는 데 사용합니다.
       const self = domain.active.data.inst;
-      self.cb.call(self, chunk);
+      self.cb(chunk);
     });
   });
 };

--- a/locale/ko/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/ko/docs/guides/event-loop-timers-and-nexttick.md
@@ -204,34 +204,30 @@ _**Note**: 기술적으로는 [**poll** 단계](#poll)에서 타이머를 언제
 
 <!--
 ```js
+const fs = require('fs');
 
-var fs = require('fs');
-
-function someAsyncOperation (callback) {
+function someAsyncOperation(callback) {
   // Assume this takes 95ms to complete
   fs.readFile('/path/to/file', callback);
 }
 
-var timeoutScheduled = Date.now();
+const timeoutScheduled = Date.now();
 
-setTimeout(function () {
+setTimeout(() => {
+  const delay = Date.now() - timeoutScheduled;
 
-  var delay = Date.now() - timeoutScheduled;
-
-  console.log(delay + "ms have passed since I was scheduled");
+  console.log(`${delay}ms have passed since I was scheduled`);
 }, 100);
 
 
 // do someAsyncOperation which takes 95 ms to complete
-someAsyncOperation(function () {
-
-  var startCallback = Date.now();
+someAsyncOperation(() => {
+  const startCallback = Date.now();
 
   // do something that will take 10ms...
   while (Date.now() - startCallback < 10) {
-    ; // do nothing
+    // do nothing
   }
-
 });
 ```
 
@@ -255,34 +251,30 @@ more events.
 -->
 
 ```js
+const fs = require('fs');
 
-var fs = require('fs');
-
-function someAsyncOperation (callback) {
+function someAsyncOperation(callback) {
   // 이 작업이 완료되는데 95ms가 걸린다고 가정합니다.
   fs.readFile('/path/to/file', callback);
 }
 
-var timeoutScheduled = Date.now();
+const timeoutScheduled = Date.now();
 
-setTimeout(function () {
+setTimeout(() => {
+  const delay = Date.now() - timeoutScheduled;
 
-  var delay = Date.now() - timeoutScheduled;
-
-  console.log(delay + "ms have passed since I was scheduled");
+  console.log(`${delay}ms have passed since I was scheduled`);
 }, 100);
 
 
 // 완료하는데 95ms가 걸리는 someAsyncOperation를 실행합니다.
-someAsyncOperation(function () {
-
-  var startCallback = Date.now();
+someAsyncOperation(() => {
+  const startCallback = Date.now();
 
   // 10ms가 걸릴 어떤 작업을 합니다.
   while (Date.now() - startCallback < 10) {
-    ; // 아무것도 하지 않습니다.
+    // 아무것도 하지 않습니다.
   }
-
 });
 ```
 
@@ -459,11 +451,11 @@ process:
 <!--
 ```js
 // timeout_vs_immediate.js
-setTimeout(function timeout () {
+setTimeout(() => {
   console.log('timeout');
-},0);
+}, 0);
 
-setImmediate(function immediate () {
+setImmediate(() => {
   console.log('immediate');
 });
 ```
@@ -483,16 +475,16 @@ callback is always executed first:
 
 ```js
 // timeout_vs_immediate.js
-var fs = require('fs')
+const fs = require('fs');
 
 fs.readFile(__filename, () => {
   setTimeout(() => {
-    console.log('timeout')
-  }, 0)
+    console.log('timeout');
+  }, 0);
   setImmediate(() => {
-    console.log('immediate')
-  })
-})
+    console.log('immediate');
+  });
+});
 ```
 
 ```
@@ -512,11 +504,11 @@ within an I/O cycle, independently of how many timers are present.
 
 ```js
 // timeout_vs_immediate.js
-setTimeout(function timeout () {
+setTimeout(() => {
   console.log('timeout');
-},0);
+}, 0);
 
-setImmediate(function immediate () {
+setImmediate(() => {
   console.log('immediate');
 });
 ```
@@ -535,16 +527,16 @@ timeout
 
 ```js
 // timeout_vs_immediate.js
-var fs = require('fs')
+const fs = require('fs');
 
 fs.readFile(__filename, () => {
   setTimeout(() => {
-    console.log('timeout')
-  }, 0)
+    console.log('timeout');
+  }, 0);
   setImmediate(() => {
-    console.log('immediate')
-  })
-})
+    console.log('immediate');
+  });
+});
 ```
 
 ```
@@ -603,10 +595,10 @@ design philosophy where an API should always be asynchronous even where
 it doesn't have to be. Take this code snippet for example:
 
 ```js
-function apiCall (arg, callback) {
+function apiCall(arg, callback) {
   if (typeof arg !== 'string')
     return process.nextTick(callback,
-      new TypeError('argument should be string'));
+                            new TypeError('argument should be string'));
 }
 ```
 -->
@@ -617,10 +609,10 @@ function apiCall (arg, callback) {
 설계 철학 때문입니다. 예제로 다음 코드를 보겠습니다.
 
 ```js
-function apiCall (arg, callback) {
+function apiCall(arg, callback) {
   if (typeof arg !== 'string')
     return process.nextTick(callback,
-      new TypeError('argument should be string'));
+                            new TypeError('argument should be string'));
 }
 ```
 
@@ -658,18 +650,18 @@ This philosophy can lead to some potentially problematic situations.
 Take this snippet for example:
 
 ```js
+let bar;
+
 // this has an asynchronous signature, but calls callback synchronously
-function someAsyncApiCall (callback) { callback(); };
+function someAsyncApiCall(callback) { callback(); }
 
 // the callback is called before `someAsyncApiCall` completes.
 someAsyncApiCall(() => {
-
   // since someAsyncApiCall has completed, bar hasn't been assigned any value
   console.log('bar', bar); // undefined
-
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 The user defines `someAsyncApiCall()` to have an asynchronous signature,
@@ -691,18 +683,18 @@ allowed to continue. Here is the previous example using `process.nextTick()`:
 이 철학은 잠재적인 문제 상황을 만들 수 있습니다. 다음 예제를 보겠습니다.
 
 ```js
+let bar;
+
 // 비동기 시그니처를 갖지만, 동기로 콜백을 호출합니다.
-function someAsyncApiCall (callback) { callback(); };
+function someAsyncApiCall(callback) { callback(); }
 
 // `someAsyncApiCall`이 완료되면 콜백을 호출한다.
 someAsyncApiCall(() => {
-
   // someAsyncApiCall는 완료되었지만, bar에는 어떤 값도 할당되지 않았다.
   console.log('bar', bar); // undefined
-
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 개발자가 `someAsyncApiCall()`을 비동기 시그니처로 정의했지만 실제로는 동기로 동작합니다.
@@ -718,15 +710,17 @@ var bar = 1;
 
 <!--
 ```js
-function someAsyncApiCall (callback) {
+let bar;
+
+function someAsyncApiCall(callback) {
   process.nextTick(callback);
-};
+}
 
 someAsyncApiCall(() => {
   console.log('bar', bar); // 1
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 Here's another real world example:
@@ -747,15 +741,17 @@ any event handlers they want.
 -->
 
 ```js
-function someAsyncApiCall (callback) {
+let bar;
+
+function someAsyncApiCall(callback) {
   process.nextTick(callback);
-};
+}
 
 someAsyncApiCall(() => {
   console.log('bar', bar); // 1
 });
 
-var bar = 1;
+bar = 1;
 ```
 
 다음은 또 다른 예제입니다.
@@ -823,11 +819,11 @@ stack has unwound but before the event loop continues.
 One example is to match the user's expectations. Simple example:
 
 ```js
-var server = net.createServer();
-server.on('connection', function(conn) { });
+const server = net.createServer();
+server.on('connection', (conn) => { });
 
 server.listen(8080);
-server.on('listening', function() { });
+server.on('listening', () => { });
 ```
 -->
 
@@ -843,11 +839,11 @@ server.on('listening', function() { });
 한 가지 예는 사용자의 기대를 맞추는 것입니다. 다음은 간단한 예제입니다.
 
 ```js
-var server = net.createServer();
-server.on('connection', function(conn) { });
+const server = net.createServer();
+server.on('connection', (conn) => { });
 
 server.listen(8080);
-server.on('listening', function() { });
+server.on('listening', () => { });
 ```
 
 <!--
@@ -873,7 +869,7 @@ function MyEmitter() {
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```
@@ -898,7 +894,7 @@ function MyEmitter() {
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```
@@ -918,14 +914,14 @@ function MyEmitter() {
   EventEmitter.call(this);
 
   // use nextTick to emit the event once a handler is assigned
-  process.nextTick(function () {
+  process.nextTick(() => {
     this.emit('event');
-  }.bind(this));
+  });
 }
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```
@@ -946,14 +942,14 @@ function MyEmitter() {
   EventEmitter.call(this);
 
   // 핸들러가 할당되면 이벤트를 발생시키려고 nextTick을 사용합니다.
-  process.nextTick(function () {
+  process.nextTick(() => {
     this.emit('event');
-  }.bind(this));
+  });
 }
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 ```

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -40,7 +40,7 @@ Docker를 사용하면 애플리케이션과 모든 의존성을 소프트웨어
 First, create a new directory where all the files would live. In this directory
 create a `package.json` file that describes your app and its dependencies:
 
-```javascript
+```json
 {
   "name": "docker_web_app",
   "version": "1.0.0",
@@ -62,7 +62,7 @@ create a `package.json` file that describes your app and its dependencies:
 우선, 모든 파일을 넣은 새로운 디렉터리를 만들겠습니다. 이 디렉터리 안에 애플리케이션과 의존성을
 알려주는 `package.json` 파일을 생성하겠습니다.
 
-```javascript
+```json
 {
   "name": "docker_web_app",
   "version": "1.0.0",
@@ -93,12 +93,12 @@ const HOST = '0.0.0.0';
 
 // App
 const app = express();
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('Hello world\n');
 });
 
 app.listen(PORT, HOST);
-console.log('Running on http://' + HOST + ':' + PORT);
+console.log(`Running on http://${HOST}:${PORT}`);
 ```
 
 In the next steps, we'll look at how you can run this app inside a Docker
@@ -119,12 +119,12 @@ const HOST = '0.0.0.0';
 
 // 앱
 const app = express();
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('Hello world\n');
 });
 
 app.listen(PORT, HOST);
-console.log('Running on http://' + HOST + ':' + PORT);
+console.log(`Running on http://${HOST}:${PORT}`);
 ```
 
 다음 단계에서 공식 Docker 이미지를 사용해서 Docker 컨테이너 안에서 이 앱을 실행하는 방법을

--- a/locale/ko/docs/guides/simple-profiling.md
+++ b/locale/ko/docs/guides/simple-profiling.md
@@ -58,9 +58,9 @@ tick 프로파일러의 사용방법을 설명하기 위해 간단한 Express �
 
 <!--
 ```javascript
-app.get('/newUser', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/newUser', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -68,13 +68,10 @@ app.get('/newUser', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var salt = crypto.randomBytes(128).toString('base64');
-  var hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const salt = crypto.randomBytes(128).toString('base64');
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
 
-  users[username] = {
-    salt: salt,
-    hash: hash
-  };
+  users[username] = { salt, hash };
 
   res.sendStatus(200);
 });
@@ -84,9 +81,9 @@ and another for validating user authentication attempts:
 -->
 
 ```javascript
-app.get('/newUser', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/newUser', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -94,13 +91,10 @@ app.get('/newUser', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var salt = crypto.randomBytes(128).toString('base64');
-  var hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const salt = crypto.randomBytes(128).toString('base64');
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
 
-  users[username] = {
-    salt: salt,
-    hash: hash
-  };
+  users[username] = { salt, hash };
 
   res.sendStatus(200);
 });
@@ -110,9 +104,9 @@ app.get('/newUser', function (req, res) {
 
 <!--
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -120,7 +114,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
 
   if (users[username].hash.toString() === hash.toString()) {
     res.sendStatus(200);
@@ -132,9 +126,9 @@ app.get('/auth', function (req, res) {
 -->
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -142,7 +136,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
 
   if (users[username].hash.toString() === hash.toString()) {
     res.sendStatus(200);
@@ -436,9 +430,9 @@ To remedy this issue, you make a small modification to the above handlers to use
 the asynchronous version of the pbkdf2 function:
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -446,7 +440,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  crypto.pbkdf2(password, users[username].salt, 10000, 512, function(err, hash) {
+  crypto.pbkdf2(password, users[username].salt, 10000, 512, (err, hash) => {
     if (users[username].hash.toString() === hash.toString()) {
       res.sendStatus(200);
     } else {
@@ -460,9 +454,9 @@ app.get('/auth', function (req, res) {
 이 이슈를 처리하려면 pdkdf2 함수의 비동기 버전을 사용하도록 핸들러를 수정하면 됩니다.
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -470,7 +464,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  crypto.pbkdf2(password, users[username].salt, 10000, 512, function(err, hash) {
+  crypto.pbkdf2(password, users[username].salt, 10000, 512, (err, hash) => {
     if (users[username].hash.toString() === hash.toString()) {
       res.sendStatus(200);
     } else {

--- a/locale/ko/docs/guides/timers-in-node.md
+++ b/locale/ko/docs/guides/timers-in-node.md
@@ -54,8 +54,8 @@ arguments may also be included and these will be passed on to the function. Here
 is an example of that:
 
 ```js
-function myFunc (arg) {
-  console.log('arg was => ' + arg);
+function myFunc(arg) {
+  console.log(`arg was => ${arg}`);
 }
 
 setTimeout(myFunc, 1500, 'funky');
@@ -73,8 +73,8 @@ setTimeout(myFunc, 1500, 'funky');
 부가적인 인자를 더 전달할 수도 있는데 이는 함수로 전달될 것입니다. 다음은 그 예제입니다.
 
 ```js
-function myFunc (arg) {
-  console.log('arg was => ' + arg);
+function myFunc(arg) {
+  console.log(`arg was => ${arg}`);
 }
 
 setTimeout(myFunc, 1500, 'funky');
@@ -207,7 +207,7 @@ that may hold on to the event loop, and therefore should be treated as an
 approximate delay. See the below example:
 
 ```js
-function intervalFunc () {
+function intervalFunc() {
   console.log('Cant stop me now!');
 }
 
@@ -229,7 +229,7 @@ can be used to reference and modify the interval that was set.
 보장되지 않습니다. 그러므로 대략적인 지연시간으로 생각해야 합니다. 아래 예시를 보겠습니다.
 
 ```js
-function intervalFunc () {
+function intervalFunc() {
   console.log('Cant stop me now!');
 }
 
@@ -252,15 +252,15 @@ that object will be halted completely. The respective functions are
 below for an example of each:
 
 ```js
-let timeoutObj = setTimeout(() => {
+const timeoutObj = setTimeout(() => {
   console.log('timeout beyond time');
 }, 1500);
 
-let immediateObj = setImmediate(() => {
+const immediateObj = setImmediate(() => {
   console.log('immediately executing immediate');
 });
 
-let intervalObj = setInterval(() => {
+const intervalObj = setInterval(() => {
   console.log('interviewing the interval');
 }, 500);
 
@@ -279,15 +279,15 @@ clearInterval(intervalObj);
 `clearInterval()`입니다. 각 예제는 아래에 나와 있습니다.
 
 ```js
-let timeoutObj = setTimeout(() => {
+const timeoutObj = setTimeout(() => {
   console.log('timeout beyond time');
 }, 1500);
 
-let immediateObj = setImmediate(() => {
+const immediateObj = setImmediate(() => {
   console.log('immediately executing immediate');
 });
 
-let intervalObj = setInterval(() => {
+const intervalObj = setInterval(() => {
   console.log('interviewing the interval');
 }, 500);
 
@@ -314,7 +314,7 @@ not *exactly* restore the initial behavior for performance reasons. See
 below for examples of both:
 
 ```js
-let timerObj = setTimeout(() => {
+const timerObj = setTimeout(() => {
   console.log('will i run?');
 });
 
@@ -344,7 +344,7 @@ setImmediate(() => {
 아래의 예제를 보겠습니다.
 
 ```js
-let timerObj = setTimeout(() => {
+const timerObj = setTimeout(() => {
   console.log('will i run?');
 });
 

--- a/locale/uk/docs/guides/anatomy-of-an-http-transaction.md
+++ b/locale/uk/docs/guides/anatomy-of-an-http-transaction.md
@@ -18,9 +18,9 @@ Any node web server application will at some point have to create a web server
 object. This is done by using [`createServer`][].
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer((request, response) => {
   // magic happens here!
 });
 ```
@@ -32,8 +32,8 @@ handler. In fact, the [`Server`][] object returned by [`createServer`][] is an
 `server` object and then adding the listener later.
 
 ```javascript
-var server = http.createServer();
-server.on('request', function(request, response) {
+const server = http.createServer();
+server.on('request', (request, response) => {
   // the same kind of magic happens here!
 });
 ```
@@ -54,8 +54,7 @@ the method and URL, so that appropriate actions can be taken. Node makes this
 relatively painless by putting handy properties onto the `request` object.
 
 ```javascript
-var method = request.method;
-var url = request.url;
+const { method, url } = request;
 ```
 > **Note:** The `request` object is an instance of [`IncomingMessage`][].
 
@@ -67,8 +66,8 @@ Headers are also not far away. They're in their own object on `request` called
 `headers`.
 
 ```javascript
-var headers = request.headers;
-var userAgent = headers['user-agent'];
+const { headers } = request;
+const userAgent = headers['user-agent'];
 ```
 
 It's important to note here that all headers are represented in lower-case only,
@@ -93,10 +92,10 @@ going to be string data, the best thing to do is collect the data in an array,
 then at the `'end'`, concatenate and stringify it.
 
 ```javascript
-var body = [];
-request.on('data', function(chunk) {
+let body = [];
+request.on('data', (chunk) => {
   body.push(chunk);
-}).on('end', function() {
+}).on('end', () => {
   body = Buffer.concat(body).toString();
   // at this point, `body` has the entire request body stored in it as a string
 });
@@ -120,7 +119,7 @@ continue on your way. (Though it's probably best to send some kind of HTTP error
 response. More on that later.)
 
 ```javascript
-request.on('error', function(err) {
+request.on('error', (err) => {
   // This prints the error message and stack trace to `stderr`.
   console.error(err.stack);
 });
@@ -137,18 +136,16 @@ headers and body out of requests. When we put that all together, it might look
 something like this:
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // At this point, we have the headers, method, url and body, and can now
     // do whatever we need to in order to respond to this request.
@@ -251,22 +248,20 @@ using `JSON.stringify`.
 
 ```javascript
 
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var headers = request.headers;
-  var method = request.method;
-  var url = request.url;
-  var body = [];
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  const { headers, method, url } = request;
+  let body = [];
+  request.on('error', (err) => {
     console.error(err);
-  }).on('data', function(chunk) {
+  }).on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     // BEGINNING OF NEW STUFF
 
-    response.on('error', function(err) {
+    response.on('error', (err) => {
       console.error(err);
     });
 
@@ -275,12 +270,7 @@ http.createServer(function(request, response) {
     // Note: the 2 lines above could be replaced with this next one:
     // response.writeHead(200, {'Content-Type': 'application/json'})
 
-    var responseBody = {
-      headers: headers,
-      method: method,
-      url: url,
-      body: body
-    };
+    const responseBody = { headers, method, url, body };
 
     response.write(JSON.stringify(responseBody));
     response.end();
@@ -300,13 +290,13 @@ we need to do is grab the data from the request stream and write that data to
 the response stream, similar to what we did previously.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  var body = [];
-  request.on('data', function(chunk) {
+http.createServer((request, response) => {
+  let body = [];
+  request.on('data', (chunk) => {
     body.push(chunk);
-  }).on('end', function() {
+  }).on('end', () => {
     body = Buffer.concat(body).toString();
     response.end(body);
   });
@@ -322,17 +312,17 @@ conditions:
 In any other case, we want to simply respond with a 404.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
-    var body = [];
-    request.on('data', function(chunk) {
+    let body = [];
+    request.on('data', (chunk) => {
       body.push(chunk);
-    }).on('end', function() {
+    }).on('end', () => {
       body = Buffer.concat(body).toString();
       response.end(body);
-    })
+    });
   } else {
     response.statusCode = 404;
     response.end();
@@ -351,9 +341,9 @@ That means we can use [`pipe`][] to direct data from one to the other. That's
 exactly what we want for an echo server!
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
+http.createServer((request, response) => {
   if (request.method === 'GET' && request.url === '/echo') {
     request.pipe(response);
   } else {
@@ -377,15 +367,15 @@ and message would be. As usual with errors, you should consult the
 On the response, we'll just log the error to `stdout`.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-http.createServer(function(request, response) {
-  request.on('error', function(err) {
+http.createServer((request, response) => {
+  request.on('error', (err) => {
     console.error(err);
     response.statusCode = 400;
     response.end();
   });
-  response.on('error', function(err) {
+  response.on('error', (err) => {
     console.error(err);
   });
   if (request.method === 'GET' && request.url === '/echo') {

--- a/locale/uk/docs/guides/nodejs-docker-webapp.md
+++ b/locale/uk/docs/guides/nodejs-docker-webapp.md
@@ -25,7 +25,7 @@ you load into a container.
 First, create a new directory where all the files would live. In this directory
 create a `package.json` file that describes your app and its dependencies:
 
-```javascript
+```json
 {
   "name": "docker_web_app",
   "version": "1.0.0",
@@ -55,12 +55,12 @@ const HOST = '0.0.0.0';
 
 // App
 const app = express();
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('Hello world\n');
 });
 
 app.listen(PORT, HOST);
-console.log('Running on http://' + HOST + ':' + PORT);
+console.log(`Running on http://${HOST}:${PORT}`);
 ```
 
 In the next steps, we'll look at how you can run this app inside a Docker
@@ -119,7 +119,7 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run 
+your runtime. Here we will use the basic `npm start` which will run
 `node server.js` to start your server:
 
 ```docker

--- a/locale/uk/docs/guides/simple-profiling.md
+++ b/locale/uk/docs/guides/simple-profiling.md
@@ -31,9 +31,9 @@ application. Our application will have two handlers, one for adding new users to
 our system:
 
 ```javascript
-app.get('/newUser', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/newUser', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -41,13 +41,10 @@ app.get('/newUser', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var salt = crypto.randomBytes(128).toString('base64');
-  var hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const salt = crypto.randomBytes(128).toString('base64');
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
 
-  users[username] = {
-    salt: salt,
-    hash: hash
-  };
+  users[username] = { salt, hash };
 
   res.sendStatus(200);
 });
@@ -56,9 +53,9 @@ app.get('/newUser', function (req, res) {
 and another for validating user authentication attempts:
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -66,7 +63,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  var hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, users[username].salt, 10000, 512);
 
   if (users[username].hash.toString() === hash.toString()) {
     res.sendStatus(200);
@@ -220,9 +217,9 @@ To remedy this issue, you make a small modification to the above handlers to use
 the asynchronous version of the pbkdf2 function:
 
 ```javascript
-app.get('/auth', function (req, res) {
-  var username = req.query.username || '';
-  var password = req.query.password || '';
+app.get('/auth', (req, res) => {
+  let username = req.query.username || '';
+  const password = req.query.password || '';
 
   username = username.replace(/[!@#$%^&*]/g, '');
 
@@ -230,7 +227,7 @@ app.get('/auth', function (req, res) {
     return res.sendStatus(400);
   }
 
-  crypto.pbkdf2(password, users[username].salt, 10000, 512, function(err, hash) {
+  crypto.pbkdf2(password, users[username].salt, 10000, 512, (err, hash) => {
     if (users[username].hash.toString() === hash.toString()) {
       res.sendStatus(200);
     } else {


### PR DESCRIPTION
* Lint code examples in guides according to the main repository rules (also add some eslint-plugin-markdown comments to ease possible future linting).

* Modernize some fragments (arrow functions in callbacks, destructuring, template literals, object shorthand, Buffer.alloc() etc).

Refs: https://github.com/nodejs/nodejs.org/pull/1281

In `ko` locale, many code fragments are duplicated in HTML comments, so it is needed to duplicate the changes as well.