### PR TITLE
Display security announcement for july security releases

### DIFF
--- a/build.js
+++ b/build.js
@@ -272,8 +272,8 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: false,
-          content: ''
+          visible: true,
+          content: 'Important <a href="https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/">security releases</a>, please update now!'
         }
       }
     }


### PR DESCRIPTION
This adds a link to the security releases announcement to the home page as we did in the past.