### PR TITLE
Add code block to security release

### DIFF
--- a/locale/en/blog/vulnerability/june-2018-security-releases.md
+++ b/locale/en/blog/vulnerability/june-2018-security-releases.md
@@ -67,12 +67,14 @@ Versions 9.7.0 and later are vulnerable and the severity is MEDIUM. A bug introd
 
 Calling Buffer.fill() or Buffer.alloc() with some parameters can lead to a hang which could result in a Denial of Service. The following examples show the cases which hang:
 
+```
 Buffer.alloc(100).fill(Buffer.alloc(0))
 Buffer.alloc(100).fill(Buffer.from(''))
 Buffer.alloc(100).fill(new Uint8Array([]))
 Buffer.alloc(100, Buffer.alloc(0))
 Buffer.alloc(100, new Uint8Array([]))
 new Buffer(10).fill(new Buffer(''))
+```
 
 In order to address this vulnerability, the implementations of Buffer.alloc() and Buffer.fill() were updated so that they zero fill instead of hanging in these cases.
 


### PR DESCRIPTION
Currently, the code does not render well in the live version. This should (hopefully) fix it!

Here's a screenshot: 
![image](https://user-images.githubusercontent.com/502396/41354931-41601a5c-6eee-11e8-8f16-9b64da788694.png)
