### PR TITLE
Remove node-center.ru from get-involved page

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -56,7 +56,6 @@ right place. Explore our community resources to find out how you can help:
 - [Japanese user group](http://nodejs.jp/)
 - [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
 - [Nicaragua Node.js community](http://nodenica.com/)
-- [Russian website](http://node-center.ru/)
 - [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
 - [Turkey group in Turkish (Türkçe)](http://node.ist/)

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -53,6 +53,5 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - [Comunidad en Facebook de usuarios Israelí de Node.js](https://www.facebook.com/groups/node.il/)
 - [Grupo de usuarios de Japón](http://nodejs.jp/)
 - [Comunidad de Nicaragua de Node.js](http://nodenica.com/)
-- [Sitio Ruso](http://node-center.ru/)
 - [Grupo de Turquía en turco (Türkçe)](http://node.ist/)
 - [Comunidad Việt Nam](http://nodejs.vn)

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -49,7 +49,6 @@ layout: contribute.hbs
 - [Japanese user group](http://nodejs.jp/)
 - [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
 - [Nicaragua Node.js community](http://nodenica.com/)
-- [Russian website](http://node-center.ru/)
 - [Spanish language community](http://nodehispano.com)
 - [Turkey group in Turkish (Türkçe)](http://node.ist/)
 - [Việt Nam Node.js community](http://nodejs.vn)


### PR DESCRIPTION
Removes no longer existing site from https://nodejs.org/en/get-involved/.
Fixes: https://github.com/nodejs/nodejs.org/issues/1405