### PR TITLE
French translation of Downloads page

### DIFF
--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -20,21 +20,21 @@
       <li>
         <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x86.msi" id="windows-downloadbutton" data-version="{{version.node}}">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M1.589 23.55l-0.017-15.31 18.839-2.558v17.868zM23.55 5.225l25.112-3.654v21.979h-25.112zM48.669 26.69l-0.006 21.979-25.112-3.533v-18.446zM20.41 44.736l-18.824-2.58-0.001-15.466h18.825z"></path></svg>
-          Windows Installer
+          {{downloads.WindowsInstaller}}
           <p class="small color-lightgray">node-{{version.node}}-x86.msi</p>
         </a>
       </li>
       <li>
         <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M39.054 34.065q-1.093 3.504-3.448 7.009-3.617 5.495-7.205 5.495-1.374 0-3.925-0.897-2.411-0.897-4.233-0.897-1.71 0-3.981 0.925-2.271 0.953-3.701 0.953-4.261 0-8.439-7.261-4.121-7.317-4.121-14.102 0-6.392 3.168-10.485 3.14-4.037 7.962-4.037 2.019 0 4.962 0.841 2.916 0.841 3.869 0.841 1.262 0 4.009-0.953 2.86-0.953 4.85-0.953 3.336 0 5.972 1.822 1.458 1.009 2.916 2.804-2.215 1.878-3.196 3.308-1.822 2.635-1.822 5.803 0 3.476 1.934 6.252t4.43 3.533zM28.512 1.179q0 1.71-0.813 3.813-0.841 2.103-2.607 3.869-1.514 1.514-3.028 2.019-1.037 0.308-2.916 0.477 0.084-4.177 2.187-7.205 2.075-3 7.009-4.149 0.028 0.084 0.070 0.308t0.070 0.308q0 0.112 0.014 0.28t0.014 0.28z"></path></svg>
-          macOS Installer
+          {{downloads.MacOSInstaller}}
           <p class="small color-lightgray">node-{{version.node}}.pkg</p>
         </a>
       </li>
       <li>
         <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.tar.gz">
           <svg class="download-logo" width="50" height="50" viewBox="0 0 50 50"><path d="M25.030 0.934l-24.871 10.716 24.895 10.632 25.152-10.656-25.176-10.691zM26.050 23.62v25.686l24.188-11.483v-24.478l-24.188 10.275zM0.001 37.824l24.27 11.483v-25.686l-24.27-10.275v24.478z"></path></svg>
-          Source Code
+          {{downloads.SourceCode}}
           <p class="small color-lightgray">node-{{version.node}}.tar.gz</p>
         </a>
       </li>
@@ -44,48 +44,48 @@
   <table class="download-matrix full-width">
     <tbody>
       <tr>
-        <th>Windows Installer (.msi)</th>
+        <th>{{downloads.WindowsInstaller}} (.msi)</th>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x86.msi">32-bit</a></td>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-x64.msi">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>Windows Binary (.zip)</th>
+        <th>{{downloads.WindowsBinary}} (.zip)</th>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-win-x86.zip">32-bit</a></td>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-win-x64.zip">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>macOS Installer (.pkg)</th>
+        <th>{{downloads.MacOSInstaller}} (.pkg)</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>macOS Binaries (.tar.gz)</th>
+        <th>{{downloads.MacOSBinary}} (.tar.gz)</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
       </tr>
       {{#if versionTypeCurrent }}
       <tr>
-        <th>Linux Binaries (x64)</th>
+        <th>{{downloads.LinuxBinaries}} (x64)</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x64.tar.xz">64-bit</a></td>
       </tr>
       {{else}}
         <tr>
-          <th>Linux Binaries (x86/x64)</th>
+          <th>{{downloads.LinuxBinaries}} (x86/x64)</th>
           <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x86.tar.xz">32-bit</a></td>
           <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x64.tar.xz">64-bit</a></td>
         </tr>
       {{/if}}
 
       <tr>
-        <th>Linux Binaries (ARM)</th>
+        <th>{{downloads.LinuxBinaries}} (ARM)</th>
         <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv6l.tar.xz">ARMv6</a></td>
         <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-armv7l.tar.xz">ARMv7</a></td>
         <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-arm64.tar.xz">ARMv8</a></td>
       </tr>
 
       <tr>
-        <th>Source Code</th>
+        <th>{{downloads.SourceCode}}</th>
         <td colspan="6">
           <a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.tar.gz">node-{{version.node}}.tar.gz</a>
         </td>

--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -3,27 +3,27 @@
   <table class="download-matrix full-width">
     <tbody>
       <tr>
-        <th>SunOS Binaries</th>
+        <th>{{additional.SunOSBinaries}}</th>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x86.tar.xz">32-bit</a></td>
         <td colspan="3"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x64.tar.xz">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>Docker Image</th>
-        <td colspan="6"><a href="https://hub.docker.com/_/node/">Official Node.js Docker Image</a></td>
+        <th>{{additional.DockerImage}}</th>
+        <td colspan="6"><a href="https://hub.docker.com/_/node/">{{additional.officialDockerImage}}</a></td>
       </tr>
 
       <tr>
-        <th>Linux on Power Systems</th>
-        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit le</a></td>
+        <th>{{additional.LinuxPowerSystems}}</th>
+        <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-ppc64le.tar.xz">64-bit</a></td>
       </tr>
 
       <tr>
-        <th>Linux on System z</th>
+        <th>{{additional.LinuxSystemZ}}</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-s390x.tar.xz">64-bit</a></td>
       </tr>
       <tr>
-        <th>AIX on Power Systems</th>
+        <th>{{additional.AIXPowerSystems}}</th>
         <td colspan="6"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-aix-ppc64.tar.gz">64-bit</a></td>
       </tr>
     </tbody>

--- a/locale/ca/download/index.md
+++ b/locale/ca/download/index.md
@@ -13,10 +13,24 @@ downloads:
         Descarregui el codi font de Node.js o un instal·lador pre-compilat per a la seva plataforma, i comenci a desenvolupar avui.
     currentVersion: Versió actual
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Plataformes addicionals
     intro: >
         Membres de la comunitat de Node.js proveeixen paquets pre-compilats de forma no oficial per a plataformes addicionals no suportades per l'equip central de Node.js que poden no estar al mateix nivell de les versions actuals oficials de Node.js.
     platform: Plataforma
     provider: Proveïdor
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/de/download/index.md
+++ b/locale/de/download/index.md
@@ -13,6 +13,14 @@ downloads:
         Lade den Node.js-Quellcode oder ein bestehendes Installationsprogramm für deine Plattform herunter und beginne gleich mit der Entwicklung.
     currentVersion: Aktuellste LTS-Version
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Weitere Plattformen
     intro: >
@@ -21,4 +29,10 @@ additional:
         aktuelle Node.js-Version sind.
     platform: Plattform
     provider: Anbieter
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/en/download/current.md
+++ b/locale/en/download/current.md
@@ -13,10 +13,22 @@ downloads:
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
     currentVersion: Latest Current Version
     buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Additional Platforms
     intro: >
         Members of the Node.js community maintain unofficial builds of Node.js for additional platforms. Note that such builds are not supported by the Node.js core team and may not yet be at the same build level as current Node.js release.
     platform: Platform
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/en/download/index.md
+++ b/locale/en/download/index.md
@@ -13,10 +13,22 @@ downloads:
         Download the Node.js source code or a pre-built installer for your platform, and start developing today.
     currentVersion: Latest LTS Version
     buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Additional Platforms
     intro: >
         Members of the Node.js community maintain unofficial builds of Node.js for additional platforms. Note that such builds are not supported by the Node.js core team and may not yet be at the same build level as current Node.js release.
     platform: Platform
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/es/download/current.md
+++ b/locale/es/download/current.md
@@ -13,10 +13,24 @@ downloads:
         Descargue el código fuente de Node.js o un instalador pre-compilado para su plataforma, y comience a desarrollar hoy.
     currentVersion: Versión actual
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Plataformas adicionales
     intro: >
         Miembros de la comunidad de Node.js proveén paquetes pre-compilados de forma no oficial para plataformas adicionales no soportadas por el equipo central de Node.js que pueden no estar al mismo nivel de las versiones actuales oficiales de Node.js.
     platform: Plataforma
     provider: Proveedor
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/es/download/index.md
+++ b/locale/es/download/index.md
@@ -13,10 +13,24 @@ downloads:
         Descargue el código fuente de Node.js o un instalador pre-compilado para su plataforma, y comience a desarrollar hoy.
     currentVersion: Versión actual
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Plataformas adicionales
     intro: >
         Miembros de la comunidad de Node.js proveén paquetes pre-compilados de forma no oficial para plataformas adicionales no soportadas por el equipo central de Node.js que pueden no estar al mismo nivel de las versiones actuales oficiales de Node.js.
     platform: Plataforma
     provider: Proveedor
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -22,7 +22,7 @@ downloads:
 additional:
     headline: Autres plate-formes
     intro: >
-        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément la même qualité que les téléchargements officiels.
+        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément le même niveau de support que les téléchargements officiels.
     dockerImage: Image officielle Node.js pour Docker
     platform: Plate-forme
     provider: Fournisseur

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -10,7 +10,7 @@ downloads:
     tagline-lts: Recommandé pour la plupart des utilisateurs
     display-hint: Afficher les téléchargement pour Node
     intro: >
-        Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
+        Téléchargez le code source de Node.js pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version Actuelle
     buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
     WindowsInstaller: Installeur Windows

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -8,7 +8,7 @@ downloads:
     current: Actuelle
     tagline-current: Dernières fonctionnalités
     tagline-lts: Recommandé pour la plupart des utilisateurs
-    display-hint: Afficher les téléchargement pour Node
+    display-hint: Afficher les téléchargements pour Node
     intro: >
         Téléchargez le code source de Node.js pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version Actuelle

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -13,6 +13,12 @@ downloads:
         Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version Actuelle
     buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
+    WindowsInstaller: Installeur Windows
+    WindowsBinary: Binaire Windows
+    MacOSInstaller: Installeur macOS
+    MacOSBinary: Binaire macOS
+    LinuxBinaries: Binaires Linux
+    SourceCode: Code Source
 additional:
     headline: Autres plate-formes
     intro: >
@@ -20,4 +26,10 @@ additional:
     dockerImage: Image officielle Node.js pour Docker
     platform: Plate-forme
     provider: Fournisseur
+    SunOSBinaries: Binaires SunOS
+    DockerImage: Image Docker
+    officialDockerImage: Image officielle Node.js pour Docker
+    LinuxPowerSystems: Linux sur Power Systems
+    LinuxSystemZ: Linux sur System z
+    AIXPowerSystems: AIX sur Power Systems
 ---

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -1,0 +1,23 @@
+---
+layout: download.hbs
+title: Téléchargements
+download: Télécharger
+downloads:
+    headline: Téléchargements
+    lts: LTS
+    current: Actuelle
+    tagline-current: Dernières fonctionnalités
+    tagline-lts: Recommandé pour la plupart des utilisateurs
+    display-hint: Afficher les téléchargement pour Node
+    intro: >
+        Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
+    currentVersion: Dernière version Actuelle
+    buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
+additional:
+    headline: Autres plate-formes
+    intro: >
+        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément la même qualité que les téléchargements officiels.
+    dockerImage: Image officielle Node.js pour Docker
+    platform: Plate-forme
+    provider: Fournisseur
+---

--- a/locale/fr/download/index.md
+++ b/locale/fr/download/index.md
@@ -1,0 +1,23 @@
+---
+layout: download.hbs
+title: Téléchargements
+download: Télécharger
+downloads:
+    headline: Téléchargements
+    lts: LTS
+    current: Actuelle
+    tagline-current: Dernières fonctionnalités
+    tagline-lts: Recommandé pour la plupart des utilisateurs
+    display-hint: Afficher les téléchargement pour Node
+    intro: >
+        Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
+    currentVersion: Dernière version LTS
+    buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
+additional:
+    headline: Autres plate-formes
+    intro: >
+        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément la même qualité que les téléchargements officiels.
+    dockerImage: Image officielle Node.js pour Docker
+    platform: Plate-forme
+    provider: Fournisseur
+---

--- a/locale/fr/download/index.md
+++ b/locale/fr/download/index.md
@@ -22,7 +22,7 @@ downloads:
 additional:
     headline: Autres plate-formes
     intro: >
-        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément la même qualité que les téléchargements officiels.
+        Les membres de la communauté Node.js maintiennent des installeurs de Node.js pour d'autres plate-formes. Veuillez noter que ces téléchargements ne sont pas maintenus par l'équipe principale de Node.js et n'offrent pas forcément le même niveau de support que les téléchargements officiels.
     dockerImage: Image officielle Node.js pour Docker
     platform: Plate-forme
     provider: Fournisseur

--- a/locale/fr/download/index.md
+++ b/locale/fr/download/index.md
@@ -8,7 +8,7 @@ downloads:
     current: Actuelle
     tagline-current: Dernières fonctionnalités
     tagline-lts: Recommandé pour la plupart des utilisateurs
-    display-hint: Afficher les téléchargement pour Node
+    display-hint: Afficher les téléchargements pour Node
     intro: >
         Téléchargez le code source de Node.js pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version LTS

--- a/locale/fr/download/index.md
+++ b/locale/fr/download/index.md
@@ -10,7 +10,7 @@ downloads:
     tagline-lts: Recommandé pour la plupart des utilisateurs
     display-hint: Afficher les téléchargement pour Node
     intro: >
-        Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
+        Téléchargez le code source de Node.js pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version LTS
     buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
     WindowsInstaller: Installeur Windows

--- a/locale/fr/download/index.md
+++ b/locale/fr/download/index.md
@@ -13,6 +13,12 @@ downloads:
         Téléchargez le code source de Node.js ou pour votre système d'exploitation et commencez à développer dès aujourd'hui.
     currentVersion: Dernière version LTS
     buildInstructions: Compiler Node.js depuis les sources sur les systèmes d'exploitation maintenus
+    WindowsInstaller: Installeur Windows
+    WindowsBinary: Binaire Windows
+    MacOSInstaller: Installeur macOS
+    MacOSBinary: Binaire macOS
+    LinuxBinaries: Binaires Linux
+    SourceCode: Code Source
 additional:
     headline: Autres plate-formes
     intro: >
@@ -20,4 +26,10 @@ additional:
     dockerImage: Image officielle Node.js pour Docker
     platform: Plate-forme
     provider: Fournisseur
+    SunOSBinaries: Binaires SunOS
+    DockerImage: Image Docker
+    officialDockerImage: Image officielle Node.js pour Docker
+    LinuxPowerSystems: Linux sur Power Systems
+    LinuxSystemZ: Linux sur System z
+    AIXPowerSystems: AIX sur Power Systems
 ---

--- a/locale/fr/site.json
+++ b/locale/fr/site.json
@@ -61,7 +61,7 @@
     "text": "Téléchargements",
     "releases": {
       "link": "download/releases",
-      "text": "Précédentes versions"
+      "text": "Versions précédentes"
     },
     "package-manager": {
       "link": "download/package-manager",

--- a/locale/ja/download/current.md
+++ b/locale/ja/download/current.md
@@ -13,10 +13,24 @@ downloads:
         Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
     currentVersion: 最新のバージョン
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: その他のプラットフォーム
     intro: >
         その他のプラットフォームのための Node.js のビルドは、 Node.js コミュニティのメンバーによってメンテナンスされています。これらは Node.js のコアチームによってサポートされていません。また、最新の Node.js のリリースと同じ状態ではないかもしれないことにご注意ください。
     platform: Platform
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/ja/download/index.md
+++ b/locale/ja/download/index.md
@@ -13,10 +13,24 @@ downloads:
         Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
     currentVersion: 最新のバージョン
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: その他のプラットフォーム
     intro: >
         その他のプラットフォームのための Node.js のビルドは、 Node.js コミュニティのメンバーによってメンテナンスされています。これらは Node.js のコアチームによってサポートされていません。また、最新の Node.js のリリースと同じ状態ではないかもしれないことにご注意ください。
     platform: Platform
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/ko/download/current.md
+++ b/locale/ko/download/current.md
@@ -13,10 +13,24 @@ downloads:
         플랫폼에 맞게 미리 빌드된 Node.js 인스톨러나 소스코드를 다운받아서 바로 개발을 시작하세요.
     currentVersion: 최신 현재 버전
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: 그 밖의 플랫폼
     intro: >
         Members of the Node.js community maintain unofficial builds of Node.js for additional platforms. Note that such builds are not supported by the Node.js core team and may not yet be at the same build level as current Node.js release.
     platform: 플랫폼
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/ko/download/index.md
+++ b/locale/ko/download/index.md
@@ -13,10 +13,24 @@ downloads:
         플랫폼에 맞게 미리 빌드된 Node.js 인스톨러나 소스코드를 다운받아서 바로 개발을 시작하세요.
     currentVersion: 최신 LTS 버전
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: 그 밖의 플랫폼
     intro: >
         Members of the Node.js community maintain unofficial builds of Node.js for additional platforms. Note that such builds are not supported by the Node.js core team and may not yet be at the same build level as current Node.js release.
     platform: 플랫폼
     provider: Provider
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/uk/download/current.md
+++ b/locale/uk/download/current.md
@@ -13,10 +13,24 @@ downloads:
         Завантажте початковий код Node.js або інсталятор для вашої платформи та почніть розробку сьогодні.
     currentVersion: Поточна версія
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Додаткові платформи
     intro: >
         Учасники спільноти Node.js підтримують неофіційні збірки Node.js для додаткових платформ. Майте на увазі, що ці збірки не підтримуються основною командою Node.js і можуть не мати того ж функціоналу що й поточний реліз Node.js.
     platform: Платформа
     provider: Провайдер
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/uk/download/index.md
+++ b/locale/uk/download/index.md
@@ -13,10 +13,24 @@ downloads:
         Завантажте початковий код Node.js або інсталятор для вашої платформи та почніть розробку сьогодні.
     currentVersion: Поточна версія
     buildInstructions: Building Node.js from source on supported platforms
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: Додаткові платформи
     intro: >
         Учасники спільноти Node.js підтримують неофіційні збірки Node.js для додаткових платформ. Майте на увазі, що ці збірки не підтримуються основною командою Node.js і можуть не мати тієї ж функціональності що й поточний реліз Node.js.
     platform: Платформа
     provider: Провайдер
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/zh-cn/download/current.md
+++ b/locale/zh-cn/download/current.md
@@ -13,10 +13,24 @@ downloads:
         在你的平台上下载 Node.js 源码或预编译安装包，然后即可马上进行开发。
     currentVersion: 当前版本
     buildInstructions: 在支持的平台上，使用源代码构建 Node.js
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: 其他平台
     intro: >
         Node.js 社区为其他平台维护非官方的构建。请注意这些构建并不受 Node.js 核心团队技术支持且可能尚未跟 Node.js 的当前发布版本保持一致。
     platform: 平台
     provider: 提供者
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---

--- a/locale/zh-cn/download/index.md
+++ b/locale/zh-cn/download/index.md
@@ -13,10 +13,24 @@ downloads:
         在你的平台上下载 Node.js 源码或预编译安装包，然后即可马上进行开发。
     currentVersion: 当前版本
     buildInstructions: 在支持的平台上，使用源代码构建 Node.js
+    currentVersion: Latest LTS Version
+    buildInstructions: Building Node.js from source on supported platforms
+    WindowsInstaller: Windows Installer
+    WindowsBinary: Windows Binary
+    MacOSInstaller: macOS Installer
+    MacOSBinary: macOS Binary
+    LinuxBinaries: Linux Binaries
+    SourceCode: Source Code
 additional:
     headline: 其他平台
     intro: >
         Node.js 社区为其他平台维护非官方的构建。请注意这些构建并不受 Node.js 核心团队技术支持且可能尚未跟 Node.js 的当前发布版本保持一致。
     platform: 平台
     provider: 提供者
+    SunOSBinaries: SunOS Binaries
+    DockerImage: Docker Image
+    officialDockerImage: Official Node.js Docker Image
+    LinuxPowerSystems: Linux on Power Systems
+    LinuxSystemZ: Linux on System z
+    AIXPowerSystems: AIX on Power Systems
 ---


### PR DESCRIPTION
Pardon my French! As part of the writing of [this book][], I wanted to offer the french audience a translated Downloads page 🙂 

The PR has two commits:

1. the french translations of download/current and download pages
1. modified partials (primary-download-matrix.hbs and secondary-download-matrics.hbs) to extract strings and make them translatable

The latter contains default strings (in English and in French) for the new translation keys.

I was a bit confused by the location of translation strings (sometimes in `locale/*/site.json`, sometimes directly in `locale/**/*.md`). I am happy to relocate them if I did not do the right move.

[this book]: https://github.com/oncletom/nodebook