### PR TITLE
Fix Docker tutorial

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -96,11 +96,14 @@ WORKDIR /usr/src/app
 This image comes with Node.js and NPM already installed so the next thing we
 need to do is to install your app dependencies using the `npm` binary. Please
 note that if you are using `npm` version 5 or later you will also want to copy
-`package-lock.json`:
+`package-lock.json`, which is gernerated once you run `npm install`:
 
 ```docker
 # Install app dependencies
-COPY package.json package-lock.json .
+COPY package.json .
+# For npm@5 or later, copy package-lock.json as well
+# COPY package.json package-lock.json .
+
 RUN npm install
 ```
 
@@ -141,7 +144,10 @@ FROM node:boron
 WORKDIR /usr/src/app
 
 # Install app dependencies
-COPY package.json package-lock.json .
+COPY package.json .
+# For npm@5 or later, copy package-lock.json as well
+# COPY package.json package-lock.json .
+
 RUN npm install
 
 # Bundle app source


### PR DESCRIPTION
Example uses the Node.js 6 Docker image with npm@3, so "npm install" won't
create a `package-lock.json`. If the reader follows the tutorial step-by-step,
it would not have been created even for npm@5, as a local `npm install` step
is missing.