### PR TITLE
doc: about/releases traduzido para pt-br

### DIFF
--- a/locale/pt-br/about/releases.md
+++ b/locale/pt-br/about/releases.md
@@ -1,6 +1,6 @@
 ---
 layout: about-release-schedule.hbs
-title: Releases
+title: Lançamentos
 statuses:
   maintenance: 'Maintenance LTS'
   active: 'Active LTS'
@@ -29,6 +29,6 @@ _LTS_ release status is "long-term support", which typically guarantees that cri
 Production applications should only use _Active LTS_ or _Maintenance LTS_ releases.
  -->
 
- As pricipais versões do Node.js entram em status de lançamento _Atual_ por seis meses, o qual dá tempo aos autores da biblioteca adicionarem suporte a elas. Depois de seis meses, os lançamentos ímpares (9, 11, etc.) tornam-se sem suporte, e lançamentos pares (10, 12, etc.) passam para _LTS Ativo_ e prontos para uso geral.
+ As principais versões do Node.js entram em status de lançamento _Atual_ por seis meses, o qual dá tempo aos autores da biblioteca adicionarem suporte a elas. Depois de seis meses, os lançamentos ímpares (9, 11, etc.) tornam-se sem suporte, e lançamentos pares (10, 12, etc.) passam para _LTS Ativo_ e prontos para uso geral.
  Status de lançamento _LTS_ é "suporte de longo prazo", que tipicamente garante que erros críticos serão corrigidos em um total de 30 meses.
  A produção de aplicações devem usar somente lançamentos _LTS Ativo_ ou _LTS de Manutenção_.

--- a/locale/pt-br/about/releases.md
+++ b/locale/pt-br/about/releases.md
@@ -1,0 +1,34 @@
+---
+layout: about-release-schedule.hbs
+title: Releases
+statuses:
+  maintenance: 'Maintenance LTS'
+  active: 'Active LTS'
+  current: 'Current'
+  pending: 'Pending'
+columns:
+  - 'Release'
+  - 'Status'
+  - 'Codename'
+  - 'Initial Release'
+  - 'Active LTS Start'
+  - 'Maintenance LTS Start'
+  - 'End-of-life'
+schedule-footer: Dates are subject to change.
+---
+
+<!-- 
+# Releases 
+-->
+# Lançamentos
+
+<!--
+Major Node.js versions enter _Current_ release status for six months, which gives library authors time to add support for them.
+After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to _Active LTS_ status and are ready for general use.
+_LTS_ release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
+Production applications should only use _Active LTS_ or _Maintenance LTS_ releases.
+ -->
+
+ As pricipais versões do Node.js entram em status de lançamento _Atual_ por seis meses, o qual dá tempo aos autores da biblioteca adicionarem suporte a elas. Depois de seis meses, os lançamentos ímpares (9, 11, etc.) tornam-se sem suporte, e lançamentos pares (10, 12, etc.) passam para _LTS Ativo_ e prontos para uso geral.
+ Status de lançamento _LTS_ é "suporte de longo prazo", que tipicamente garante que erros críticos serão corrigidos em um total de 30 meses.
+ A produção de aplicações devem usar somente lançamentos _LTS Ativo_ ou _LTS de Manutenção_.


### PR DESCRIPTION
Nesse PR a página about/release foi traduzida
@nodejs/nodejs-pt 