### PR TITLE
Link version schedule to about/releases page

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -64,7 +64,7 @@
           </div>
         {{/if}}
         <p>
-          {{{ labels.version-schedule-prompt }}} <a href="https://github.com/nodejs/Release#release-schedule">{{ labels.version-schedule-prompt-link-text }}</a>
+          {{{ labels.version-schedule-prompt }}} <a href="https://nodejs.org/{{site.locale}}/about/releases/">{{ labels.version-schedule-prompt-link-text }}</a>
         </p>
         {{#if labels.newsletter }}
         <p>


### PR DESCRIPTION
As we now copy the English pages where they are missing in locales, this is the remaining change needed from #1893.