### PR TITLE
Fix spelling of API name in 10.0.0 release post

### DIFF
--- a/locale/en/blog/release/v10.0.0.md
+++ b/locale/en/blog/release/v10.0.0.md
@@ -58,7 +58,7 @@ The full set of changes for the Node.js 10.0.0 release are detailed below.
 * EventEmitter
   * The `EventEmitter.prototype.off()` method has been added as an alias for `EventEmitter.prototype.removeListener()`. [[`3bb6f07d52`](https://github.com/nodejs/node/commit/3bb6f07d52)]
 * File System
-  * The `fs.promises` API provides experimental promisified versions of the `fs` functions. [[`329fc78e49`](https://github.com/nodejs/node/commit/329fc78e49)]
+  * The `fs/promises` API provides experimental promisified versions of the `fs` functions. [[`329fc78e49`](https://github.com/nodejs/node/commit/329fc78e49)]
   * Invalid path errors are now thrown synchronously. [[`d8f73385e2`](https://github.com/nodejs/node/commit/d8f73385e2)]
   * The `fs.readFile()` method now partitions reads to avoid thread pool exhaustion. [[`67a4ce1c6e`](https://github.com/nodejs/node/commit/67a4ce1c6e)]
 * HTTP

--- a/locale/en/blog/release/v10.0.0.md
+++ b/locale/en/blog/release/v10.0.0.md
@@ -88,7 +88,7 @@ The full set of changes for the Node.js 10.0.0 release are detailed below.
 * Timers
   * The `enroll()` and `unenroll()` methods have been deprecated. [[`68783ae0b8`](https://github.com/nodejs/node/commit/68783ae0b8)]
 * TLS
-  * The `tls.convertNONProtocols()` method has been deprecated. [[`9204a0db6e`](https://github.com/nodejs/node/commit/9204a0db6e)]
+  * The `tls.convertNPNProtocols()` method has been deprecated. [[`9204a0db6e`](https://github.com/nodejs/node/commit/9204a0db6e)]
   * Support for NPN (next protocol negotiation) has been dropped. [[`5bfbe5ceae`](https://github.com/nodejs/node/commit/5bfbe5ceae)]
   * The `ecdhCurve` default is now `'auto'`. [[`af78840b19`](https://github.com/nodejs/node/commit/af78840b19)]
 * Trace Events


### PR DESCRIPTION
This is a trivial change (`convertNONProtocols` → `convertNPNProtocols`).

Refs: https://github.com/nodejs/node/pull/20257