### PR TITLE
doc: fix typo in anatomy-of-an-http-transaction

### DIFF
--- a/locale/en/docs/guides/anatomy-of-an-http-transaction.md
+++ b/locale/en/docs/guides/anatomy-of-an-http-transaction.md
@@ -363,7 +363,7 @@ though, we'd want to inspect the error to figure out what the correct status cod
 and message would be. As usual with errors, you should consult the
 [`Error` documentation][].
 
-On the response, we'll just log the error to `stdout`.
+On the response, we'll just log the error to `stderr`.
 
 ```javascript
 const http = require('http');


### PR DESCRIPTION
The response error handler in the code example uses `console.error()`, so the note should mention `stderr`, not `stdout`.