### PR TITLE
Fix list item in event-loop-timers-and-nexttick.md

### DIFF
--- a/locale/en/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/en/docs/guides/event-loop-timers-and-nexttick.md
@@ -218,8 +218,8 @@ emitted via `process.nextTick()`.
 `setImmediate()` and `setTimeout()` are similar, but behave in different
 ways depending on when they are called.
 
-* `setImmediate()` is designed to execute a script once the current
-**poll** phase completes.
+* `setImmediate()` is designed to execute a script once the
+current **poll** phase completes.
 * `setTimeout()` schedules a script to be run after a minimum threshold
 in ms has elapsed.
 


### PR DESCRIPTION
Double asterisk used for bold text is interpreted as list item.

**Before**

![](https://user-images.githubusercontent.com/13399152/53260080-fa2f1d80-36d0-11e9-8530-628a276fb157.png)

**After**

![](https://user-images.githubusercontent.com/13399152/53260095-fe5b3b00-36d0-11e9-8473-35996511c7f1.png)