### PR TITLE
fixed link parsing error in Chinese

### DIFF
--- a/locale/zh-cn/docs/guides/getting-started-guide.md
+++ b/locale/zh-cn/docs/guides/getting-started-guide.md
@@ -25,4 +25,4 @@ server.listen(port, hostname, () => {
 });
 ```
 
-然后使用 ``` node app.js ``` 运行程序，访问 http://localhost:3000，你就会看到一个消息，写着“Hello World”。
+然后使用 ``` node app.js ``` 运行程序，访问 <http://localhost:3000>，你就会看到一个消息，写着“Hello World”。


### PR DESCRIPTION
Markdown made a wrong participle of the Chinese hyperlink.

as shown

![](https://user-images.githubusercontent.com/359395/48325305-e6a2fe00-e66f-11e8-8e22-d478306c8267.png)
