### PR TITLE
blog: fix URL of SmartOS 32-bit binary of v6.9.3

### DIFF
--- a/locale/en/blog/release/v6.9.3.md
+++ b/locale/en/blog/release/v6.9.3.md
@@ -354,7 +354,7 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc
 Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x32.tar.xz<br>
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x86.tar.xz<br>
 SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x64.tar.xz<br>
 ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv6l.tar.xz<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv7l.tar.xz<br>


### PR DESCRIPTION
The URL points to `node-v6.9.3-sunos-x32.tar.xz`, but the actual file name contains `x86` instead of `x32`. The SHASUMS are correctly generated against the files named with x86.