### PR TITLE
Add "Node.js • Apprendre par la pratique" French book

### DIFF
--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -46,6 +46,8 @@ de notre communauté pour trouver comment vous pouvez aider&nbps;:
 
 - [How To Node](http://howtonode.org/) a de nombreux tutoriaux utiles (en anglais).
 
+- [Node.js • Apprendre par la pratique](https://oncletom.io/node.js/) est un livre pour apprendre Node.js pas à pas, édité par les Éditions Eyrolles. Le code source est ouvert ; il est lisible en ligne gratuitement ; les copies numérique et papier sont payantes.
+
 
 ## Site et projets des commuanutés internationales 
 


### PR DESCRIPTION
This is a proposition to add a new resource, available only in French, which is free online (on the web and on npm) but paid as a print and ebook copy.

I guess it calls 2 discussions, one with the @nodejs/nodejs-fr team for the content and @nodejs/website for the legitimacy of the content. Here is its meaning in English:

> [Node.js • Learning by doing](https://oncletom.io/node.js/) is a book to learn Node.js step by step, published by Éditions Eyrolles. Its source code is open; it is free to read online; the paper and ebook copies are paid.

_Disclaimer_: I have written the book.