### PR TITLE
server: highlight server url

### DIFF
--- a/server.js
+++ b/server.js
@@ -105,7 +105,7 @@ http.createServer((req, res) => {
     req.url = '/en'
   }
   mount(req, res, redirectToEnglishUrl(req, res))
-}).listen(port, () => console.log(`http://localhost:${port}/en/`))
+}).listen(port, () => console.log(`\x1B[32mServer running at http://localhost:${port}/en/\x1B[39m`))
 
 // Start the initial build of static HTML pages
 build.fullBuild()


### PR DESCRIPTION
Highlight the server url with green color when `npm run serve` so that users can know which url to visit quickly and clearly.

![screen shot 2018-09-02 at 4 52 25 pm](https://user-images.githubusercontent.com/23313266/44954178-9588c800-aed0-11e8-9d23-122a84a2b149.png)
