### PR TITLE
[pt-BR] Translate about/governance.md

### DIFF
--- a/locale/pt-br/about/governance.md
+++ b/locale/pt-br/about/governance.md
@@ -1,13 +1,22 @@
 ---
-title: Project Governance
+title: Governança do Projeto
 layout: about.hbs
 ---
+<!--
 # Project Governance
+-->
+# Governança do Projeto
 
+<!--
 ## Consensus Seeking Process
 
 The Node.js project follows a [Consensus Seeking][] decision making model.
+-->
+## Processo de Busca por Consenso
 
+O projeto Node.js segue o modelo de [Busca por Consenso][] para tomada de decisão.
+
+<!--
 ## Collaborators
 
 The [nodejs/node][] core GitHub repository is maintained by the Collaborators
@@ -20,17 +29,38 @@ TSC and their nomination is discussed with the existing Collaborators.
 For the current list of Collaborators, see the project's [README.md][].
 
 A guide for Collaborators is maintained at [COLLABORATOR_GUIDE.md][].
+-->
+## Colaboradores
 
+O repositório principal [nodejs/node][] no Github é mantido por Colaboradores
+que são nomeados continuamente pelo _Technical Steering Committee_ ([TSC][]).
+
+Pessoas que fazem contribuições significantes e valiosas são nomeadas Colaboradores
+e tem permissão para realizar _commits_ no projeto. Essas pessoas são identificadas
+pelo TSC e sua nomeação é debatida com os demais Colaboradores.
+
+Para ver a lista atual de Colaboradores, acesse o [README.md][] do projeto.
+
+Um guia para Colaboradores é mantido em [COLLABORATOR_GUIDE.md][].
+
+<!--
 ## Top Level Committees
 
 The project is governed jointly by the [Technical Steering Committee (TSC)][]
 which is responsible for high-level guidance of the project, and the
 [Community Committee (CommComm)][] which is responsible for guiding and
 extending the Node.js community.
+-->
+## Comitês Superiores
+
+O projeto é governado de forma conjunta pelo _[Technical Steering Committee (TSC)][]_
+responsável pelas diretrizes do projeto, e pelo _[Community Committee (CommComm)][]_
+responsável por orientar e ampliar a comunidade Node.js.
+
 
 [COLLABORATOR_GUIDE.md]: https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md
 [Community Committee (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
-[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[Busca por Consenso]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members
 [Technical Steering Committee (TSC)]: https://github.com/nodejs/TSC/blob/master/TSC-Charter.md
 [TSC]: https://github.com/nodejs/TSC

--- a/locale/pt-br/about/governance.md
+++ b/locale/pt-br/about/governance.md
@@ -1,0 +1,37 @@
+---
+title: Project Governance
+layout: about.hbs
+---
+# Project Governance
+
+## Consensus Seeking Process
+
+The Node.js project follows a [Consensus Seeking][] decision making model.
+
+## Collaborators
+
+The [nodejs/node][] core GitHub repository is maintained by the Collaborators
+who are added by the Technical Steering Committee ([TSC][]) on an ongoing basis.
+
+Individuals making significant and valuable contributions are made Collaborators
+and given commit-access to the project. These individuals are identified by the
+TSC and their nomination is discussed with the existing Collaborators.
+
+For the current list of Collaborators, see the project's [README.md][].
+
+A guide for Collaborators is maintained at [COLLABORATOR_GUIDE.md][].
+
+## Top Level Committees
+
+The project is governed jointly by the [Technical Steering Committee (TSC)][]
+which is responsible for high-level guidance of the project, and the
+[Community Committee (CommComm)][] which is responsible for guiding and
+extending the Node.js community.
+
+[COLLABORATOR_GUIDE.md]: https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md
+[Community Committee (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
+[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members
+[Technical Steering Committee (TSC)]: https://github.com/nodejs/TSC/blob/master/TSC-Charter.md
+[TSC]: https://github.com/nodejs/TSC
+[nodejs/node]: https://github.com/nodejs/node

--- a/locale/pt-br/site.json
+++ b/locale/pt-br/site.json
@@ -35,7 +35,7 @@
     "text": "Sobre",
     "governance": {
       "link": "about/governance",
-      "text": "Projeto Governance"
+      "text": "Governança do Projeto"
     },
     "community": {
       "link": "about/community",


### PR DESCRIPTION
Translated `about/governance.md` from `en` to `pt-BR`

Refs: https://github.com/nodejs/nodejs-pt/issues/71

/cc @nodejs/nodejs-pt 