### PR TITLE
Update links to official Node.js Docker image

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -267,7 +267,7 @@ on Docker.
 You can find more information about Docker and Node.js on Docker in the
 following places:
 
-* [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
+* [Official Node.js Docker Image](https://hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
 * [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -514,7 +514,7 @@ on Docker.
 You can find more information about Docker and Node.js on Docker in the
 following places:
 
-* [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
+* [Official Node.js Docker Image](https://hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
 * [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)
@@ -525,7 +525,7 @@ following places:
 
 다음 링크에서 Docker와 Docker에서의 Node.js에 대한 정보를 더 자세히 볼 수 있습니다.
 
-* [공식 Node.js Docker 이미지](https://registry.hub.docker.com/_/node/)
+* [공식 Node.js Docker 이미지](https://hub.docker.com/_/node/)
 * [Node.js Docker 사용사례 문서](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [공시 Docker 문서](https://docs.docker.com/)
 * [Stack Overflow에 Docker 태그로 올라온 질문](https://stackoverflow.com/questions/tagged/docker)

--- a/locale/uk/docs/guides/nodejs-docker-webapp.md
+++ b/locale/uk/docs/guides/nodejs-docker-webapp.md
@@ -267,7 +267,7 @@ on Docker.
 You can find more information about Docker and Node.js on Docker in the
 following places:
 
-* [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
+* [Official Node.js Docker Image](https://hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
 * [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)

--- a/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
+++ b/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
@@ -230,7 +230,7 @@ Hello world
 
 你也可以在以下一些地方寻觅到更多有关于 Docker 和基于 Docker 的 Node.js 相关内容：
 
-* [官方 Node.js 的 Docker 镜像](https://registry.hub.docker.com/_/node/)
+* [官方 Node.js 的 Docker 镜像](https://hub.docker.com/_/node/)
 * [Node.js 基于 Docker 使用的最佳经验](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [官方 Docker 文档](https://docs.docker.com/)
 * [在 StackOverFlow 上有关 Docker 标记内容](https://stackoverflow.com/questions/tagged/docker)


### PR DESCRIPTION
I wasn’t entirely sure whether to update the links to [hub.docker.com](https://hub.docker.com/_/node/) or [store.docker.com](https://store.docker.com/images/node). However, given the promotion on hub.docker.com (“node is now available in the Docker Store, the new place to discover public Docker content”), the Docker Store seems to be the way to go.