### PR TITLE
Update built-in debugger link to latest

### DIFF
--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -327,7 +327,7 @@ which translates the Inspector Protocol used in Chromium to the V8 Debugger
 protocol used in Node.js.
 -->
 
-#### [내장 디버거](https://github.com/nodejs/node/blob/master/lib/_debugger.js)
+#### [내장 디버거](https://nodejs.org/dist/latest-v6.x/docs/api/debugger.html)
 
 Node의 내장 명령형 디버거로 스크립트를 실행하려면 `node debug script_name.js`로 실행하세요.
 스크립트가 다른 Node 프로세스에서 `--debug-brk` 옵션으로 시작되고 원래의 Node 프로세스는

--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -313,7 +313,7 @@ TCP 포트(기본 `5858`)로 지금은 중단된 V8 디버깅 프로토콜에서
 V8 디버깅 프로토콜은 더는 관리되지 않고 문서화도 되지 않습니다.
 
 <!--
-#### [Built-in Debugger](https://github.com/nodejs/node/blob/master/lib/_debugger.js)
+#### [Built-in Debugger](https://nodejs.org/dist/latest-v6.x/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with


### PR DESCRIPTION
Update built-in debugger link to the latest in [guides/debugging-getting-started](https://nodejs.org/en/docs/guides/debugging-getting-started/).