### PR TITLE
update metalsmith-permalinks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,20 +3944,20 @@
       }
     },
     "metalsmith-permalinks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-1.0.0.tgz",
-      "integrity": "sha512-VGQjs7iIJYDHZDSRAaGCu7W+QJRI7o0/I7agrHAT7YVgYKyUolQJ5+7Rl9YbtuQMD0X6Is6QPVodoVLvryaRvA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-2.0.0.tgz",
+      "integrity": "sha512-Vunug89+fdMlrOO5z1WZP/Zceo/9Y3PB1tRz8w/xY2PjcqkGqYVzHF4jw9HdU2kdMlU1h6+tcJ5Tj59NfpqTgw==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "moment": "^2.5.1",
-        "slug": "^0.9.1",
+        "slugify": "^1.3.1",
         "substitute": "https://github.com/segmentio/substitute/archive/0.1.0.tar.gz"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5319,13 +5319,10 @@
         }
       }
     },
-    "slug": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
-      "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
-      "requires": {
-        "unicode": ">= 0.3.1"
-      }
+    "slugify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.1.tgz",
+      "integrity": "sha512-6BwyhjF5tG5P8s+0DPNyJmBSBePG6iMyhjvIW5zGdA3tFik9PtK+yNkZgTeiroCRGZYgkHftFA62tGVK1EI9Kw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -6337,11 +6334,6 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
-    },
-    "unicode": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/unicode/-/unicode-11.0.1.tgz",
-      "integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ=="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "metalsmith-layouts": "2.1.0",
     "metalsmith-markdown": "^1.0.1",
     "metalsmith-metadata": "0.0.4",
-    "metalsmith-permalinks": "^1.0.0",
+    "metalsmith-permalinks": "^2.0.0",
     "metalsmith-prism": "3.1.1",
     "metalsmith-stylus": "3.0.0",
     "metalsmith-yearly-pagination": "^2.0.1",


### PR DESCRIPTION
This resolves the only issue reported currently by `npm audit`.

Major version change for the dependency, but it doesn't appear to change the results for our permalinks.