### PR TITLE
Remove 'v' from displayed Node.js versions

### DIFF
--- a/build.js
+++ b/build.js
@@ -163,27 +163,23 @@ function buildLocale (source, locale) {
       pattern: '**/*.html',
       partials: 'layouts/partials',
       helpers: {
+        apidocslink: require('./scripts/helpers/apidocslink.js'),
+        changeloglink: require('./scripts/helpers/changeloglink.js'),
         copyright: require('./scripts/helpers/copyright-year.js'),
         equals: require('./scripts/helpers/equals.js'),
-        startswith: require('./scripts/helpers/startswith.js'),
-        changeloglink: require('./scripts/helpers/changeloglink.js'),
-        strftime: require('./scripts/helpers/strftime.js'),
-        apidocslink: require('./scripts/helpers/apidocslink.js'),
         majorapidocslink: require('./scripts/helpers/majorapidocslink.js'),
+        startswith: require('./scripts/helpers/startswith.js'),
+        strftime: require('./scripts/helpers/strftime.js'),
         stripv: require('./scripts/helpers/stripv.js'),
         summary: require('./scripts/helpers/summary.js'),
-        json: function (context) {
-          return JSON.stringify(context)
-        },
-        getListJson: function (context) {
-          var result = context.map(function (item) {
-            return {
-              title: item.title,
-              date: item.date,
-              local: true,
-              path: item.path.replace(/\\/, '/')
-            }
-          })
+        json: (context) => JSON.stringify(context),
+        getListJson: (context) => {
+          const result = context.map(item => ({
+            title: item.title,
+            date: item.date,
+            local: true,
+            path: item.path.replace(/\\/, '/')
+          }))
           return JSON.stringify(result)
         }
       }

--- a/build.js
+++ b/build.js
@@ -170,6 +170,7 @@ function buildLocale (source, locale) {
         strftime: require('./scripts/helpers/strftime.js'),
         apidocslink: require('./scripts/helpers/apidocslink.js'),
         majorapidocslink: require('./scripts/helpers/majorapidocslink.js'),
+        stripv: require('./scripts/helpers/stripv.js'),
         summary: require('./scripts/helpers/summary.js'),
         json: function (context) {
           return JSON.stringify(context)

--- a/layouts/download-releases.hbs
+++ b/layouts/download-releases.hbs
@@ -32,7 +32,7 @@
             <tbody>
               {{#each project.versions}}
               <tr>
-                <td data-label="Version">{{name}} {{version}}</td>
+                <td data-label="Version">{{name}} {{stripv version}}</td>
                 <td data-label="LTS">{{#if lts}}{{lts}}{{/if}}</td>
                 <td data-label="Date"><time>{{date}}</time></td>
                 <td data-label="V8">{{v8}}</td>

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -31,8 +31,8 @@
 
         <div class="home-downloadblock">
 
-          <a href="https://nodejs.org/dist/{{ project.latestVersions.lts.node }}/" class="home-downloadbutton" title="{{ labels.download }} {{ project.latestVersions.lts.node }} {{ labels.lts }}" data-version="{{ project.latestVersions.lts.node }}">
-            {{ project.latestVersions.lts.node }} {{ labels.lts }}
+          <a href="https://nodejs.org/dist/{{ project.latestVersions.lts.node }}/" class="home-downloadbutton" title="{{ labels.download }} {{stripv project.latestVersions.lts.node }} {{ labels.lts }}" data-version="{{ project.latestVersions.lts.node }}">
+            {{stripv project.latestVersions.lts.node }} {{ labels.lts }}
             <small>{{ labels.tagline-lts }}</small>
           </a>
 
@@ -53,8 +53,8 @@
         {{#if project.latestVersions.current.node}}
           <div class="home-downloadblock">
 
-            <a href="https://nodejs.org/dist/{{ project.latestVersions.current.node }}/" class="home-downloadbutton"  title="{{ labels.download }} {{ project.latestVersions.current.node }} {{ labels.current }}"  data-version="{{ project.latestVersions.current.node }}">
-              {{ project.latestVersions.current.node }} {{ labels.current }}
+            <a href="https://nodejs.org/dist/{{ project.latestVersions.current.node }}/" class="home-downloadbutton"  title="{{ labels.download }} {{stripv project.latestVersions.current.node }} {{ labels.current }}"  data-version="{{ project.latestVersions.current.node }}">
+              {{stripv project.latestVersions.current.node }} {{ labels.current }}
               <small>{{ labels.tagline-current }}</small>
             </a>
 

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -1,5 +1,5 @@
 <section>
-  <p class="color-lightgray">{{downloads.currentVersion}}: <strong>{{version.node}}</strong> (includes npm {{version.npm}})</p>
+  <p class="color-lightgray">{{downloads.currentVersion}}: <strong>{{stripv version.node}}</strong> (includes npm {{version.npm}})</p>
   <p>{{downloads.intro}}</p>
   <div class="download-hero full-width">
     <ul class="no-padding download-version-toggle">

--- a/scripts/helpers/stripv.js
+++ b/scripts/helpers/stripv.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (version) => version.replace(/^v/, '')


### PR DESCRIPTION
Node.js versions are the only ones (historically) prefixed with a 'v', contrary to other included components like npm or v8.

As the content of `versions.json` is used on multiple occasions and I didn't want to break any functionality requiring the prefix (e.g. download links), I added a new Handlebars helper to remove the prefix where needed.

At the moment, this is implemented on the home page, download page headline and the revision list.

Fixes #1246.