### PR TITLE
Add note about package-lock.json to docker guide.

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -95,11 +95,14 @@ WORKDIR /usr/src/app
 ```
 
 This image comes with Node.js and NPM already installed so the next thing we
-need to do is to install your app dependencies using the `npm` binary:
+need to do is to install your app dependencies using the `npm` binary. Please
+note that if you are using `npm` version 5 or later you will also want to copy
+`package-lock.json`:
 
 ```docker
 # Install app dependencies
 COPY package.json /usr/src/app/
+COPY package-lock.json /usr/src/app/
 RUN npm install
 ```
 

--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -101,8 +101,7 @@ note that if you are using `npm` version 5 or later you will also want to copy
 
 ```docker
 # Install app dependencies
-COPY package.json /usr/src/app/
-COPY package-lock.json /usr/src/app/
+COPY package.json package-lock.json /usr/src/app/
 RUN npm install
 ```
 


### PR DESCRIPTION
Realized while dockerizing an app that users will also want to copy `package-lock.json` to the Docker image.