### PR TITLE
Add Node.js Everywhere newsletter to homepage, fixes #1190

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -75,6 +75,11 @@
         <p>
           {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#lts-schedule1">{{ labels.version-schedule-prompt-link-text }}.</a>
         </p>
+        {{#if labels.newsletter }}
+        <p>
+          {{{ labels.newsletter-prefix }}} <a href="https://newsletter.nodejs.org/">Node.js Everywhere</a>{{{ labels.newsletter-postfix }}}
+        </p>
+        {{/if}}
       </div>
 
     </div>

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -15,6 +15,9 @@ labels:
   api: API Docs
   version-schedule-prompt: Or have a look at the
   version-schedule-prompt-link-text: LTS schedule
+  newsletter: true
+  newsletter-prefix: Sign up for
+  newsletter-postfix: ", the official Node.js Weekly Newsletter."
 ---
 
 Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://developers.google.com/v8/).


### PR DESCRIPTION
/cc @ZibbyKeaton 

I added a `newsletter: true` field to avoid rendering the link if no description is set. I deliberately didn't check for the prefix/postfix, as translations might not have both fields filled.