### PR TITLE
Add shortcut link for v7.x API docs

### DIFF
--- a/locale/de/docs/index.md
+++ b/locale/de/docs/index.md
@@ -28,6 +28,7 @@ von der Community zur Verfügung gestellt werden, sind dort nicht dokumentiert.
     <h4>Du suchst nach API Referenzen für ältere Versionen?</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -24,6 +24,7 @@ This documentation describes the built-in modules provided by Node.js. It does n
     <h4>Looking for API docs of previous releases?</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>

--- a/locale/es/docs/index.md
+++ b/locale/es/docs/index.md
@@ -24,6 +24,7 @@ También describe los módulos incluidos que proporciona Node.js, mas no documen
     <h4>¿Buscando la referencia de la API para una versión anterior?</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -31,6 +31,7 @@ labels:
     <h4>以前のバージョンの API リファレンスをお探しですか？</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>

--- a/locale/ko/docs/index.md
+++ b/locale/ko/docs/index.md
@@ -56,6 +56,7 @@ This documentation describes the built-in modules provided by Node.js. It does n
     <h4>이전 버전에 대한 API 문서가 필요한가요?</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>

--- a/locale/uk/docs/index.md
+++ b/locale/uk/docs/index.md
@@ -22,6 +22,7 @@ labels:
     <h4>Шукаєте документацію про API для попередніх релізів?</h4>
 
     <ul>
+        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
         <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>


### PR DESCRIPTION
This adds a shortcut link for the v7.x API docs. Maybe we can also remove that box now that the "View another version" is available.

![screen shot 2017-10-16 at 15 40 34](https://user-images.githubusercontent.com/1443911/31615100-ce22ca66-b288-11e7-8352-2b8f8d48af6a.png)
