### PR TITLE
Added additional inspector option description

### DIFF
--- a/locale/en/docs/inspector.md
+++ b/locale/en/docs/inspector.md
@@ -109,5 +109,14 @@ The following table lists the impact of various runtime flags on debugging:
       </ul>
     </td>
   </tr>
+  <tr>
+    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td>
+      <ul>
+        <li>Spawn child process to run user's script under --inspect flag;
+            and use main process to run CLI debugger.</li>
+        <li>Listen on port <i>port</i> (default: 9229)</li>
+      </ul>
+    </td>
+  </tr>
 </table>
-


### PR DESCRIPTION
Resolves nodejs/node#19066

I'm not sure what the convention is for a possible input so I've used `xxxx` for now. Let me know if there's a standardised way of displaying this.