### PR TITLE
add Gitpod as an inspector client

### DIFF
--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -127,6 +127,10 @@ info on these follows:
 
 * Library to ease connections to Inspector Protocol endpoints.
 
+#### [Gitpod](https://www.gitpod.io)
+
+* Start a Node.js debug configuration from the `Debug` view or hit `F5`. [Detailed instructions](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
+
 ---
 
 ## Command-line options


### PR DESCRIPTION
Hi 👋 [Gitpod](https://www.gitpod.io) comes with Node.js debugging support. [Here](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1) is an overview.
<img width="1919" alt="Debugging Node.js application in Gitpod" src="https://user-images.githubusercontent.com/3082655/49211171-3ea36980-f3bf-11e8-8bde-4676983cf824.png">
You can try it with the demo repo:
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/nodejs-shopping-cart)



