### PR TITLE
remove several questionable links from get-involved

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -33,15 +33,10 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 
 ## Llocs de la comunitat internacional i projectes
 
-- [Blog Australià de Node.js blog &amp; llista de desenvolupadors](http://nodejs.org.au/)
 - [Comunitat Xinesa de Node.js](http://cnodejs.org)
 - [Comunitat en Google+ d'usuaris Francesos de Node.js](https://plus.google.com/communities/113346206415381691435)
 - [Comunitat d'Hongria(Magyar)](http://nodehun.blogspot.com/)
-- [Grup d'Iran en persa](http://nodejs.ir)
 - [Grup de Facebook israelià per Node.js](https://www.facebook.com/groups/node.il/)
 - [Grup d'usuaris de Japó](http://nodejs.jp/)
-- [Comunitat Coreana de Node.js](http://nodejs.github.io/nodejs-ko/)
-- [Comunitat de Nicaragua de Node.js](http://nodenica.com/)
 - [Grup de Facebook en espanyol de Node.js](https://www.facebook.com/groups/node.es/)
 - [Comunitat en espanyol](http://nodehispano.com)
-- [Comunitat Node.js de Việt Nam](http://nodejs.vn)

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -30,15 +30,10 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 
 ## International community sites and projects
 
-- [Australian Node.js blog &amp; developers listing](http://nodejs.org.au/)
 - [Chinese community](http://cnodejs.org)
 - [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
-- [Iranian group in Persian](http://nodejs.ir)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)
-- [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
-- [Nicaragua Node.js community](http://nodenica.com/)
 - [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
-- [Việt Nam Node.js community](http://nodejs.vn)

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -31,17 +31,10 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 
 ## Sitios de la comunidad internacional y proyectos
 
-- [Comunidad Alemana de Node.js](http://nodecode.de)
-- [Blog Australiano de Node.js blog &amp; lista de desarrolladores](http://nodejs.org.au/)
 - [Comunidad China](http://cnodejs.org)
-- [Comunidad Coreana de Node.js](http://nodejs.github.io/nodejs-ko/)
-- [Comunidad en Facebook de Español/Castellano](https://www.facebook.com/groups/node.es/)
 - [Comunidad en Google+ de usuarios Franceses de Node.js](https://plus.google.com/communities/113346206415381691435)
-- [Comunidad de lenguaje hispano](http://nodehispano.com)
 - [Comunidad de Hungría (Magyar)](http://nodehun.blogspot.com/)
-- [Grupo de Irán en persa](http://nodejs.ir)
 - [Comunidad en Facebook de usuarios Israelí de Node.js](https://www.facebook.com/groups/node.il/)
 - [Grupo de usuarios de Japón](http://nodejs.jp/)
-- [Comunidad de Nicaragua de Node.js](http://nodenica.com/)
-- [Grupo de Turquía en turco (Türkçe)](http://node.ist/)
-- [Comunidad Việt Nam](http://nodejs.vn)
+- [Comunidad en Facebook de Español/Castellano](https://www.facebook.com/groups/node.es/)
+- [Comunidad de lenguaje hispano](http://nodehispano.com)

--- a/locale/fa/get-involved/index.md
+++ b/locale/fa/get-involved/index.md
@@ -29,15 +29,10 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 
 ## International community sites and projects
 
-- [Australian Node.js blog &amp; developers listing](http://nodejs.org.au/)
 - [Chinese community](http://cnodejs.org)
 - [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
-- [Iranian group in Persian](http://nodejs.ir)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)
-- [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
-- [Nicaragua Node.js community](http://nodenica.com/)
 - [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
-- [Việt Nam Node.js community](http://nodejs.vn)

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -45,17 +45,10 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 ## Site et projets des commuanutés internationales 
 
-- [blog Node.js australien](http://nodejs.org.au/)
 - [communauté chinoise](http://cnodejs.org)
 - [communauté française Google+ des utilisateurs Node.js](https://plus.google.com/communities/113346206415381691435)
-- [communauté allemande Node.js](http://nodecode.de)
 - [communauté hongroise (Magyar)](http://nodehun.blogspot.com/)
-- [communauté iranienne](http://nodejs.ir)
 - [communauté israelienne sur Facebook](https://www.facebook.com/groups/node.il/)
 - [communauté japonaise](http://nodejs.jp/)
-- [communauté Coréenne](http://nodejs.github.io/nodejs-ko/)
-- [communauté du Nicaragua](http://nodenica.com/)
 - [communauté espagnole sur Facebook](https://www.facebook.com/groups/node.es/)
 - [communauté espagnole](http://nodehispano.com)
-- [communauté turque](http://node.ist/)
-- [communauté du Viêt Nam](http://nodejs.vn)

--- a/locale/pt-br/get-involved/index.md
+++ b/locale/pt-br/get-involved/index.md
@@ -30,15 +30,10 @@ A comunidade Node.js é ampla, inclusiva e animada em possibilitar que todos os 
 
 ## Sites e projetos internacionais da comunidade
 
-- [Blog Node.js Australino &amp; lista de desenvolvedores](http://nodejs.org.au/)
 - [Comunidade Chinesa](http://cnodejs.org)
 - [Comunidade Francesa de usuários Node.js no Google+](https://plus.google.com/communities/113346206415381691435)
 - [Comunidade Húngara(Magyar)](http://nodehun.blogspot.com/)
-- [Grupo Iraniano em Persa](http://nodejs.ir)
 - [Grupo Node.js Israelense no Facebook](https://www.facebook.com/groups/node.il/)
 - [Grupo de usuários Japoneses](http://nodejs.jp/)
-- [Comunidade Coreana Node.js](http://nodejs.github.io/nodejs-ko/)
-- [Comunidade Node.js de Nicarágua](http://nodenica.com/)
 - [Grupo Node.js em espanhol no Facebook](https://www.facebook.com/groups/node.es/)
 - [Comunidade em lingua Espanhola](http://nodehispano.com)
-- [Comunidade Node.js do Vietnã](http://nodejs.vn)

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -29,16 +29,10 @@ layout: contribute.hbs
 
 ## Сайти міжнародних спільнот та проекти
 
-- [Australian Node.js blog &amp; developers listing](http://nodejs.org.au/)
 - [Chinese community](http://cnodejs.org)
 - [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
-- [German Node.js community](http://nodecode.de)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
-- [Iranian group in Persian](http://nodejs.ir)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)
-- [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
-- [Nicaragua Node.js community](http://nodenica.com/)
+- [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
-- [Turkey group in Turkish (Türkçe)](http://node.ist/)
-- [Việt Nam Node.js community](http://nodejs.vn)

--- a/locale/zh-cn/get-involved/index.md
+++ b/locale/zh-cn/get-involved/index.md
@@ -30,15 +30,10 @@ Node.js 是个包容的大家庭，因此我们鼓励用户各施所长。 若�
 
 ## 国际化社区站点及项目
 
-- [Australian Node.js blog &amp; developers listing](http://nodejs.org.au/)
 - [Chinese community](http://cnodejs.org)
 - [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
-- [Iranian group in Persian](http://nodejs.ir)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)
-- [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
-- [Nicaragua Node.js community](http://nodenica.com/)
 - [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
-- [Việt Nam Node.js community](http://nodejs.vn)

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -28,15 +28,10 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 
 ## 國際性社群網站及專案
 
-- [Australian Node.js blog &amp; developers listing](http://nodejs.org.au/)
 - [Chinese community](http://cnodejs.org)
 - [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
-- [Iranian group in Persian](http://nodejs.ir)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)
-- [Korean Node.js community](http://nodejs.github.io/nodejs-ko/)
-- [Nicaragua Node.js community](http://nodenica.com/)
 - [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
 - [Spanish language community](http://nodehispano.com)
-- [Việt Nam Node.js community](http://nodejs.vn)


### PR DESCRIPTION
I'd like to see us weed this page more. There should be a much smaller number of links. Only durable, high-quality links should be listed. Otherwise, it reflects badly on the website and the project. No one will maintain the list and users will have a bad experience.

For example: Right now, if you click on the Nicaraqua Node.js Community link, you will be sent to a placeholder screen that tries to sell you car insurance.

<img width="623" alt="screen shot 2018-12-27 at 9 16 46 am" src="https://user-images.githubusercontent.com/718899/50488601-2facd880-09b8-11e9-8770-ffd715e71baa.png">

Meanwhile, the Vietnam Node.js Community link is broken, the Korean link is questionable (seems to link to an out-of-date version of https://nodejs.org/ko/blog/), the Iranian link seems to be to an even *more* out-of-date version of the website, many of the others don't appear to be community links at all but are people's personal blogs which often have not been updated in years, the Australian site has an invalid cert...

Let someone else curate a living list that tries to be comprehensive. (Maybe someone can start one of those "Awesome" lists on GitHub for Node.js community/getting-involved stuff if there isn't one already.) The website is a poor choice of venue for that kind of thing.

This page needs fewer things, not more, IMO.