### PR TITLE
feature: add link to verification docs

### DIFF
--- a/layouts/partials/download-list.hbs
+++ b/layouts/partials/download-list.hbs
@@ -1,6 +1,6 @@
 <section>
   <ul>
-    <li><a href="https://nodejs.org/dist/{{version.node}}/{{site.download.shasums.link}}">{{site.download.shasums.text}}</a></li>
+    <li><a href="https://nodejs.org/dist/{{version.node}}/{{site.download.shasums.link}}">{{site.download.shasums.text}}</a> (<a href="{{site.download.shasums.verify-link}}">{{site.download.shasums.verify-text}}</a>)</li>
     <li><a href="https://nodejs.org/dist/{{version.node}}">{{site.all-downloads}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}">{{site.download.package-manager.text}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.releases.link}}/">{{site.download.releases.text}}</a></li>

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -75,7 +75,9 @@
     },
     "shasums": {
       "link": "SHASUMS256.txt.asc",
-      "text": "Signed SHASUMS for release files"
+      "text": "Signed SHASUMS for release files",
+      "verify-link": "https://github.com/nodejs/node#verifying-binaries",
+      "verify-text": "How to verify"
     }
   },
   "docs": {


### PR DESCRIPTION
Add a link on the /download page to the documentation regarding
verification of the node binary in the README of the nodejs/node
repository.

Fixes: https://github.com/nodejs/nodejs.org/issues/1621
Refs: https://github.com/nodejs/help/issues/1203

/cc @fhemberger 