### PR TITLE
nodejs-ja: Fix link

### DIFF
--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -48,7 +48,7 @@ labels:
 ### ES6 の機能
 
 <!-- The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find version of V8 shipped with a particular Node.js release. -->
-[ES6 のセクション](/en/docs/es6/) では、ES6 の3つの機能について説明しており、それぞれの機能ごとのリンクと一緒に Node.js の標準で有効化されているかについて書いてあります。また、リリースされた Node.js のバージョンごとに組み込まれている V8 のバージョンを知るのにも利用することができます。
+[ES6 のセクション](/ja/docs/es6/) では、ES6 の3つの機能について説明しており、それぞれの機能ごとのリンクと一緒に Node.js の標準で有効化されているかについて書いてあります。また、リリースされた Node.js のバージョンごとに組み込まれている V8 のバージョンを知るのにも利用することができます。
 
 <!-- ### Guides -->
 ### ガイド


### PR DESCRIPTION
Fix link to `/ja/docs/es6` in `/ja/docs/index.md`.
