### PR TITLE
Tiny typo in spectre/meltdown blog post

### DIFF
--- a/locale/en/blog/vulnerability/jan-2018-spectre-meltdown.md
+++ b/locale/en/blog/vulnerability/jan-2018-spectre-meltdown.md
@@ -24,7 +24,7 @@ are more severe than possible through these new attacks.
 
 This does not mean that you don't need to protect yourself from
 these new attacks when running Node.js applications. If an attacker
-manages to run malicious code on an upatched OS (whether using
+manages to run malicious code on an unpatched OS (whether using
 JavaScript or something else) they may be able to access memory and or
 data that they should not have access to.  In order to protect yourself
 from these cases, apply the security patches for your operating


### PR DESCRIPTION
Fix tiny typo in spectre/meltdown blog post (upatched -> unpatched)