### PR TITLE
Fix description of CVE-2017-3736

### DIFF
--- a/locale/en/blog/vulnerability/openssl-november-2017.md
+++ b/locale/en/blog/vulnerability/openssl-november-2017.md
@@ -28,7 +28,7 @@ CVE-2017-3735 fixes buffer over-read in parsing X.509 certificates using extensi
 
 Node.js disables RFC3779 support by defining `OPENSSL_NO_RFC3779` during compile. It is therefore **unlikely that Node.js is impacted in any way by this vulnerability**.
 
-### [CVE-2017-3736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3736): OOB read parsing IPAdressFamily in an X.509 certificate
+### [CVE-2017-3736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3736): Carry propagating bug in the x86_64 Montgomery squaring procedure
 
 CVE-2017-3736 fixes a carry propagating bug in the x86_64 [_Montgomery squaring_](https://en.wikipedia.org/wiki/Exponentiation_by_squaring#Montgomery.27s_ladder_technique) procedure.
 


### PR DESCRIPTION
The description was the same with it of CVE-2017-3735.