### PR TITLE
fix: changed link to lts-release-schedule page

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -64,7 +64,7 @@
           </div>
         {{/if}}
         <p>
-          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/LTS#release-schedule">{{ labels.version-schedule-prompt-link-text }}</a>
+          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/Release#release-schedule">{{ labels.version-schedule-prompt-link-text }}</a>
         </p>
         {{#if labels.newsletter }}
         <p>


### PR DESCRIPTION
nodejs/lts repository was renamed to nodejs/release