### PR TITLE
update metalsmith-yearly-pagination to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,17 +4003,17 @@
       }
     },
     "metalsmith-yearly-pagination": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-yearly-pagination/-/metalsmith-yearly-pagination-2.0.0.tgz",
-      "integrity": "sha1-vMi2zfO/64VV/a0inQdlFIhKO5s=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/metalsmith-yearly-pagination/-/metalsmith-yearly-pagination-2.0.1.tgz",
+      "integrity": "sha512-PgSr2Eco8AOvwdW3OQnN1QTSsQAII4sjMRcdXk5/C7F2jo3M3AxDXBKgySw1mQJJ9Vn6DwbKe+9KqN5XGk/7CQ==",
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "metalsmith-permalinks": "0.5.0",
     "metalsmith-prism": "3.1.1",
     "metalsmith-stylus": "3.0.0",
-    "metalsmith-yearly-pagination": "2.0.0",
+    "metalsmith-yearly-pagination": "^2.0.1",
     "ncp": "2.0.0",
     "node-version-data": "1.0.1",
     "octonode": "^0.9.3",


### PR DESCRIPTION
Update metalsmith-yearly-pagination from 2.0.0 to 2.0.1. This eliminates
one warning from `npm audit`.