### PR TITLE
Fix link to rubyeventmachine.com

### DIFF
--- a/locale/ca/about/index.md
+++ b/locale/ca/about/index.md
@@ -62,5 +62,5 @@ compartir sockets entre processos per activar el balanceig de càrregues en els 
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [bucle de eventos]: https://github.com/nodejs/node/blob/master/doc/topics/event-loop-timers-and-nexttick.md
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/de/about/index.md
+++ b/locale/de/about/index.md
@@ -70,5 +70,5 @@ ermöglichen.
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`Cluster`]: https://nodejs.org/api/cluster.html
 [Ereignisschleife]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/en/about/index.md
+++ b/locale/en/about/index.md
@@ -65,5 +65,5 @@ over your cores.
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/es/about/index.md
+++ b/locale/es/about/index.md
@@ -61,5 +61,5 @@ el cual permite compartir sockets entre procesos para activar el balanceo de car
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [bucle de eventos]: https://github.com/nodejs/node/blob/master/doc/topics/event-loop-timers-and-nexttick.md
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/fr/about/index.md
+++ b/locale/fr/about/index.md
@@ -68,5 +68,5 @@ vous pourrez communiquer facilement. Basé sur la même interface, le
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [boucle événnementielle]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/ja/about/index.md
+++ b/locale/ja/about/index.md
@@ -107,5 +107,5 @@ Node はスレッドがない設計をしているという理由だけで、複
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [イベントループ]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/ko/about/index.md
+++ b/locale/ko/about/index.md
@@ -103,7 +103,7 @@ Node는 스레드를 사용하지 않도록 설계되지만 멀티 코어 환경
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/
 -->
 
@@ -111,5 +111,5 @@ Node는 스레드를 사용하지 않도록 설계되지만 멀티 코어 환경
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/uk/about/index.md
+++ b/locale/uk/about/index.md
@@ -66,5 +66,5 @@ HTTP є об'єктом першого роду в Node, розробленим 
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[Event Machine]: http://rubyeventmachine.com/
+[Event Machine]: https://github.com/eventmachine/eventmachine
 [Twisted]: http://twistedmatrix.com/

--- a/locale/zh-cn/about/index.md
+++ b/locale/zh-cn/about/index.md
@@ -42,5 +42,5 @@ HTTP 是 Node 中的一等公民。它设计的是流式和低延迟。这使得
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
 [`cluster`]: https://nodejs.org/api/cluster.html
 [事件轮询]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
-[事件机]: http://rubyeventmachine.com/
+[事件机]: https://github.com/eventmachine/eventmachine
 [扭曲]: http://twistedmatrix.com/


### PR DESCRIPTION
As `rubyeventmachine.com` seems to be gone, link to GitHub repo instead.

![domain registration screenshot](https://user-images.githubusercontent.com/153481/44638525-96dd6080-a9b7-11e8-9103-bd39e1bdbd4b.png)

Fixes: #1779