### PR TITLE
Fix HTML rendering on Docs index page

### DIFF
--- a/locale/ca/docs/index.md
+++ b/locale/ca/docs/index.md
@@ -22,16 +22,16 @@ relacionats al mateix. També indica quins mètodes són a l'abast per les difer
 També descriu els mòduls inclosos que proporciona Node.js, mes no documenta els mòduls que proporciona la comunitat.
 
 <div class="highlight-box">
-    <h4>Buscant la referència de l'API per a una versió anterior?</h4>
+  <h4>Buscant la referència de l'API per a una versió anterior?</h4>
 
    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">Totes les versions</a></li>
-    </ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">Totes les versions</a></li>
+  </ul>
 </div>
 
 ### Característiques d'ES6

--- a/locale/de/docs/index.md
+++ b/locale/de/docs/index.md
@@ -25,16 +25,16 @@ Die API-Referenz beschreibt Module, die in Node.js integriert sind. Module, die
 von der Community zur Verfügung gestellt werden, sind dort nicht dokumentiert.
 
 <div class="highlight-box">
-    <h4>Du suchst nach API Referenzen für ältere Versionen?</h4>
+  <h4>Du suchst nach API Referenzen für ältere Versionen?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">Alle Versionen</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">Alle Versionen</a></li>
+  </ul>
 </div>
 
 ### ES6 Funktionalitäten

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -20,18 +20,18 @@ The [API reference documentation](/api/) provides detailed information about a f
 This documentation describes the built-in modules provided by Node.js. It does not document modules provided by the community.
 
 <div class="highlight-box">
-    <h4>Looking for API docs of previous releases?</h4>
+  <h4>Looking for API docs of previous releases?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v9.x/api/">Node.js 9.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v6.x/api/">Node.js 6.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">all versions</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v9.x/api/">Node.js 9.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v6.x/api/">Node.js 6.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">all versions</a></li>
+  </ul>
 </div>
 
 ### ES6 Features

--- a/locale/es/docs/index.md
+++ b/locale/es/docs/index.md
@@ -21,16 +21,16 @@ relacionados al mismo. También indica qué métodos están disponibles para las
 También describe los módulos incluidos que proporciona Node.js, mas no documenta los módulos que proporciona la comunidad.
 
 <div class="highlight-box">
-    <h4>¿Buscando la referencia de la API para una versión anterior?</h4>
+  <h4>¿Buscando la referencia de la API para una versión anterior?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">Todas las versiones</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">Todas las versiones</a></li>
+  </ul>
 </div>
 
 ### Características de ES6

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -27,18 +27,18 @@ labels:
 このドキュメントでは Node.js によって提供された組み込みのモジュールについて説明しています。コアに組み込まれていないモジュールは含みません。
 
 <div class="highlight-box">
-    <!-- <h4>Looking for API docs of previous releases?</h4> -->
-    <h4>以前のバージョンの API リファレンスをお探しですか？</h4>
+  <!-- <h4>Looking for API docs of previous releases?</h4> -->
+  <h4>以前のバージョンの API リファレンスをお探しですか？</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <!-- <li><a href="https://nodejs.org/docs/">all versions</a></li> -->
-        <li><a href="https://nodejs.org/docs/">すべてのバージョン</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <!-- <li><a href="https://nodejs.org/docs/">all versions</a></li> -->
+    <li><a href="https://nodejs.org/docs/">すべてのバージョン</a></li>
+  </ul>
 </div>
 
 <!-- ### ES6 Features -->

--- a/locale/ko/docs/index.md
+++ b/locale/ko/docs/index.md
@@ -40,30 +40,30 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
 <!--
 <div class="highlight-box">
-    <h4>Looking for API docs of previous releases?</h4>
+  <h4>Looking for API docs of previous releases?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">all versions</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">all versions</a></li>
+  </ul>
 </div>
 -->
 
 <div class="highlight-box">
-    <h4>이전 버전에 대한 API 문서가 필요한가요?</h4>
+  <h4>이전 버전에 대한 API 문서가 필요한가요?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">모든 버전</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">모든 버전</a></li>
+  </ul>
 </div>
 
 <!--

--- a/locale/uk/docs/index.md
+++ b/locale/uk/docs/index.md
@@ -19,16 +19,16 @@ labels:
 Ця документація описує вбудовані модулі, які надаються Node.js. Вона не документує модулі, що надаються спільнотою.
 
 <div class="highlight-box">
-    <h4>Шукаєте документацію про API для попередніх релізів?</h4>
+  <h4>Шукаєте документацію про API для попередніх релізів?</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">всі версії</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">всі версії</a></li>
+  </ul>
 </div>
 
 ### Функціонал ES6

--- a/locale/zh-cn/docs/index.md
+++ b/locale/zh-cn/docs/index.md
@@ -20,18 +20,18 @@ labels:
 此文档描述了 Node.js 内建的模块，社区提供的模块并不记载在内。
 
 <div class="highlight-box">
-    <h4>在寻找先前发布的 API 函数接口文档吗？</h4>
+  <h4>在寻找先前发布的 API 函数接口文档吗？</h4>
 
-    <ul>
-        <li><a href="https://nodejs.org/docs/latest-v9.x/api/">Node.js 9.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v6.x/api/">Node.js 6.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
-        <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
-        <li><a href="https://nodejs.org/docs/">所有版本</a></li>
-    </ul>
+  <ul>
+    <li><a href="https://nodejs.org/docs/latest-v9.x/api/">Node.js 9.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v6.x/api/">Node.js 6.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a></li>
+    <li><a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a></li>
+    <li><a href="https://nodejs.org/docs/">所有版本</a></li>
+  </ul>
 </div>
 
 ### ES6 特性


### PR DESCRIPTION
Hi!

This pull request is for a small fix to the 'Docs' index page:
https://nodejs.org/en/docs/

In section 'Looking for API docs of previous releases?', the block of links is currently rendered as plain text instead of HTML.

This fix changes the level of indentation of the HTML snippet within the Markdown document, from 4 spaces to 2 spaces.

#### Before:
![before](https://user-images.githubusercontent.com/7805679/45955224-546e6a00-bfdd-11e8-9b1f-d97cde5b5e5d.png)

#### After:
![after](https://user-images.githubusercontent.com/7805679/45955241-5b957800-bfdd-11e8-85f2-f785b3e69180.png)

