### PR TITLE
Update TSC members

### DIFF
--- a/locale/en/foundation/tsc/index.md
+++ b/locale/en/foundation/tsc/index.md
@@ -22,25 +22,65 @@ can be found on the project's [GitHub profile](https://github.com/orgs/nodejs/pe
 
 ## Current members of the Technical Steering Committee
 
-* Brian White ([mscdex](https://github.com/mscdex))
-* Colin Ihrig ([cjihrig](https://github.com/cjihrig))
-* Fedor Indutny ([indutny](https://github.com/indutny))
-* James M Snell ([jasnell](https://github.com/jasnell))
-* Josh Gavant ([joshgav](https://github.com/joshgav))
-* Michael Dawson ([mhdawson](https://github.com/mhdawson))
-* Rod Vagg ([rvagg](https://github.com/rvagg))
-* Shigeki Ohtsu ([shigeki](https://github.com/shigeki))
-* Trevor Norris ([trevnorris](https://github.com/trevnorris))
+### Current Members
+* [addaleax](https://github.com/addaleax) -
+**Anna Henningsen** &lt;anna@addaleax.net&gt; (she/her)
+* [ChALkeR](https://github.com/ChALkeR) -
+**Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt; (he/him)
+* [cjihrig](https://github.com/cjihrig) -
+**Colin Ihrig** &lt;cjihrig@gmail.com&gt;
+* [evanlucas](https://github.com/evanlucas) -
+**Evan Lucas** &lt;evanlucas@me.com&gt; (he/him)
+* [fhinkel](https://github.com/fhinkel) -
+**Franziska Hinkelmann** &lt;franziska.hinkelmann@gmail.com&gt; (she/her)
+* [Fishrock123](https://github.com/Fishrock123) -
+**Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
+* [indutny](https://github.com/indutny) -
+**Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
+* [jasnell](https://github.com/jasnell) -
+**James M Snell** &lt;jasnell@gmail.com&gt; (he/him)
+* [joshgav](https://github.com/joshgav) -
+**Josh Gavant** &lt;josh.gavant@outlook.com&gt;
+* [joyeecheung](https://github.com/joyeecheung) -
+**Joyee Cheung** &lt;joyeec9h3@gmail.com&gt; (she/her)
+* [mcollina](https://github.com/mcollina) -
+**Matteo Collina** &lt;matteo.collina@gmail.com&gt; (he/him)
+* [mhdawson](https://github.com/mhdawson) -
+**Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt; (he/him)
+* [mscdex](https://github.com/mscdex) -
+**Brian White** &lt;mscdex@mscdex.net&gt;
+* [MylesBorins](https://github.com/MylesBorins) -
+**Myles Borins** &lt;myles.borins@gmail.com&gt; (he/him)
+* [ofrobots](https://github.com/ofrobots) -
+**Ali Ijaz Sheikh** &lt;ofrobots@google.com&gt;
+* [rvagg](https://github.com/rvagg) -
+**Rod Vagg** &lt;rod@vagg.org&gt;
+* [shigeki](https://github.com/shigeki) -
+**Shigeki Ohtsu** &lt;ohtsu@ohtsu.org&gt; (he/him)
+* [targos](https://github.com/targos) -
+**Michaël Zasso** &lt;targos@protonmail.com&gt; (he/him)
+* [thefourtheye](https://github.com/thefourtheye) -
+**Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt; (he/him)
+* [trevnorris](https://github.com/trevnorris) -
+**Trevor Norris** &lt;trev.norris@gmail.com&gt;
+* [Trott](https://github.com/Trott) -
+**Rich Trott** &lt;rtrott@gmail.com&gt; (he/him)
+
 
 ## Emeritus Members
 
-* Anna Henningsen ([addaleax](https://github.com/addaleax))
-* Ben Noordhuis ([bnoordhuis](https://github.com/bnoordhuis))
-* Bert Belder ([piscisaureus](https://github.com/piscisaureus))
-* Bryan Hughes ([nebrius](https://github.com/nebrius))
-* Chris Dickinson ([chrisdickinson](https://github.com/chrisdickinson))
-* Jeremiah Senkpiel ([Fishrock123](https://github.com/Fishrock123))
-* Myles Borins ([MylesBorins](https://github.com/MylesBorins))
+* [bnoordhuis](https://github.com/bnoordhuis) -
+**Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
+* [chrisdickinson](https://github.com/chrisdickinson) -
+**Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
+* [isaacs](https://github.com/isaacs) -
+**Isaac Z. Schlueter** &lt;i@izs.me&gt;
+* [nebrius](https://github.com/nebrius) -
+**Bryan Hughes** &lt;bryan@nebri.us&gt;
+* [orangemocha](https://github.com/orangemocha) -
+**Alexis Campailla** &lt;orangemocha@nodejs.org&gt;
+* [piscisaureus](https://github.com/piscisaureus) -
+**Bert Belder** &lt;bertbelder@gmail.com&gt;
 
 ## Technical Steering Committee Meetings
 


### PR DESCRIPTION
The member list is outdated. 

Copied from https://github.com/nodejs/TSC/blob/master/README.md.

Only needed if we don't merge https://github.com/nodejs/nodejs.org/pull/1368