### PR TITLE
docs: fix broken text image

### DIFF
--- a/layouts/css/_base.styl
+++ b/layouts/css/_base.styl
@@ -67,7 +67,7 @@ pre
   border-radius 3px
   padding 0.75em 1.2em
   font-size 0.8em
-  white-space pre-wrap
+  white-space pre
   color $light-gray3
   overflow-x auto
 


### PR DESCRIPTION
Fixes: #2125 
Currently, the text-image is broken on mobile for /en/docs/guides/event-loop-timers-and-nexttick 
But it should not be so.
@ZYSzys @Maledong @WofWca Can you please review?