### PR TITLE
Use bash code blocks to fix ampersand rendering

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -236,13 +236,13 @@ The most recent release of Node.js is available via the [www/node](http://freshp
 
 Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
-```sh
+```bash
 pkg install node
 ```
 
 Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?ports):
 
-```sh
+```bash
 cd /usr/ports/www/node && make install
 ```
 

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -222,13 +222,13 @@ The most recent release of Node.js is available via the [www/node](http://freshp
 
 Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
-```sh
+```bash
 pkg install node
 ```
 
 Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?ports):
 
-```sh
+```bash
 cd /usr/ports/www/node && make install
 ```
 


### PR DESCRIPTION
If sh is used instead of bash "&&" is displayed as "&amp;&amp;".

Fix #1660 (hopefully).