### PR TITLE
Describe preferred way to start Chrome DevTools

### DIFF
--- a/locale/en/docs/inspector.md
+++ b/locale/en/docs/inspector.md
@@ -27,11 +27,10 @@ These commercial and open source tools make debugging Node.js apps easier.
 * Can also be installed independently with `npm install -g node-inspect`
   and invoked with `node-inspect myscript.js`.
 
-### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
+### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend)
 
 * **Option 1**: Open `chrome://inspect` in a Chromium-based
-  browser. Click the Configure button and ensure your target host and port
-  are listed. Then select your Node.js app from the list.
+  browser. Click the "Open dedicated DevTools for Node" link.
 * **Option 2**: Install the Chrome Extension NIM (Node Inspector Manager):
   https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,6 @@
         }
       }
     },
-    "after": {
-      "version": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -897,36 +893,6 @@
       "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-      "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
-      "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        }
-      }
-    },
     "consolidate": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
@@ -950,35 +916,6 @@
     "core-util-is": {
       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cross-spawn": {
-      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz",
-      "integrity": "sha1-q2/Yk6CZdZ2bhSIOOmQ5felGsPY=",
-      "dev": true,
-      "requires": {
-        "cross-spawn-async": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
-        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz"
-      }
-    },
-    "cross-spawn-async": {
-      "version": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
-      "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-          "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
-          "dev": true,
-          "requires": {
-            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-          }
-        }
-      }
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -1183,13 +1120,6 @@
       "requires": {
         "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
         "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-      }
-    },
-    "duplexer2": {
-      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
       }
     },
     "ecc-jsbn": {
@@ -1498,7 +1428,8 @@
     },
     "esprima": {
       "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-      "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk="
+      "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.0",
@@ -3670,14 +3601,6 @@
         "sshpk": "1.13.1"
       }
     },
-    "hyperquest": {
-      "version": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
-      "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
-      "requires": {
-        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-      }
-    },
     "ignore": {
       "version": "https://registry.npmjs.org/ignore/-/ignore-3.1.3.tgz",
       "integrity": "sha1-nokMBlJRkRWulCfaR1Fr1U0daZk=",
@@ -4021,15 +3944,6 @@
       "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
-    "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isexe": {
-      "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
     "isobject": {
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
@@ -4063,6 +3977,7 @@
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
       "requires": {
         "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
         "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
@@ -4125,41 +4040,6 @@
       "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
-    },
-    "jsonist": {
-      "version": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
-      "integrity": "sha1-wMdLle8clSA4YZsp76UgscyYdVY=",
-      "requires": {
-        "bl": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-        "hyperquest": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
-          "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-          }
-        },
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        }
-      }
     },
     "jsonpointer": {
       "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
@@ -4474,19 +4354,50 @@
       }
     },
     "metalsmith-metadata": {
-      "version": "https://registry.npmjs.org/metalsmith-metadata/-/metalsmith-metadata-0.0.4.tgz",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/metalsmith-metadata/-/metalsmith-metadata-0.0.4.tgz",
       "integrity": "sha1-07ByWcZqDNPGGFDV5jI6JbLBCA4=",
       "requires": {
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
+        "js-yaml": "3.10.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
       }
     },
     "metalsmith-permalinks": {
-      "version": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-0.5.0.tgz",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-0.5.0.tgz",
       "integrity": "sha1-D+xbHwaHgowZjTO11HnMHOxLGh8=",
       "requires": {
         "debug": "0.7.4",
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-        "slug-component": "https://registry.npmjs.org/slug-component/-/slug-component-1.1.0.tgz",
+        "moment": "2.20.1",
+        "slug-component": "1.1.0",
         "substitute": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz"
       },
       "dependencies": {
@@ -4494,6 +4405,16 @@
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "moment": {
+          "version": "2.20.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+          "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+        },
+        "slug-component": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/slug-component/-/slug-component-1.1.0.tgz",
+          "integrity": "sha1-IkKQoEWRv5rAi5xiLToU9D46Dfc="
         }
       }
     },
@@ -4673,10 +4594,6 @@
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
-    "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI="
-    },
     "mout": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mout/-/mout-0.5.0.tgz",
@@ -4831,17 +4748,158 @@
       }
     },
     "node-version-data": {
-      "version": "https://registry.npmjs.org/node-version-data/-/node-version-data-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-version-data/-/node-version-data-1.0.1.tgz",
       "integrity": "sha1-QhMreskON8NAVel6tHTSFRb1lJI=",
       "requires": {
-        "after": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-        "jsonist": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+        "after": "0.8.2",
+        "jsonist": "1.3.0",
+        "semver": "5.0.3"
       },
       "dependencies": {
+        "after": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+          "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+        },
+        "bl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+          "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+          "requires": {
+            "readable-stream": "2.0.6"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "requires": {
+            "readable-stream": "1.1.14"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            }
+          }
+        },
+        "hyperquest": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
+          "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
+          "requires": {
+            "duplexer2": "0.0.2",
+            "through2": "0.6.5"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonist": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
+          "integrity": "sha1-wMdLle8clSA4YZsp76UgscyYdVY=",
+          "requires": {
+            "bl": "1.0.3",
+            "hyperquest": "1.2.0",
+            "json-stringify-safe": "5.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
@@ -5101,11 +5159,6 @@
         "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
       }
     },
-    "os-shim": {
-      "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
-    },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
@@ -5301,12 +5354,129 @@
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
     },
     "pre-commit": {
-      "version": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.1.3.tgz",
-      "integrity": "sha1-bV7ZB0BHIHKVjHEaFfZ2qiwjE3c=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
       "dev": true,
       "requires": {
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.2.14"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "os-shim": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+          "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "spawn-sync": {
+          "version": "1.0.15",
+          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "os-shim": "0.1.3"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        }
       }
     },
     "prelude-ls": {
@@ -5417,16 +5587,6 @@
       "requires": {
         "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
         "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-      }
-    },
-    "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
       }
     },
     "readdirp": {
@@ -5744,14 +5904,25 @@
         "split-string": "3.1.0"
       }
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "slug-component": {
-      "version": "https://registry.npmjs.org/slug-component/-/slug-component-1.1.0.tgz",
-      "integrity": "sha1-IkKQoEWRv5rAi5xiLToU9D46Dfc="
     },
     "snapdragon": {
       "version": "0.8.1",
@@ -5873,15 +6044,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
-    },
-    "spawn-sync": {
-      "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
-      "integrity": "sha1-kECRua1IoPOvsOhHUhVMAegv2Ng=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-        "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
-      }
     },
     "spdx-correct": {
       "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -6826,26 +6988,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "through2": {
-      "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        }
-      }
-    },
     "thunkify": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
@@ -7214,14 +7356,6 @@
         "defaults": "1.0.3"
       }
     },
-    "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-      "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
-      "dev": true,
-      "requires": {
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-      }
-    },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -7284,16 +7418,12 @@
     },
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
       "dev": true
     },
     "yaml-js": {


### PR DESCRIPTION
Chrome DevTools have been shipping an option to open a "dedicated" Node
frontend for a long time. That frontend has several Node-specific
enhancements, including being able to reattach to a Node instance that
was restarted.