### PR TITLE
Fix macOS package manager anchors.

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -17,7 +17,7 @@ title: Installing Node.js via package manager
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
 * [openSUSE and SLE](#opensuse-and-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -16,7 +16,7 @@ title: Instalando Node.js usando un gestor de paquetes
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
 * [openSUSE y SLE](#opensuse-and-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS y illumos](#smartos-and-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)
@@ -289,7 +289,7 @@ sudo zypper in nodejs nodejs-devel
 ```
 
 
-## OSX
+## macOS
 
 Simplemente descargue el [Instalador para Macintosh](http://nodejs.org/#download) directamente desde el sitio web de [nodejs.org](http://nodejs.org).
 

--- a/locale/ja/download/package-manager.md
+++ b/locale/ja/download/package-manager.md
@@ -18,7 +18,7 @@ title: パッケージマネージャを利用した Node.js のインストー�
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
 * [openSUSE と SLE](#opensuse-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS と illumos](#smartos-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)
@@ -348,7 +348,7 @@ sudo zypper in nodejs nodejs-devel
 ```
 
 
-## OSX
+## macOS
 
 <!-- Simply download the [Macintosh Installer](http://nodejs.org/#download) direct from the [nodejs.org](http://nodejs.org) web site. -->
 直接 [nodejs.org](http://nodejs.org) のサイトから [Macintosh Installer](http://nodejs.org/#download) をダウンロードしてください。

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -18,7 +18,7 @@ title: 패키지 매니저로 Node.js 설치하기
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
 * [openSUSE and SLE](#opensuse-and-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)
@@ -41,7 +41,7 @@ title: 패키지 매니저로 Node.js 설치하기
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
 * [openSUSE와 SLE](#opensuse-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS와 illumos](#smartos-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)
@@ -673,7 +673,7 @@ zypper install nodejs4
 ```
 
 <!--
-## OSX
+## macOS
 
 Simply download the [Macintosh Installer](http://nodejs.org/#download) direct from the [nodejs.org](http://nodejs.org) web site.
 
@@ -683,7 +683,7 @@ _If you want to download the package with bash:_
 curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
 ```
 -->
-## OSX
+## macOS
 
 [nodejs.org](http://nodejs.org) 웹사이트에서 [매킨토시 인스톨러](http://nodejs.org/#download)를 다운로드 받으세요.
 

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -16,7 +16,7 @@ title: Installing Node.js via package manager
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
-* [OSX](#osx)
+* [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
 * [Void Linux](#void-linux)
 * [Windows](#windows)
@@ -289,7 +289,7 @@ sudo zypper in nodejs nodejs-devel
 ```
 
 
-## OSX
+## macOS
 
 Simply download the [Macintosh Installer](http://nodejs.org/#download) direct from the [nodejs.org](http://nodejs.org) web site.
 


### PR DESCRIPTION
I noticed that the OSX link at the top of https://nodejs.org/en/download/package-manager/ was broken, due to inconsistent terminology (OSX vs macOS).

I fixed the link and normalized all localized pages to use macOS instead of OSX.