### PR TITLE
Add link to the callback pattern page

### DIFF
--- a/locale/en/docs/guides/blocking-vs-non-blocking.md
+++ b/locale/en/docs/guides/blocking-vs-non-blocking.md
@@ -8,7 +8,7 @@ layout: docs.hbs
 This overview covers the difference between **blocking** and **non-blocking**
 calls in Node.js. This overview will refer to the event loop and libuv but no
 prior knowledge of those topics is required. Readers are assumed to have a
-basic understanding of the JavaScript language and Node.js callback pattern.
+basic understanding of the JavaScript language and Node.js [callback pattern](https://nodejs.org/en/knowledge/getting-started/control-flow/what-are-callbacks/).
 
 > "I/O" refers primarily to interaction with the system's disk and
 > network supported by [libuv](http://libuv.org/).


### PR DESCRIPTION
Added a link to the callback pattern page in the knowledge/getting-started section of the node docs.  

As I was reading the blocking/non-blocking documentation, I realized that some people might not know what the node callback pattern was and figured a link could be added to that page for easy access to readers.

(I did notice that the page I added a link to is from 2011, but I couldn't find a more updated one when searching (so not sure if a more updated entry on explaining callbacks exists))