### PR TITLE
Remove stale resources from get-involved

### DIFF
--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -18,7 +18,6 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 - The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) és el Butlletí oficial mensual de Node.js.
 - [Node.js Collection](https://medium.com/the-node-js-collection) és una col·lecció de contingut comissat per la comunitat a Medium.
-- [NodeUp](http://nodeup.com) és un podcast cobrint les últimes notícies en la comunitat de Node.
 - La [Community Committee](https://github.com/nodejs/community-committee) és una comissió de primer nivell a la Fundació Node.js centrada en els esforços que afronta la comunitat.
 
 ## Aprenentatge
@@ -28,7 +27,6 @@ contribuir de la manera que puguin. Si vols [reportar un error](https://github.c
 - L'[etiqueta de Node.js en Stack Overflow](http://stackoverflow.com/questions/tagged/node.js) col·lecciona nova informació cada dia.
 - L'[etiqueta de Node.js en la DEV Community](https://dev.to/t/node) és un lloc on compartir projectes de Node.js, articles i tutorials, així com iniciar debats i demanar realimentació sobre temes relacionats amb Node.js. Els desenvolupadors de tots els nivells d'experiència són benvinguts a participar.
 - [Nodeiflux](https://discordapp.com/invite/vUsrbjd) és una comunitat amigable de desenvolupadors de backend amb Node.js que es recolzen mútuament a Discord.
-- [How To Node](http://howtonode.org/) té un nombre creixent d'útils tutorials.
 
 
 ## Llocs de la comunitat internacional i projectes

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -15,7 +15,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 - [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
-- [NodeUp](http://nodeup.com) is a podcast covering the latest Node.js news in the community.
 - The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 
 

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -26,7 +26,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) collects new information every day.
 - [The DEV Community Node.js tag](https://dev.to/t/node) is a place to share Node.js projects, articles and tutorials as well as start discussions and ask for feedback on Node.js-related topics. Developers of all skill-levels are welcome to take part.
 - [Nodeiflux](https://discordapp.com/invite/vUsrbjd) is a friendly community of Node.js backend developers supporting each other on Discord.
-- [How To Node](http://howtonode.org/) has a growing number of useful tutorials.
 
 ## International community sites and projects
 

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -17,7 +17,6 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La cuenta de Twitter oficial de Node.js es [nodejs](https://twitter.com/nodejs).
 - El [calendario de la Fundación Node.js](https://nodejs.org/calendar) con todas las reuniones del equipo público.
 - [Node Weekly](http://nodeweekly.com) es una lista de correo que recopila los últimos eventos y noticias alrededor de la comunidad de Node.js.
-- [NodeUp](http://nodeup.com) es un podcast cubriendo las últimas noticias en la comunidad de Node.
 - La [Community Committee](https://github.com/nodejs/community-committee) es un comité de alto nivel de la Fundación Node.js centrado en los esfuerzos de la comunidad.
 
 
@@ -26,7 +25,6 @@ a contribuir de cualquier forma posible. Si usted quiere [reportar un error](htt
 - La [Documentación oficial de la API](/api) detalla la API de Node.
 - [NodeSchool.io](http://nodeschool.io) le enseñará conceptos de Node.js de forma interactiva mediante juegos utilizando la línea de comandos.
 - La [etiqueta de Node.js en Stack Overflow](http://stackoverflow.com/questions/tagged/node.js) colecciona nueva información cada día.
-- [How To Node](http://howtonode.org/) tiene un número creciente de útiles tutoriales.
 
 
 ## Sitios de la comunidad internacional y proyectos

--- a/locale/fa/get-involved/index.md
+++ b/locale/fa/get-involved/index.md
@@ -14,7 +14,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 - [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 - [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
-- [NodeUp](http://nodeup.com) is a podcast covering the latest Node news in the community.
 - The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 
 
@@ -25,7 +24,6 @@ The Node.js community is large, inclusive, and excited to enable as many users t
 - [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) collects new information every day.
 - [The DEV Community Node.js tag](https://dev.to/t/node) is a place to share Node.js projects, articles and tutorials as well as start discussions and ask for feedback on Node.js-related topics. Developers of all skill-levels are welcome to take part.
 - [Nodeiflux](https://discordapp.com/invite/vUsrbjd) is a friendly community of Node backend developers supporting each other on Discord.
-- [How To Node](http://howtonode.org/) has a growing number of useful tutorials.
 
 ## International community sites and projects
 

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -27,8 +27,6 @@ de notre communauté pour trouver comment vous pouvez aider:
 
 - [Node.js Collection](https://medium.com/the-node-js-collection) est une liste de contenus maintenue par la communauté sur Medium [en].
 
-- [NodeUp](http://nodeup.com) est un podcast sur les actualités de la communauté Node [en].
-
 - La [Community Committee](https://github.com/nodejs/community-committee) s'agit d'un comité de haut niveau de la Fondation Node.js axé sur les efforts communautaires.
 
 
@@ -39,8 +37,6 @@ de notre communauté pour trouver comment vous pouvez aider:
 - [NodeSchool.io](http://nodeschool.io) vous apprendra les concepts de Node.js avec des jeux intéractifs en ligne de commande [en].
 
 - [L'étiquette Stack Overflow Node.js](http://stackoverflow.com/questions/tagged/node.js) rassemble de nouvelles informations chaque jours [en].
-
-- [How To Node](http://howtonode.org/) a de nombreux tutoriaux utiles [en].
 
 
 ## Site et projets des commuanutés internationales 

--- a/locale/pt-br/get-involved/index.md
+++ b/locale/pt-br/get-involved/index.md
@@ -15,7 +15,6 @@ A comunidade Node.js é ampla, inclusiva e animada em possibilitar que todos os 
 - O [calendário da Fundação Node.js](https://nodejs.org/calendar) contém todas as reuniões dos times públicos
 - [Node.js Everywhere](https://newsletter.nodejs.org) é o boletim oficial do Node.js.
 - [Node.js Collection](https://medium.com/the-node-js-collection) é uma coleção de conteúdos, com curadoria da comunidade, disponível no Medium.
-- [NodeUp](http://nodeup.com) é um _podcast_ sobre as últimas notícias do Node.js na comunidade.
 - O [Community Committee](https://github.com/nodejs/community-committee) é um dos principais comitês na Fundação Node.js, focado nos esforços da comunidade.
 
 
@@ -26,7 +25,6 @@ A comunidade Node.js é ampla, inclusiva e animada em possibilitar que todos os 
 - [Tag Node.js no Stack Overflow](http://stackoverflow.com/questions/tagged/node.js) coleta novas informações todos os dias.
 - [Tag Node.js na DEV Community](https://dev.to/t/node) é o lugar para compartilhar projetos, artigos e tutoriais, bem como iniciar discussões e solicitar _feedback_ sobre tópicos relacionados ao Node.js. Desenvolvedores de todos os níveis são bem-vindos a participar.
 - [Nodeiflux](https://discordapp.com/invite/vUsrbjd) é uma comunidade de desenvolvedores _backend_ que utilizam Node.js, auxiliando uns aos outros através do Discord.
-- [How To Node](http://howtonode.org/) possui um número cada vez maior de tutoriais com grande utilidade.
 
 ## Sites e projetos internacionais da comunidade
 

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -15,7 +15,6 @@ layout: contribute.hbs
 - Офіційний аккаунт Node.js у Twitter [nodejs](https://twitter.com/nodejs).
 - The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node Weekly](http://nodeweekly.com) це поштове розсилання, що збирає найсвіжіші події та новини довкола спільноти Node.js.
-- [NodeUp](http://nodeup.com) подкаст в якому обговорюють найсвіжіші новини з Nod–спільноти.
 - [Community Committee](https://github.com/nodejs/community-committee) є комітетом вищого рівня в Node.js Фонд зосереджений на спільних зусиллях.
 
 
@@ -24,7 +23,6 @@ layout: contribute.hbs
 - [Офіційна довідкова документація по API](/api) описує Node API.
 - [NodeSchool.io](http://nodeschool.io) навчить вас концепцій Node.js через інтерактивні консольні ігри.
 - [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) щодня поповнюється новою інформацією.
-- [How To Node](http://howtonode.org/) має велику кількість корисних туторіалів.
 
 
 ## Сайти міжнародних спільнот та проекти

--- a/locale/zh-cn/get-involved/index.md
+++ b/locale/zh-cn/get-involved/index.md
@@ -15,7 +15,6 @@ Node.js 是个包容的大家庭，因此我们鼓励用户各施所长。 若�
 - The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 - [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月报。
 - [Node.js Collection](https://medium.com/the-node-js-collection) 是一堆在媒体上的社区策划内容集合。
-- [NodeUp](http://nodeup.com) 是一个播客，它覆盖了所有相关于 Node 社区最新消息。
 - [Community Committee](https://github.com/nodejs/community-committee) 是 Node.js 基金会中的高级委员会，专注于社区事务。
 
 
@@ -26,7 +25,6 @@ Node.js 是个包容的大家庭，因此我们鼓励用户各施所长。 若�
 - [Stack Overflow Node.js tag](http://stackoverflow.com/questions/tagged/node.js) 每日收集最新资讯。
 - [The DEV Community Node.js tag](https://dev.to/t/node) 是一个共享 Node.js 项目、文章和教程，以及开始讨论、并接受与 Node.js 相关的主题。欢迎所有技能级别的开发人员参与。
 - [Nodeiflux](https://discordapp.com/invite/vUsrbjd) 是一个 Nodejs 后端开发者在 Discord 上互相支援的友好社区。
-- [How To Node](http://howtonode.org/) 包含不断增长的有用教程。
 
 ## 国际化社区站点及项目
 

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -15,7 +15,6 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 - [Node.js Foundation 行事曆](https://nodejs.org/calendar) 中列出了所有的公開團隊會議。
 - [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月報。
 - [Node.js Collection](https://medium.com/the-node-js-collection) 是個由社群策劃的 Medium 文章合集。
-- [NodeUp](http://nodeup.com) 是關於 Node 社群最新消息的 podcast。
 - [Community Committee](https://github.com/nodejs/community-committee) 是 Node.js 基金會中的高級委員會，專責社群事務。
 
 
@@ -24,6 +23,8 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 - [官方 API 參考文件](/api)中詳細介紹了 Node API。
 - [NodeSchool.io](http://nodeschool.io) 以互動命令列的方式，教會你 Node.js 的概念。
 - [Stack Overflow 上的 Node.js 標籤](http://stackoverflow.com/questions/tagged/node.js)搜羅了每日新資訊。
+- [開發社區上的 Node.js 標籤](https://dev.to/t/node) 是一個共亯Node.js項目、文章和教程，以及開始討論、並接受與Node.js相關的主題。歡迎所有技能級別的開發人員參與。
+- [Nodeiflux](https://discordapp.com/invite/vUsrbjd) 是一個Nodejs後端開發者在Discord上互相支援的友好社區。
 
 
 ## 國際性社群網站及專案

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -23,8 +23,8 @@ Node.js 是個包容的大家庭，我們鼓勵用戶一展長才。若你想[�
 - [官方 API 參考文件](/api)中詳細介紹了 Node API。
 - [NodeSchool.io](http://nodeschool.io) 以互動命令列的方式，教會你 Node.js 的概念。
 - [Stack Overflow 上的 Node.js 標籤](http://stackoverflow.com/questions/tagged/node.js)搜羅了每日新資訊。
-- [開發社區上的 Node.js 標籤](https://dev.to/t/node) 是一個共亯Node.js項目、文章和教程，以及開始討論、並接受與Node.js相關的主題。歡迎所有技能級別的開發人員參與。
-- [Nodeiflux](https://discordapp.com/invite/vUsrbjd) 是一個Nodejs後端開發者在Discord上互相支援的友好社區。
+- [開發社區上的 Node.js 標籤](https://dev.to/t/node) 是一個共亯 Node.js項目、文章和教程，以及開始討論、並接受與 Node.js 相關的主題。歡迎所有技能級別的開發人員參與。
+- [Nodeiflux](https://discordapp.com/invite/vUsrbjd) 是一個 Nodejs 後端開發者在 Discord 上互相支援的友好社區。
 
 
 ## 國際性社群網站及專案


### PR DESCRIPTION
How To Node has not been updated in over two years. A lot has happened
in Node.js in that time. Remove it from the list.

NodeUp is awesome, but there was one episode in all of 2018. It's also
questionable that it occurs in a list with 7 other resources that are
all officially blessed. It gives the impression that NodeUp is official.
It is not. Remove NodeUp from the list.