### PR TITLE
Remove unnecessary Korean translation from index.md

### DIFF
--- a/locale/ko/index.md
+++ b/locale/ko/index.md
@@ -19,5 +19,3 @@ labels:
 ---
 
 Node.js®는 [Chrome V8 JavaScript 엔진](https://developers.google.com/v8/)으로 빌드된 JavaScript 런타임입니다.
-Node.js는 이벤트 기반, 논 블로킹 I/O 모델을 사용해 가볍고 효율적입니다. Node.js의 패키지 생태계인 [npm](https://www.npmjs.com/)은
-세계에서 가장 큰 오픈 소스 라이브러리 생태계이기도 합니다.


### PR DESCRIPTION
As @Maledong [mentioned](https://github.com/nodejs/nodejs.org/pull/1719#issuecomment-403442481), the Korean translation for `index.md` should drop the last paragraph since now the main page has only one explanation for NodeJS.