### PR TITLE
Use Node.js version number instead of codename in Docker guide

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -82,11 +82,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `carbon` of `node`
+Here we will use the latest LTS (long term support) version `8` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:carbon
+FROM node:8
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -144,7 +144,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:carbon
+FROM node:8
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -195,7 +195,7 @@ $ docker images
 
 # Example
 REPOSITORY                      TAG        ID              CREATED
-node                            carbon     1934b0b038d1    5 days ago
+node                            8          1934b0b038d1    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -147,11 +147,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `carbon` of `node`
+Here we will use the latest LTS (long term support) version `8` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:carbon
+FROM node:8
 ```
 -->
 
@@ -167,10 +167,10 @@ touch Dockerfile
 
 가장 먼저 해야 할 것은 어떤 이미지를 사용해서 빌드할 것인지를 정의하는 것입니다. 여기서는
 [Docker Hub](https://hub.docker.com/)에 있는
-`node`의 최신 LTS(장기 지원) 버전인 `carbon`을 사용할 것입니다.
+`node`의 최신 LTS(장기 지원) 버전인 `8`을 사용할 것입니다.
 
 ```docker
-FROM node:carbon
+FROM node:8
 ```
 
 <!--
@@ -264,7 +264,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:carbon
+FROM node:8
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -296,7 +296,7 @@ CMD [ "npm", "start" ]
 `Dockerfile`은 다음과 같아야 합니다.
 
 ```docker
-FROM node:carbon
+FROM node:8
 
 # 앱 디렉터리 생성
 WORKDIR /usr/src/app
@@ -357,7 +357,7 @@ $ docker images
 
 # Example
 REPOSITORY                      TAG        ID              CREATED
-node                            carbon     1934b0b038d1    5 days ago
+node                            8          1934b0b038d1    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 -->
@@ -379,7 +379,7 @@ $ docker images
 
 # 예시
 REPOSITORY                      TAG        ID              CREATED
-node                            carbon     1934b0b038d1    5 days ago
+node                            8          1934b0b038d1    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 

--- a/locale/uk/docs/guides/nodejs-docker-webapp.md
+++ b/locale/uk/docs/guides/nodejs-docker-webapp.md
@@ -82,11 +82,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `carbon` of `node`
+Here we will use the latest LTS (long term support) version `8` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:carbon
+FROM node:8
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -144,7 +144,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:carbon
+FROM node:8
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -195,7 +195,7 @@ $ docker images
 
 # Example
 REPOSITORY                      TAG        ID              CREATED
-node                            carbon     1934b0b038d1    5 days ago
+node                            8          1934b0b038d1    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 


### PR DESCRIPTION
The use of Node.js’s release codenames isn’t very widespread and, if I had to guess, not a lot of people are aware that Node.js v8 is codenamed Carbon. Therefore, I’d argue that using the actual version number in the Docker guide would reduce confusion and make it more obvious which Node.js version is being used.