### PR TITLE
add entry for Dependencies

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -99,6 +99,10 @@
     "guides": {
       "link": "docs/guides",
       "text": "Guides"
+    },
+    "dependencies": {
+      "link": "docs/meta/topics/dependencies",
+      "text": "Dependencies"
     }
   },
   "getinvolved": {

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -99,6 +99,10 @@
     "guides": {
       "link": "docs/guides",
       "text": "教程"
+    },
+    "dependencies": {
+      "link": "docs/meta/topics/dependencies",
+      "text": "依赖项"
     }
   },
   "getinvolved": {


### PR DESCRIPTION
It looks like there is no entry for [Dependencies](https://nodejs.org/en/docs/meta/topics/dependencies/) site in docs site. 
So add the entry entering [Dependencies](https://nodejs.org/en/docs/meta/topics/dependencies/) site in docs site.