### PR TITLE
shorten intro

### DIFF
--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -22,6 +22,3 @@ labels:
 ---
 
 Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://developers.google.com/v8/).
-Node.js uses an event-driven, non-blocking I/O model that makes it
-lightweight and efficient. Node.js' package ecosystem, [npm](https://www.npmjs.com/), is the largest ecosystem of open
-source libraries in the world.


### PR DESCRIPTION
There seems to be universal agreement that the paragraph describing
Node.js could stand improvement, but attempts to replace it seem to
stall. Here's a proposal to strip it down to the absolute essential
information.