### PR TITLE
Remove past events from collab summit

### DIFF
--- a/locale/en/get-involved/collab-summit.md
+++ b/locale/en/get-involved/collab-summit.md
@@ -27,10 +27,6 @@ familiarize themselves before folks get onsite, having the general collaborator
 discussions, and then dive into breakout sessions.
 
 We'd love to see you at Collab Summit! Check out the [Summit repo](https://github.com/nodejs/summit)
-for [issues filed](https://github.com/nodejs/summit/issues) that share what
+for upcoming and past Collab Summits and have a look at the
+[issues filed](https://github.com/nodejs/summit/issues) that share what
 individual working groups and committees are looking to discuss in-person.
-
-## Past Collab Summit events
-- Berlin in May 2017
-- Austin in December 2016
-- Amsterdam in September 2016


### PR DESCRIPTION
Don't list past events, instead link to the summit repo that has a more up-to-date list of events, including upcoming.

I'm not feeling strong about this. Just if we keep the Past Events section, we should add Vancouver 2017. 