### PR TITLE
build: Don't throw when 'releases' is undefined

### DIFF
--- a/scripts/helpers/latestversion.js
+++ b/scripts/helpers/latestversion.js
@@ -11,11 +11,11 @@ const map = (release) => release && {
 }
 
 exports.current = (releases) => {
-  const match = releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
+  const match = releases && releases.find((release) => !release.lts && semver.gte(release.version, '5.0.0'))
   return map(match)
 }
 
-exports.lts = (releases) => map(releases.find((release) => release.lts))
+exports.lts = (releases) => map(releases && releases.find((release) => release.lts))
 
 function majorStr (release) {
   return `v${semver.major(release.version)}.x`


### PR DESCRIPTION
In case `versions.json` could not be properly downloaded/parsed by
'node-version-data', avoid `TypeError: Cannot read property 'find' of undefined`
when `releases` is `undefined` and return `undefined` instead.

Error should be handled properly elsewhere.

See: #1618