### PR TITLE
Fixed cursor flickering on nav menu

### DIFF
--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -7,7 +7,10 @@ header
 
   li
     position relative
-
+  
+  nav
+    cursor default
+  
   nav
     a,
     a:link,


### PR DESCRIPTION
## Nav Cursor Update
* Added a rule to make the cursor stop flickering between the default, hand, and text-selection cursor when hovering over the nav menu items.
* The rule causes the cursor to stay default unless directly on an anchor element, in which case it follows normal behavior over a link.