### PR TITLE
build: switch travis to node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.5
+  - 8


### PR DESCRIPTION
So @nodejs/website we're running Node 6 on the server, travis is testing Node 4, would you like us to upgrade to Node 8 on the server?