### PR TITLE
Homepage: Only show 64bit builds for Linux

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -12,11 +12,11 @@
 
         {{{ contents }}}
 
-      {{#if project.banner.visible}}
-        <p class="home-version home-version-banner">
-          <a href="{{ project.banner.link }}">{{ project.banner.text }}</a>
-        </p>
-      {{/if}}
+        {{#if project.banner.visible}}
+          <p class="home-version home-version-banner">
+            <a href="{{ project.banner.link }}">{{ project.banner.text }}</a>
+          </p>
+        {{/if}}
 
         <h2 id="home-downloadhead" data-dl-local="{{ labels.download-for }}">{{ labels.download }}</h2>
 

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -66,8 +66,8 @@
         downloadHead[text] = dlLocal + ' Windows (' + arch + ')'
         break
       case 'Linux':
-        versionIntoHref(buttons, 'node-%version%-linux-' + arch + '.tar.xz')
-        downloadHead[text] = dlLocal + ' Linux (' + arch + ')'
+        versionIntoHref(buttons, 'node-%version%-linux-x64.tar.xz')
+        downloadHead[text] = dlLocal + ' Linux (x64)'
         break
     }
   }


### PR DESCRIPTION
When browsing the homepage, the download buttons show direct download links to the detected platform. For Linux, only 64bit builds are supported as of 10.0.0.

Fixes #2173
