### PR TITLE
Fix typo in v10.12.0.md

### DIFF
--- a/locale/en/blog/release/v10.12.0.md
+++ b/locale/en/blog/release/v10.12.0.md
@@ -49,7 +49,7 @@ author: Michaël Zasso
   * Added the `sorted` option to `util.inspect()`. If set to `true`, all
     properties of an object and Set and Map entries will be sorted in the
     returned string. If set to a function, it is used as a compare function. [#22788](https://github.com/nodejs/node/pull/22788)
-  * The `util.instpect.custom` symbol is now defined in the global symbol
+  * The `util.inspect.custom` symbol is now defined in the global symbol
     registry as `Symbol.for('nodejs.util.inspect.custom')`. [#20857](https://github.com/nodejs/node/pull/20857)
   * Added support for `BigInt` numbers in `util.format()`. [#22097](https://github.com/nodejs/node/pull/22097)
 * **V8 API**


### PR DESCRIPTION
This PR fixes a tiny typo in the changelog 