### PR TITLE
layout: get rid of `.` and add to locale

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -64,7 +64,7 @@
           </div>
         {{/if}}
         <p>
-          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#release-schedule">{{ labels.version-schedule-prompt-link-text }}.</a>
+          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#release-schedule">{{ labels.version-schedule-prompt-link-text }}</a>
         </p>
         {{#if labels.newsletter }}
         <p>

--- a/locale/ca/index.md
+++ b/locale/ca/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Canvis
   api: Documentació de l'API
   version-schedule-prompt: O revisi la
-  version-schedule-prompt-link-text: Agenda de LTS
+  version-schedule-prompt-link-text: Agenda de LTS.
 ---
 
 Node.js® és un entorn d'execució per a JavaScript construït amb el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).

--- a/locale/de/index.md
+++ b/locale/de/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Änderungshistorie
   api: API Doku
   version-schedule-prompt: Oder wirf einen Blick auf den
-  version-schedule-prompt-link-text: LTS Release Plan
+  version-schedule-prompt-link-text: LTS Release Plan.
 ---
 
 Node.js® ist eine JavaScript-Laufzeitumgebung, die auf  [Chromes V8 JavaScript-Engine](https://developers.google.com/v8/) basiert.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Changelog
   api: API Docs
   version-schedule-prompt: Or have a look at the
-  version-schedule-prompt-link-text: LTS schedule
+  version-schedule-prompt-link-text: LTS schedule.
   newsletter: true
   newsletter-prefix: Sign up for
   newsletter-postfix: ", the official Node.js Weekly Newsletter."

--- a/locale/es/index.md
+++ b/locale/es/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Cambios
   api: Documentación del API
   version-schedule-prompt: Ó revise la
-  version-schedule-prompt-link-text: Agenda de LTS
+  version-schedule-prompt-link-text: Agenda de LTS.
 ---
 
 Node.js® es un entorno de ejecución para JavaScript construido con el [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).

--- a/locale/fr/index.md
+++ b/locale/fr/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Journal des modifications
   api: API Docs
   version-schedule-prompt: Ou regardez le
-  version-schedule-prompt-link-text: Planning LTS
+  version-schedule-prompt-link-text: Planning LTS.
 ---
 
 Node.js® est un environnement d’exécution JavaScript construit sur le [moteur JavaScript V8 de Chrome](https://developers.google.com/v8/).

--- a/locale/gl/index.md
+++ b/locale/gl/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Cambios
   api: Documentación do API
   version-schedule-prompt: Ou revise á
-  version-schedule-prompt-link-text: Axenda de LTS
+  version-schedule-prompt-link-text: Axenda de LTS.
 ---
 
 Node.js® é un entorno de execución para JavaScript construído co [motor de Javascript V8 de Chrome](https://developers.google.com/v8/).

--- a/locale/it/index.md
+++ b/locale/it/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Changelog
   api: Documentazione API
   version-schedule-prompt: Dai un'occhiata alla
-  version-schedule-prompt-link-text: tabella di marcia LTS
+  version-schedule-prompt-link-text: tabella di marcia LTS.
   newsletter: true
   newsletter-prefix: Iscriviti a
   newsletter-postfix: ", la newsletter settimanale di Node.js"

--- a/locale/ja/index.md
+++ b/locale/ja/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: 変更履歴
   api: API ドキュメント
   version-schedule-prompt: または、
-  version-schedule-prompt-link-text: LTSのリリーススケジュールをご覧ください
+  version-schedule-prompt-link-text: LTSのリリーススケジュールをご覧ください。
   newsletter: true
   newsletter-prefix: "公式 Node.js ニュースレター"
   newsletter-postfix: "を購読しましょう。"

--- a/locale/ko/index.md
+++ b/locale/ko/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: 변경사항
   api: API 문서
   version-schedule-prompt: LTS 일정은
-  version-schedule-prompt-link-text: 여기서 확인하세요
+  version-schedule-prompt-link-text: 여기서 확인하세요.
 ---
 
 Node.js®는 [Chrome V8 JavaScript 엔진](https://developers.google.com/v8/)으로 빌드된 JavaScript 런타임입니다.

--- a/locale/uk/index.md
+++ b/locale/uk/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: Список змін
   api: Документація
   version-schedule-prompt: Або подивіться на
-  version-schedule-prompt-link-text: графік LTS
+  version-schedule-prompt-link-text: графік LTS.
 ---
 
 Node.js® — це JavaScript–оточення побудоване на JavaScript–рушієві [Chrome V8](https://developers.google.com/v8/).

--- a/locale/zh-cn/index.md
+++ b/locale/zh-cn/index.md
@@ -14,7 +14,7 @@ labels:
   changelog: 更新日志
   api: API 文档
   version-schedule-prompt: 可参考
-  version-schedule-prompt-link-text: LTS 日程
+  version-schedule-prompt-link-text: LTS 日程。
   newsletter: true
   newsletter-prefix: 注册
   newsletter-postfix: ", Node.js 官方的新闻周报。"


### PR DESCRIPTION
In Japanese and Chinese, a full stop is `。` instead of a period. I just moved period from template to locale and replace it with `。` in `ja` and `zh-ch`.

Refs: https://github.com/nodejs/nodejs.org/pull/1463#issuecomment-343437897

cc @nodejs/nodejs-ja @nodejs/nodejs-cn