### PR TITLE
translation of the package-manager page in download section

### DIFF
--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -149,7 +149,7 @@ zypper install nodejs4
 
 Basta baixar o [macOS Installer](https://nodejs.org/#download) diretamente do site [nodejs.org](https://nodejs.org).
 
-_Se você quer baixar o pacote com bash:_
+_Se desejar baixar o pacote com bash:_
 
 ```bash
 curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -28,7 +28,7 @@ title: Instalando Node.js via gerenciador pacotes
 
 ## Android
 
-O suporte ao Android ainda é experimental no Node.js, portanto, os binários pré-compilados ainda não são fornecidos pelos programadores do Node.js
+O suporte ao Android ainda é experimental no Node.js, portanto, os binários pré-compilados ainda não são fornecidos pelos desenvolvedores do Node.js
 
 Entretanto, existem algumas soluções de terceiros. Por exemplo, a comunidade [Termux](https://termux.com/) que fornece um emulador de terminal e ambiente Linux para Android, assim como seu próprio gerenciador de pacotes e [extensa coleção](https://github.com/termux/termux-packages) com muitas aplicações pré-compiladas. Esse comando no Termux vai instalar a última versão disponível do Node.js:
 

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -194,7 +194,7 @@ Imagens do SmartOS vêm com o pkgsrc pré-instalado. Em outras distribuições i
 pkgin -y install nodejs
 ```
 
-Ou construa manualmente pelo pkgsrc:
+Ou compile manualmente pelo pkgsrc:
 
 ```bash
 cd pkgsrc/lang/nodejs && bmake install

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -68,7 +68,7 @@ cd /usr/ports/www/node && make install
 
 ## Gentoo
 
-O Node.js está disponível na portage tree.
+O Node.js está disponível no diretório portage.
 
 ```bash
 emerge nodejs

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -108,7 +108,7 @@ Por exemplo, se a versão do Node.js é v8.0.0-pre:
 $ nvm use 8
 ```
 
-Uma vez que a versão oficial for lançada você pode querer desinstalar a versão construída
+Uma vez que a versão oficial for lançada você pode querer desinstalar a versão compilada
 a partir do fonte:
 
 ```bash

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -180,7 +180,7 @@ Instale o pacote binário:
 pkgin -y install nodejs
 ```
 
-Ou constrindo manualmente pelo pkgsrc:
+Ou compile manualmente pelo pkgsrc:
 
 ```bash
 cd pkgsrc/lang/nodejs && bmake install

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -109,7 +109,7 @@ $ nvm use 8
 ```
 
 Uma vez que a versão oficial for lançada você pode querer desinstalar a versão compilada
-a partir do fonte:
+a partir do código fonte:
 
 ```bash
 $ nvm uninstall 8

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -11,7 +11,7 @@ title: Instalando Node.js via gerenciador pacotes
 
 * [Android](#android)
 * [Arch Linux](#arch-linux)
-* [Debian e Destribuições Linux baseadas em Ubuntu, Enterprise Linux/Fedora e pacotes Snap](#debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages)
+* [Debian e Distribuições Linux baseadas em Ubuntu, Enterprise Linux/Fedora e pacotes Snap](#debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages)
 * [FreeBSD](#freebsd)
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -212,7 +212,7 @@ sudo eopkg install nodejs
 
 ## Void Linux
 
-Void Linux entrega o Node.js estável no repositório principal.
+Void Linux possui versões estáveis de Node.js no seu repositório principal.
 
 ```bash
 xbps-install -Sy nodejs

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -220,7 +220,7 @@ xbps-install -Sy nodejs
 
 ## Windows
 
-Apenas baixe o [Windows Installer](https://nodejs.org/#download) diretamente do site [nodejs.org](https://nodejs.org).
+Baixe o [Windows Installer](https://nodejs.org/#download) diretamente do site [nodejs.org](https://nodejs.org).
 
 ### Alternativas
 

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -91,7 +91,7 @@ pkgin -y install nodejs
 ## nvm
 
 Node Version Manager é um script bash utilizado para gerenciar múltiplas versões do Node.js. Ele Permite
-que você instale, desinstale e mude de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
+que você instale, desinstale, mude de versão e etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
 
 Em sistemas Unix / OS X o Node.js compilado a partir do código fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando-o no
 local em que o nvm espera:

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -90,7 +90,7 @@ pkgin -y install nodejs
 
 ## nvm
 
-Node Version Manager é um bash script usado para gerenciar múltiplas versões lançadas do Node.js. Ele Permite
+Node Version Manager é um script bash utilizado para gerenciar múltiplas versões do Node.js. Ele Permite
 que você instale, desinstale e mude de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
 
 Em sistemas Unix / OS X o Node.js compilado a partir do código fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando-o no

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -1,0 +1,239 @@
+---
+layout: page.hbs
+title: Instalando Node.js via gerenciador pacotes
+---
+
+# Instalando Node.js via gerenciador pacotes
+
+***Nota:*** Os pacotes nessa página são mantidos e suportados por seus respectivos empacotadores, **não** pela equipe principal do Node.js. Por favor, relate quaisquer problemas encontrados para o mantenedor do pacote.
+
+----------------------------
+
+* [Android](#android)
+* [Arch Linux](#arch-linux)
+* [Debian e Destribuições Linux baseadas em Ubuntu, Enterprise Linux/Fedora e pacotes Snap](#debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages)
+* [FreeBSD](#freebsd)
+* [Gentoo](#gentoo)
+* [NetBSD](#netbsd)
+* [nvm](#nvm)
+* [OpenBSD](#openbsd)
+* [openSUSE e SLE](#opensuse-and-sle)
+* [macOS](#macos)
+* [SmartOS e illumos](#smartos-and-illumos)
+* [Solus](#solus)
+* [Void Linux](#void-linux)
+* [Windows](#windows)
+
+----------------------------
+
+## Android
+
+O suporte ao Android ainda é experimental no Node.js, portanto, os binários pré-compilados ainda não são fornecidos pelos programadores do Node.js
+
+Entretanto, existem algumas soluções de terceiros. Por exemplo, a comunidade [Termux](https://termux.com/) que fornece um emulador de terminal e ambiente Linux para Android, assim como seu próprio gerenciador de pacotes e [extensa coleção](https://github.com/termux/termux-packages) com muitas aplicações pré-compiladas. Esse comando no Termux vai instalar a última versão disponível do Node.js:
+
+```bash
+pkg install nodejs
+```
+
+Atualmente, os binários do Node.js no Termux estão ligados ao `system-icu` (dependência do pacote `libicu`)
+
+## Arch Linux
+
+O Node.js pacotes npm estão disponíveis no Repositório da Comunidade.
+
+```bash
+pacman -S nodejs npm
+```
+
+## Debian e distribuições Linux basedas em  Ubuntu, Enterprise Linux/Fedora e pacotes Snap
+
+[Distribuição dos binários oficiais do Node.js](https://github.com/nodesource/distributions/blob/master/README.md) são fornecidos pelo NodeSource.
+
+## FreeBSD
+
+A versão mais recente do Node.js está disponível na porta [www/node](http://freshports.org/www/node).
+
+Intalar um pacote binário via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
+
+```bash
+pkg install node
+```
+
+Ou compile por conta própria usando [ports](https://www.freebsd.org/cgi/man.cgi?ports):
+
+```bash
+cd /usr/ports/www/node && make install
+```
+
+## Gentoo
+
+O Node.js está disponível na portage tree.
+
+```bash
+emerge nodejs
+```
+
+## NetBSD
+
+Node.js está disponível na pkgsrc tree:
+
+```bash
+cd /usr/pkgsrc/lang/nodejs && make install
+```
+
+Ou instale um pacote binário (se estiver disponível para sua plataforma)  usando pkgin:
+
+```bash
+pkgin -y install nodejs
+```
+
+## nvm
+
+Node Version Manager é um bash script usado para gerenciar múltiplas versões lançadas do Node.js. Ele Permite
+que você execute operações como instalar, desinstalar e mudar de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
+
+Em sistemas Unix / OS X o Node.js construído a partir do fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando no
+local em que o nvm espera:
+
+```bash
+$ env VERSION=`python tools/getnodeversion.py` make install DESTDIR=`nvm_version_path v$VERSION` PREFIX=""
+```
+
+Despois disso, você pode usar o `nvm` para alternar entre versões lançadas e versões
+construidas a partir do fonte.
+Por exemplo, se a versão do Node.js é v8.0.0-pre:
+
+```bash
+$ nvm use 8
+```
+
+Uma vez que a versão oficial for lançada você pode querer desinstalar a versão construída
+a partir do fonte:
+
+```bash
+$ nvm uninstall 8
+```
+
+## OpenBSD
+
+O Node.js está disponível através das portas do sistema.
+
+```bash
+/usr/ports/lang/node
+```
+
+Usando [pkg_add](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) no OpenBSD:
+
+```bash
+pkg_add node
+```
+
+## openSUSE e SLE
+
+Node.js está disponível nos principais repositórios nos seguintes pacotes:
+
+* **openSUSE Leap 42.2**: `nodejs4`
+* **openSUSE Leap 42.3**: `nodejs4`, `nodejs6`
+* **openSUSE Tumbleweed**: `nodejs4`, `nodejs6`, `nodejs8`
+* **SUSE Linux Enterprise Server (SLES) 12**: `nodejs4`, `nodejs6`
+  (O "Web and Scripting Module" deve ser [adicionado antes da instalação](https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html).)
+
+Por exemplo, para instalar o Node.js 4.x no openSUSE 42.2, execute o seguinte como root:
+
+```bash
+zypper install nodejs4
+```
+
+## macOS
+
+Basta baixar o [macOS Installer](https://nodejs.org/#download) diretamente do site [nodejs.org](https://nodejs.org).
+
+_Se você quer baixar o pacote com bash:_
+
+```bash
+curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
+```
+
+### Alternativas
+
+Usando **[Homebrew](http://brew.sh/)**:
+
+```bash
+brew install node
+```
+
+Usando **[MacPorts](http://www.macports.org/)**:
+
+```bash
+port install nodejs<major version>
+
+# Exemplo
+port install nodejs7
+```
+
+Usando **[pkgsrc](https://pkgsrc.joyent.com/install-on-osx/)**:
+
+Instale o pacote binário:
+
+```bash
+pkgin -y install nodejs
+```
+
+Ou constrindo manualmente pelo pkgsrc:
+
+```bash
+cd pkgsrc/lang/nodejs && bmake install
+```
+
+## SmartOS e illumos
+
+Imagens do SmartOS vêm com o pkgsrc pré-instalado. Em outras distribuições illumos, primeiro instale **[pkgsrc](https://pkgsrc.joyent.com/install-on-illumos/)**, então você pode instalar o binário normalmente:
+
+```bash
+pkgin -y install nodejs
+```
+
+Ou construa manualmente pelo pkgsrc:
+
+```bash
+cd pkgsrc/lang/nodejs && bmake install
+```
+
+
+## Solus
+
+O Solus fornece o Node.js em seu repositório principal.
+
+```bash
+sudo eopkg install nodejs
+```
+
+
+## Void Linux
+
+Void Linux entrega o Node.js estável no repositório principal.
+
+```bash
+xbps-install -Sy nodejs
+```
+
+## Windows
+
+Apenas baixe o [Windows Installer](https://nodejs.org/#download) diretamente do site [nodejs.org](https://nodejs.org).
+
+### Alternativas
+
+Usando **[Chocolatey](http://chocolatey.org)**:
+
+```bash
+cinst nodejs
+# or for full install with npm
+cinst nodejs.install
+```
+
+Usando **[Scoop](http://scoop.sh/)**:
+
+```bash
+scoop install nodejs
+```

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -5,7 +5,7 @@ title: Instalando Node.js via gerenciador pacotes
 
 # Instalando Node.js via gerenciador pacotes
 
-***Nota:*** Os pacotes nessa página são mantidos e suportados por seus respectivos empacotadores, **não** pela equipe principal do Node.js. Por favor, relate quaisquer problemas encontrados para o mantenedor do pacote.
+***Nota:*** Os pacotes nessa página são mantidos e suportados por seus respectivos empacotadores, **não** pela equipe principal do Node.js. Por favor, relate quaisquer problemas encontrados para o mantenedor do pacote. Se o problema for um bug no próprio Node.js, a mantenedor deve reportar o problema.
 
 ----------------------------
 
@@ -46,7 +46,7 @@ Os pacotes para o Node.js e o npm estão disponíveis no Repositório da Comunid
 pacman -S nodejs npm
 ```
 
-## Debian e distribuições Linux basedas em  Ubuntu, Enterprise Linux/Fedora e pacotes Snap
+## Debian e distribuições Linux basedas em Ubuntu, Enterprise Linux/Fedora e pacotes Snap
 
 [Distribuição dos binários oficiais do Node.js](https://github.com/nodesource/distributions/blob/master/README.md) são fornecidos pelo NodeSource.
 
@@ -60,7 +60,7 @@ Instale um pacote binário via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 pkg install node
 ```
 
-Ou compile por conta própria usando [ports](https://www.freebsd.org/cgi/man.cgi?ports):
+Ou compile-o por conta própria usando [ports](https://www.freebsd.org/cgi/man.cgi?ports):
 
 ```bash
 cd /usr/ports/www/node && make install
@@ -76,13 +76,13 @@ emerge nodejs
 
 ## NetBSD
 
-Node.js está disponível na pkgsrc tree:
+Node.js está disponível no diretório pkgsrc:
 
 ```bash
 cd /usr/pkgsrc/lang/nodejs && make install
 ```
 
-Ou instale um pacote binário (se estiver disponível para sua plataforma)  usando pkgin:
+Ou instale um pacote binário (se estiver disponível para sua plataforma) usando pkgin:
 
 ```bash
 pkgin -y install nodejs
@@ -90,8 +90,7 @@ pkgin -y install nodejs
 
 ## nvm
 
-Node Version Manager é um script bash utilizado para gerenciar múltiplas versões do Node.js. Ele Permite
-que você instale, desinstale, mude de versão e etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
+Node Version Manager é um script bash utilizado para gerenciar múltiplas versões do Node.js. Ele Permite que você instale, desinstale, mude de versão e etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
 
 Em sistemas Unix / OS X o Node.js compilado a partir do código fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando-o no
 local em que o nvm espera:
@@ -228,7 +227,7 @@ Usando **[Chocolatey](http://chocolatey.org)**:
 
 ```bash
 cinst nodejs
-# or for full install with npm
+# ou para a instalação completa com npm
 cinst nodejs.install
 ```
 

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -91,7 +91,7 @@ pkgin -y install nodejs
 ## nvm
 
 Node Version Manager é um bash script usado para gerenciar múltiplas versões lançadas do Node.js. Ele Permite
-que você execute operações como instalar, desinstalar e mudar de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
+que você instale, desinstale e mude de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
 
 Em sistemas Unix / OS X o Node.js construído a partir do fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando no
 local em que o nvm espera:

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -93,7 +93,7 @@ pkgin -y install nodejs
 Node Version Manager é um bash script usado para gerenciar múltiplas versões lançadas do Node.js. Ele Permite
 que você instale, desinstale e mude de versão etc. Para instalar o nvm, use esse [script de instalação](https://github.com/creationix/nvm#install-script).
 
-Em sistemas Unix / OS X o Node.js construído a partir do fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando no
+Em sistemas Unix / OS X o Node.js compilado a partir do código fonte pode ser instalado usando [nvm](https://github.com/creationix/nvm), instalando-o no
 local em que o nvm espera:
 
 ```bash

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -101,7 +101,7 @@ $ env VERSION=`python tools/getnodeversion.py` make install DESTDIR=`nvm_version
 ```
 
 Despois disso, você pode usar o `nvm` para alternar entre versões lançadas e versões
-construidas a partir do fonte.
+compiladas a partir do código fonte.
 Por exemplo, se a versão do Node.js é v8.0.0-pre:
 
 ```bash

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -131,7 +131,7 @@ pkg_add node
 
 ## openSUSE e SLE
 
-Node.js está disponível nos principais repositórios nos seguintes pacotes:
+Node.js está disponível nos principais repositórios sob os seguintes pacotes:
 
 * **openSUSE Leap 42.2**: `nodejs4`
 * **openSUSE Leap 42.3**: `nodejs4`, `nodejs6`

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -40,7 +40,7 @@ Atualmente, os binários do Node.js no Termux estão ligados ao `system-icu` (de
 
 ## Arch Linux
 
-O Node.js pacotes npm estão disponíveis no Repositório da Comunidade.
+Os pacotes para o Node.js e o npm estão disponíveis no Repositório da Comunidade.
 
 ```bash
 pacman -S nodejs npm

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -5,7 +5,7 @@ title: Instalando Node.js via gerenciador pacotes
 
 # Instalando Node.js via gerenciador pacotes
 
-***Nota:*** Os pacotes nessa página são mantidos e suportados por seus respectivos empacotadores, **não** pela equipe principal do Node.js. Por favor, relate quaisquer problemas encontrados para o mantenedor do pacote. Se o problema for um bug no próprio Node.js, a mantenedor deve reportar o problema.
+***Nota:*** Os pacotes nessa página são mantidos e suportados por seus respectivos empacotadores, **não** pela equipe principal do Node.js. Por favor, relate quaisquer problemas encontrados para o mantenedor do pacote. Se o problema for um bug no próprio Node.js, o mantenedor deve relatar para o issue upstream.
 
 ----------------------------
 

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -30,7 +30,7 @@ title: Instalando Node.js via gerenciador pacotes
 
 O suporte ao Android ainda é experimental no Node.js, portanto, os binários pré-compilados ainda não são fornecidos pelos desenvolvedores do Node.js
 
-Entretanto, existem algumas soluções de terceiros. Por exemplo, a comunidade [Termux](https://termux.com/) que fornece um emulador de terminal e ambiente Linux para Android, assim como seu próprio gerenciador de pacotes e [extensa coleção](https://github.com/termux/termux-packages) com muitas aplicações pré-compiladas. Esse comando no Termux vai instalar a última versão disponível do Node.js:
+Entretanto, existem algumas soluções de terceiros. Por exemplo, a comunidade [Termux](https://termux.com/) que fornece um emulador de terminal e ambiente Linux para Android, assim como seu próprio gerenciador de pacotes e [extensa coleção](https://github.com/termux/termux-packages) com muitas aplicações pré-compiladas. Esse comando vai instalar a última versão disponível do Node.js no Termux:
 
 ```bash
 pkg install nodejs

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -54,7 +54,7 @@ pacman -S nodejs npm
 
 A versão mais recente do Node.js está disponível na porta [www/node](http://freshports.org/www/node).
 
-Intalar um pacote binário via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
+Instale um pacote binário via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
 
 ```bash
 pkg install node


### PR DESCRIPTION
Translated download/package-manager.md from en to pt-BR

Refs: [nodejs/nodejs-pt#72](https://github.com/nodejs/nodejs-pt/issues/72)

/cc @nodejs/nodejs-pt