### PR TITLE
blog: insert security release details to release posts

### DIFF
--- a/locale/en/blog/release/v10.14.0.md
+++ b/locale/en/blog/release/v10.14.0.md
@@ -8,6 +8,16 @@ layout: blog-post.hbs
 author: Rod Vagg
 ---
 
+**This is a security release.** All Node.js users should consult the security release summary at https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/ for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+* Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+* Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+* Node.js: Hostname spoofing in URL parser for javascript protocol (CVE-2018-12123)
+* OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+* OpenSSL: Timing vulnerability in ECDSA signature generation (CVE-2019-0735)
+
 ### Notable Changes
 
 * **deps**: Upgrade to OpenSSL 1.1.0j, fixing CVE-2018-0734 and CVE-2019-0735

--- a/locale/en/blog/release/v11.3.0.md
+++ b/locale/en/blog/release/v11.3.0.md
@@ -8,6 +8,16 @@ layout: blog-post.hbs
 author: Rod Vagg
 ---
 
+**This is a security release.** All Node.js users should consult the security release summary at https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/ for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+* Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+* Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+* Node.js: Hostname spoofing in URL parser for javascript protocol (CVE-2018-12123)
+* OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+* OpenSSL: Timing vulnerability in ECDSA signature generation (CVE-2019-0735)
+
 ### Notable Changes
 
 * **deps**: Upgrade to OpenSSL 1.1.0j, fixing CVE-2018-0734 and CVE-2019-0735

--- a/locale/en/blog/release/v6.15.0.md
+++ b/locale/en/blog/release/v6.15.0.md
@@ -8,6 +8,18 @@ layout: blog-post.hbs
 author: Rod Vagg
 ---
 
+**This is a security release.** All Node.js users should consult the security release summary at https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/ for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+* Node.js: Debugger port 5858 listens on any interface by default (CVE-2018-12120)
+* Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+* Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+* Node.js: Hostname spoofing in URL parser for javascript protocol (CVE-2018-12123)
+* Node.js: HTTP request splitting (CVE-2018-12116)
+* OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+* OpenSSL: Microarchitecture timing vulnerability in ECC scalar multiplication (CVE-2018-5407)
+
 ### Notable Changes
 
 * **debugger**: Backport of [nodejs/node#8106](https://github.com/nodejs/node/pull/8106) to prevent the debugger from listening on `0.0.0.0`. It now defaults to `127.0.0.1`. Reported by Ben Noordhuis. (CVE-2018-12120 / Ben Noordhuis).

--- a/locale/en/blog/release/v8.14.0.md
+++ b/locale/en/blog/release/v8.14.0.md
@@ -8,6 +8,17 @@ layout: blog-post.hbs
 author: Rod Vagg
 ---
 
+**This is a security release.** All Node.js users should consult the security release summary at https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/ for details on patched vulnerabilities.
+
+Fixes for the following CVEs are included in this release:
+
+* Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
+* Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
+* Node.js: Hostname spoofing in URL parser for javascript protocol (CVE-2018-12123)
+* Node.js: HTTP request splitting (CVE-2018-12116)
+* OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
+* OpenSSL: Microarchitecture timing vulnerability in ECC scalar multiplication (CVE-2018-5407)
+
 ### Notable Changes
 
 * **deps**: Upgrade to OpenSSL 1.0.2q, fixing CVE-2018-0734 and CVE-2018-5407


### PR DESCRIPTION
I forgot to insert the commit header that has the security release details on each release blog post (this is on the commit and in the changelog but our post generation tool doesn't pick it up).