### PR TITLE
Better GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,6 @@
-<!--
-Thanks for wanting to report an issue you've found on the nodejs.org website.
+<!---
+Thanks for filing an issue 😄! Before you submit, please read the following:
 
-For issues regarding the Node.js API docs, please head over to:
-https://github.com/nodejs/node/issues/ (prefix your issue name with "doc")
-
-For general questions about Node.js:
-https://github.com/nodejs/help/issues/
-
-Please fill in the template below by replacing the HTML comments with an
-appropriate answer. If unsure about something, just do as best as you're able.
-If you are reporting a visual glitch, it will be much easier for us to fix it
-when you attach a screenshot as well.
-
-Thank you!
+Check the other issue templates if you are trying to submit a bug report, feature request, or question
+Search open/closed issues before submitting since someone might have asked the same thing before!
 -->
-
-* **URL**:
-* **Browser version**:
-* **Operating system**:
-
-<!-- Enter your issue details below this comment. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!---
 Thanks for filing an issue 😄! Before you submit, please read the following:
 
-Check the other issue templates if you are trying to submit a bug report, feature request, or question
+Check the other issue templates if you are trying to submit a bug report, feature request, or question.
 Search open/closed issues before submitting since someone might have asked the same thing before!
 -->

--- a/.github/ISSUE_TEMPLATE/api_docs.md
+++ b/.github/ISSUE_TEMPLATE/api_docs.md
@@ -1,0 +1,10 @@
+
+---
+name: 📗 Node.js API Docs
+about: Please open an issue in the main [Node.js repo](https://github.com/nodejs/node/issues/), prefixed with "doc".
+
+---
+<!--
+For issues regarding the Node.js API docs, please head over to:
+https://github.com/nodejs/node/issues/ (prefix your issue name with "doc")
+-->

--- a/.github/ISSUE_TEMPLATE/api_docs.md
+++ b/.github/ISSUE_TEMPLATE/api_docs.md
@@ -6,5 +6,5 @@ about: Please open an issue in the main [Node.js repo](https://github.com/nodejs
 ---
 <!--
 For issues regarding the Node.js API docs, please head over to:
-https://github.com/nodejs/node/issues/ (prefix your issue name with "doc")
+https://github.com/nodejs/node/issues/ (prefix your issue name with "doc").
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+
+---
+<!--
+Thanks for wanting to report an issue you've found on the nodejs.org website.
+
+Please fill in the template below. If unsure about something, just do as best
+as you're able. If you are reporting a visual glitch, it will be much easier
+for us to fix it when you attach a screenshot as well.
+-->
+
+* **URL**:
+* **Browser version**:
+* **Operating system**:
+
+<!-- Enter your issue details below this comment. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,8 @@ You have an idea how to improve the site? That's awesome!
 Before submitting, please have a look at the existing issues if there's already
 something related to your suggestion.
 
-We are also [working on a relaunch](https://github.com/nodejs/website-redesign/issues/)
-at the moment, so it might be a good idea to check out our plans there as well.
+We are also working on a relaunch at the moment, so it might be a good idea to
+check out our plans there as well: https://github.com/nodejs/website-redesign/issues/
+
 Help is always welcome!
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+
+---
+<!--
+You have an idea how to improve the site? That's awesome!
+
+Before submitting, please have a look at the existing issues if there's already
+something related to your suggestion.
+
+We are also [working on a relaunch](https://github.com/nodejs/website-redesign/issues/)
+at the moment, so it might be a good idea to check out our plans there as well.
+Help is always welcome!
+-->

--- a/.github/ISSUE_TEMPLATE/help.md
+++ b/.github/ISSUE_TEMPLATE/help.md
@@ -1,0 +1,9 @@
+---
+name: ⁉️ General Questions
+about: Need help with Node.js? File an Issue [here](https://github.com/nodejs/help/issues/).
+
+---
+<!--
+We have a special help section for general quesitons about Node.js:
+https://github.com/nodejs/help/issues/
+-->

--- a/.github/ISSUE_TEMPLATE/help.md
+++ b/.github/ISSUE_TEMPLATE/help.md
@@ -4,6 +4,6 @@ about: Need help with Node.js? File an Issue [here](https://github.com/nodejs/he
 
 ---
 <!--
-We have a special help section for general quesitons about Node.js:
+We have a special help section for general questions about Node.js:
 https://github.com/nodejs/help/issues/
 -->

--- a/.github/ISSUE_TEMPLATE/i18n.md
+++ b/.github/ISSUE_TEMPLATE/i18n.md
@@ -1,0 +1,8 @@
+---
+name: 🔡 Internationalization and translations
+about: Hello. Hola. Salut. Ciao. Здравствуйте. こんにちは.
+
+---
+<!--
+Please mention the relevant localization team in your issue, it helps us having the right people take a look, e.g. `@nodejs/node-cn` for Chinese translations.
+-->


### PR DESCRIPTION
The [babel](https://github.com/babel/babel/issues/new/choose) project had a pretty neat idea for GitHub issue templates, so I'd like to adapt them for the Node.js website.

As we receive issues for API docs (which are not hosted here) and other, it might be a good idea to guide the user to the right place directly.

![](https://user-images.githubusercontent.com/153481/41191847-cece978e-6bf5-11e8-89bf-86096b83ff98.png)
