### PR TITLE
Update FreeBSD installation instructions

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -16,8 +16,8 @@ title: Installing Node.js via package manager
 * [FreeBSD](#freebsd)
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
-* [OpenBSD](#openbsd)
 * [nvm](#nvm)
+* [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
@@ -232,7 +232,7 @@ Additionally, versions of **CentOS** and **Scientific Linux** corresponding to t
 
 ## FreeBSD 
 
-The most recent release of Node.js is always available via the [www/node](http://freshports.org/www/node) port.
+The most recent release of Node.js is available via the [www/node](http://freshports.org/www/node) port.
 
 Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
@@ -304,7 +304,7 @@ Node.js is available through the ports system.
 /usr/ports/lang/node
 ```
 
-Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD
+Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD:
 
 ```bash
 pkg_add node

--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -13,9 +13,10 @@ title: Installing Node.js via package manager
 * [Arch Linux](#arch-linux)
 * [Debian and Ubuntu based Linux distributions](#debian-and-ubuntu-based-linux-distributions)
 * [Enterprise Linux and Fedora](#enterprise-linux-and-fedora)
-* [FreeBSD and OpenBSD](#freebsd-and-openbsd)
+* [FreeBSD](#freebsd)
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
+* [OpenBSD](#openbsd)
 * [nvm](#nvm)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -229,51 +230,20 @@ Additionally, versions of **CentOS** and **Scientific Linux** corresponding to t
 * **Fedora 27** (i686/x86_64/armv7hl/aarch64/ppc64/ppc64le/s390x)
 * **Fedora 26** (i686/x86_64/armv7hl/aarch64/ppc64/ppc64le)
 
+## FreeBSD 
 
-## FreeBSD and OpenBSD
+The most recent release of Node.js is always available via the [www/node](http://freshports.org/www/node) port.
 
-Node.js is available through the ports system.
+Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
-**FreeBSD**:
-
-```bash
-/usr/ports/www/node
-```
-
-**OpenBSD**:
-
-```bash
-/usr/ports/lang/node
-```
-
-Development versions are also available using ports on FreeBSD
-
-```bash
-cd /usr/ports/www/node-devel/ && make install clean
-```
-
-Or packages on FreeBSD:
-
-```bash
-pkg_add -r node-devel
-```
-
-Using [pkg-ng](https://wiki.freebsd.org/pkgng) on FreeBSD
-
-```bash
+```sh
 pkg install node
 ```
 
-Or the development versions:
+Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?ports):
 
-```bash
-pkg install node-devel
-```
-
-Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD
-
-```bash
-pkg_add node
+```sh
+cd /usr/ports/www/node && make install
 ```
 
 ## Gentoo
@@ -324,6 +294,20 @@ from source:
 
 ```bash
 $ nvm uninstall 8
+```
+
+## OpenBSD
+
+Node.js is available through the ports system.
+
+```bash
+/usr/ports/lang/node
+```
+
+Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD
+
+```bash
+pkg_add node
 ```
 
 ## openSUSE and SLE

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -12,9 +12,10 @@ title: Installing Node.js via package manager
 * [Arch Linux](#arch-linux)
 * [Debian and Ubuntu based Linux distributions](#debian-and-ubuntu-based-linux-distributions)
 * [Enterprise Linux and Fedora](#enterprise-linux-and-fedora)
-* [FreeBSD and OpenBSD](#freebsd-and-openbsd)
+* [FreeBSD](#freebsd) 
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
+* [OpenBSD)(#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
@@ -215,39 +216,21 @@ Additionally, versions of **CentOS** and **Scientific Linux** corresponding to t
 * **Fedora 20 (Heisenbug)** (i686/x86_64/armv6hl/armv7hl)
 * **Fedora 19 (Schrödinger's Cat)** (i686/x86_64/armv7hl)
 
+## FreeBSD 
 
-## FreeBSD and OpenBSD
+The most recent release of Node.js is always available via the [www/node](http://freshports.org/www/node) port.
 
-Node.js is available through the ports system.
+Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
-```bash
-/usr/ports/www/node
-```
-
-Development versions are also available using ports
-
-```bash
-cd /usr/ports/www/node-devel/ && make install clean
-```
-
-Or packages on FreeBSD:
-
-```bash
-pkg_add -r node-devel
-```
-
-Using [pkg-ng](https://wiki.freebsd.org/pkgng) on FreeBSD
-
-```bash
+```sh
 pkg install node
 ```
 
-Or the development versions:
+Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?ports):
 
-```bash
-pkg install node-devel
+```sh
+cd /usr/ports/www/node && make install
 ```
-
 
 ## Gentoo
 
@@ -272,6 +255,19 @@ Or install a binary package (if available for your platform) using pkgin:
 pkgin -y install nodejs
 ```
 
+## OpenBSD
+
+Node.js is available through the ports system.
+
+```bash
+/usr/ports/lang/node
+```
+
+Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD
+
+```bash
+pkg_add node
+```
 
 ## openSUSE and SLE
 

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -15,7 +15,7 @@ title: Installing Node.js via package manager
 * [FreeBSD](#freebsd) 
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
-* [OpenBSD)(#openbsd)
+* [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
 * [SmartOS and illumos](#smartos-and-illumos)
@@ -218,7 +218,7 @@ Additionally, versions of **CentOS** and **Scientific Linux** corresponding to t
 
 ## FreeBSD 
 
-The most recent release of Node.js is always available via the [www/node](http://freshports.org/www/node) port.
+The most recent release of Node.js is available via the [www/node](http://freshports.org/www/node) port.
 
 Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
@@ -263,7 +263,7 @@ Node.js is available through the ports system.
 /usr/ports/lang/node
 ```
 
-Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD
+Using [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD:
 
 ```bash
 pkg_add node


### PR DESCRIPTION
It requires splitting the FreeBSD and OpenBSD section into two sections
as those operating systems use different tools for package management.

Also, this patch updates only instructions in English.