### PR TITLE
doc: remove ppc BE from download matrix

### DIFF
--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -15,12 +15,7 @@
 
       <tr>
         <th>Linux on Power Systems</th>
-        <td colspan="3">
-          <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit le</a>
-        </td>
-        <td colspan="3">
-          <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64.tar.xz">64-bit be</a>
-        </td>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit le</a></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
We removed Linux PPC **BE** from the supported list for Node Version 8.x
Remove from the download matrix now that both LTS and current are >= 8.x.
NOTE:  Linux PPC le is still supported and remains in the matrix.