### PR TITLE
Add border radius to banner on home page

### DIFF
--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -40,6 +40,9 @@
   h2
     margin-bottom 0
 
+.home-banner > img
+  border-radius 2px
+
 .home-downloadblock
   display inline-block
   margin 0 8px

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -13,7 +13,7 @@
         {{{ contents }}}
 
         <p>
-          <a class="imagelink" href="https://events.linuxfoundation.org/events/js-interactive-2018/?utm_source=nodesite&utm_medium=homepagebanner&utm_campaign=jsint18&utm_term=eventpage">
+          <a class="imagelink home-banner" href="https://events.linuxfoundation.org/events/js-interactive-2018/?utm_source=nodesite&utm_medium=homepagebanner&utm_campaign=jsint18&utm_term=eventpage">
             <img src="/static/images/jsinteractive-2018-banner.png" alt="JS Interactive on October 10-12, 2018 in Vancouver, Canada">
           </a>
         </p>


### PR DESCRIPTION
The download buttons have a `border-radius` of `2px`, so I think it makes sense to apply the same to the new JS Interactive banner.