### PR TITLE
doc: fix dependencies.md link

### DIFF
--- a/locale/en/docs/meta/topics/dependencies.md
+++ b/locale/en/docs/meta/topics/dependencies.md
@@ -7,14 +7,14 @@ layout: docs.hbs
 
 There are several dependencies that Node.js relies on to work the way it does.
 
-- [Libraries](#Libraries)
-  - [V8](#V8)
+- [Libraries](#libraries)
+  - [V8](#v8)
   - [libuv](#libuv)
   - [http-parser](#http-parser)
   - [c-ares](#c-ares)
-  - [OpenSSL](#OpenSSL)
+  - [OpenSSL](#openssl)
   - [zlib](#zlib)
-- [Tools](#Tools)
+- [Tools](#tools)
   - [npm](#npm)
   - [gyp](#gyp)
   - [gtest](#gtest)

--- a/locale/uk/docs/meta/topics/dependencies.md
+++ b/locale/uk/docs/meta/topics/dependencies.md
@@ -7,19 +7,19 @@ layout: docs.hbs
 
 Node.js використовує кілька залежностей, на які використовуються для забезпечення його роботи.
 
-- [Бібліотеки](#Бібліотеки)
-  - [V8](#V8)
+- [Бібліотеки](#libraries)
+  - [V8](#v8)
   - [libuv](#libuv)
   - [http-parser](#http-parser)
   - [c-ares](#c-ares)
-  - [OpenSSL](#OpenSSL)
+  - [OpenSSL](#openssl)
   - [zlib](#zlib)
-- [Інструменти](#Інструменти)
+- [Інструменти](#tools)
   - [npm](#npm)
   - [gyp](#gyp)
   - [gtest](#gtest)
 
-## Бібліотеки
+## <!--libraries-->Бібліотеки
 
 ### V8
 
@@ -73,7 +73,7 @@ Node.js використовує zlib для створення синхронн
 
 - [Документація](http://www.zlib.net/manual.html)
 
-## Інструменти
+## <!--tools-->Інструменти
 
 ### npm
 

--- a/locale/zh-cn/docs/meta/topics/dependencies.md
+++ b/locale/zh-cn/docs/meta/topics/dependencies.md
@@ -7,19 +7,19 @@ layout: docs.hbs
 
 Node.js 依赖于以下一些依赖项，这样它才能正常工作。
 
-- [Libraries](#Libraries)
-  - [V8](#V8)
+- [类库](#libraries)
+  - [V8](#v8)
   - [libuv](#libuv)
   - [http-parser](#http-parser)
   - [c-ares](#c-ares)
-  - [OpenSSL](#OpenSSL)
+  - [OpenSSL](#openssl)
   - [zlib](#zlib)
-- [Tools](#Tools)
+- [工具](#tools)
   - [npm](#npm)
   - [gyp](#gyp)
   - [gtest](#gtest)
 
-## 类库
+## <!--libraries-->类库
 
 ### V8
 
@@ -57,7 +57,7 @@ OpenSSL 广泛地在 `tls` 和 `crypto` 模块中使用。它提供了战争环�
 
 - [相关文档](http://www.zlib.net/manual.html)
 
-## 工具
+## <!--tools-->工具
 
 ### npm
 


### PR DESCRIPTION
url: [Dependencies](https://nodejs.org/en/docs/meta/topics/dependencies/)

when click the link(`Libraries` or `V8`...) with uppercase, it seems to be invalid.

In fact, Markdown is using lowercase to index content in self .md file.