### PR TITLE
Add special format for external 'Foundation' link in main navigation

### DIFF
--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -7,10 +7,10 @@ header
 
   li
     position relative
-  
+
   nav
     cursor default
-  
+
   nav
     a,
     a:link,
@@ -23,6 +23,17 @@ header
     a:hover
       background-color transparent
       text-decoration underline
+
+// Special format for external 'Foundation' link in main navigation
+.nav-foundation
+  margin-left 8px
+  background-color #026e00
+
+  &:before
+    content none !important
+
+  a
+    padding 0 16px !important
 
 @media screen and (min-width: 481px)
   header

--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -12,7 +12,7 @@
         </li>
 
         {{#each nav.main}}
-          <li{{#startswith ../path link}} class="active"{{/startswith}}>
+          <li{{#startswith ../path link}} class="active"{{/startswith}}{{#startswith link 'https://foundation.nodejs.org'}} class="nav-foundation"{{/startswith}}>
             {{#startswith link 'http'}}
               <a href="{{link}}">{{text}}</a>
             {{else}}

--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -13,7 +13,8 @@
   "chakracore-nightly": "Versions Node-ChakraCore Nightly",
   "previous": "Précédent",
   "next": "Prochain",
-  "feeds": [{
+  "feeds": [
+    {
       "link": "feed/blog.xml",
       "text": "Node.js Blog"
     },
@@ -30,7 +31,9 @@
       "text": "Minutes de les reunions del TSC de Node.js"
     }
   ],
-  "home": { "text": "Inici" },
+  "home": {
+    "text": "Inici"
+  },
   "about": {
     "link": "about",
     "text": "Quant a",
@@ -100,10 +103,6 @@
       "text": "Guies"
     }
   },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fundació"
-  },
   "getinvolved": {
     "link": "get-involved",
     "text": "Implica't",
@@ -124,9 +123,18 @@
       "text": "Conducta"
     }
   },
-  "security": { "link": "security", "text": "Seguretat" },
-  "blog": { "link": "blog", "text": "Notícies" },
-
+  "security": {
+    "link": "security",
+    "text": "Seguretat"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Notícies"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Fundació"
+  },
   "releases": {
     "title": "Històric de Versions",
     "downloads": "Descarrègues"

--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -1,131 +1,138 @@
 {
-    "title": "Node.js",
-    "author": "Node.js Foundation",
-    "url": "https://nodejs.org/de/",
-    "locale": "de",
-    "scrollToTop": "Zum Seitenanfang",
-    "reportNodeIssue": "Node.js-Fehler melden",
-    "reportWebsiteIssue": "Webseitenfehler melden",
-    "getHelpIssue": "Hilfe",
-    "by": "von",
-    "all-downloads": "Alle Download-Optionen",
-    "nightly": "Nightly Builds",
-    "previous": "Zurück",
-    "next": "Weiter",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js-Blog"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js-Blog: Versionen"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js-Blog: Berichte über Sicherheitslücken"
-        },
-        {
-            "link": "feed/tsc-minutes.xml",
-            "text": "Node.js TSC-Sitzungsprotokoll"
-        }
-    ],
-    "home": { "text": "Startseite" },
-    "about": {
-        "link": "about",
-        "text": "Über Node.js",
-        "governance": {
-            "link": "about/governance",
-            "text": "Governance"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Arbeitskreise"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Versionen"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Ressourcen"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Trademark"
-        }
+  "title": "Node.js",
+  "author": "Node.js Foundation",
+  "url": "https://nodejs.org/de/",
+  "locale": "de",
+  "scrollToTop": "Zum Seitenanfang",
+  "reportNodeIssue": "Node.js-Fehler melden",
+  "reportWebsiteIssue": "Webseitenfehler melden",
+  "getHelpIssue": "Hilfe",
+  "by": "von",
+  "all-downloads": "Alle Download-Optionen",
+  "nightly": "Nightly Builds",
+  "previous": "Zurück",
+  "next": "Weiter",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js-Blog"
     },
-    "download": {
-        "link": "download",
-        "text": "Downloads",
-        "releases": {
-            "link": "download/releases",
-            "text": "Alle Versionen"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Node.js mit Paketmanagern installieren"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "Signierte SHASUMS für die Versionsdateien"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js-Blog: Versionen"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Dokumentation",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 und darüber hinaus"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Anleitungen"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js-Blog: Berichte über Sicherheitslücken"
     },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Foundation"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Mitmachen",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Programmiere + Lerne"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Mitwirken"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Entwicklung"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Verhaltenskodex"
-        }
-    },
-    "security"   : { "link": "security",        "text": "Sicherheit" },
-    "blog"       : { "link": "blog",            "text": "Neuigkeiten" },
-
-    "releases": {
-        "title": "Versionshistorie",
-        "downloads": "Downloads"
-    },
-    "links": {
-        "pages": {
-            "changelog": "Änderungshistorie"
-        }
+    {
+      "link": "feed/tsc-minutes.xml",
+      "text": "Node.js TSC-Sitzungsprotokoll"
     }
+  ],
+  "home": {
+    "text": "Startseite"
+  },
+  "about": {
+    "link": "about",
+    "text": "Über Node.js",
+    "governance": {
+      "link": "about/governance",
+      "text": "Governance"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Arbeitskreise"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Versionen"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Ressourcen"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Trademark"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Downloads",
+    "releases": {
+      "link": "download/releases",
+      "text": "Alle Versionen"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Node.js mit Paketmanagern installieren"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "Signierte SHASUMS für die Versionsdateien"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Dokumentation",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 und darüber hinaus"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Anleitungen"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Mitmachen",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Programmiere + Lerne"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Mitwirken"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Entwicklung"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Verhaltenskodex"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Sicherheit"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Neuigkeiten"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Foundation"
+  },
+  "releases": {
+    "title": "Versionshistorie",
+    "downloads": "Downloads"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Änderungshistorie"
+    }
+  }
 }

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -1,149 +1,151 @@
 {
-    "title": "Node.js",
-    "author": "Node.js Foundation",
-    "url": "https://nodejs.org/en/",
-    "locale": "en",
-    "scrollToTop": "Scroll to top",
-    "reportNodeIssue": "Report Node.js issue",
-    "reportWebsiteIssue": "Report website issue",
-    "getHelpIssue": "Get Help",
-    "by": "by",
-    "all-downloads": "All download options",
-    "nightly": "Nightly builds",
-    "chakracore-nightly": "Node-ChakraCore Nightly builds",
-    "previous": "Previous",
-    "next": "Next",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js Blog"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js Blog: Releases"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js Blog: Vulnerability Reports"
-        }
-    ],
-    "home": { "text": "Home" },
-    "about": {
-        "link": "about",
-        "text": "About",
-        "governance": {
-            "link": "about/governance",
-            "text": "Governance"
-        },
-        "community": {
-            "link": "about/community",
-            "text": "Community"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Working Groups"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Releases"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Resources"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Trademark"
-        },
-        "privacy": {
-            "link": "about/privacy",
-            "text": "Privacy Policy"
-        }
+  "title": "Node.js",
+  "author": "Node.js Foundation",
+  "url": "https://nodejs.org/en/",
+  "locale": "en",
+  "scrollToTop": "Scroll to top",
+  "reportNodeIssue": "Report Node.js issue",
+  "reportWebsiteIssue": "Report website issue",
+  "getHelpIssue": "Get Help",
+  "by": "by",
+  "all-downloads": "All download options",
+  "nightly": "Nightly builds",
+  "chakracore-nightly": "Node-ChakraCore Nightly builds",
+  "previous": "Previous",
+  "next": "Next",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js Blog"
     },
-    "download": {
-        "link": "download",
-        "text": "Downloads",
-        "releases": {
-            "link": "download/releases",
-            "text": "Previous Releases"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Installing Node.js via package manager"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "Signed SHASUMS for release files"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js Blog: Releases"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Docs",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 and beyond"
-        },
-        "inspector": {
-            "link": "docs/inspector",
-            "text": "Inspector"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Guides"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js Blog: Vulnerability Reports"
+    }
+  ],
+  "home": {
+    "text": "Home"
+  },
+  "about": {
+    "link": "about",
+    "text": "About",
+    "governance": {
+      "link": "about/governance",
+      "text": "Governance"
     },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Foundation"
+    "community": {
+      "link": "about/community",
+      "text": "Community"
     },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Get Involved",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Code + Learn"
-        },
-        "collab-summit": {
-            "link": "get-involved/collab-summit",
-            "text": "Collab Summit"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Contribute"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Development"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Conduct"
-        }
-    },
-    "security": {
-        "link": "security",
-        "text": "Security"
-    },
-    "blog": {
-        "link": "blog",
-        "text": "News"
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Working Groups"
     },
     "releases": {
-        "title": "Release History",
-        "downloads": "Downloads"
+      "link": "about/releases",
+      "text": "Releases"
     },
-    "links": {
-        "pages": {
-            "changelog": "Changelog"
-        }
+    "resources": {
+      "link": "about/resources",
+      "text": "Resources"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Trademark"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "Privacy Policy"
     }
+  },
+  "download": {
+    "link": "download",
+    "text": "Downloads",
+    "releases": {
+      "link": "download/releases",
+      "text": "Previous Releases"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Installing Node.js via package manager"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "Signed SHASUMS for release files"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Docs",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 and beyond"
+    },
+    "inspector": {
+      "link": "docs/inspector",
+      "text": "Inspector"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guides"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Get Involved",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Code + Learn"
+    },
+    "collab-summit": {
+      "link": "get-involved/collab-summit",
+      "text": "Collab Summit"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribute"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Development"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Conduct"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Security"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "News"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Foundation"
+  },
+  "releases": {
+    "title": "Release History",
+    "downloads": "Downloads"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Changelog"
+    }
+  }
 }

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -1,127 +1,134 @@
 {
-    "title": "Node.js",
-    "author": "Fundación de Node.js",
-    "url": "https://nodejs.org/es/",
-    "locale": "es",
-    "scrollToTop": "Vuelve al comienzo",
-    "reportNodeIssue": "Reporte un problema con Node.js",
-    "reportWebsiteIssue": "Reporte un problema con el sitio",
-    "getHelpIssue": "Consiga ayuda",
-    "by": "por",
-    "all-downloads": "Todas las opciones de descarga",
-    "nightly": "Versiones nightly",
-    "previous": "Anterior",
-    "next": "Siguiente",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js Blog"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js Blog: Versiones"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js Blog: Reportes de vulnerabilidades"
-        }
-    ],
-    "home": { "text": "Inicio" },
-    "about": {
-        "link": "about",
-        "text": "Acerca",
-        "governance": {
-            "link": "about/governance",
-            "text": "Gobierno"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Grupos de trabajo"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Versiones"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Recursos"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Marca"
-        }
+  "title": "Node.js",
+  "author": "Fundación de Node.js",
+  "url": "https://nodejs.org/es/",
+  "locale": "es",
+  "scrollToTop": "Vuelve al comienzo",
+  "reportNodeIssue": "Reporte un problema con Node.js",
+  "reportWebsiteIssue": "Reporte un problema con el sitio",
+  "getHelpIssue": "Consiga ayuda",
+  "by": "por",
+  "all-downloads": "Todas las opciones de descarga",
+  "nightly": "Versiones nightly",
+  "previous": "Anterior",
+  "next": "Siguiente",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js Blog"
     },
-    "download": {
-        "link": "download",
-        "text": "Descargas",
-        "releases": {
-            "link": "download/releases",
-            "text": "Versiones anteriores"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Instale Node.js mediante un manejador de paquetes"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "Firmas SHASUMS de los arvhivos de versiones"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js Blog: Versiones"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Documentación",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 y más allá"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Guías"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Fundación"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Participa",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Programa y Aprende"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Contribuye"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Desarrollo"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Conducta"
-        }
-    },
-    "security"   : { "link": "security",        "text": "Seguridad" },
-    "blog"       : { "link": "blog",            "text": "Noticias" },
-
-    "releases": {
-        "title": "Histórico de versiones",
-        "downloads": "Descargas"
-    },
-    "links": {
-        "pages": {
-            "changelog": "Cambios"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js Blog: Reportes de vulnerabilidades"
     }
+  ],
+  "home": {
+    "text": "Inicio"
+  },
+  "about": {
+    "link": "about",
+    "text": "Acerca",
+    "governance": {
+      "link": "about/governance",
+      "text": "Gobierno"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Grupos de trabajo"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Versiones"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Recursos"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Marca"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Descargas",
+    "releases": {
+      "link": "download/releases",
+      "text": "Versiones anteriores"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Instale Node.js mediante un manejador de paquetes"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "Firmas SHASUMS de los arvhivos de versiones"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Documentación",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 y más allá"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guías"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Participa",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Programa y Aprende"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribuye"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Desarrollo"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Conducta"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Seguridad"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Noticias"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Fundación"
+  },
+  "releases": {
+    "title": "Histórico de versiones",
+    "downloads": "Descargas"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Cambios"
+    }
+  }
 }

--- a/locale/fr/site.json
+++ b/locale/fr/site.json
@@ -1,134 +1,141 @@
 {
-    "title": "Node.js",
-    "author": "Node.js Foundation",
-    "url": "https://nodejs.org/fr/",
-    "locale": "fr",
-    "scrollToTop": "Faire défiler en haut",
-    "reportNodeIssue": "Rapporter un problème Node.js",
-    "reportWebsiteIssue": "Rapporter un problème sur le site web",
-    "getHelpIssue": "Obtenir de l’aide",
-    "by": "par",
-    "all-downloads": "Toutes les options de téléchargement",
-    "nightly": "Versions quotidiennes",
-    "chakracore-nightly": "Versions quotidiennes de Node-ChakraCore",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Blog de Node.js"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Blog de Node.js: Versions"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Blog de Node.js: Rapport de Vulnérabilité"
-        }
-    ],
-    "home": { "text": "Accueil" },
-    "about": {
-        "link": "about",
-        "text": "À propos",
-        "governance": {
-            "link": "about/governance",
-            "text": "Gouvernance"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Groupes de travail"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Versions"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Ressources"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Marque déposée"
-        },
-        "privacy": {
-            "link": "about/privacy",
-            "text": "Politique de confidentialité"
-        }
+  "title": "Node.js",
+  "author": "Node.js Foundation",
+  "url": "https://nodejs.org/fr/",
+  "locale": "fr",
+  "scrollToTop": "Faire défiler en haut",
+  "reportNodeIssue": "Rapporter un problème Node.js",
+  "reportWebsiteIssue": "Rapporter un problème sur le site web",
+  "getHelpIssue": "Obtenir de l’aide",
+  "by": "par",
+  "all-downloads": "Toutes les options de téléchargement",
+  "nightly": "Versions quotidiennes",
+  "chakracore-nightly": "Versions quotidiennes de Node-ChakraCore",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Blog de Node.js"
     },
-    "download": {
-        "link": "download",
-        "text": "Téléchargements",
-        "releases": {
-            "link": "download/releases",
-            "text": "Précédentes versions"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Installer Node.js via le gestionnaire de paquets"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "SHASUMS signés pour les fichiers des versions"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Blog de Node.js: Versions"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Docs",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 et au-delà"
-        },
-        "inspector": {
-            "link": "docs/inspector",
-            "text": "Inspecteur"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Guides"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Fondation"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "S’impliquer",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Coder + Apprendre"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Contribuer"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Développement"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Code de conduite"
-        }
-    },
-    "security"   : { "link": "security",        "text": "Securité" },
-    "blog"       : { "link": "blog",            "text": "Actualités" },
-
-    "releases": {
-        "title": "Historique des versions",
-        "downloads": "Téléchargements"
-    },
-    "links": {
-        "pages": {
-            "changelog": "Journal des modifications"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Blog de Node.js: Rapport de Vulnérabilité"
     }
+  ],
+  "home": {
+    "text": "Accueil"
+  },
+  "about": {
+    "link": "about",
+    "text": "À propos",
+    "governance": {
+      "link": "about/governance",
+      "text": "Gouvernance"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Groupes de travail"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Versions"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Ressources"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Marque déposée"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "Politique de confidentialité"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Téléchargements",
+    "releases": {
+      "link": "download/releases",
+      "text": "Précédentes versions"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Installer Node.js via le gestionnaire de paquets"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "SHASUMS signés pour les fichiers des versions"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Docs",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 et au-delà"
+    },
+    "inspector": {
+      "link": "docs/inspector",
+      "text": "Inspecteur"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guides"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "S’impliquer",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Coder + Apprendre"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribuer"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Développement"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Code de conduite"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Securité"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Actualités"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Fondation"
+  },
+  "releases": {
+    "title": "Historique des versions",
+    "downloads": "Téléchargements"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Journal des modifications"
+    }
+  }
 }

--- a/locale/gl/site.json
+++ b/locale/gl/site.json
@@ -1,132 +1,139 @@
 {
-    "title": "Node.js",
-    "author": "Fundación de Node.js",
-    "url": "https://nodejs.org/gl/",
-    "locale": "gl",
-    "scrollToTop": "Volta ao principio",
-    "reportNodeIssue": "Informar dun problema con Node.js",
-    "reportWebsiteIssue": "Informar dun problema co sitio",
-    "getHelpIssue": "Obter axuda",
-    "by": "por",
-    "all-downloads": "Todas as opcións de descarga",
-    "nightly": "Versións Nightly",
-    "chakracore-nightly": "Versións Node-ChakraCore Nightly",
-    "previous": "Anterior",
-    "next": "Seguinte",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js Blog"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js Blog: Versións"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js Blog: Informes de vulnerabilidade"
-        }
-    ],
-    "home": { "text": "Inicio" },
-    "about": {
-        "link": "about",
-        "text": "Acerca de",
-        "governance": {
-            "link": "about/governance",
-            "text": "Goberno"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Grupos de traballo"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Versións"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Recursos"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Marca"
-        },
-        "privacy": {
-            "link": "about/privacy",
-            "text": "Política de Privacidade"
-        }
+  "title": "Node.js",
+  "author": "Fundación de Node.js",
+  "url": "https://nodejs.org/gl/",
+  "locale": "gl",
+  "scrollToTop": "Volta ao principio",
+  "reportNodeIssue": "Informar dun problema con Node.js",
+  "reportWebsiteIssue": "Informar dun problema co sitio",
+  "getHelpIssue": "Obter axuda",
+  "by": "por",
+  "all-downloads": "Todas as opcións de descarga",
+  "nightly": "Versións Nightly",
+  "chakracore-nightly": "Versións Node-ChakraCore Nightly",
+  "previous": "Anterior",
+  "next": "Seguinte",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js Blog"
     },
-    "download": {
-        "link": "download",
-        "text": "Descargas",
-        "releases": {
-            "link": "download/releases",
-            "text": "Versións anteriores"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Instalar Node.js usando un xestor de paquetes"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "Firmas SHASUMS para os arquivos de versións"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js Blog: Versións"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Documentación",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 e máis aló"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Guías"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Fundación"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Participa",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Programa e Aprende"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Contribúe"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Desenvolvemento"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Comportamento"
-        }
-    },
-    "security"   : { "link": "security",        "text": "Seguridade" },
-    "blog"       : { "link": "blog",            "text": "Noticias" },
-
-    "releases": {
-        "title": "Histórico de versións",
-        "downloads": "Descargas"
-    },
-    "links": {
-        "pages": {
-            "changelog": "Cambios"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js Blog: Informes de vulnerabilidade"
     }
+  ],
+  "home": {
+    "text": "Inicio"
+  },
+  "about": {
+    "link": "about",
+    "text": "Acerca de",
+    "governance": {
+      "link": "about/governance",
+      "text": "Goberno"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Grupos de traballo"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Versións"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Recursos"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Marca"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "Política de Privacidade"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Descargas",
+    "releases": {
+      "link": "download/releases",
+      "text": "Versións anteriores"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Instalar Node.js usando un xestor de paquetes"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "Firmas SHASUMS para os arquivos de versións"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Documentación",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 e máis aló"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guías"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Participa",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Programa e Aprende"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribúe"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Desenvolvemento"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Comportamento"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Seguridade"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Noticias"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Fundación"
+  },
+  "releases": {
+    "title": "Histórico de versións",
+    "downloads": "Descargas"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Cambios"
+    }
+  }
 }

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -1,130 +1,130 @@
 {
-    "title": "Node.js",
-    "author": "Node.js Foundation",
-    "url": "https://nodejs.org/en/",
-    "locale": "it",
-    "scrollToTop": "Portami all'inizio",
-    "reportNodeIssue": "Segnala un problema di Node.js",
-    "reportWebsiteIssue": "Segnala un problema del sito",
-    "getHelpIssue": "Chiedi aiuto",
-    "by": "da",
-    "all-downloads": "Tutti i download",
-    "nightly": "Build notturne",
-    "previous": "Precedente",
-    "next": "Successiva",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Blog Node.js"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Blog Node.js: Releases"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Blog Node.js: Rapporti di Vulnerabilità"
-        }
-    ],
-    "home": {
-        "text": "Home"
+  "title": "Node.js",
+  "author": "Node.js Foundation",
+  "url": "https://nodejs.org/en/",
+  "locale": "it",
+  "scrollToTop": "Portami all'inizio",
+  "reportNodeIssue": "Segnala un problema di Node.js",
+  "reportWebsiteIssue": "Segnala un problema del sito",
+  "getHelpIssue": "Chiedi aiuto",
+  "by": "da",
+  "all-downloads": "Tutti i download",
+  "nightly": "Build notturne",
+  "previous": "Precedente",
+  "next": "Successiva",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Blog Node.js"
     },
-    "about": {
-        "link": "about",
-        "text": "About",
-        "governance": {
-            "link": "about/governance",
-            "text": "Governance"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Gruppi di lavoro"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Release"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Risorse"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Marchio Registrato"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Blog Node.js: Releases"
     },
-    "download": {
-        "link": "download",
-        "text": "Download",
-        "releases": {
-            "link": "download/releases",
-            "text": "Release Precedenti"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Installa Node.js con un gestore di pacchetti"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Blog Node.js: Rapporti di Vulnerabilità"
+    }
+  ],
+  "home": {
+    "text": "Home"
+  },
+  "about": {
+    "link": "about",
+    "text": "About",
+    "governance": {
+      "link": "about/governance",
+      "text": "Governance"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Documentazione",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 e oltre"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Guide"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Fondazione"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Come partecipare",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Programma + Impara"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Contribuire"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Sviluppo"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Condotta"
-        }
-    },
-    "security": {
-        "link": "security",
-        "text": "Sicurezza"
-    },
-    "blog": {
-        "link": "blog",
-        "text": "Blog"
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Gruppi di lavoro"
     },
     "releases": {
-        "title": "Cronologia delle Release",
-        "downloads": "Download"
+      "link": "about/releases",
+      "text": "Release"
     },
-    "links": {
-        "pages": {
-            "changelog": "Registro modifiche"
-        }
+    "resources": {
+      "link": "about/resources",
+      "text": "Risorse"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Marchio Registrato"
     }
+  },
+  "download": {
+    "link": "download",
+    "text": "Download",
+    "releases": {
+      "link": "download/releases",
+      "text": "Release Precedenti"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Installa Node.js con un gestore di pacchetti"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Documentazione",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 e oltre"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Guide"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Come partecipare",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Programma + Impara"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Contribuire"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Sviluppo"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Condotta"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Sicurezza"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Blog"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Fondazione"
+  },
+  "releases": {
+    "title": "Cronologia delle Release",
+    "downloads": "Download"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Registro modifiche"
+    }
+  }
 }

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -1,127 +1,134 @@
 {
-    "title": "Node.js",
-    "author": "Node.js 財団",
-    "url": "https://nodejs.org/ja/",
-    "locale": "ja",
-    "scrollToTop": "上部へスクロールする",
-    "reportNodeIssue": "Node.js の不具合を報告",
-    "reportWebsiteIssue": "サイトの不具合を報告",
-    "getHelpIssue": "ヘルプ",
-    "by": "by",
-    "all-downloads": "All download options",
-    "nightly": "Nightly builds",
-    "previous": "前",
-    "next": "次",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js ブログ"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js ブログ: リリース"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js ブログ: 脆弱性のレポート"
-        }
-    ],
-    "home": { "text": "ホーム" },
-    "about": {
-        "link": "about",
-        "text": "Node.js とは",
-        "governance": {
-            "link": "about/governance",
-            "text": "委員会"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "ワーキンググループ"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "リリース"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "リソース"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "トレードマーク"
-        }
+  "title": "Node.js",
+  "author": "Node.js 財団",
+  "url": "https://nodejs.org/ja/",
+  "locale": "ja",
+  "scrollToTop": "上部へスクロールする",
+  "reportNodeIssue": "Node.js の不具合を報告",
+  "reportWebsiteIssue": "サイトの不具合を報告",
+  "getHelpIssue": "ヘルプ",
+  "by": "by",
+  "all-downloads": "All download options",
+  "nightly": "Nightly builds",
+  "previous": "前",
+  "next": "次",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js ブログ"
     },
-    "download": {
-        "link": "download",
-        "text": "ダウンロード",
-        "releases": {
-            "link": "download/releases",
-            "text": "バージョンの一覧"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "パッケージマネージャを使用したダウンロード"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "リリースファイルのための SHASUM 署名"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js ブログ: リリース"
     },
-    "docs": {
-        "link": "docs",
-        "text": "ドキュメント",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 について"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "ガイド"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "財団"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "参加する",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Code + Learn"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "貢献する"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "開発体制"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "行動規範"
-        }
-    },
-    "security"   : { "link": "security",        "text": "セキュリティ" },
-    "blog"       : { "link": "blog",            "text": "ニュース" },
-
-    "releases": {
-        "title": "過去のリリース",
-        "downloads": "ダウンロード"
-    },
-    "links": {
-        "pages": {
-            "changelog": "変更履歴"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js ブログ: 脆弱性のレポート"
     }
+  ],
+  "home": {
+    "text": "ホーム"
+  },
+  "about": {
+    "link": "about",
+    "text": "Node.js とは",
+    "governance": {
+      "link": "about/governance",
+      "text": "委員会"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "ワーキンググループ"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "リリース"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "リソース"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "トレードマーク"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "ダウンロード",
+    "releases": {
+      "link": "download/releases",
+      "text": "バージョンの一覧"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "パッケージマネージャを使用したダウンロード"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "リリースファイルのための SHASUM 署名"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "ドキュメント",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 について"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "ガイド"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "参加する",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Code + Learn"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "貢献する"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "開発体制"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "行動規範"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "セキュリティ"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "ニュース"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "財団"
+  },
+  "releases": {
+    "title": "過去のリリース",
+    "downloads": "ダウンロード"
+  },
+  "links": {
+    "pages": {
+      "changelog": "変更履歴"
+    }
+  }
 }

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -1,132 +1,139 @@
 {
-    "title": "Node.js",
-    "author": "Node.js 재단",
-    "url": "https://nodejs.org/ko/",
-    "locale": "ko",
-    "scrollToTop": "맨 위로",
-    "reportNodeIssue": "Node.js 이슈 보고",
-    "reportWebsiteIssue": "웹사이트 이슈 보고",
-    "getHelpIssue": "도움 얻기",
-    "by": "by",
-    "all-downloads": "모든 다운로드 보기",
-    "nightly": "나이틀리 빌드",
-    "chakracore-nightly": "Node-ChakraCore 나이틀리 빌드",
-    "previous": "너무 이른",
-    "next": "다음 것",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js 블로그"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js 블로그: 릴리스"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js 블로그: 취약점 보고"
-        }
-    ],
-    "home": { "text": "홈" },
-    "about": {
-        "link": "about",
-        "text": "About",
-        "governance": {
-            "link": "about/governance",
-            "text": "거버넌스"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "워킹 그룹"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "릴리스"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "관련 자료"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "트레이드마크"
-        },
-        "privacy": {
-            "link": "about/privacy",
-            "text": "개인정보 보호정책"
-        }
+  "title": "Node.js",
+  "author": "Node.js 재단",
+  "url": "https://nodejs.org/ko/",
+  "locale": "ko",
+  "scrollToTop": "맨 위로",
+  "reportNodeIssue": "Node.js 이슈 보고",
+  "reportWebsiteIssue": "웹사이트 이슈 보고",
+  "getHelpIssue": "도움 얻기",
+  "by": "by",
+  "all-downloads": "모든 다운로드 보기",
+  "nightly": "나이틀리 빌드",
+  "chakracore-nightly": "Node-ChakraCore 나이틀리 빌드",
+  "previous": "너무 이른",
+  "next": "다음 것",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js 블로그"
     },
-    "download": {
-        "link": "download",
-        "text": "다운로드",
-        "releases": {
-            "link": "download/releases",
-            "text": "이전 릴리스"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "패키지 관리자를 통한 Node.js 설치"
-        },
-        "shasums":{
-          "link": "SHASUMS256.txt.asc",
-          "text": "릴리스 파일에 서명된 SHASUMS"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js 블로그: 릴리스"
     },
-    "docs": {
-        "link": "docs",
-        "text": "문서",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6와 그 이후"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "안내"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "재단"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "참여하기",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "코딩 + 배우기"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "기여하기"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "개발하기"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "행동강령"
-        }
-    },
-    "security"   : { "link": "security",        "text": "보안" },
-    "blog"       : { "link": "blog",            "text": "뉴스" },
-
-    "releases": {
-        "title": "릴리스 이력",
-        "downloads": "다운로드"
-    },
-    "links": {
-        "pages": {
-            "changelog": "변경사항"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js 블로그: 취약점 보고"
     }
+  ],
+  "home": {
+    "text": "홈"
+  },
+  "about": {
+    "link": "about",
+    "text": "About",
+    "governance": {
+      "link": "about/governance",
+      "text": "거버넌스"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "워킹 그룹"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "릴리스"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "관련 자료"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "트레이드마크"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "개인정보 보호정책"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "다운로드",
+    "releases": {
+      "link": "download/releases",
+      "text": "이전 릴리스"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "패키지 관리자를 통한 Node.js 설치"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "릴리스 파일에 서명된 SHASUMS"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "문서",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6와 그 이후"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "안내"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "참여하기",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "코딩 + 배우기"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "기여하기"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "개발하기"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "행동강령"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "보안"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "뉴스"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "재단"
+  },
+  "releases": {
+    "title": "릴리스 이력",
+    "downloads": "다운로드"
+  },
+  "links": {
+    "pages": {
+      "changelog": "변경사항"
+    }
+  }
 }

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -1,123 +1,130 @@
 {
-    "title": "Node.js",
-    "author": "Node.js Foundation",
-    "url": "https://nodejs.org/uk/",
-    "locale": "uk",
-    "scrollToTop": "Вгору",
-    "reportNodeIssue": "Проблеми з Node.js",
-    "reportWebsiteIssue": "Проблеми з сайтом",
-    "getHelpIssue": "Допомога",
-    "by": "від",
-    "all-downloads": "Всі варіанти завантажень",
-    "nightly": "Нічні збірки",
-    "previous": "Попередній",
-    "next": "Далі",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Блог Node.js"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Блог Node.js: Релізи"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js Blog: Звіти про вразливості"
-        }
-    ],
-    "home": { "text": "Головна" },
-    "about": {
-        "link": "about",
-        "text": "Про проект",
-        "governance": {
-            "link": "about/governance",
-            "text": "Управління"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "Робочі групи"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "Релізи"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "Ресурси"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "Товарний знак"
-        }
+  "title": "Node.js",
+  "author": "Node.js Foundation",
+  "url": "https://nodejs.org/uk/",
+  "locale": "uk",
+  "scrollToTop": "Вгору",
+  "reportNodeIssue": "Проблеми з Node.js",
+  "reportWebsiteIssue": "Проблеми з сайтом",
+  "getHelpIssue": "Допомога",
+  "by": "від",
+  "all-downloads": "Всі варіанти завантажень",
+  "nightly": "Нічні збірки",
+  "previous": "Попередній",
+  "next": "Далі",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Блог Node.js"
     },
-    "download": {
-        "link": "download",
-        "text": "Завантаження",
-        "releases": {
-            "link": "download/releases",
-            "text": "Попередні Релізи"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "Встановлення Node.js через пакетний менеджер"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Блог Node.js: Релізи"
     },
-    "docs": {
-        "link": "docs",
-        "text": "Документація",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 і вище"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "Керівництва"
-        }
-    },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "Фундація"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "Приєднатись",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "Code + Learn"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "Сприяння"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "Розробка"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "Правила"
-        }
-    },
-    "security"   : { "link": "security",        "text": "Безпека" },
-    "blog"       : { "link": "blog",            "text": "Новини" },
-
-    "releases": {
-        "title": "Історія релізів",
-        "downloads": "Завантаження"
-    },
-    "links": {
-        "pages": {
-            "changelog": "Список змін"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js Blog: Звіти про вразливості"
     }
+  ],
+  "home": {
+    "text": "Головна"
+  },
+  "about": {
+    "link": "about",
+    "text": "Про проект",
+    "governance": {
+      "link": "about/governance",
+      "text": "Управління"
+    },
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "Робочі групи"
+    },
+    "releases": {
+      "link": "about/releases",
+      "text": "Релізи"
+    },
+    "resources": {
+      "link": "about/resources",
+      "text": "Ресурси"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "Товарний знак"
+    }
+  },
+  "download": {
+    "link": "download",
+    "text": "Завантаження",
+    "releases": {
+      "link": "download/releases",
+      "text": "Попередні Релізи"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "Встановлення Node.js через пакетний менеджер"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "Документація",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 і вище"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "Керівництва"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "Приєднатись",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "Code + Learn"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "Сприяння"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "Розробка"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "Правила"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "Безпека"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "Новини"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "Фундація"
+  },
+  "releases": {
+    "title": "Історія релізів",
+    "downloads": "Завантаження"
+  },
+  "links": {
+    "pages": {
+      "changelog": "Список змін"
+    }
+  }
 }

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -1,141 +1,143 @@
 {
-    "title": "Node.js",
-    "author": "Node.js 基金会",
-    "url": "https://nodejs.org/zh-cn/",
-    "locale": "zh-cn",
-    "scrollToTop": "回到页顶",
-    "reportNodeIssue": "报告 Node.js 问题 ",
-    "reportWebsiteIssue": "报告 Node.js 网站问题",
-    "getHelpIssue": "获取帮助",
-    "by": "于",
-    "all-downloads": "所有下载选项",
-    "nightly": "每日构建",
-    "chakracore-nightly": "Node-ChakraCore 每日构建",
-    "previous": "以前",
-    "next": "下一個",
-    "feeds": [
-        {
-            "link": "feed/blog.xml",
-            "text": "Node.js 博客"
-        },
-        {
-            "link": "feed/releases.xml",
-            "text": "Node.js 博客: 发布"
-        },
-        {
-            "link": "feed/vulnerability.xml",
-            "text": "Node.js 博客: 安全报告"
-        }
-    ],
-    "home": { "text": "首页" },
-    "about": {
-        "link": "about",
-        "text": "关于我们",
-        "governance": {
-            "link": "about/governance",
-            "text": "管理规则"
-        },
-        "workinggroups": {
-            "link": "about/working-groups",
-            "text": "工作组"
-        },
-        "releases": {
-            "link": "about/releases",
-            "text": "发布"
-        },
-        "resources": {
-            "link": "about/resources",
-            "text": "资源"
-        },
-        "trademark": {
-            "link": "about/trademark",
-            "text": "商标"
-        },
-        "privacy": {
-            "link": "about/privacy",
-            "text": "隐私政策"
-        }
+  "title": "Node.js",
+  "author": "Node.js 基金会",
+  "url": "https://nodejs.org/zh-cn/",
+  "locale": "zh-cn",
+  "scrollToTop": "回到页顶",
+  "reportNodeIssue": "报告 Node.js 问题 ",
+  "reportWebsiteIssue": "报告 Node.js 网站问题",
+  "getHelpIssue": "获取帮助",
+  "by": "于",
+  "all-downloads": "所有下载选项",
+  "nightly": "每日构建",
+  "chakracore-nightly": "Node-ChakraCore 每日构建",
+  "previous": "以前",
+  "next": "下一個",
+  "feeds": [
+    {
+      "link": "feed/blog.xml",
+      "text": "Node.js 博客"
     },
-    "download": {
-        "link": "download",
-        "text": "下载",
-        "releases": {
-            "link": "download/releases",
-            "text": "以往的版本"
-        },
-        "package-manager": {
-            "link": "download/package-manager",
-            "text": "使用包管理器安装 Node.js"
-        },
-        "shasums": {
-          "link": "SHASUMS256.txt.asc",
-          "text": "查看发布文件的 SHASUM 签名"
-        }
+    {
+      "link": "feed/releases.xml",
+      "text": "Node.js 博客: 发布"
     },
-    "docs": {
-        "link": "docs",
-        "text": "文档",
-        "es6": {
-            "link": "docs/es6",
-            "text": "ES6 相关"
-        },
-        "inspector": {
-            "link": "docs/inspector",
-            "text": "调试"
-        },
-        "api-lts": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "subtext": "LTS",
-            "text": "%ver% API"
-        },
-        "api-current": {
-            "link": "/dist/latest-%ver-major%/docs/api",
-            "text": "%ver% API"
-        },
-        "guides": {
-            "link": "docs/guides",
-            "text": "教程"
-        }
+    {
+      "link": "feed/vulnerability.xml",
+      "text": "Node.js 博客: 安全报告"
+    }
+  ],
+  "home": {
+    "text": "首页"
+  },
+  "about": {
+    "link": "about",
+    "text": "关于我们",
+    "governance": {
+      "link": "about/governance",
+      "text": "管理规则"
     },
-    "foundation": {
-        "link": "https://foundation.nodejs.org/",
-        "text": "基金会"
-    },
-    "getinvolved": {
-        "link": "get-involved",
-        "text": "加入我们",
-        "code-and-learn": {
-            "link": "get-involved/code-and-learn",
-            "text": "代码与学习"
-        },
-        "contribute": {
-            "link": "get-involved/contribute",
-            "text": "贡献"
-        },
-        "development": {
-            "link": "get-involved/development",
-            "text": "开发"
-        },
-        "conduct": {
-            "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
-            "text": "管理"
-        }
-    },
-    "security": {
-        "link": "security",
-        "text": "安全"
-    },
-    "blog": {
-        "link": "blog",
-        "text": "博客"
+    "workinggroups": {
+      "link": "about/working-groups",
+      "text": "工作组"
     },
     "releases": {
-        "title": "发布历史",
-        "downloads": "下载"
+      "link": "about/releases",
+      "text": "发布"
     },
-    "links": {
-        "pages": {
-            "changelog": "更新日志"
-        }
+    "resources": {
+      "link": "about/resources",
+      "text": "资源"
+    },
+    "trademark": {
+      "link": "about/trademark",
+      "text": "商标"
+    },
+    "privacy": {
+      "link": "about/privacy",
+      "text": "隐私政策"
     }
+  },
+  "download": {
+    "link": "download",
+    "text": "下载",
+    "releases": {
+      "link": "download/releases",
+      "text": "以往的版本"
+    },
+    "package-manager": {
+      "link": "download/package-manager",
+      "text": "使用包管理器安装 Node.js"
+    },
+    "shasums": {
+      "link": "SHASUMS256.txt.asc",
+      "text": "查看发布文件的 SHASUM 签名"
+    }
+  },
+  "docs": {
+    "link": "docs",
+    "text": "文档",
+    "es6": {
+      "link": "docs/es6",
+      "text": "ES6 相关"
+    },
+    "inspector": {
+      "link": "docs/inspector",
+      "text": "调试"
+    },
+    "api-lts": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "subtext": "LTS",
+      "text": "%ver% API"
+    },
+    "api-current": {
+      "link": "/dist/latest-%ver-major%/docs/api",
+      "text": "%ver% API"
+    },
+    "guides": {
+      "link": "docs/guides",
+      "text": "教程"
+    }
+  },
+  "getinvolved": {
+    "link": "get-involved",
+    "text": "加入我们",
+    "code-and-learn": {
+      "link": "get-involved/code-and-learn",
+      "text": "代码与学习"
+    },
+    "contribute": {
+      "link": "get-involved/contribute",
+      "text": "贡献"
+    },
+    "development": {
+      "link": "get-involved/development",
+      "text": "开发"
+    },
+    "conduct": {
+      "link": "https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-of-conduct",
+      "text": "管理"
+    }
+  },
+  "security": {
+    "link": "security",
+    "text": "安全"
+  },
+  "blog": {
+    "link": "blog",
+    "text": "博客"
+  },
+  "foundation": {
+    "link": "https://foundation.nodejs.org/",
+    "text": "基金会"
+  },
+  "releases": {
+    "title": "发布历史",
+    "downloads": "下载"
+  },
+  "links": {
+    "pages": {
+      "changelog": "更新日志"
+    }
+  }
 }


### PR DESCRIPTION
This change:
- Moves the 'Foundation' link to the right side of the main navigation
- Applies a different style to it

![bildschirmfoto 2017-12-01 um 09 00 18](https://user-images.githubusercontent.com/153481/33474068-41d18614-d679-11e7-92e3-22a847653761.png)
![bildschirmfoto 2017-12-01 um 09 00 35](https://user-images.githubusercontent.com/153481/33474069-41ee46d2-d679-11e7-8d21-344c024caeef.png)

Long diffs in `site.json` are [whitespace change only](https://github.com/nodejs/nodejs.org/pull/1492/files?w=1).
