### PR TITLE
fix silver section head and paypal location

### DIFF
--- a/locale/en/foundation/members.md
+++ b/locale/en/foundation/members.md
@@ -55,10 +55,10 @@ Individual membership costs [$100 a year, or $25 for students](https://identity.
 <a target="_new" class="imagelink" href="//nodesource.com">
   <img alt="NodeSource" class="memberlogo" src="/static/images/foundation/nodesourceLogo.png" />
 </a>
-</div>
 <a target="_new" class="imagelink" href="//paypal.com">
   <img alt="PayPal" class="memberlogo" src="/static/images/foundation/paypalLogo.png" />
 </a>
+</div>
 
 ## Silver
 


### PR DESCRIPTION
Got some weirdness going on with the PayPal logo placement (they should be listed with Gold Members just after Nodesource) and also the Silver heading is messed up - I think we were just lacking a div

Appreciate a review. Thanks!