### PR TITLE
Remove NodeSource repo support for Ubuntu 12.04 since it is EOL

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -69,7 +69,6 @@ sudo apt-get install -y build-essential
 
 **Supported Ubuntu versions:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -87,7 +86,6 @@ The Node.js modules available in the distribution official repositories do not n
 
 **Supported Linux Mint versions:**
 
-* **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
@@ -95,12 +93,10 @@ The Node.js modules available in the distribution official repositories do not n
 
 **Supported elementary OS versions:**
 
-* **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 
 **Supported Trisquel versions:**
 
-* **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
 
 **Supported BOSS versions:**

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -68,7 +68,6 @@ sudo apt-get install -y build-essential
 
 **Versiones de Ubuntu soportadas:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -86,7 +85,6 @@ Los módulos de Node.js disponibles en el repositorio de la distribución oficia
 
 **Versiones de Linux Mint soportadas:**
 
-* **Linux Mint 13 "Maya"** (mediante Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (mediante Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (mediante Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (mediante Ubuntu 14.04 LTS)
@@ -94,12 +92,10 @@ Los módulos de Node.js disponibles en el repositorio de la distribución oficia
 
 **Versiones de elementary OS soportadas:**
 
-* **elementary OS Luna** (mediante Ubuntu 12.04 LTS)
 * **elementary OS Freya** (mediante Ubuntu 14.04 LTS)
 
 **Versiones de Trisquel soportadas:**
 
-* **Trisquel 6 "Toutatis"** (mediante Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (mediante Ubuntu 14.04 LTS)
 
 **Versiones de BOSS soportadas:**

--- a/locale/ja/download/package-manager.md
+++ b/locale/ja/download/package-manager.md
@@ -79,7 +79,6 @@ sudo apt-get install -y build-essential
 <!-- **Supported Ubuntu versions:** -->
 **サポートしている Ubuntu のバージョン:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -102,7 +101,6 @@ The Node.js modules available in the distribution official repositories do not n
 <!-- **Supported Linux Mint versions:** -->
 **サポートしている Linux Mint のバージョン:**
 
-* **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
@@ -111,13 +109,11 @@ The Node.js modules available in the distribution official repositories do not n
 <!-- **Supported elementary OS versions:** -->
 **サポートしている elementary OS のバージョン:**
 
-* **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 
 <!-- **Supported Trisquel versions:** -->
 **サポートしている  Trisquel のバージョン:**
 
-* **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
 
 <!-- **Supported BOSS versions:** -->

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -125,7 +125,6 @@ sudo apt-get install -y build-essential
 
 **Supported Ubuntu versions:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -159,7 +158,6 @@ sudo apt-get install -y build-essential
 
 **지원하는 Ubuntu 버전:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -187,7 +185,6 @@ Debian Sid(unstable), Jessie(testing), Wheezy(wheezy-backports)의
 <!--
 **Supported Linux Mint versions:**
 
-* **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
@@ -195,12 +192,10 @@ Debian Sid(unstable), Jessie(testing), Wheezy(wheezy-backports)의
 
 **Supported elementary OS versions:**
 
-* **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 
 **Supported Trisquel versions:**
 
-* **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
 
 **Supported BOSS versions:**
@@ -209,7 +204,6 @@ Debian Sid(unstable), Jessie(testing), Wheezy(wheezy-backports)의
 -->
 **지원하는 Linux Mint 버전:**
 
-* **Linux Mint 13 "Maya"** (Ubuntu 12.04 LTS에서)
 * **Linux Mint 17 "Qiana"** (Ubuntu 14.04 LTS에서)
 * **Linux Mint 17.1 "Rebecca"** (Ubuntu 14.04 LTS에서)
 * **Linux Mint 17.2 "Rafaela"** (Ubuntu 14.04 LTS에서)
@@ -217,12 +211,10 @@ Debian Sid(unstable), Jessie(testing), Wheezy(wheezy-backports)의
 
 **지원하는 elementary OS 버전:**
 
-* **elementary OS Luna** (Ubuntu 12.04 LTS에서)
 * **elementary OS Freya** (Ubuntu 14.04 LTS에서)
 
 **지원하는 Trisquel 버전:**
 
-* **Trisquel 6 "Toutatis"** (Ubuntu 12.04 LTS에서)
 * **Trisquel 7 "Belenos"** (Ubuntu 14.04 LTS에서)
 
 **지원하는 BOSS 버전:**

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -68,7 +68,6 @@ sudo apt-get install -y build-essential
 
 **Supported Ubuntu versions:**
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
 * **Ubuntu 16.04 LTS** (Xenial Xerus)
 
@@ -86,7 +85,6 @@ The Node.js modules available in the distribution official repositories do not n
 
 **Supported Linux Mint versions:**
 
-* **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
@@ -94,12 +92,10 @@ The Node.js modules available in the distribution official repositories do not n
 
 **Supported elementary OS versions:**
 
-* **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 
 **Supported Trisquel versions:**
 
-* **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
 
 **Supported BOSS versions:**


### PR DESCRIPTION
NodeSource's repo will no longer be providing updates for Ubuntu 12.04 Precise Pangolin.

See https://github.com/nodesource/distributions/issues/494