### PR TITLE
update metalsmith-discover-helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,13 +3835,34 @@
       }
     },
     "metalsmith-discover-helpers": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-discover-helpers/-/metalsmith-discover-helpers-0.1.0.tgz",
-      "integrity": "sha1-vMzFVqcgvRtTfHG1PACw3i33sZY=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/metalsmith-discover-helpers/-/metalsmith-discover-helpers-0.1.1.tgz",
+      "integrity": "sha512-aM+O5osa5F+uM9iTenWzE8aaPhTkIH2ibmYRConud2YUjLO4IBt1MdryBNdDLAzn8nyQT/n/lVoqXTFsPGo6Sg==",
       "requires": {
         "defaults": "^1.0.3",
-        "fs-tools": "^0.2.11",
+        "fs-tools": "^0.5.0",
         "handlebars": "*"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "fs-tools": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/fs-tools/-/fs-tools-0.5.0.tgz",
+          "integrity": "sha512-iJG+dKoTlWevEBvsZYkq7Fy1XJVYHMObel+MIKOf+3HbiENQG0JH5bgTlzJYsrdwZvft1vE/yl/P/T4wngAv8A==",
+          "requires": {
+            "async": "~ 0.2.9",
+            "lodash": "^4.17.10"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
       }
     },
     "metalsmith-discover-partials": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "marked": "0.3.19",
     "metalsmith": "2.3.0",
     "metalsmith-collections": "0.9.0",
-    "metalsmith-discover-helpers": "0.1.0",
+    "metalsmith-discover-helpers": "^0.1.1",
     "metalsmith-discover-partials": "0.1.0",
     "metalsmith-feed": "1.0.0",
     "metalsmith-layouts": "2.1.0",


### PR DESCRIPTION
Update metalsmith-discover-helpers to 0.1.1 to eliminate an npm audit
warning.