### PR TITLE
update metalsmith-discover-partials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,12 +2056,12 @@
       }
     },
     "fs-tools": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/fs-tools/-/fs-tools-0.2.11.tgz",
-      "integrity": "sha1-ZKYzkRn42mh75NH9vaN+4PiOZEw=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fs-tools/-/fs-tools-0.5.0.tgz",
+      "integrity": "sha512-iJG+dKoTlWevEBvsZYkq7Fy1XJVYHMObel+MIKOf+3HbiENQG0JH5bgTlzJYsrdwZvft1vE/yl/P/T4wngAv8A==",
       "requires": {
         "async": "~ 0.2.9",
-        "lodash": "~ 2.4.1"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "async": {
@@ -3645,9 +3645,9 @@
       }
     },
     "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -3866,12 +3866,12 @@
       }
     },
     "metalsmith-discover-partials": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-discover-partials/-/metalsmith-discover-partials-0.1.0.tgz",
-      "integrity": "sha1-+PI5O8vV4XKspzFc3BFgHhOU+yM=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/metalsmith-discover-partials/-/metalsmith-discover-partials-0.1.2.tgz",
+      "integrity": "sha512-rjVOCSnoXJyEQand85o8l8Z9Yevbyis23q+gCA5Q6w5SG2L+H/jMQYGokpj3a5cOl0Fkl+MaXZSHJ9elpKYNFg==",
       "requires": {
         "defaults": "^1.0.3",
-        "fs-tools": "^0.2.11",
+        "fs-tools": "^0.5.0",
         "handlebars": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "metalsmith": "2.3.0",
     "metalsmith-collections": "0.9.0",
     "metalsmith-discover-helpers": "^0.1.1",
-    "metalsmith-discover-partials": "0.1.0",
+    "metalsmith-discover-partials": "^0.1.2",
     "metalsmith-feed": "1.0.0",
     "metalsmith-layouts": "2.1.0",
     "metalsmith-markdown": "0.2.2",


### PR DESCRIPTION
update metalsmith-discover-partials from 0.1.0 to 0.1.2 to remove a
warning from `npm audit`