### PR TITLE
Remove link to docs.nodejitsu.com

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -26,7 +26,6 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 - La [Documentació oficial de l'API](/api) detalla l'API de Node.
 - [NodeSchool.io](http://nodeschool.io) li ensenyarà conceptes de Node.js de forma interactiva mitjançant jocs utilitzant la línia de comandes.
 - L'[etiqueta de Node.js en StackOverflow](http://stackoverflow.com/questions/tagged/node.js) col·lecciona nova informació cada dia.
-- [docs.nodejitsu.com](http://docs.nodejitsu.com/) soluciona molts dels problemes més comuns que la gent es troba.
 - [How To Node](http://howtonode.org/) té un nombre creixent d'útils tutorials.
 
 

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -23,7 +23,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - [Official API reference documentation](/api) details the Node API.
 - [NodeSchool.io](http://nodeschool.io) will teach you Node.js concepts via interactive command-line games.
 - [StackOverflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) collects new information every day.
-- [docs.nodejitsu.com](http://docs.nodejitsu.com/) answers many of the common problems people come across.
 
 
 ## International community sites and projects

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -25,7 +25,6 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La [Documentación oficial de la API](/api) detalla la API de Node.
 - [NodeSchool.io](http://nodeschool.io) le enseñará conceptos de Node.js de forma interactiva mediante juegos utilizando la línea de comandos.
 - La [etiqueta de Node.js en StackOverflow](http://stackoverflow.com/questions/tagged/node.js) colecciona nueva información cada día.
-- [docs.nodejitsu.com](http://docs.nodejitsu.com/) soluciona muchos de los problemas más comunes que la gente se encuentra.
 - [How To Node](http://howtonode.org/) tiene un número creciente de útiles tutoriales.
 
 

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -39,8 +39,6 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - [L'étiquette StackOverflow Node.js](http://stackoverflow.com/questions/tagged/node.js) rassemble de nouvelles informations chaque jours [en].
 
-- [docs.nodejitsu.com](http://docs.nodejitsu.com/) répond à de nombreux problèmes communs et récurrents [en].
-
 - [How To Node](http://howtonode.org/) a de nombreux tutoriaux utiles [en].
 
 

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -23,7 +23,6 @@ layout: contribute.hbs
 - [Офіційна довідкова документація по API](/api) описує Node API.
 - [NodeSchool.io](http://nodeschool.io) навчить вас концепцій Node.js через інтерактивні консольні ігри.
 - [StackOverflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) щодня поповнюється новою інформацією.
-- [docs.nodejitsu.com](http://docs.nodejitsu.com/) відповіді на загальні питання, які виникають у людей.
 - [How To Node](http://howtonode.org/) має велику кількість корисних туторіалів.
 
 


### PR DESCRIPTION
Website doesn't exist any more, the tutorials are available in `locale/en/knowledge`
but need detailled review.

Fixes #1604