### PR TITLE
update metalsmith-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3907,23 +3907,31 @@
       }
     },
     "metalsmith-markdown": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-0.2.2.tgz",
-      "integrity": "sha512-2WMtfd2xhBagmoyRZXg04EHd/jmWnK21aGOvEZG5/eDEBTn9zGtkeptZrl+fQV+CNwhWtoggn1s9d+yi0+JLqQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-1.0.1.tgz",
+      "integrity": "sha512-BsIvWg8F60ZH9kQ0n3heNexaOUpdxVPf4rJ8Ecsw4HT3rSpUt8xqK6dK3RsFP5bdgLiTDHvCF6IOqdte76H2XA==",
       "requires": {
-        "debug": "~0.7.4",
-        "marked": "~0.3.9"
+        "debug": "^4.0.1",
+        "marked": "~0.4.0"
       },
       "dependencies": {
         "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
+          "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
         },
         "marked": {
-          "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "metalsmith-discover-partials": "^0.1.2",
     "metalsmith-feed": "1.0.0",
     "metalsmith-layouts": "2.1.0",
-    "metalsmith-markdown": "0.2.2",
+    "metalsmith-markdown": "^1.0.1",
     "metalsmith-metadata": "0.0.4",
     "metalsmith-permalinks": "^1.0.0",
     "metalsmith-prism": "3.1.1",


### PR DESCRIPTION
This eliminates a warning from `npm audit`. It's a semver major update,
so we should look at output carefully, but all tests pass, so that's
something...