### PR TITLE
Add link to Node.js Foundation calendar

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -15,6 +15,7 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 - La [llista d'incidències de Github](https://github.com/nodejs/node/issues) és el lloc per discutir les característiques del nucli de Node.js.
 - Per xatejar en temps real sobre el desenvolupament de Node.js vagi a `irc.freenode.net` al canal `#node.js` fent servir un [client d'IRC](http://es.wikipedia.org/wiki/Anexo:Clientes_IRC) o connecti's amb el seu navegador al canal usant [WebChat de freenode](http://webchat.freenode.net/?channels=node.js).
 - El compte de Twitter oficial de Node.js és [nodejs](https://twitter.com/nodejs).
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) és el Butlletí oficial mensual de Node.js.
 - [Node.js Collection](https://medium.com/the-node-js-collection) és una col·lecció de contingut comissat per la comunitat a Medium.
 - [NodeUp](http://nodeup.com) és un podcast cobrint les últimes notícies en la comunitat de Node.

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -12,6 +12,7 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 - For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](http://webchat.freenode.net/?channels=node.js).
 - The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 - [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 - [NodeUp](http://nodeup.com) is a podcast covering the latest Node.js news in the community.

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -15,6 +15,7 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La [lista de errores en ](https://github.com/nodejs/node/issues) es el lugar para discutir las características del núcleo de Node.js.
 - Para chatear en tiempo real sobre el desarrollo de Node vaya a `irc.freenode.net` en el canal `#node.js` usando un [cliente de IRC](http://es.wikipedia.org/wiki/Anexo:Clientes_IRC) ó conéctese con su navegador al canal usando [WebChat de freenode](http://webchat.freenode.net/?channels=node.js).
 - La cuenta de Twitter oficial de Node.js es [nodejs](https://twitter.com/nodejs).
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node Weekly](http://nodeweekly.com) es una lista de correo que recopila los últimos eventos y noticias alrededor de la comunidad de Node.js.
 - [NodeUp](http://nodeup.com) es un podcast cubriendo las últimas noticias en la comunidad de Node.
 - La [Community Committee](https://github.com/nodejs/community-committee) es un comité de alto nivel de la Fundación Node.js centrado en los esfuerzos de la comunidad.

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -15,7 +15,7 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La [lista de errores en ](https://github.com/nodejs/node/issues) es el lugar para discutir las características del núcleo de Node.js.
 - Para chatear en tiempo real sobre el desarrollo de Node vaya a `irc.freenode.net` en el canal `#node.js` usando un [cliente de IRC](http://es.wikipedia.org/wiki/Anexo:Clientes_IRC) ó conéctese con su navegador al canal usando [WebChat de freenode](http://webchat.freenode.net/?channels=node.js).
 - La cuenta de Twitter oficial de Node.js es [nodejs](https://twitter.com/nodejs).
-- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
+- El [calendario de la Fundación Node.js](https://nodejs.org/calendar) con todas las reuniones del equipo público.
 - [Node Weekly](http://nodeweekly.com) es una lista de correo que recopila los últimos eventos y noticias alrededor de la comunidad de Node.js.
 - [NodeUp](http://nodeup.com) es un podcast cubriendo las últimas noticias en la comunidad de Node.
 - La [Community Committee](https://github.com/nodejs/community-committee) es un comité de alto nivel de la Fundación Node.js centrado en los esfuerzos de la comunidad.

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -21,12 +21,13 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - Le compte Twitter officiel de Node.js est [nodejs](https://twitter.com/nodejs) [en].
 
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
+
 - [Node.js Everywhere](https://newsletter.nodejs.org) est la newsletter mensuelle officielle de Node.js [en].
 
 - [Node.js Collection](https://medium.com/the-node-js-collection) est une liste de contenus maintenue par la communauté sur Medium [en].
 
 - [NodeUp](http://nodeup.com) est un podcast sur les actualités de la communauté Node [en].
-
 
 - La [Community Committee](https://github.com/nodejs/community-committee) s'agit d'un comité de haut niveau de la Fondation Node.js axé sur les efforts communautaires.
 

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -21,7 +21,7 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - Le compte Twitter officiel de Node.js est [nodejs](https://twitter.com/nodejs) [en].
 
-- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
+- Le [calendaire de la Fondation Node.js](https://nodejs.org/calendar) avec toutes les réunions d'équipe publiques.
 
 - [Node.js Everywhere](https://newsletter.nodejs.org) est la newsletter mensuelle officielle de Node.js [en].
 

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -13,6 +13,7 @@ layout: contribute.hbs
 - [Список іш’ю на GitHub](https://github.com/nodejs/node/issues) — це місце, де обговорюють ключовий функціонал Node.js.
 - Для живого чату про розробку на Node перейдіть на `irc.freenode.net` у канал `#node.js` через [IRC клієнт](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) або підключіться до каналу через веб–браузер з допомогою [ WebChat від freenode](http://webchat.freenode.net/?channels=node.js).
 - Офіційний аккаунт Node.js у Twitter [nodejs](https://twitter.com/nodejs).
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node Weekly](http://nodeweekly.com) це поштове розсилання, що збирає найсвіжіші події та новини довкола спільноти Node.js.
 - [NodeUp](http://nodeup.com) подкаст в якому обговорюють найсвіжіші новини з Nod–спільноти.
 - [Community Committee](https://github.com/nodejs/community-committee) є комітетом вищого рівня в Node.js Фонд зосереджений на спільних зусиллях.

--- a/locale/zh-cn/get-involved/index.md
+++ b/locale/zh-cn/get-involved/index.md
@@ -12,6 +12,7 @@ Node.js 是个包容的大家庭，因此我们鼓励用户各施所长。 若�
 - [GitHub 议题清单](https://github.com/nodejs/node/issues) 是讨论 Node.js 核心功能的好地方。
 - 关于 Node.js 开发的实时对话，请使用 [IRC 客户端](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) 或 [freenode 网页聊天室](http://webchat.freenode.net/?channels=node.js) 转到 `irc.freenode.net` 中的 `#node.js` 頻道。
 - Node.js 官方的 Twitter 账号：[nodejs](https://twitter.com/nodejs).
+- The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月报。
 - [Node.js Collection](https://medium.com/the-node-js-collection) 是一堆在媒体上的社区策划内容集合。
 - [NodeUp](http://nodeup.com) 是一个播客，它覆盖了所有相关于 Node 社区最新消息。

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -9,7 +9,7 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 
 ## 社群討論
 
-- [GitHub issues 清單](https://github.com/nodejs/node/issues) 是討論 Node.js 核心功能的好地方。
+- [GitHub issues 清單](https://github.com/nodejs/node/issues)是討論 Node.js 核心功能的好地方。
 - 關於 Node.js 開發的即時對話請使用 [IRC 用戶端](http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) 或 [freenode 網頁聊天室](http://webchat.freenode.net/?channels=node.js) 連線至 `irc.freenode.net` 中的 `#node.js` 頻道。
 - Node.js 官方的 Twitter 帳號是 [nodejs](https://twitter.com/nodejs)。
 - [Node.js Foundation 行事曆](https://nodejs.org/calendar) 中列出了所有的公開團隊會議。


### PR DESCRIPTION
Fixes: #1857 

Needs translations:
- [ ] Catalan
- [x] @nodejs/nodejs-es
- [x] @nodejs/nodejs-fr
- [x] @nodejs/nodejs-uk
- [x] @nodejs/nodejs-cn
- [x] @nodejs/nodejs-tw 