### PR TITLE
blog: update hash-seed security post

### DIFF
--- a/locale/en/blog/vulnerability/july-2017-security-releases.md
+++ b/locale/en/blog/vulnerability/july-2017-security-releases.md
@@ -7,6 +7,15 @@ layout: blog-post.hbs
 author: Michael Dawson
 ---
 
+# _(Update 10-August-2017)_ Snapshots Re-enabled on 8.3.0
+
+The vulnerability has been patched upstream and snapshots have been re-enabled in 8.3.0
+
+Expect a backport and update with the next release of 6.x
+
+**Download**
+* [Node.js v8 (Current)](https://nodejs.org/en/blog/release/v8.3.0)
+
 # _(Update 11-July-2017)_ Security releases available
 
 ## Summary


### PR DESCRIPTION
A fix has landed in 8.3.0. We should update the blog post to relfect this