### PR TITLE
Release blog posts: Rename 'SunOS' download option to 'SmartOS'

### DIFF
--- a/locale/en/blog/release/v0.10.41.md
+++ b/locale/en/blog/release/v0.10.41.md
@@ -71,8 +71,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.41/<br>
 Documentation: https://nodejs.org/docs/v0.10.41/api/

--- a/locale/en/blog/release/v0.10.42.md
+++ b/locale/en/blog/release/v0.10.42.md
@@ -44,8 +44,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.42/<br>
 Documentation: https://nodejs.org/docs/v0.10.42/api/

--- a/locale/en/blog/release/v0.10.43.md
+++ b/locale/en/blog/release/v0.10.43.md
@@ -42,8 +42,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.43/<br>
 Documentation: https://nodejs.org/docs/v0.10.43/api/

--- a/locale/en/blog/release/v0.10.44.md
+++ b/locale/en/blog/release/v0.10.44.md
@@ -33,8 +33,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.44/<br>
 Documentation: https://nodejs.org/docs/v0.10.44/api/

--- a/locale/en/blog/release/v0.10.45.md
+++ b/locale/en/blog/release/v0.10.45.md
@@ -35,8 +35,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.45/<br>
 Documentation: https://nodejs.org/docs/v0.10.45/api/

--- a/locale/en/blog/release/v0.10.46.md
+++ b/locale/en/blog/release/v0.10.46.md
@@ -30,8 +30,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.46/node-v0.10.46.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.46/<br>
 Documentation: https://nodejs.org/docs/v0.10.46/api/

--- a/locale/en/blog/release/v0.10.47.md
+++ b/locale/en/blog/release/v0.10.47.md
@@ -45,8 +45,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.47/node-v0.10.47.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.47/<br>
 Documentation: https://nodejs.org/docs/v0.10.47/api/

--- a/locale/en/blog/release/v0.10.48.md
+++ b/locale/en/blog/release/v0.10.48.md
@@ -29,8 +29,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x64.t
 macOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.10.48/node-v0.10.48.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.10.48/<br>
 Documentation: https://nodejs.org/docs/v0.10.48/api/

--- a/locale/en/blog/release/v0.12.10.md
+++ b/locale/en/blog/release/v0.12.10.md
@@ -44,8 +44,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.10/<br>
 Documentation: https://nodejs.org/docs/v0.12.10/api/

--- a/locale/en/blog/release/v0.12.11.md
+++ b/locale/en/blog/release/v0.12.11.md
@@ -48,8 +48,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.11/<br>
 Documentation: https://nodejs.org/docs/v0.12.11/api/

--- a/locale/en/blog/release/v0.12.12.md
+++ b/locale/en/blog/release/v0.12.12.md
@@ -27,8 +27,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.12/<br>
 Documentation: https://nodejs.org/docs/v0.12.12/api/

--- a/locale/en/blog/release/v0.12.13.md
+++ b/locale/en/blog/release/v0.12.13.md
@@ -39,8 +39,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.13/<br>
 Documentation: https://nodejs.org/docs/v0.12.13/api/

--- a/locale/en/blog/release/v0.12.14.md
+++ b/locale/en/blog/release/v0.12.14.md
@@ -37,8 +37,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.14/<br>
 Documentation: https://nodejs.org/docs/v0.12.14/api/

--- a/locale/en/blog/release/v0.12.15.md
+++ b/locale/en/blog/release/v0.12.15.md
@@ -36,8 +36,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.15/node-v0.12.15.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.15/<br>
 Documentation: https://nodejs.org/docs/v0.12.15/api/

--- a/locale/en/blog/release/v0.12.16.md
+++ b/locale/en/blog/release/v0.12.16.md
@@ -45,8 +45,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x6
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.16/node-v0.12.16.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.16/<br>
 Documentation: https://nodejs.org/docs/v0.12.16/api/

--- a/locale/en/blog/release/v0.12.17.md
+++ b/locale/en/blog/release/v0.12.17.md
@@ -27,8 +27,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x64.t
 macOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.17/node-v0.12.17.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.17/<br>
 Documentation: https://nodejs.org/docs/v0.12.17/api/

--- a/locale/en/blog/release/v0.12.18.md
+++ b/locale/en/blog/release/v0.12.18.md
@@ -34,8 +34,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x64.t
 macOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 Source Code: https://nodejs.org/dist/v0.12.18/node-v0.12.18.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.18/<br>
 Documentation: https://nodejs.org/docs/v0.12.18/api/

--- a/locale/en/blog/release/v0.12.8.md
+++ b/locale/en/blog/release/v0.12.8.md
@@ -101,8 +101,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.8/<br>
 Documentation: https://nodejs.org/docs/v0.12.8/api/

--- a/locale/en/blog/release/v0.12.9.md
+++ b/locale/en/blog/release/v0.12.9.md
@@ -30,8 +30,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x64.
 Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x86.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz<br>
 Source Code: https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz<br>
 Other release files: https://nodejs.org/dist/v0.12.9/<br>
 Documentation: https://nodejs.org/docs/v0.12.9/api/

--- a/locale/en/blog/release/v0.4.7.md
+++ b/locale/en/blog/release/v0.4.7.md
@@ -14,7 +14,7 @@ layout: blog-post.hbs
 <li>Fix: Multiple pipes to the same stream were broken #929 (Felix Geisendörfer)</li>
 <li>URL parsing/formatting corrections #954 (isaacs)</li>
 <li>make it possible to do repl.start('', stream) (Wade Simmons)</li>
-<li>Add os.loadavg for SunOS (Robert Mustacchi)</li>
+<li>Add os.loadavg for SmartOS (Robert Mustacchi)</li>
 <li>Fix timeouts with floating point numbers #897  (Jorge Chamorro Bieling)</li>
 <li>Improve docs.</li></ul>
 

--- a/locale/en/blog/release/v0.4.8.md
+++ b/locale/en/blog/release/v0.4.8.md
@@ -26,7 +26,7 @@ layout: blog-post.hbs
 
 * Disable compression with OpenSSL. Improves memory perf.
 
-* Implement os.totalmem() and os.freemem() for SunOS (Alexandre Marangone)
+* Implement os.totalmem() and os.freemem() for SmartOS (Alexandre Marangone)
 
 * Fix a special characters in URL regression (isaacs)
 

--- a/locale/en/blog/release/v0.5.5.md
+++ b/locale/en/blog/release/v0.5.5.md
@@ -12,7 +12,7 @@ layout: blog-post.hbs
 <p>2011.08.26, Version 0.5.5 (unstable)</p>
 <ul>
 <li>typed arrays, implementation from Plesk</li>
-<li>fix IP multicast on SunOS</li>
+<li>fix IP multicast on SmartOS</li>
 <li>fix DNS lookup order: IPv4 first, IPv6 second (--use-uv only)</li>
 <li>remove support for UNIX datagram sockets (--use-uv only)</li>
 <li>UDP support for Windows (Bert Belder)</li>

--- a/locale/en/blog/release/v0.7.1.md
+++ b/locale/en/blog/release/v0.7.1.md
@@ -15,7 +15,7 @@ layout: blog-post.hbs
 <li>Update V8 to 3.8.8</li>
 <li>Install node-waf by default (Fedor Indutny)</li>
 <li>crypto: Add ability to turn off PKCS padding (Ingmar Runge)</li>
-<li>v8: implement VirtualMemory class on SunOS (Ben Noordhuis)</li>
+<li>v8: implement VirtualMemory class on SmartOS (Ben Noordhuis)</li>
 <li>Add cluster.setupMaster (Andreas Madsen)</li>
 <li>move <code>path.exists*</code> to <code>fs.exists*</code> (Maciej Małecki)</li>
 <li>typed arrays: set class name (Ben Noordhuis)</li>

--- a/locale/en/blog/release/v0.8.6.md
+++ b/locale/en/blog/release/v0.8.6.md
@@ -10,7 +10,7 @@ layout: blog-post.hbs
 2012.08.07, Version 0.8.6 (Stable)
 
 This is the first release to include binary distributions for all
-supported Unix operating systems (Linux, Darwin, and SunOS).  To use
+supported Unix operating systems (Linux, Darwin, and SmartOS).  To use
 the binary distribution tarballs, you can unpack them directly into a
 destination directory:
 

--- a/locale/en/blog/release/v0.8.8.md
+++ b/locale/en/blog/release/v0.8.8.md
@@ -46,9 +46,9 @@ Linux 32-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-linux-x86.tar.gz
 
 Linux 64-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-linux-x64.tar.gz
 
-SunOS 32-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x86.tar.gz
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x86.tar.gz
 
-SunOS 64-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x64.tar.gz
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x64.tar.gz
 
 Other release files: https://nodejs.org/dist/v0.8.8/
 

--- a/locale/en/blog/release/v0.8.9.md
+++ b/locale/en/blog/release/v0.8.9.md
@@ -35,7 +35,7 @@ layout: blog-post.hbs
 
 * build: add a "--dest-os" option to force a gyp "flavor" (Nathan Rajlich)
 
-* build: set `process.platform` to "sunos" on SunOS (Nathan Rajlich)
+* build: set `process.platform` to "sunos" on SmartOS (Nathan Rajlich)
 
 * build: fix `make -j` fails after `make clean` (Bearice Ren)
 

--- a/locale/en/blog/release/v10.0.0.md
+++ b/locale/en/blog/release/v10.0.0.md
@@ -934,8 +934,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: *Coming soon*<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: *Coming soon*<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.1.0.md
+++ b/locale/en/blog/release/v10.1.0.md
@@ -206,7 +206,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.10.0.md
+++ b/locale/en/blog/release/v10.10.0.md
@@ -269,7 +269,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.11.0.md
+++ b/locale/en/blog/release/v10.11.0.md
@@ -141,7 +141,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.12.0.md
+++ b/locale/en/blog/release/v10.12.0.md
@@ -332,7 +332,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.13.0.md
+++ b/locale/en/blog/release/v10.13.0.md
@@ -34,7 +34,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.14.0.md
+++ b/locale/en/blog/release/v10.14.0.md
@@ -46,7 +46,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.14.1.md
+++ b/locale/en/blog/release/v10.14.1.md
@@ -28,7 +28,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.14.2.md
+++ b/locale/en/blog/release/v10.14.2.md
@@ -405,7 +405,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.15.0.md
+++ b/locale/en/blog/release/v10.15.0.md
@@ -41,7 +41,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.ta
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.2.0.md
+++ b/locale/en/blog/release/v10.2.0.md
@@ -250,8 +250,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: *Coming soon*<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: *Coming soon*<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.2.1.md
+++ b/locale/en/blog/release/v10.2.1.md
@@ -28,7 +28,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.3.0.md
+++ b/locale/en/blog/release/v10.3.0.md
@@ -74,7 +74,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.4.0.md
+++ b/locale/en/blog/release/v10.4.0.md
@@ -120,7 +120,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.4.1.md
+++ b/locale/en/blog/release/v10.4.1.md
@@ -46,8 +46,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: *Coming soon*<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: *Coming soon*<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.5.0.md
+++ b/locale/en/blog/release/v10.5.0.md
@@ -184,7 +184,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.6.0.md
+++ b/locale/en/blog/release/v10.6.0.md
@@ -154,7 +154,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.7.0.md
+++ b/locale/en/blog/release/v10.7.0.md
@@ -159,7 +159,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.8.0.md
+++ b/locale/en/blog/release/v10.8.0.md
@@ -131,7 +131,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v10.9.0.md
+++ b/locale/en/blog/release/v10.9.0.md
@@ -197,7 +197,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.0.0.md
+++ b/locale/en/blog/release/v11.0.0.md
@@ -527,7 +527,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.1.0.md
+++ b/locale/en/blog/release/v11.1.0.md
@@ -113,7 +113,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.2.0.md
+++ b/locale/en/blog/release/v11.2.0.md
@@ -288,7 +288,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.3.0.md
+++ b/locale/en/blog/release/v11.3.0.md
@@ -49,7 +49,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.4.0.md
+++ b/locale/en/blog/release/v11.4.0.md
@@ -360,7 +360,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.5.0.md
+++ b/locale/en/blog/release/v11.5.0.md
@@ -115,7 +115,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.6.0.md
+++ b/locale/en/blog/release/v11.6.0.md
@@ -93,7 +93,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v11.7.0.md
+++ b/locale/en/blog/release/v11.7.0.md
@@ -284,7 +284,7 @@ Linux 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-aix-ppc64.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-sunos-x64.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.0.0.md
+++ b/locale/en/blog/release/v4.0.0.md
@@ -122,8 +122,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.1.0.md
+++ b/locale/en/blog/release/v4.1.0.md
@@ -101,8 +101,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv7.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.1.1.md
+++ b/locale/en/blog/release/v4.1.1.md
@@ -70,8 +70,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.1.2.md
+++ b/locale/en/blog/release/v4.1.2.md
@@ -88,8 +88,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.0.md
+++ b/locale/en/blog/release/v4.2.0.md
@@ -116,8 +116,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.1.md
+++ b/locale/en/blog/release/v4.2.1.md
@@ -37,8 +37,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.2.md
+++ b/locale/en/blog/release/v4.2.2.md
@@ -110,8 +110,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/download/release/latest-v4.x/node-v4.2.2-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.3.md
+++ b/locale/en/blog/release/v4.2.3.md
@@ -43,8 +43,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.4.md
+++ b/locale/en/blog/release/v4.2.4.md
@@ -193,8 +193,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.5.md
+++ b/locale/en/blog/release/v4.2.5.md
@@ -240,8 +240,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.2.6.md
+++ b/locale/en/blog/release/v4.2.6.md
@@ -35,8 +35,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.3.0.md
+++ b/locale/en/blog/release/v4.3.0.md
@@ -38,8 +38,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.3.1.md
+++ b/locale/en/blog/release/v4.3.1.md
@@ -101,8 +101,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v4.3.2.md
+++ b/locale/en/blog/release/v4.3.2.md
@@ -31,8 +31,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.0.md
+++ b/locale/en/blog/release/v4.4.0.md
@@ -272,8 +272,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.1.md
+++ b/locale/en/blog/release/v4.4.1.md
@@ -148,8 +148,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.2.md
+++ b/locale/en/blog/release/v4.4.2.md
@@ -77,8 +77,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.3.md
+++ b/locale/en/blog/release/v4.4.3.md
@@ -83,8 +83,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.4.md
+++ b/locale/en/blog/release/v4.4.4.md
@@ -37,8 +37,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.5.md
+++ b/locale/en/blog/release/v4.4.5.md
@@ -108,8 +108,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.6.md
+++ b/locale/en/blog/release/v4.4.6.md
@@ -28,8 +28,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.4.7.md
+++ b/locale/en/blog/release/v4.4.7.md
@@ -124,8 +124,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.5.0.md
+++ b/locale/en/blog/release/v4.5.0.md
@@ -310,8 +310,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.6.0.md
+++ b/locale/en/blog/release/v4.6.0.md
@@ -55,8 +55,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.6.1.md
+++ b/locale/en/blog/release/v4.6.1.md
@@ -28,8 +28,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.6.2.md
+++ b/locale/en/blog/release/v4.6.2.md
@@ -249,8 +249,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x86.tar.xz<br><br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x86.tar.xz<br><br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.7.0.md
+++ b/locale/en/blog/release/v4.7.0.md
@@ -147,8 +147,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.7.1.md
+++ b/locale/en/blog/release/v4.7.1.md
@@ -212,8 +212,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.7.2.md
+++ b/locale/en/blog/release/v4.7.2.md
@@ -25,8 +25,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.7.3.md
+++ b/locale/en/blog/release/v4.7.3.md
@@ -34,8 +34,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: *Coming soon*<br>
 AIX 64-bit Binary: *Coming soon*<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.0.md
+++ b/locale/en/blog/release/v4.8.0.md
@@ -157,8 +157,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.1.md
+++ b/locale/en/blog/release/v4.8.1.md
@@ -177,8 +177,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.2.md
+++ b/locale/en/blog/release/v4.8.2.md
@@ -31,8 +31,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.3.md
+++ b/locale/en/blog/release/v4.8.3.md
@@ -47,8 +47,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.4.md
+++ b/locale/en/blog/release/v4.8.4.md
@@ -32,8 +32,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.5.md
+++ b/locale/en/blog/release/v4.8.5.md
@@ -27,8 +27,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.6.md
+++ b/locale/en/blog/release/v4.8.6.md
@@ -78,8 +78,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.8.7.md
+++ b/locale/en/blog/release/v4.8.7.md
@@ -33,8 +33,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.9.0.md
+++ b/locale/en/blog/release/v4.9.0.md
@@ -43,8 +43,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: *Coming soon*<br>
 AIX 64-bit Binary: *Coming soon*<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v4.9.1.md
+++ b/locale/en/blog/release/v4.9.1.md
@@ -27,8 +27,8 @@ Linux 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x86.tar.xz
 Linux 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64le.tar.xz<br>
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.0.0.md
+++ b/locale/en/blog/release/v5.0.0.md
@@ -187,8 +187,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.1.0.md
+++ b/locale/en/blog/release/v5.1.0.md
@@ -179,8 +179,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.1.1.md
+++ b/locale/en/blog/release/v5.1.1.md
@@ -43,8 +43,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.10.0.md
+++ b/locale/en/blog/release/v5.10.0.md
@@ -100,8 +100,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-darwin-x64.
 Linux 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.10.1.md
+++ b/locale/en/blog/release/v5.10.1.md
@@ -60,8 +60,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-darwin-x64.
 Linux 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.11.0.md
+++ b/locale/en/blog/release/v5.11.0.md
@@ -141,8 +141,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-darwin-x64.
 Linux 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.11.1.md
+++ b/locale/en/blog/release/v5.11.1.md
@@ -39,8 +39,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-darwin-x64.
 Linux 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.12.0.md
+++ b/locale/en/blog/release/v5.12.0.md
@@ -36,8 +36,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-darwin-x64.
 Linux 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.2.0.md
+++ b/locale/en/blog/release/v5.2.0.md
@@ -144,8 +144,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.3.0.md
+++ b/locale/en/blog/release/v5.3.0.md
@@ -93,8 +93,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.4.0.md
+++ b/locale/en/blog/release/v5.4.0.md
@@ -139,8 +139,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.4.1.md
+++ b/locale/en/blog/release/v5.4.1.md
@@ -62,8 +62,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.5.0.md
+++ b/locale/en/blog/release/v5.5.0.md
@@ -100,8 +100,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv6l.tar.gz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.6.0.md
+++ b/locale/en/blog/release/v5.6.0.md
@@ -173,8 +173,8 @@ Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0.pkg<br>
 Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-darwin-x64.tar.gz<br>
 Linux 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x86.tar.gz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x86.tar.gz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x64.tar.gz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x86.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x64.tar.gz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv7l.tar.gz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-arm64.tar.gz<br>

--- a/locale/en/blog/release/v5.7.0.md
+++ b/locale/en/blog/release/v5.7.0.md
@@ -152,8 +152,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.7.1.md
+++ b/locale/en/blog/release/v5.7.1.md
@@ -111,8 +111,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.8.0.md
+++ b/locale/en/blog/release/v5.8.0.md
@@ -64,8 +64,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.9.0.md
+++ b/locale/en/blog/release/v5.9.0.md
@@ -94,8 +94,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v5.9.1.md
+++ b/locale/en/blog/release/v5.9.1.md
@@ -73,8 +73,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.0.0.md
+++ b/locale/en/blog/release/v6.0.0.md
@@ -318,8 +318,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.1.0.md
+++ b/locale/en/blog/release/v6.1.0.md
@@ -100,8 +100,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.10.0.md
+++ b/locale/en/blog/release/v6.10.0.md
@@ -206,8 +206,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.10.1.md
+++ b/locale/en/blog/release/v6.10.1.md
@@ -341,8 +341,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.10.2.md
+++ b/locale/en/blog/release/v6.10.2.md
@@ -40,8 +40,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.10.3.md
+++ b/locale/en/blog/release/v6.10.3.md
@@ -185,8 +185,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.0.md
+++ b/locale/en/blog/release/v6.11.0.md
@@ -178,8 +178,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.1.md
+++ b/locale/en/blog/release/v6.11.1.md
@@ -34,8 +34,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.2.md
+++ b/locale/en/blog/release/v6.11.2.md
@@ -260,8 +260,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.3.md
+++ b/locale/en/blog/release/v6.11.3.md
@@ -189,8 +189,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.4.md
+++ b/locale/en/blog/release/v6.11.4.md
@@ -119,8 +119,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.11.5.md
+++ b/locale/en/blog/release/v6.11.5.md
@@ -29,8 +29,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.12.0.md
+++ b/locale/en/blog/release/v6.12.0.md
@@ -176,8 +176,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.12.1.md
+++ b/locale/en/blog/release/v6.12.1.md
@@ -295,8 +295,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.12.2.md
+++ b/locale/en/blog/release/v6.12.2.md
@@ -35,8 +35,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.12.3.md
+++ b/locale/en/blog/release/v6.12.3.md
@@ -143,8 +143,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.13.0.md
+++ b/locale/en/blog/release/v6.13.0.md
@@ -172,8 +172,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.13.1.md
+++ b/locale/en/blog/release/v6.13.1.md
@@ -51,8 +51,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.14.0.md
+++ b/locale/en/blog/release/v6.14.0.md
@@ -44,8 +44,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.14.1.md
+++ b/locale/en/blog/release/v6.14.1.md
@@ -29,8 +29,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.14.2.md
+++ b/locale/en/blog/release/v6.14.2.md
@@ -255,8 +255,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.14.3.md
+++ b/locale/en/blog/release/v6.14.3.md
@@ -28,8 +28,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.14.4.md
+++ b/locale/en/blog/release/v6.14.4.md
@@ -43,8 +43,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.15.0.md
+++ b/locale/en/blog/release/v6.15.0.md
@@ -58,8 +58,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.15.1.md
+++ b/locale/en/blog/release/v6.15.1.md
@@ -30,8 +30,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.16.0.md
+++ b/locale/en/blog/release/v6.16.0.md
@@ -38,8 +38,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.2.0.md
+++ b/locale/en/blog/release/v6.2.0.md
@@ -161,8 +161,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.2.1.md
+++ b/locale/en/blog/release/v6.2.1.md
@@ -166,8 +166,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.2.2.md
+++ b/locale/en/blog/release/v6.2.2.md
@@ -91,8 +91,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.3.0.md
+++ b/locale/en/blog/release/v6.3.0.md
@@ -196,8 +196,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.3.1.md
+++ b/locale/en/blog/release/v6.3.1.md
@@ -116,8 +116,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.4.0.md
+++ b/locale/en/blog/release/v6.4.0.md
@@ -187,8 +187,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.5.0.md
+++ b/locale/en/blog/release/v6.5.0.md
@@ -118,8 +118,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.6.0.md
+++ b/locale/en/blog/release/v6.6.0.md
@@ -143,8 +143,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.7.0.md
+++ b/locale/en/blog/release/v6.7.0.md
@@ -59,8 +59,8 @@ Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-darwin-x64.ta
 Linux 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.8.0.md
+++ b/locale/en/blog/release/v6.8.0.md
@@ -246,8 +246,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.8.1.md
+++ b/locale/en/blog/release/v6.8.1.md
@@ -29,8 +29,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.0.md
+++ b/locale/en/blog/release/v6.9.0.md
@@ -73,8 +73,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.1.md
+++ b/locale/en/blog/release/v6.9.1.md
@@ -30,8 +30,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.2.md
+++ b/locale/en/blog/release/v6.9.2.md
@@ -179,8 +179,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.3.md
+++ b/locale/en/blog/release/v6.9.3.md
@@ -354,8 +354,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x32.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x32.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.4.md
+++ b/locale/en/blog/release/v6.9.4.md
@@ -33,8 +33,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v6.9.5.md
+++ b/locale/en/blog/release/v6.9.5.md
@@ -34,8 +34,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.0.0.md
+++ b/locale/en/blog/release/v7.0.0.md
@@ -243,8 +243,8 @@ macOS 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-darwin-x64.tar.g
 Linux 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x86.tar.xz<br>
 Linux 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x64.tar.xz<br>
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-ppc64le.tar.xz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.1.0.md
+++ b/locale/en/blog/release/v7.1.0.md
@@ -154,8 +154,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.10.0.md
+++ b/locale/en/blog/release/v7.10.0.md
@@ -217,8 +217,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.10.1.md
+++ b/locale/en/blog/release/v7.10.1.md
@@ -43,8 +43,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-p
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.2.0.md
+++ b/locale/en/blog/release/v7.2.0.md
@@ -139,8 +139,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.2.1.md
+++ b/locale/en/blog/release/v7.2.1.md
@@ -226,8 +226,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.3.0.md
+++ b/locale/en/blog/release/v7.3.0.md
@@ -167,8 +167,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.4.0.md
+++ b/locale/en/blog/release/v7.4.0.md
@@ -175,8 +175,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: *Coming soon*<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.5.0.md
+++ b/locale/en/blog/release/v7.5.0.md
@@ -324,8 +324,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.6.0.md
+++ b/locale/en/blog/release/v7.6.0.md
@@ -155,8 +155,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.7.0.md
+++ b/locale/en/blog/release/v7.7.0.md
@@ -200,8 +200,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.7.1.md
+++ b/locale/en/blog/release/v7.7.1.md
@@ -35,8 +35,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.7.2.md
+++ b/locale/en/blog/release/v7.7.2.md
@@ -76,8 +76,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.7.3.md
+++ b/locale/en/blog/release/v7.7.3.md
@@ -56,8 +56,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.7.4.md
+++ b/locale/en/blog/release/v7.7.4.md
@@ -77,8 +77,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.8.0.md
+++ b/locale/en/blog/release/v7.8.0.md
@@ -101,8 +101,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v7.9.0.md
+++ b/locale/en/blog/release/v7.9.0.md
@@ -80,8 +80,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.0.0.md
+++ b/locale/en/blog/release/v8.0.0.md
@@ -1221,8 +1221,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.1.0.md
+++ b/locale/en/blog/release/v8.1.0.md
@@ -168,8 +168,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.1.1.md
+++ b/locale/en/blog/release/v8.1.1.md
@@ -98,8 +98,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: *Coming soon*<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.1.2.md
+++ b/locale/en/blog/release/v8.1.2.md
@@ -24,8 +24,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.1.3.md
+++ b/locale/en/blog/release/v8.1.3.md
@@ -96,8 +96,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.1.4.md
+++ b/locale/en/blog/release/v8.1.4.md
@@ -33,8 +33,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.10.0.md
+++ b/locale/en/blog/release/v8.10.0.md
@@ -341,8 +341,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.11.0.md
+++ b/locale/en/blog/release/v8.11.0.md
@@ -43,8 +43,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.11.1.md
+++ b/locale/en/blog/release/v8.11.1.md
@@ -33,8 +33,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.11.2.md
+++ b/locale/en/blog/release/v8.11.2.md
@@ -249,8 +249,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.11.3.md
+++ b/locale/en/blog/release/v8.11.3.md
@@ -36,8 +36,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.11.4.md
+++ b/locale/en/blog/release/v8.11.4.md
@@ -41,8 +41,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.12.0.md
+++ b/locale/en/blog/release/v8.12.0.md
@@ -337,8 +337,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.13.0.md
+++ b/locale/en/blog/release/v8.13.0.md
@@ -162,8 +162,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.14.0.md
+++ b/locale/en/blog/release/v8.14.0.md
@@ -53,8 +53,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.14.1.md
+++ b/locale/en/blog/release/v8.14.1.md
@@ -116,8 +116,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.15.0.md
+++ b/locale/en/blog/release/v8.15.0.md
@@ -39,8 +39,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.2.0.md
+++ b/locale/en/blog/release/v8.2.0.md
@@ -309,8 +309,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.2.1.md
+++ b/locale/en/blog/release/v8.2.1.md
@@ -32,8 +32,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.3.0.md
+++ b/locale/en/blog/release/v8.3.0.md
@@ -216,8 +216,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.4.0.md
+++ b/locale/en/blog/release/v8.4.0.md
@@ -146,8 +146,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.5.0.md
+++ b/locale/en/blog/release/v8.5.0.md
@@ -299,8 +299,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.6.0.md
+++ b/locale/en/blog/release/v8.6.0.md
@@ -180,8 +180,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.7.0.md
+++ b/locale/en/blog/release/v8.7.0.md
@@ -256,8 +256,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.8.0.md
+++ b/locale/en/blog/release/v8.8.0.md
@@ -326,8 +326,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.8.1.md
+++ b/locale/en/blog/release/v8.8.1.md
@@ -41,8 +41,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.9.0.md
+++ b/locale/en/blog/release/v8.9.0.md
@@ -150,8 +150,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.9.1.md
+++ b/locale/en/blog/release/v8.9.1.md
@@ -43,8 +43,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.9.2.md
+++ b/locale/en/blog/release/v8.9.2.md
@@ -138,8 +138,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-ppc
 Linux PPC BE 64-bit Binary: *Coming soon*<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.9.3.md
+++ b/locale/en/blog/release/v8.9.3.md
@@ -49,8 +49,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-ppc
 Linux PPC BE 64-bit Binary: *Coming soon*<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v8.9.4.md
+++ b/locale/en/blog/release/v8.9.4.md
@@ -315,8 +315,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.0.0.md
+++ b/locale/en/blog/release/v9.0.0.md
@@ -324,8 +324,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.1.0.md
+++ b/locale/en/blog/release/v9.1.0.md
@@ -130,8 +130,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.10.0.md
+++ b/locale/en/blog/release/v9.10.0.md
@@ -128,8 +128,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.10.1.md
+++ b/locale/en/blog/release/v9.10.1.md
@@ -33,8 +33,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.11.0.md
+++ b/locale/en/blog/release/v9.11.0.md
@@ -116,8 +116,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.11.1.md
+++ b/locale/en/blog/release/v9.11.1.md
@@ -26,8 +26,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.11.2.md
+++ b/locale/en/blog/release/v9.11.2.md
@@ -39,8 +39,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.2.0.md
+++ b/locale/en/blog/release/v9.2.0.md
@@ -165,8 +165,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.2.1.md
+++ b/locale/en/blog/release/v9.2.1.md
@@ -42,8 +42,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.3.0.md
+++ b/locale/en/blog/release/v9.3.0.md
@@ -426,8 +426,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.4.0.md
+++ b/locale/en/blog/release/v9.4.0.md
@@ -291,8 +291,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.5.0.md
+++ b/locale/en/blog/release/v9.5.0.md
@@ -199,8 +199,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.6.0.md
+++ b/locale/en/blog/release/v9.6.0.md
@@ -256,8 +256,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.6.1.md
+++ b/locale/en/blog/release/v9.6.1.md
@@ -30,8 +30,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.7.0.md
+++ b/locale/en/blog/release/v9.7.0.md
@@ -105,8 +105,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.7.1.md
+++ b/locale/en/blog/release/v9.7.1.md
@@ -23,8 +23,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.8.0.md
+++ b/locale/en/blog/release/v9.8.0.md
@@ -109,8 +109,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-arm64.tar.xz<br>

--- a/locale/en/blog/release/v9.9.0.md
+++ b/locale/en/blog/release/v9.9.0.md
@@ -174,8 +174,8 @@ Linux 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x64.tar.xz
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-aix-ppc64.tar.gz<br>
-SunOS 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x86.tar.xz<br>
-SunOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x64.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x86.tar.xz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-arm64.tar.xz<br>


### PR DESCRIPTION
Old builds tagged with `sunos` are still called "Solaris", all other references
to "SunOS" have been renamed. See https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1

Follow up PR to #1989