### PR TITLE
Replaced curl with wget for Debian and Ubuntu

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -57,14 +57,14 @@ Node.js is available from the [NodeSource](https://nodesource.com) Debian and Ub
 **NOTE:** If you are using Ubuntu Precise or Debian Wheezy, you might want to read about [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md).
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 Alternatively, for Node.js 10:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -41,14 +41,14 @@ Node.js está disponible desde el repositorio de binarios para Debian y Ubuntu d
 **NOTA:** Si usted está usando Ubuntu Precise ó Debian Wheezy, Usted probablemente deba leer sobre [ejecutar Node.js >= 6.x en distribuciones antiguas](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md).
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 Alternativamente, para Node.js v8:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/ja/download/package-manager.md
+++ b/locale/ja/download/package-manager.md
@@ -47,7 +47,7 @@ Node.js は [NodeSource](https://nodesource.com) の Debian と Ubuntu ベース
 **注意:** Ubuntu Precise や Debian Wheezy をお使いの場合は、 [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md) を読むことをお勧めします。
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -55,7 +55,7 @@ sudo apt-get install -y nodejs
 Node.js v8 を利用するには:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -76,7 +76,7 @@ Node.js is available from the [NodeSource](https://nodesource.com) Debian and Ub
 **NOTE:** If you are using Ubuntu Precise or Debian Wheezy, you might want to read about [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md).
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 -->
@@ -96,7 +96,7 @@ Node.js를 이용할 수 있습니다. 이 저장소의 지원내용과 스크�
 읽어볼 필요가 있습니다.
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -105,7 +105,7 @@ sudo apt-get install -y nodejs
 Alternatively, for Node.js 10:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -138,7 +138,7 @@ sudo apt-get install -y build-essential
 Node.js 10를 사용하고 싶다면 다음을 실행합니다.
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/uk/download/package-manager.md
+++ b/locale/uk/download/package-manager.md
@@ -42,14 +42,14 @@ Node.js is available from the [NodeSource](https://nodesource.com) Debian and Ub
 **NOTE:** If you are using Ubuntu Precise or Debian Wheezy, you might want to read about [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md).
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 Alternatively, for Node.js v8:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/zh-cn/download/package-manager.md
+++ b/locale/zh-cn/download/package-manager.md
@@ -58,14 +58,14 @@ pacman -S nodejs npm
 **注意：** 如果你在使用 Ubuntu Precise 或 Debian Wheezy 系统，你可能需要阅读相关信息：[在更古老的发行版系统上运行大于 6.0 版的 Nodejs](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md)。
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 而在 Node.js 10 版本中：
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 

--- a/locale/zh-tw/download/package-manager.md
+++ b/locale/zh-tw/download/package-manager.md
@@ -60,14 +60,14 @@ Node.js 可由 [NodeSource](https://nodesource.com)（前身為  [Chris Lea](htt
 **請注意：**如果你正在使用 Ubuntu Precise 或 Debian Wheezy，你可能需要閱讀 [running Node.js >= 6.x on older distros](https://github.com/nodesource/distributions/blob/master/OLDER_DISTROS.md)。
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 或者若你想安裝的是 Node.js 10：
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 


### PR DESCRIPTION
By default, Ubuntu (checked on my Ubuntu 18 LTS) and Debian (checked on Jessie in Vagrant) come with `wget` installed, but no `curl`. Therefore, it's preferable to use `wget` in docs to make it more accessible to users. 