### PR TITLE
Remove NodeJS Reactions from "Getting Started" page

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -18,7 +18,6 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 - [Node Weekly](http://nodeweekly.com) és una llista de correu que recopila els últims esdeveniments i notícies al voltant de la comunitat de Node.js.
 - [Planet Node](http://planetnodejs.com) és un agregador de blogs de desenvolupadors de Node.
 - [NodeUp](http://nodeup.com) és un podcast cobrint les últimes notícies en la comunitat de Node.
-- [NodeJS Reactions](http://nodejsreactions.tumblr.com) captura l'experiència de Node.js en forma de GIFs animats.
 - La [Community Committee](https://github.com/nodejs/community-committee) és una comissió de primer nivell a la Fundació Node.js centrada en els esforços que afronta la comunitat.
 
 

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -15,7 +15,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Weekly Newsletter.
 - [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 - [NodeUp](http://nodeup.com) is a podcast covering the latest Node news in the community.
-- [NodeJS Reactions](http://nodejsreactions.tumblr.com) captures the Node.js experience in the form of animated GIFs.
 - The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 
 

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -17,7 +17,6 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La cuenta de Twitter oficial de Node.js es [nodejs](https://twitter.com/nodejs).
 - [Node Weekly](http://nodeweekly.com) es una lista de correo que recopila los últimos eventos y noticias alrededor de la comunidad de Node.js.
 - [NodeUp](http://nodeup.com) es un podcast cubriendo las últimas noticias en la comunidad de Node.
-- [NodeJS Reactions](http://nodejsreactions.tumblr.com) captura la experiencia de Node.js en forma de GIFs animados.
 - La [Community Committee](https://github.com/nodejs/community-committee) es un comité de alto nivel de la Fundación Node.js centrado en los esfuerzos de la comunidad.
 
 

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -27,7 +27,6 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - [NodeUp](http://nodeup.com) est un podcast sur les actualités de la communauté Node [en].
 
-- [NodeJS Reactions](http://nodejsreactions.tumblr.com) capture des experiences Node.js sous forme de GIFs animés [en].
 
 - La [Community Committee](https://github.com/nodejs/community-committee) s'agit d'un comité de haut niveau de la Fondation Node.js axé sur les efforts communautaires.
 

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -15,7 +15,6 @@ layout: contribute.hbs
 - Офіційний аккаунт Node.js у Twitter [nodejs](https://twitter.com/nodejs).
 - [Node Weekly](http://nodeweekly.com) це поштове розсилання, що збирає найсвіжіші події та новини довкола спільноти Node.js.
 - [NodeUp](http://nodeup.com) подкаст в якому обговорюють найсвіжіші новини з Nod–спільноти.
-- [NodeJS Reactions](http://nodejsreactions.tumblr.com) відображає досвід роботи з Node.js через анімовані GIF.
 - [Community Committee](https://github.com/nodejs/community-committee) є комітетом вищого рівня в Node.js Фонд зосереджений на спільних зусиллях.
 
 


### PR DESCRIPTION
The Node.js Reactions site has some content that's generally negative toward the project and individual community members, which doesn't really promote a strong and healthy community.

Would it be beneficial to remove this from the other locales as well, or are those handled differently?