### PR TITLE
Correct navigation link to Node.js Foundation

### DIFF
--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -13,7 +13,11 @@
 
         {{#each nav.main}}
           <li{{#startswith ../path link}} class="active"{{/startswith}}>
-            <a href="/{{../site.locale}}/{{link}}/">{{text}}</a>
+            {{#startswith link 'http'}}
+              <a href="{{link}}">{{text}}</a>
+            {{else}}
+              <a href="/{{../site.locale}}/{{link}}/">{{text}}</a>
+            {{/startswith}}
           </li>
         {{/each}}
       </ul>


### PR DESCRIPTION
A recent commit [1] removed the Node.js Foundation pages and updated the
site navigation to reference an external site via an absolute URL.
Update the navigation template to support the new URL.

[1] 104eeaf43384a3b532da904e2f8e511799c385c2