### PR TITLE
tools: update lodash dependency

### DIFF
--- a/scripts/contributor-list/index.js
+++ b/scripts/contributor-list/index.js
@@ -8,7 +8,7 @@ const GithubGraphQLApi = require('node-github-graphql')
 const args = process.argv.splice(2)
 const since = new Date(args[0])
 
-if (_.isNaN(since.getTime())) {
+if (Number.isNaN(since.getTime())) {
   console.error(`usage: ${path.basename(process.argv[1])} YYYY-MM-DD`)
   process.exit(1)
 }

--- a/scripts/contributor-list/package-lock.json
+++ b/scripts/contributor-list/package-lock.json
@@ -38,7 +38,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "asynckit": {
@@ -281,9 +281,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "mime-db": {
       "version": "1.36.0",

--- a/scripts/contributor-list/package.json
+++ b/scripts/contributor-list/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.11",
     "node-github-graphql": "^0.2.7"
   }
 }


### PR DESCRIPTION
Update lodash so `npm audit` comes up clean. While we're at it, replace
`_.isNan()` with `Number.isNan()` which is all that lodash does under
the hood (if `Number.isNaN()` exists, which it does in all supported
versions of Node.js.