### PR TITLE
Fix spelling of “Stack Overflow”

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -25,7 +25,7 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 
 - La [Documentació oficial de l'API](/api) detalla l'API de Node.
 - [NodeSchool.io](http://nodeschool.io) li ensenyarà conceptes de Node.js de forma interactiva mitjançant jocs utilitzant la línia de comandes.
-- L'[etiqueta de Node.js en StackOverflow](http://stackoverflow.com/questions/tagged/node.js) col·lecciona nova informació cada dia.
+- L'[etiqueta de Node.js en Stack Overflow](http://stackoverflow.com/questions/tagged/node.js) col·lecciona nova informació cada dia.
 - [How To Node](http://howtonode.org/) té un nombre creixent d'útils tutorials.
 
 

--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -270,5 +270,5 @@ following places:
 * [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
-* [Docker Tag on StackOverflow](https://stackoverflow.com/questions/tagged/docker)
+* [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)
 * [Docker Subreddit](https://reddit.com/r/docker)

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -22,7 +22,7 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 
 - [Official API reference documentation](/api) details the Node API.
 - [NodeSchool.io](http://nodeschool.io) will teach you Node.js concepts via interactive command-line games.
-- [StackOverflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) collects new information every day.
+- [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) collects new information every day.
 
 
 ## International community sites and projects

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -24,7 +24,7 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 
 - La [Documentación oficial de la API](/api) detalla la API de Node.
 - [NodeSchool.io](http://nodeschool.io) le enseñará conceptos de Node.js de forma interactiva mediante juegos utilizando la línea de comandos.
-- La [etiqueta de Node.js en StackOverflow](http://stackoverflow.com/questions/tagged/node.js) colecciona nueva información cada día.
+- La [etiqueta de Node.js en Stack Overflow](http://stackoverflow.com/questions/tagged/node.js) colecciona nueva información cada día.
 - [How To Node](http://howtonode.org/) tiene un número creciente de útiles tutoriales.
 
 

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -37,7 +37,7 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - [NodeSchool.io](http://nodeschool.io) vous apprendra les concepts de Node.js avec des jeux intéractifs en ligne de commande [en].
 
-- [L'étiquette StackOverflow Node.js](http://stackoverflow.com/questions/tagged/node.js) rassemble de nouvelles informations chaque jours [en].
+- [L'étiquette Stack Overflow Node.js](http://stackoverflow.com/questions/tagged/node.js) rassemble de nouvelles informations chaque jours [en].
 
 - [How To Node](http://howtonode.org/) a de nombreux tutoriaux utiles [en].
 

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -517,7 +517,7 @@ following places:
 * [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
-* [Docker Tag on StackOverflow](https://stackoverflow.com/questions/tagged/docker)
+* [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)
 * [Docker Subreddit](https://reddit.com/r/docker)
 -->
 
@@ -528,5 +528,5 @@ following places:
 * [공식 Node.js Docker 이미지](https://registry.hub.docker.com/_/node/)
 * [Node.js Docker 사용사례 문서](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [공시 Docker 문서](https://docs.docker.com/)
-* [StackOverflow에 Docker 태그로 올라온 질문](https://stackoverflow.com/questions/tagged/docker)
+* [Stack Overflow에 Docker 태그로 올라온 질문](https://stackoverflow.com/questions/tagged/docker)
 * [Docker 레딧](https://reddit.com/r/docker)

--- a/locale/uk/docs/guides/nodejs-docker-webapp.md
+++ b/locale/uk/docs/guides/nodejs-docker-webapp.md
@@ -270,5 +270,5 @@ following places:
 * [Official Node.js Docker Image](https://registry.hub.docker.com/_/node/)
 * [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md)
 * [Official Docker documentation](https://docs.docker.com/)
-* [Docker Tag on StackOverflow](https://stackoverflow.com/questions/tagged/docker)
+* [Docker Tag on Stack Overflow](https://stackoverflow.com/questions/tagged/docker)
 * [Docker Subreddit](https://reddit.com/r/docker)

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -22,7 +22,7 @@ layout: contribute.hbs
 
 - [Офіційна довідкова документація по API](/api) описує Node API.
 - [NodeSchool.io](http://nodeschool.io) навчить вас концепцій Node.js через інтерактивні консольні ігри.
-- [StackOverflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) щодня поповнюється новою інформацією.
+- [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) щодня поповнюється новою інформацією.
 - [How To Node](http://howtonode.org/) має велику кількість корисних туторіалів.
 
 

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -22,7 +22,7 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 
 - [官方 API 參考文件](/api)中詳細介紹了 Node API。
 - [NodeSchool.io](http://nodeschool.io) 以互動命令列的方式，教會你 Node.js 的概念。
-- [StackOverflow 上的 Node.js 標籤](http://stackoverflow.com/questions/tagged/node.js)搜羅了每日新資訊。
+- [Stack Overflow 上的 Node.js 標籤](http://stackoverflow.com/questions/tagged/node.js)搜羅了每日新資訊。
 
 
 ## 國際性社群網站及專案


### PR DESCRIPTION
“StackOverflow” → “Stack Overflow”