### PR TITLE
Update Node.js Everywhere copy from weekly to monthly

### DIFF
--- a/locale/ar/index.md
+++ b/locale/ar/index.md
@@ -18,7 +18,7 @@ labels:
   version-schedule-prompt-link-text: LTS schedule.
   newsletter: نعم
   newsletter-prefix: قم بالانضمام الى
-  newsletter-postfix: " , القائمة البريدية الأسبوعية الرسمية ل  Node.js "
+  newsletter-postfix: " , الرسالة الإخبارية الشّهريّة عن Node.js "
 ---
 
 Node.js® هو اطار عمل مبني على محرك [Chrome V8](https://developers.google.com/v8/).

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -12,7 +12,7 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 - For real-time chat about Node development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](http://webchat.freenode.net/?channels=node.js).
 - The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
-- [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Weekly Newsletter.
+- [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 - [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 - [NodeUp](http://nodeup.com) is a podcast covering the latest Node news in the community.
 - The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -18,7 +18,7 @@ labels:
   version-schedule-prompt-link-text: Long Term Support (LTS) schedule.
   newsletter: true
   newsletter-prefix: Sign up for
-  newsletter-postfix: ", the official Node.js Weekly Newsletter."
+  newsletter-postfix: ", the official Node.js Monthly Newsletter."
 ---
 
 Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://developers.google.com/v8/).

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -21,7 +21,7 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - Le compte Twitter officiel de Node.js est [nodejs](https://twitter.com/nodejs) [en].
 
-- [Node.js Everywhere](https://newsletter.nodejs.org) est la newsletter hebdomadaire officielle de Node.js [en].
+- [Node.js Everywhere](https://newsletter.nodejs.org) est la newsletter mensuelle officielle de Node.js [en].
 
 - [Node.js Collection](https://medium.com/the-node-js-collection) est une liste de contenus maintenue par la communauté sur Medium [en].
 

--- a/locale/it/index.md
+++ b/locale/it/index.md
@@ -18,7 +18,7 @@ labels:
   version-schedule-prompt-link-text: tabella di marcia LTS.
   newsletter: true
   newsletter-prefix: Iscriviti a
-  newsletter-postfix: ", la newsletter settimanale di Node.js"
+  newsletter-postfix: ", la newsletter mensile di Node.js"
 ---
 
 Node.js® è un runtime JavaScript costruito sul [motore JavaScript V8 di Chrome](https://developers.google.com/v8/).

--- a/locale/zh-cn/index.md
+++ b/locale/zh-cn/index.md
@@ -18,7 +18,7 @@ labels:
   version-schedule-prompt-link-text: LTS 日程。
   newsletter: true
   newsletter-prefix: 订阅
-  newsletter-postfix: ，Node.js 官方的新闻周报。
+  newsletter-postfix: ，Node.js 官方的新闻月报。
 ---
 
 Node.js® 是一个基于 [Chrome V8 引擎](https://developers.google.com/v8/) 的 JavaScript 运行时。

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -12,7 +12,7 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 - [GitHub issues 清單](https://github.com/nodejs/node/issues)是討論 Node.js 核心功能的好地方。
 - 關於 Node.js 開發的即時對話請使用 [IRC 用戶端](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) 或 [freenode 網頁聊天室](http://webchat.freenode.net/?channels=node.js) 連線至 `irc.freenode.net` 中的 `#node.js` 頻道。
 - Node.js 官方的 Twitter 帳號是 [nodejs](https://twitter.com/nodejs).
-- [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的週報。
+- [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月報。
 - [Node.js Collection](https://medium.com/the-node-js-collection) 是個由社群策劃的 Medium 文章合集。
 - [NodeUp](http://nodeup.com) 是關於 Node 社群最新消息的 podcast。
 - [Community Committee](https://github.com/nodejs/community-committee) 是 Node.js 基金會中的高級委員會，專責社群事務。

--- a/locale/zh-tw/index.md
+++ b/locale/zh-tw/index.md
@@ -18,7 +18,7 @@ labels:
   version-schedule-prompt-link-text: LTS（長期維護版）時程
   newsletter: true
   newsletter-prefix: 訂閱
-  newsletter-postfix: "：Node.js 官方的新聞週報。"
+  newsletter-postfix: "：Node.js 官方的新聞月報。"
 ---
 
 Node.js® 是款基於 [Chrome V8 引擎](https://developers.google.com/v8/)的 JavaScript 執行環境。


### PR DESCRIPTION
Resolves #1745. The copy is updated on both the [home page](https://nodejs.org/en/) and the [“Get Involved” page](https://nodejs.org/en/get-involved/).