### PR TITLE
Allow locale on github links middleware

### DIFF
--- a/build.js
+++ b/build.js
@@ -118,7 +118,7 @@ function buildLocale (source, locale) {
       })
     }))
     .use(markdown(markedOptions))
-    .use(githubLinks({ locale: locale }))
+    .use(githubLinks({ locale: locale, site: i18nJSON(locale) }))
     .use(prism())
     // Set pretty permalinks, we don't want .html suffixes everywhere.
     .use(permalinks({
@@ -184,9 +184,10 @@ function githubLinks (options) {
 
       const file = files[path]
       const url = `https://github.com/nodejs/nodejs.org/edit/master/locale/${options.locale}/${path.replace('.html', '.md')}`
+      const editText = options.site.editOnGithub || 'Edit on GitHub'
 
       const contents = file.contents.toString().replace(/<h1(.*?)>(.*?)<\/h1>/, (match, $1, $2) => {
-        return `<a class="edit-link" href="${url}">Edit on GitHub</a> <h1${$1}>${$2}</h1>`
+        return `<a class="edit-link" href="${url}">${editText}</a> <h1${$1}>${$2}</h1>`
       })
 
       file.contents = Buffer.from(contents)

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -1,5 +1,6 @@
 {
   "title": "Node.js",
+  "editOnGithub":"Editar en Github",
   "author": "Fundación de Node.js",
   "url": "https://nodejs.org/es/",
   "locale": "es",


### PR DESCRIPTION
This PR modifies the *githubLinks* middleware to be able to use locales instead of the fixed "Edit on Github" message.
I also added the Spanish translation as an example. Default text remains in English.