### PR TITLE
update profiling crypto example

### DIFF
--- a/locale/en/docs/guides/simple-profiling.md
+++ b/locale/en/docs/guides/simple-profiling.md
@@ -42,7 +42,7 @@ app.get('/newUser', (req, res) => {
   }
 
   const salt = crypto.randomBytes(128).toString('base64');
-  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512, 'sha512');
 
   users[username] = { salt, hash };
 

--- a/locale/ko/docs/guides/simple-profiling.md
+++ b/locale/ko/docs/guides/simple-profiling.md
@@ -69,7 +69,7 @@ app.get('/newUser', (req, res) => {
   }
 
   const salt = crypto.randomBytes(128).toString('base64');
-  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512, 'sha512');
 
   users[username] = { salt, hash };
 
@@ -92,7 +92,7 @@ app.get('/newUser', (req, res) => {
   }
 
   const salt = crypto.randomBytes(128).toString('base64');
-  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512, 'sha512');
 
   users[username] = { salt, hash };
 

--- a/locale/uk/docs/guides/simple-profiling.md
+++ b/locale/uk/docs/guides/simple-profiling.md
@@ -42,7 +42,7 @@ app.get('/newUser', (req, res) => {
   }
 
   const salt = crypto.randomBytes(128).toString('base64');
-  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512, 'sha512');
 
   users[username] = { salt, hash };
 

--- a/locale/zh-cn/docs/guides/simple-profiling.md
+++ b/locale/zh-cn/docs/guides/simple-profiling.md
@@ -31,7 +31,7 @@ app.get('/newUser', (req, res) => {
   }
 
   const salt = crypto.randomBytes(128).toString('base64');
-  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512);
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 512, 'sha512');
 
   users[username] = { salt, hash };
 


### PR DESCRIPTION
The digest parameter is required as of v6.0.0, otherwise the example code errors out like this:
```
TypeError: The "digest" argument is required and must not be undefined
    at pbkdf2 (crypto.js:694:11)
    at Object.exports.pbkdf2Sync (crypto.js:687:10)
```

Details: https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2sync_password_salt_iterations_keylen_digest