### PR TITLE
Fixed markdown emphasis parsing bug by updating dependency. #2104

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,12 +3713,12 @@
       }
     },
     "metalsmith-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-1.1.0.tgz",
-      "integrity": "sha512-0KIh0/EWBHCd7gIE+/dkTVPpYszq2ZtRSlgM0nitUi6Q+xezDUIuSpc3Nqvd3qsQtKRKeaSuskUOi0ebk3G6KQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-1.2.0.tgz",
+      "integrity": "sha512-YAZZ1G4Y+AfnlJEoba6sr8zGBxg2xiAetf2xvGCTOpUR5CKV6G+X3Oq0BcS1aKBLYf86rWmm6Nu0Wq/5O2CEMQ==",
       "requires": {
-        "debug": "^4.1.0",
-        "marked": "^0.5.1"
+        "debug": "^4.1.1",
+        "marked": "^0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -3730,9 +3730,9 @@
           }
         },
         "marked": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.2.tgz",
-          "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
+          "integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA=="
         },
         "ms": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "metalsmith-discover-partials": "^0.1.2",
     "metalsmith-feed": "1.0.0",
     "metalsmith-layouts": "2.1.0",
-    "metalsmith-markdown": "^1.0.1",
+    "metalsmith-markdown": "^1.2.0",
     "metalsmith-metadata": "0.0.4",
     "metalsmith-permalinks": "^2.0.0",
     "metalsmith-prism": "3.1.1",


### PR DESCRIPTION
Fixed markdown emphasis parsing bug by updating dependency.
Ref：https://github.com/nodejs/nodejs.org/issues/2104