### PR TITLE
blog: amend v9.4.0 blogpost

### DIFF
--- a/locale/en/blog/release/v9.4.0.md
+++ b/locale/en/blog/release/v9.4.0.md
@@ -27,7 +27,6 @@ author: Myles Borins
   - perf_hooks integration (James M Snell) [#17906](https://github.com/nodejs/node/pull/17906)
   - Refactoring and cleanup of Http2Session and Http2Stream destroy (James M Snell) [#17406](https://github.com/nodejs/node/pull/17406)
 * **net**:
-  - remove Socket.prototype.write (Anna Henningsen) [#17644](https://github.com/nodejs/node/pull/17644)
   - remove Socket.prototype.listen (Ruben Bridgewater) [#13735](https://github.com/nodejs/node/pull/13735)
 * **repl**:
   - show lexically scoped vars in tab completion (Michaël Zasso) [#16591](https://github.com/nodejs/node/pull/16591)


### PR DESCRIPTION
Applied from https://github.com/nodejs/node/pull/18083

---

    doc: un-mark Socket#write “removal” as notable change

    Since the method is inherited from `Writable`, usage of the method
    does not change at all after its removal as an explicit method.

    Calling it out as notable might therefore be more confusing than
    helpful.