### PR TITLE
Update knowledge/how to use nodejs repl

### DIFF
--- a/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -37,7 +37,7 @@ You can also use the `Tab` key to autocomplete some commands. When multiple auto
 
 ## Special Commands and Exiting the REPL
 
-The following special commands are supported by all REPL instances:
+The following special commands are supported by all REPL instances (from [Node.js REPL docs](https://nodejs.org/api/repl.html#repl_commands_and_special_keys):
 
 * `.exit` - Close the I/O stream, causing the REPL to exit.
 * `.break` - When in the process of inputting a multi-line expression, entering
@@ -52,16 +52,16 @@ The following special commands are supported by all REPL instances:
   `> .load ./file/to/load.js`
 * `.editor` - Enter editor mode (`<ctrl>-D` to finish, `<ctrl>-C` to cancel).
 
-```console
+```shell
 > .editor
-// Entering editor mode (^D to finish, ^C to cancel)
+# Entering editor mode (<ctrl>-D to finish, <ctrl>-C to cancel)
 function welcome(name) {
   return `Hello ${name}!`;
 }
 
 welcome('Node.js User');
 
-// ^D
+# <ctrl>-D
 'Hello Node.js User!'
 >
 ```

--- a/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -8,17 +8,75 @@ difficulty: 1
 layout: knowledge-post.hbs
 ---
 
+# Learn to use the REPL
 
+Node.js ships with a Read-Eval-Print Loop, also known as a REPL. It is the Node.js interactive shell; any valid JavaScript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of JavaScript's more eccentric behaviors.
 
-Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the Node.js shell; any valid JavaScript which can be written in a script can be passed to the REPL. It can be extremely useful for experimenting with node.js, debugging code, and figuring out some of JavaScript's more eccentric behaviors.
+Node.js has a standalone REPL accessible from the command line, and a built in REPL module you can use to [create your own custom REPLs](https://nodejs.org/api/repl.html#repl_repl). We are going to learn about the basics of the standalone REPL.
 
-Running it is simple - just run node without a filename.
+## How to Start the REPL
+
+Starting the REPL is simple - just run node on the command line without a filename.
 
 ```shell
 $ node
 ```
 
-It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
+It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. 
+
+```shell
+$ node
+> var x = "Hello, World!"
+undefined
+> x
+"Hello, World!"
+> .exit
+```
+
+You can also use the `Tab` key to autocomplete some commands. When multiple autocomplete options are available, hit `Tab` again to cycle through them.
+
+## Special Commands and Exiting the REPL
+
+The following special commands are supported by all REPL instances:
+
+* `.exit` - Close the I/O stream, causing the REPL to exit.
+* `.break` - When in the process of inputting a multi-line expression, entering
+  the `.break` command (or pressing the `<ctrl>-C` key combination) will abort
+  further input or processing of that expression.
+* `.clear` - Resets the REPL `context` to an empty object and clears any
+  multi-line expression currently being input.
+* `.help` - Show this list of special commands.
+* `.save` - Save the current REPL session to a file:
+  `> .save ./file/to/save.js`
+* `.load` - Load a file into the current REPL session.
+  `> .load ./file/to/load.js`
+* `.editor` - Enter editor mode (`<ctrl>-D` to finish, `<ctrl>-C` to cancel).
+
+```console
+> .editor
+// Entering editor mode (^D to finish, ^C to cancel)
+function welcome(name) {
+  return `Hello ${name}!`;
+}
+
+welcome('Node.js User');
+
+// ^D
+'Hello Node.js User!'
+>
+```
+
+The following key combinations in the REPL have these special effects:
+
+* `<ctrl>-C` - When pressed once, has the same effect as the `.break` command.
+  When pressed twice on a blank line, has the same effect as the `.exit`
+  command.
+* `<ctrl>-D` - Has the same effect as the `.exit` command.
+* `<tab>` - When pressed on a blank line, displays global and local (scope)
+  variables. When pressed while entering other input, displays relevant
+  autocompletion options.
+
+## Return Values
 
 Whenever you type a command, it will print the return value of the command. If you want to reuse the previous return value, you can use the special `_` variable.
 
@@ -44,6 +102,8 @@ One thing worth noting where REPL return values are concerned:
 ```
 
 When the `var` keyword is used, the value of the expression is stored, but *NOT* returned.  When a bare identifier is used, the value is also returned, as well as stored.
+
+## Accessing Modules
 
 If you need to access any of the builtin modules, or any third party modules, they can be accessed with `require`, just like in the rest of Node.
 

--- a/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -15,7 +15,7 @@ Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the
 Running it is simple - just run node without a filename.
 
 ```shell
-docs@nodejitsu:~/$ node
+$ node
 ```
 
 It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
@@ -24,7 +24,7 @@ Whenever you type a command, it will print the return value of the command. If y
 
 For example:
 ```shell
-node
+$ node
 > 1+1
 2
 > _+1
@@ -50,7 +50,7 @@ If you need to access any of the builtin modules, or any third party modules, th
 For example:
 
 ```shell
-node
+$ node
 > path = require('path')
 { resolve: [Function],
   normalize: [Function],

--- a/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
+++ b/locale/en/knowledge/REPL/how-to-use-nodejs-repl.md
@@ -14,29 +14,34 @@ Node.js ships with a REPL, which is short for 'Read-Eval-Print Loop'.  It is the
 
 Running it is simple - just run node without a filename.
 
-     docs@nodejitsu:~/$ node
+```shell
+docs@nodejitsu:~/$ node
+```
 
 It then drops you into a simple prompt ('>') where you can type any JavaScript command you wish. As in most shells, you can press the up and down arrow keys to scroll through your command history and modify previous commands. The REPL also  `Tab` to make the REPL try to autocomplete the command.
 
 Whenever you type a command, it will print the return value of the command. If you want to reuse the previous return value, you can use the special `_` variable.
 
 For example:
-
-     node
-     > 1+1
-     2
-     > _+1
-     3
+```shell
+node
+> 1+1
+2
+> _+1
+3
+```
 
 One thing worth noting where REPL return values are concerned:
 
-     > x = 10
-     10
-     > var y = 5
-     > x
-     10
-     > y
-     5
+```shell
+> x = 10
+10
+> var y = 5
+> x
+10
+> y
+5
+```
 
 When the `var` keyword is used, the value of the expression is stored, but *NOT* returned.  When a bare identifier is used, the value is also returned, as well as stored.
 
@@ -44,17 +49,19 @@ If you need to access any of the builtin modules, or any third party modules, th
 
 For example:
 
-     node
-     > path = require('path')
-     { resolve: [Function],
-       normalize: [Function],
-       join: [Function],
-       dirname: [Function],
-       basename: [Function],
-       extname: [Function],
-       exists: [Function],
-       existsSync: [Function] }
-     > path.basename("/a/b/c.txt")
-     'c.txt'
+```shell
+node
+> path = require('path')
+{ resolve: [Function],
+  normalize: [Function],
+  join: [Function],
+  dirname: [Function],
+  basename: [Function],
+  extname: [Function],
+  exists: [Function],
+  existsSync: [Function] }
+> path.basename("/a/b/c.txt")
+'c.txt'
+```
 
 Note once again that without the `var` keyword, the contents of the object are returned immediately and displayed to `stdout`.


### PR DESCRIPTION
Updates to the knowledge article **[how to use nodejs repl](https://nodejs.org/en/knowledge/REPL/how-to-create-a-custom-repl/)**. 

This is the first of several articles I will be editing https://github.com/nodejs/nodejs.org/issues/1977#issuecomment-472619855. Any feedback is welcome. 

And to jumpstart that: 
**Is it acceptable that I added sectional headers?**

I think it helps the reader survey the content quicker, but very few of these knowledge articles use headers at all currently. My inclination is to add them to articles I edit. Please let me know if I shouldn't bother for any reason.

**Edit**: Also, any guidance on how I should handle linking between these articles? I wanted to link to the next article, "how to create a custom repl" from this one, but wasn't sure the convention. So I linked to the Node API docs instead.

* Updated code blocks to fences, added `shell` syntax.
* Added headers to sections
* Added "Special Commands" section, from the Node API docs
* Mention the existence of built in REPL module and standalone executable

cc @fhemberger @keywordnew 