### PR TITLE
remove banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -254,7 +254,7 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: true,
+          visible: false,
           text: 'Important March 2018 security upgrades now available',
           link: '/en/blog/vulnerability/march-2018-security-releases/'
         }


### PR DESCRIPTION
The banner for the March 2018 security updates has been up for many
weeks now. Not sure if there's a policy on how long to leave it up for,
but it seems that by having it there all the time, we encourage people
to not notice when the text changes to from "Important March 2018
security upgrades now available" to (say) "Important May 2018 security
upgrades now available". At least, that's my thinking...