### PR TITLE
Add elementary OS Juno

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -111,6 +111,7 @@ The Node.js modules available in the distribution official repositories do not n
 * **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 * **elementary OS Loki** (via Ubuntu 16.04 LTS)
+* **elementary OS Juno** (via Ubuntu 18.04 LTS)
 
 **Supported Trisquel versions:**
 


### PR DESCRIPTION
Via https://github.com/nodesource/distributions. Right after #1617 got merged, nodesource added Juno. 