### PR TITLE
feat(events): create new page for events

### DIFF
--- a/locale/en/get-involved/node-events.md
+++ b/locale/en/get-involved/node-events.md
@@ -5,7 +5,7 @@ layout: contribute.hbs
 
 # Node.js Events
 
-This is a list of node events and conferences. Please submit a PR if you'd like to add a new event that isn't yet tracked in the list below.
+This is a list of Node.js events and conferences. Please submit a PR if you'd like to add a new event that isn't yet tracked in the list below.
 
 ## Notes for adding events
 

--- a/locale/en/get-involved/node-events.md
+++ b/locale/en/get-involved/node-events.md
@@ -3,7 +3,7 @@ title: Node.js Events
 layout: contribute.hbs
 ---
 
-# Node Events
+# Node.js Events
 
 This is a list of node events and conferences. Please submit a PR if you'd like to add a new event that isn't yet tracked in the list below.
 

--- a/locale/en/get-involved/node-events.md
+++ b/locale/en/get-involved/node-events.md
@@ -1,5 +1,5 @@
 ---
-title: Node Events
+title: Node.js Events
 layout: contribute.hbs
 ---
 

--- a/locale/en/get-involved/node-events.md
+++ b/locale/en/get-involved/node-events.md
@@ -1,0 +1,20 @@
+---
+title: Node Events
+layout: contribute.hbs
+---
+
+# Node Events
+
+This is a list of node events and conferences. Please submit a PR if you'd like to add a new event that isn't yet tracked in the list below.
+
+## Notes for adding events
+
+FORMAT
+- [Event Name](https://) - Location, Dates
+
+## Events
+
+### 2019
+- [NodeConf Columbia](https://colombia.nodeconf.com) - Medellin, Columbia, June 21-22 
+- [NodeConf EU](https://www.nodeconf.eu/2019.html) - Lyrath Estate, Kilkenny, November 10-13
+- [NodeSummit](https://www.nodesummit.com) - San Francisco, TBA 

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -133,7 +133,7 @@
     },
     "node-events": {
       "link": "get-involved/node-events",
-      "text": "Node.js Events",
+      "text": "Node.js Events"
     },
     "node-speakers": {
       "link": "get-involved/node-speakers",

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -134,7 +134,7 @@
     "node-events": {
       "link": "get-involved/node-events",
       "text": "Node.js Events",
-    ",
+    },
     "node-speakers": {
       "link": "get-involved/node-speakers",
       "text": "Local Node.js Speakers"

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -131,6 +131,10 @@
       "link": "get-involved/node-meetups",
       "text": "Node.js Meetups"
     },
+    "node-events": {
+      "link": "get-involved/node-events",
+      "text": "Node.js Events",
+    ",
     "node-speakers": {
       "link": "get-involved/node-speakers",
       "text": "Local Node.js Speakers"

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -132,6 +132,10 @@
       "link": "get-involved/node-meetups",
       "text": "Node.js 聚会"
     },
+    "node-events": { 
+      "link": "get-involved/node-events",
+      "text": "Node.js 重大事件"
+    },
     "node-speakers": {
       "link": "get-involved/node-speakers",
       "text": "本地 Node.js 演讲者"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://nodejs.org",
   "scripts": {
     "build": "node build.js",
-    "build:deploy":"node build.js --preserveLocale",
+    "build:deploy": "node build.js --preserveLocale",
     "serve": "node server.js",
     "external:survey": "rsync -avz --exclude 'node_modules*' --exclude 'package*' external/survey-2018/ build/en/user-survey-report",
     "gzip": "find build -type f \\( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.xml' -o -name '*.json' \\) -exec gzip -kf9 {} \\;",


### PR DESCRIPTION
Creates a new page for consolidating events for the Node.js community
Related: [nodejs#2031](https://github.com/nodejs/nodejs.org/issues/2031)

Does the website markdown support tables? that would be much easier to display the events data both on the markdown as well as on the website.