### PR TITLE
Change "Discussion" to "Community Discussion"

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -10,7 +10,7 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 [ajudar amb la documentació o contribuir amb el codi](/en/get-involved/contribute/) del projecte, has vingut al lloc indicat. Explora els recursos de la nostra comunitat per trobar una forma d'ajudar:
 
 
-## Discussió
+## Discussió de la comunitat
 
 - La [llista d'errors en ](https://github.com/nodejs/node/issues) és el lloc per discutir les característiques del nucli de Node.js.
 - Per xatejar en temps real sobre el desenvolupament de Node vagi a `irc.freenode.net` al canal `#node.js` fent servir un [client d'IRC](http://es.wikipedia.org/wiki/Anexo:Clientes_IRC) o connecti's amb el seu navegador al canal usant [WebChat de freenode](http://webchat.freenode.net/?channels=node.js).

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -7,7 +7,7 @@ layout: contribute.hbs
 
 The Node.js community is large, inclusive, and excited to enable as many users to contribute in whatever way they can. If you want to [report an issue](https://github.com/nodejs/node/issues), [help with documentation or contribute to the code base](/en/get-involved/contribute/) of the project, you’ve come to the right place. Explore our community resources to find out how you can help:
 
-## Discussion
+## Community Discussion
 
 - The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 - For real-time chat about Node development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](http://webchat.freenode.net/?channels=node.js).

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -10,7 +10,7 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 [ayudar con la documentación ó contribuir con el código](/en/get-involved/contribute/) del proyecto, ha venido al lugar indicado. Explore los recursos de nuestra comunidad para encontrar una forma de ayudar:
 
 
-## Discusión
+## Discusión de la comunidad
 
 - La [lista de errores en ](https://github.com/nodejs/node/issues) es el lugar para discutir las características del núcleo de Node.js.
 - Para chatear en tiempo real sobre el desarrollo de Node vaya a `irc.freenode.net` en el canal `#node.js` usando un [cliente de IRC](http://es.wikipedia.org/wiki/Anexo:Clientes_IRC) ó conéctese con su navegador al canal usando [WebChat de freenode](http://webchat.freenode.net/?channels=node.js).

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -13,7 +13,7 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 <hr>
 
-## Discussion
+## Discussion de la communauté
 
 - La [liste des tickets GitHub](https://github.com/nodejs/node/issues) est le bon endroit pour discuter des fonctionnalités coeurs de Node.js.
 

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -8,7 +8,7 @@ layout: contribute.hbs
 Спільнота Node.js — велика, цілісна і відкрита для багатьох користувачів, які підтримують нас. Якщо ви хочете [повідомити про помилку](https://github.com/nodejs/node/issues), [допомогти з документацією або вдосконалити кодову базу](/en/get-involved/contribute/) проекту, ви прийшли за адресою. Перегляньте ресурси нашої спільноти, щоб зрозуміти, як ви можете допомогти:
 
 
-## Обговорення
+## Громадське обговорення
 
 - [Список іш’ю на GitHub](https://github.com/nodejs/node/issues) — це місце, де обговорюють ключовий функціонал Node.js.
 - Для живого чату про розробку на Node перейдіть на `irc.freenode.net` у канал `#node.js` через [IRC клієнт](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) або підключіться до каналу через веб–браузер з допомогою [ WebChat від freenode](http://webchat.freenode.net/?channels=node.js).


### PR DESCRIPTION
Per a discussion in the Moderation team meeting today, changing "Discussion" to "Community Discussion" enables a little bit more of a permissive and clear definition to what is included in this section.

cc @hackygolucky @nodejs/moderation