### PR TITLE
Download: Fix 'current' page layouts

### DIFF
--- a/locale/ca/download/current.md
+++ b/locale/ca/download/current.md
@@ -1,5 +1,5 @@
 ---
-layout: download.hbs
+layout: download-current.hbs
 title: Descàrrega
 download: Descàrrega
 downloads:
@@ -11,7 +11,7 @@ downloads:
     display-hint: Mostrar descàrregues per a
     intro: >
         Descarregui el codi font de Node.js o un instal·lador pre-compilat per a la seva plataforma, i comenci a desenvolupar avui.
-    currentVersion: Versió LTS
+    currentVersion: Versió actual
     buildInstructions: Building Node.js from source on supported platforms
     WindowsInstaller: Windows Installer
     WindowsBinary: Windows Binary

--- a/locale/de/download/current.md
+++ b/locale/de/download/current.md
@@ -1,5 +1,5 @@
 ---
-layout: download.hbs
+layout: download-current.hbs
 title: Download
 download: Download
 downloads:

--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -1,5 +1,5 @@
 ---
-layout: download.hbs
+layout: download-current.hbs
 title: Téléchargements
 download: Télécharger
 downloads:


### PR DESCRIPTION
`de` and `fr` localizations were using the wrong page template for current downloads.
`ca` was missing 'current', translations are identical besides `Versió actual` and `Versió LTS`. 

Fixes #1847