### PR TITLE
Add Collab Summit to nodejs.org 

### DIFF
--- a/locale/en/get-involved/code-and-learn.md
+++ b/locale/en/get-involved/code-and-learn.md
@@ -10,9 +10,9 @@ Code & Learn events allow you to get started (or go further) with Node.js core c
 ## Upcoming Code + Learn Events
 
 - [Oakland on April 22, 2017](https://medium.com/the-node-js-collection/code-learn-learn-how-to-contribute-to-node-js-core-8a2dbdf9be45)
-- Shanghai in July 2017 (details TBA)
-- Vancouver in October 2017 (details TBA)
-- Kilkenny in November 2017 (details TBA)
+- Shanghai at JSConf.CN: July 2017
+- Vancouver, BC at [Node Interactive](http://events.linuxfoundation.org/events/node-interactive): October 6, 2017
+- Kilkenny, Ireland at [NodeConfEU](http://www.nodeconf.eu/): November 5, 2017
 
 ## Past Code + Learn Events
 

--- a/locale/en/get-involved/collab-summit.md
+++ b/locale/en/get-involved/collab-summit.md
@@ -1,0 +1,36 @@
+---
+title: Collab Summit
+layout: contribute.hbs
+---
+
+# Collab Summit
+Collaboration Summit is an un-conference for bringing current and
+potential contributors together to discuss Node.js  with lively collaboration,
+education, and knowledge sharing. Committees and working groups come together
+twice per year to make important decisions while also being able to work on some
+exciting efforts they want to push forward in-person.
+
+## Who attends?
+
+Anyone is welcome to attend Collab Summit. Conversations can move fast as
+working groups have a lot of context. However, this Fall's instance of Collab
+Summit will include a morning [Code + Learn](https://nodejs.org/en/get-involved/code-and-learn/)
+to learn how to contribute prior to congregating for the summit. During the
+summit, leaders will help onboard new contributors to groups they'd love to help
+prior to integrating them into the working sessions.
+
+This is your opportunity to learn what is happening within the community to jump
+in and contribute with the skills you have and would like to hone.
+
+Working groups will put together a schedule so that people can
+familiarize themselves before folks get onsite, having the general collaborator
+discussions, and then dive into breakout sessions.
+
+We'd love to see you at Collab Summit! Check out the [Summit repo](https://github.com/nodejs/summit)
+for [issues filed](https://github.com/nodejs/summit/issues) that share what
+individual working groups and committees are looking to discuss in-person.
+
+## Past Collab Summit events
+- Berlin in May 2017
+- Austin in December 2016
+- Amsterdam in September 2016

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -144,6 +144,10 @@
             "link": "get-involved/code-and-learn",
             "text": "Code + Learn"
         },
+        "collab-summit": {
+            "link": "get-involved/collab-summit",
+            "text": "Collab Summit"
+        },
         "contribute": {
             "link": "get-involved/contribute",
             "text": "Contribute"
@@ -157,11 +161,11 @@
             "text": "Conduct"
         }
     },
-    "security": { 
+    "security": {
         "link": "security",
         "text": "Security"
     },
-    "blog": { 
+    "blog": {
         "link": "blog",
         "text": "News"
     },


### PR DESCRIPTION
This finally adds info as a separate page about Collab Summit and why folks should attend. Lots of points to good things happening in repos, too!