### PR TITLE
Add a link to the guides page

### DIFF
--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -41,4 +41,4 @@ The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and det
 
 ### Guides
 
-Long-form, in-depth articles about Node.js technical features and capabilities.
+The [Guides Section](en/docs/guides/) has Long-form, in-depth articles about Node.js technical features and capabilities.

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -41,4 +41,4 @@ The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and det
 
 ### Guides
 
-The [Guides Section](en/docs/guides/) has Long-form, in-depth articles about Node.js technical features and capabilities.
+The [Guides Section](en/docs/guides/) has long-form, in-depth articles about Node.js technical features and capabilities.

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -41,4 +41,4 @@ The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and det
 
 ### Guides
 
-The [Guides Section](en/docs/guides/) has long-form, in-depth articles about Node.js technical features and capabilities.
+The [Guides section](/en/docs/guides/) has long-form, in-depth articles about Node.js technical features and capabilities.


### PR DESCRIPTION
In order to get to the guides section, I had to scroll back up and use the sidebar menu.  This is much more user-friendly.