### PR TITLE
Link to GitHub for licensing information

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -20,7 +20,7 @@
       <p>Linux Foundation is a registered trademark of The Linux Foundation.</p>
       <p>Linux is a registered <a href="http://www.linuxfoundation.org/programs/legal/trademark" title="Linux Mark Institute">trademark</a> of Linus Torvalds.</p>
       <p>
-        <a href="https://raw.githubusercontent.com/nodejs/node/master/LICENSE">Node.js Project Licensing Information</a>.
+        <a href="https://github.com/nodejs/node/blob/master/LICENSE">Node.js Project Licensing Information</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
The contents are the same but the [normal view](https://github.com/nodejs/node/blob/master/LICENSE) is nicer to read than the [raw view](https://raw.githubusercontent.com/nodejs/node/master/LICENSE).