### PR TITLE
Fix spelling of “JavaScript”

### DIFF
--- a/locale/ca/about/index.md
+++ b/locale/ca/about/index.md
@@ -5,7 +5,7 @@ trademark: Trademark
 ---
 # Sobre Node.js&reg;
 
-Nascut com a un entorn d'execució de Javascript orientat a esdeveniments asíncrons, Node.js està 
+Nascut com a un entorn d'execució de JavaScript orientat a esdeveniments asíncrons, Node.js està 
 dissenyat per a crear aplicacions en xarxa de manera escalable. En la següent aplicació d'exemple 
 "hola món", es pot manegar moltes connexions concurrents. Per a cada connexió el callback serà 
 executat, no obstant si no hi hagués tasques pendents per a fer, Node.js romandrà adormit.
@@ -47,7 +47,7 @@ El comportament és típicament definit a través de *callbacks* a l'inici del s
 s'inicia el servidor mitjançant una trucada de bloqueig com `EventMachine::run()`. En Node no
 existeix aquesta trucada. Node simplement ingressa el bucle d'esdeveniments després d'executar
 el script d'entrada. Node surt del bucle d'esdeveniments quan no hi ha més *callbacks* que executar.
-s comporta d'una forma similar a Javascript al navegador - el bucle d'esdeveniments està ocult a l'usuari.
+s comporta d'una forma similar a JavaScript al navegador - el bucle d'esdeveniments està ocult a l'usuari.
 
 HTTP es ciutadà de primera classe en Node, disenyat amb operacions de streaming y baixa latència
 en ment. Això no fa a Node candidat per ser la base d'una llibrería o un framework web.

--- a/locale/de/about/index.md
+++ b/locale/de/about/index.md
@@ -52,7 +52,7 @@ In Node gibt es keinen solchen Aufruf, um die Ereignisschleife zu starten.
 Node beginnt einfach mit der Ereignisschleife, nachdem das Eingabe-Skript
 ausgeführt wurde. Node verlässt die Ereignisschleife, wenn keine
 Callback-Funktionen mehr auszuführen sind. Dieses Verhalten ist wie bei
-Browser-Javascript - die Ereignisschleife ist vor dem Nutzer versteckt.
+Browser-JavaScript - die Ereignisschleife ist vor dem Nutzer versteckt.
 
 HTTP ist ein Basiselement in Node, entworfen mit Fokus auf Streaming und
 geringe Latenz. Dadurch ist Node sehr gut als Grundlage für Web-Bibliotheken

--- a/locale/en/docs/guides/simple-profiling.md
+++ b/locale/en/docs/guides/simple-profiling.md
@@ -155,7 +155,7 @@ up by language. First, we look at the summary section and see:
 
 This tells us that 97% of all samples gathered occurred in C++ code and that
 when viewing other sections of the processed output we should pay most attention
-to work being done in C++ (as opposed to Javascript). With this in mind, we next
+to work being done in C++ (as opposed to JavaScript). With this in mind, we next
 find the [C++] section which contains information about which C++ functions are
 taking the most CPU time and see:
 

--- a/locale/en/knowledge/HTTP/clients/how-to-access-query-string-parameters.md
+++ b/locale/en/knowledge/HTTP/clients/how-to-access-query-string-parameters.md
@@ -21,6 +21,6 @@ In Node.js, functionality to aid in the accessing of URL query string parameters
       res.end('Feel free to add query parameters to the end of the url');
     }).listen(8080);
 
-The key part of this whole script is this line: `var queryObject = url.parse(req.url,true).query;`. Let's take a look at things from the inside-out.  First off, `req.url` will look like `/app.js?foo=bad&baz=foo`. This is the part that is in the URL bar of the browser. Next, it gets passed to `url.parse` which parses out the various elements of the URL (NOTE: the second paramater is a boolean stating whether the method should parse the query string, so we set it to true). Finally, we access the `.query` property, which returns us a nice, friendly Javascript object with our query string data. 
+The key part of this whole script is this line: `var queryObject = url.parse(req.url,true).query;`. Let's take a look at things from the inside-out.  First off, `req.url` will look like `/app.js?foo=bad&baz=foo`. This is the part that is in the URL bar of the browser. Next, it gets passed to `url.parse` which parses out the various elements of the URL (NOTE: the second paramater is a boolean stating whether the method should parse the query string, so we set it to true). Finally, we access the `.query` property, which returns us a nice, friendly JavaScript object with our query string data. 
 
 

--- a/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -10,13 +10,13 @@ layout: knowledge-post.hbs
 
 
 
-Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the Node.js shell; any valid Javascript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of Javascript's more eccentric behaviors.
+Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the Node.js shell; any valid JavaScript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of JavaScript's more eccentric behaviors.
 
 Running it is simple - just run node without a filename.
 
      docs@nodejitsu:~/$ node
 
-It then drops you into a simple prompt ('>') where you can type any Javascript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
+It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
 
 Whenever you type a command, it will print the return value of the command. If you want to reuse the previous return value, you can use the special `_` variable.
 

--- a/locale/en/knowledge/errors/what-is-the-error-object.md
+++ b/locale/en/knowledge/errors/what-is-the-error-object.md
@@ -33,7 +33,7 @@ Result:
 
 `error.stack` shows you where an error came from, as well as a list of the function calls that preceded it - for your convenience, `error.stack` always prints `error.message` as the first line of its output, making `error.stack` a convenient single property to log during debugging.
 
-If you want to add more information to the Error object, you can always add properities, just as with any other Javascript object: 
+If you want to add more information to the Error object, you can always add properities, just as with any other JavaScript object: 
 
     var error = new Error("The error message");
     error.http_code = 404;

--- a/locale/en/knowledge/errors/what-is-try-catch.md
+++ b/locale/en/knowledge/errors/what-is-try-catch.md
@@ -38,7 +38,7 @@ Results:
     entering and leaving the finally block
     leaving try-catch statement
 
-Javascript's `try-catch-finally` statement works very similarly to the `try-catch-finally` encountered in C++ and Java.  First, the try block is executed until and unless the code in it throws an exception (whether it is an explicit `throw` statement, the code has an uncaught native exception, or if the code calls a function that uses `throw`). 
+JavaScript's `try-catch-finally` statement works very similarly to the `try-catch-finally` encountered in C++ and Java.  First, the try block is executed until and unless the code in it throws an exception (whether it is an explicit `throw` statement, the code has an uncaught native exception, or if the code calls a function that uses `throw`). 
 
 If the code doesn't throw an exception, then the whole try block is executed. If the code threw an exception inside the try block, then the catch block is executed.  Last of all, the finally block is always executed, subsequent to the other blocks but prior to any subsequent code located outside of the `try-catch-finally` blocks.  The `finally` block will just about always execute, no matter what kind of throwing, catching, or returning one might be trying to do inside the `try` or `catch` blocks.
 

--- a/locale/en/knowledge/javascript-conventions/what-are-truthy-and-falsy-values.md
+++ b/locale/en/knowledge/javascript-conventions/what-are-truthy-and-falsy-values.md
@@ -11,7 +11,7 @@ layout: knowledge-post.hbs
 ---
 
 
-Javascript is weakly typed language. That means different types can be
+JavaScript is weakly typed language. That means different types can be
 used in operations and the language will try to convert the types
 until the operation makes sense.
 

--- a/locale/en/knowledge/javascript-conventions/what-is-json.md
+++ b/locale/en/knowledge/javascript-conventions/what-is-json.md
@@ -22,7 +22,7 @@ values, e.g. an Object.
 
 ## Encoding and Decoding
 
-Javascript provides 2 methods for encoding data structures to json and
+JavaScript provides 2 methods for encoding data structures to json and
 encoding json back to javascript objects and arrays. They are both
 available on the `JSON` object that is available in the global scope.
 

--- a/locale/gl/index.md
+++ b/locale/gl/index.md
@@ -18,4 +18,4 @@ labels:
   version-schedule-prompt-link-text: Axenda de LTS.
 ---
 
-Node.js® é un entorno de execución para JavaScript construído co [motor de Javascript V8 de Chrome](https://developers.google.com/v8/).
+Node.js® é un entorno de execución para JavaScript construído co [motor de JavaScript V8 de Chrome](https://developers.google.com/v8/).

--- a/locale/it/index.md
+++ b/locale/it/index.md
@@ -21,4 +21,4 @@ labels:
   newsletter-postfix: ", la newsletter settimanale di Node.js"
 ---
 
-Node.js® è un runtime Javascript costruito sul [motore JavaScript V8 di Chrome](https://developers.google.com/v8/).
+Node.js® è un runtime JavaScript costruito sul [motore JavaScript V8 di Chrome](https://developers.google.com/v8/).

--- a/locale/ko/docs/guides/simple-profiling.md
+++ b/locale/ko/docs/guides/simple-profiling.md
@@ -312,7 +312,7 @@ up by language. First, we look at the summary section and see:
 <!--
 This tells us that 97% of all samples gathered occurred in C++ code and that
 when viewing other sections of the processed output we should pay most attention
-to work being done in C++ (as opposed to Javascript). With this in mind, we next
+to work being done in C++ (as opposed to JavaScript). With this in mind, we next
 find the [C++] section which contains information about which C++ functions are
 taking the most CPU time and see:
 
@@ -326,7 +326,7 @@ taking the most CPU time and see:
 -->
 
 이 부분을 보면 C++ 코드에서 수집된 샘플이 97%를 차지하는 것을 볼 수 있으므로 처리된 결과에서
-다른 부분을 볼 때 C++에서 이뤄진 작업에 대부분의 관심을 기울여야 합니다.(Javascript 대비)
+다른 부분을 볼 때 C++에서 이뤄진 작업에 대부분의 관심을 기울여야 합니다.(JavaScript 대비)
 그래서 C++ 함수가 대부분의 CPU 시간을 차지한 정보를 담고 있는 [C++] 부분을 찾아볼 것입니다.
 
 ```

--- a/locale/uk/docs/guides/simple-profiling.md
+++ b/locale/uk/docs/guides/simple-profiling.md
@@ -155,7 +155,7 @@ up by language. First, we look at the summary section and see:
 
 This tells us that 97% of all samples gathered occurred in C++ code and that
 when viewing other sections of the processed output we should pay most attention
-to work being done in C++ (as opposed to Javascript). With this in mind, we next
+to work being done in C++ (as opposed to JavaScript). With this in mind, we next
 find the [C++] section which contains information about which C++ functions are
 taking the most CPU time and see:
 

--- a/locale/uk/knowledge/HTTP/clients/how-to-access-query-string-parameters.md
+++ b/locale/uk/knowledge/HTTP/clients/how-to-access-query-string-parameters.md
@@ -21,6 +21,6 @@ In Node.js, functionality to aid in the accessing of URL query string parameters
       res.end('Feel free to add query parameters to the end of the url');
     }).listen(8080);
 
-The key part of this whole script is this line: `var queryObject = url.parse(req.url,true).query;`. Let's take a look at things from the inside-out.  First off, `req.url` will look like `/app.js?foo=bad&baz=foo`. This is the part that is in the URL bar of the browser. Next, it gets passed to `url.parse` which parses out the various elements of the URL (NOTE: the second paramater is a boolean stating whether the method should parse the query string, so we set it to true). Finally, we access the `.query` property, which returns us a nice, friendly Javascript object with our query string data. 
+The key part of this whole script is this line: `var queryObject = url.parse(req.url,true).query;`. Let's take a look at things from the inside-out.  First off, `req.url` will look like `/app.js?foo=bad&baz=foo`. This is the part that is in the URL bar of the browser. Next, it gets passed to `url.parse` which parses out the various elements of the URL (NOTE: the second paramater is a boolean stating whether the method should parse the query string, so we set it to true). Finally, we access the `.query` property, which returns us a nice, friendly JavaScript object with our query string data. 
 
 

--- a/locale/uk/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/uk/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -10,13 +10,13 @@ layout: knowledge-post.hbs
 
 
 
-Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the Node.js shell; any valid Javascript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of Javascript's more eccentric behaviors.
+Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the Node.js shell; any valid JavaScript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of JavaScript's more eccentric behaviors.
 
 Running it is simple - just run node without a filename.
 
      docs@nodejitsu:~/$ node
 
-It then drops you into a simple prompt ('>') where you can type any Javascript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
+It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
 
 Whenever you type a command, it will print the return value of the command. If you want to reuse the previous return value, you can use the special `_` variable.
 

--- a/locale/uk/knowledge/errors/what-is-the-error-object.md
+++ b/locale/uk/knowledge/errors/what-is-the-error-object.md
@@ -33,7 +33,7 @@ Result:
 
 `error.stack` shows you where an error came from, as well as a list of the function calls that preceded it - for your convenience, `error.stack` always prints `error.message` as the first line of its output, making `error.stack` a convenient single property to log during debugging.
 
-If you want to add more information to the Error object, you can always add properities, just as with any other Javascript object: 
+If you want to add more information to the Error object, you can always add properities, just as with any other JavaScript object: 
 
     var error = new Error("The error message");
     error.http_code = 404;

--- a/locale/uk/knowledge/errors/what-is-try-catch.md
+++ b/locale/uk/knowledge/errors/what-is-try-catch.md
@@ -38,7 +38,7 @@ Results:
     entering and leaving the finally block
     leaving try-catch statement
 
-Javascript's `try-catch-finally` statement works very similarly to the `try-catch-finally` encountered in C++ and Java.  First, the try block is executed until and unless the code in it throws an exception (whether it is an explicit `throw` statement, the code has an uncaught native exception, or if the code calls a function that uses `throw`). 
+JavaScript's `try-catch-finally` statement works very similarly to the `try-catch-finally` encountered in C++ and Java.  First, the try block is executed until and unless the code in it throws an exception (whether it is an explicit `throw` statement, the code has an uncaught native exception, or if the code calls a function that uses `throw`). 
 
 If the code doesn't throw an exception, then the whole try block is executed. If the code threw an exception inside the try block, then the catch block is executed.  Last of all, the finally block is always executed, subsequent to the other blocks but prior to any subsequent code located outside of the `try-catch-finally` blocks.  The `finally` block will just about always execute, no matter what kind of throwing, catching, or returning one might be trying to do inside the `try` or `catch` blocks.
 

--- a/locale/uk/knowledge/javascript-conventions/what-are-truthy-and-falsy-values.md
+++ b/locale/uk/knowledge/javascript-conventions/what-are-truthy-and-falsy-values.md
@@ -11,7 +11,7 @@ layout: knowledge-post.hbs
 ---
 
 
-Javascript is weakly typed language. That means different types can be
+JavaScript is weakly typed language. That means different types can be
 used in operations and the language will try to convert the types
 until the operation makes sense.
 

--- a/locale/uk/knowledge/javascript-conventions/what-is-json.md
+++ b/locale/uk/knowledge/javascript-conventions/what-is-json.md
@@ -22,7 +22,7 @@ values, e.g. an Object.
 
 ## Encoding and Decoding
 
-Javascript provides 2 methods for encoding data structures to json and
+JavaScript provides 2 methods for encoding data structures to json and
 encoding json back to javascript objects and arrays. They are both
 available on the `JSON` object that is available in the global scope.
 


### PR DESCRIPTION
“Javascript” → “JavaScript”