### PR TITLE
Blog: v8.9.0 release post update

### DIFF
--- a/locale/en/blog/release/v8.9.0.md
+++ b/locale/en/blog/release/v8.9.0.md
@@ -8,7 +8,26 @@ layout: blog-post.hbs
 author: Gibson Fahnestock
 ---
 
-### Notable Changes
+### A New LTS Release Line
+
+Node.js 8.x is now in LTS!
+
+Node v8.9.0 marks the transition of Node v8.x into Long Term Support (LTS), with
+the codename **"Carbon"**. The v8.x line now moves into "Active LTS", and will
+remain so until April 2019, at which point it will move into "Maintenance LTS"
+until December 2019. For more info see the
+[Release Schedule](https://github.com/nodejs/Release#release-schedule).
+
+### Notable Changes between 6.x (Boron) and 8.x (Carbon)
+
+For a full list of notable changes, see the blog posts for
+[Node v7.0.0](https://nodejs.org/en/blog/release/v7.0.0/#commits) and
+[Node v8.0.0](https://nodejs.org/en/blog/release/v8.0.0/#semver-major-commits).
+
+The [Node v8.0.0 post](https://nodejs.org/en/blog/release/v8.0.0/) also contains
+an in-depth look at the significant changes in the Node 8.x release line.
+
+### Notable Changes in v8.9.0
 
 * **doc**:
   - add Gibson Fahnestock to Release team (Gibson Fahnestock) [#16620](https://github.com/nodejs/node/pull/16620)
@@ -133,7 +152,7 @@ Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-s390
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-aix-ppc64.tar.gz<br>
 SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x86.tar.xz<br>
 SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: *Coming soon*<br>
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-arm64.tar.xz<br>
 Source Code: https://nodejs.org/dist/v8.9.0/node-v8.9.0.tar.gz<br>
@@ -153,6 +172,8 @@ aaf165348bc6d20012b048a88a8f3a35cba6799496e8f4c1246d85c524a84dbc  node-v8.9.0-da
 c36655b5594dd85932bb7c8f7fd55ac1eb9ffe5ab112a1cc61cfc85c9b4a013c  node-v8.9.0-headers.tar.xz
 468af2d1936cc9daca02949774680a0d1fd24b6169561598bae71a0bc90c5c3d  node-v8.9.0-linux-arm64.tar.gz
 30cb00ac1cf6b466b1f27e7ce41363a67a66dbb64227c2dc5e33d221b09fc579  node-v8.9.0-linux-arm64.tar.xz
+139ddc93a2777ec105b2b8989157ab348dfe8cdf537f249b34e38b36f3d311bd  node-v8.9.0-linux-armv6l.tar.gz
+87ed863762b394d77b9cac36a444b655bda3b69d808aca126f862cfaccd22fc3  node-v8.9.0-linux-armv6l.tar.xz
 8a80e010b801a1f105828c3cd01636cf5ebf39669b9120138672f43e63023e85  node-v8.9.0-linux-armv7l.tar.gz
 36edb836120a68ab9a660e869e5ca3073f5cee880621d9ea4233d671632c33f5  node-v8.9.0-linux-armv7l.tar.xz
 969617525970e8eed07a86925fd8cded2dde54ca0f880889934806ed6a0256ee  node-v8.9.0-linux-ppc64le.tar.gz
@@ -189,19 +210,19 @@ f7b7b32ed6eb8f7b0f6956c71228b39848f69638ecf2a38bb8b65855e57fce6a  win-x86/node_p
 -----BEGIN PGP SIGNATURE-----
 Version: GnuPG v2
 
-iQIcBAEBCAAGBQJZ+MMfAAoJELAfu5KCHFh6gFcP/24IHkeMZb14XHYfE5HW84eU
-ufXtWGWUFhI0goMhxSZ1Rmt+L6zMNoW9XJS7wqrCwkme3n7lUPb5WLZsMH8BR/ZK
-XwGI8vsVs5tKXty0Rgy7rWDaqcKLMZ8b/afOHzQ+vm9AnbMdMfgCNbno3H/JsC/6
-9BZixrjlGzXQrVNCCWMDXH2AQomNuxEODUau3d/rg+fwtMv0JPa9bn/ipFN919wh
-fiycNjqFFD9ZD0OGXYeAg0K2guxPSA5l2I1rSaLlsW2zdGQRH25WoEkx7XGqdr3/
-gtctVPa6kiOmVfN4w13pFbVg9C6+82HY4dmKqCF5ik20QxD9jewyeWQ0VsfWw0kd
-wwLfiULmxXxoHj/lCx2Iz2M4iQFN+3OvkXDkEIval25Airs+1U1r6HGnrLm9lnD1
-8CWp/nsasD3jcSrAvis6s7tLqr8vi8THLbjU/H5IWYWR5drtm+oNzJjuO9mxajiR
-jp0eyslFRR9xkOaTxhQRZqO1tWmgm1SlphVMFol7JRCn7jxawK6BOfqUM1qU1Arh
-JI3qfTDGuzS6sTtunllmZyh1hyE67PNoJrqIKjGBUCjGNURLTolghF+dbYx7sinU
-5tV5Mq8JaEibcLGuJRsm9cB+PcnDEyTh/ePoc8nuh+fVrQTSN32YvyK3/8/u71R2
-tlEqlW61PqIsvL9ADuSp
-=9ips
+iQIcBAEBCAAGBQJZ+gVkAAoJELAfu5KCHFh6LtgP+wT/bE4PIEtZNc6h3TIHNDeA
+qUV1pAz3xdvScfZra51G6f9HnRRqqDzLTUOZZ2pwgM+d2U2m8zkPO7zAIhPYf596
+lH8JV4sJCusWxVcAAKq0b9dUvFUwXyZIZHqJMwH90PpgFbdeDJ3liVJfR3lFRd+D
+Gtw572wHybgg5YtVbScVGb2fOm8ICNVkJgnZtZJwz5lHOzgQQJpPMKj3B+kSih1w
+EjNdp9C/HviZWM0IsH7xWrgWMC7HBmqZRA0yw5qn3AGf4QxTd7SewT7DnPwGFviy
+yVLj7PIXkmAwRd8Exrw3wHMk9vwQDCFT7r/u/Mdl4/XUNqSneDrdT7Pe6nSSJOfP
+1Wrkd15zxhaxaNnx0HAHpr2EpAviaI7Q6/8tF3axsKxhQ6RfYkxLvye4JFdZH1sQ
+fIA7kW41C05LoGInGyIRoBLFLLxsqVw5setj6qw0oP9kHy45g0jr3Jv+rdBaEVIA
+aTdsviJ/ah7NSrpzJWElein5r5dmTe+OZXRX4nU2XU/UHTMAo3Q281oEubnREYlG
+O7VmJim8R2ufyT1cfCPl+sPA53Dtqe/FhF68A4DvuV728x8W+Bn6u3Je8yPOj0SX
+BnJZVhgXgoVd1m8oSA4pctyXga/eAd6xSTQTQk7/S0BW47QxSDbuu5gRDbUrcZC/
+WJYTKzyHASR87jfdrCft
+=ED8p
 -----END PGP SIGNATURE-----
 
 ```


### PR DESCRIPTION
Adds the Arm binaries and links to the 7.0.0 and 8.0.0 release posts.

Refs: https://github.com/nodejs/nodejs.org/pull/1436

cc/ @MylesBorins 