### PR TITLE
docs(events): fix spelling for colombia entry

### DIFF
--- a/locale/en/get-involved/node-events.md
+++ b/locale/en/get-involved/node-events.md
@@ -19,6 +19,6 @@ FORMAT
 
 |                     Event Name                     |        Location         |      Date      |
 | :------------------------------------------------: | :---------------------: | :------------: |
-| [NodeConf Colombia](https://colombia.nodeconf.com) |   Medellin, Columbia    |   June 21-22   |
+| [NodeConf Colombia](https://colombia.nodeconf.com) |   Medellin, Colombia    |   June 21-22   |
 |  [NodeConf EU](https://www.nodeconf.eu/2019.html)  | Lyrath Estate, Kilkenny | November 10-13 |
 |      [NodeSummit](https://www.nodesummit.com)      |      San Francisco      |      TBA       |


### PR DESCRIPTION
Fixing a left-over incorrect spelling of Colombia