### PR TITLE
Specify the correct layout for Current release for fr locale

### DIFF
--- a/locale/fr/download/current.md
+++ b/locale/fr/download/current.md
@@ -1,5 +1,5 @@
 ---
-layout: download.hbs
+layout: download-current.hbs
 title: Téléchargements
 download: Télécharger
 downloads:


### PR DESCRIPTION
I think I did it wrong when first translating the Download page in French.
Now the 'Current' tab should work as expected.
Prior to this change, the LTS tab was always displayed.

fix #1847