### PR TITLE
remove member list clearly

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,9 +19,6 @@ The Website WG has final authority over this project including:
 * Conduct guidelines
 * Maintaining the list of additional Collaborators
 
-For the current list of WG members, see the project
-[README.md](./README.md#current-project-team-members).
-
 ## Collaborators
 
 The [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org)
@@ -51,9 +48,6 @@ modifications, or modifications that have not found consensus to the
 WG for discussion by assigning the ***WG-agenda*** tag to a pull
 request or issue. The WG should serve as the final arbiter where
 required.
-
-For the current list of Collaborators, see the project
-[README.md](./README.md#website-working-group-collaborators).
 
 ## WG Membership
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you want to submit a new feature or a bugfix, the best way is to create the c
 
 Full set up is in https://github.com/nodejs/build/tree/master/setup/www minus secrets and certificates. The webhook is setup on GitHub for this project and talks to a small Node server on the host which does the work. See the [github-webhook](https://github.com/rvagg/github-webhook) package for this.
 
-## Governance and Current Members
+## Governance
 
 All of the Node.js Foundation websites, including this repo, are jointly governed by the **Website Working Group**. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 


### PR DESCRIPTION
After #1789 (member list is private now), member list was removed from README.md but not removed clearly from the [GOVERNANCE.md](https://github.com/nodejs/nodejs.org/blob/master/GOVERNANCE.md). 

So fix it clearly.