### PR TITLE
Fix extra space before period

### DIFF
--- a/locale/en/about/releases.md
+++ b/locale/en/about/releases.md
@@ -18,7 +18,7 @@ Patch releases:
 - Do not add nor change public interfaces.
 - Do not alter the expected behavior of a given interface.
 - Can correct behavior if it is out-of-sync with the documentation.
-- Do not introduce changes which make seamless upgrades impossible .
+- Do not introduce changes which make seamless upgrades impossible.
 
 ## Minors
 

--- a/locale/ko/about/releases.md
+++ b/locale/ko/about/releases.md
@@ -27,7 +27,7 @@ Patch releases:
 - Do not add nor change public interfaces.
 - Do not alter the expected behavior of a given interface.
 - Can correct behavior if it is out-of-sync with the documentation.
-- Do not introduce changes which make seamless upgrades impossible .
+- Do not introduce changes which make seamless upgrades impossible.
 -->
 
 ## 패치


### PR DESCRIPTION
> Do not introduce changes which make seamless upgrades impossible .

Fixed to:

> Do not introduce changes which make seamless upgrades impossible.