### PR TITLE
add missing semicolon

### DIFF
--- a/static/legacy/sh_main.js
+++ b/static/legacy/sh_main.js
@@ -520,7 +520,7 @@ function highlight(prefix, suffix, tag) {
     for (var j = 0; j < htmlClasses.length; j++) {
       var htmlClass = htmlClasses[j].toLowerCase();
       if (htmlClass === 'sh_none') {
-        donthighlight = true
+        donthighlight = true;
         continue;
       }
       if (htmlClass.substr(0, 3) === 'sh_') {


### PR DESCRIPTION
sh_main.js uses semicolons everywhere except in one line. Add the
missing semicolon.