### PR TITLE
Remove recommendations of Chrome Extensions

### DIFF
--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -84,8 +84,6 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
-* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):  
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
 

--- a/locale/fa/docs/guides/debugging-getting-started.md
+++ b/locale/fa/docs/guides/debugging-getting-started.md
@@ -84,8 +84,6 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
-* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):  
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
   
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
 

--- a/locale/it/docs/guides/debugging-getting-started.md
+++ b/locale/it/docs/guides/debugging-getting-started.md
@@ -106,8 +106,6 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
-* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
 

--- a/locale/ja/docs/guides/debugging-getting-started.md
+++ b/locale/ja/docs/guides/debugging-getting-started.md
@@ -174,16 +174,12 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
-* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):  
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
  -->
 #### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
 
 * **オプション 1**: Chromium ベースのブラウザで `chrome://inspect` を開きます。設定ボタンをクリックして、ターゲットホストとポートが表示されていることを確認します。
 * **オプション 2**: `/json/list`の出力 (上記を参照) または --inspect ヒントテキストから `devtoolsFrontendUrl` をコピーして Chrome に貼り付けます
-* **オプション 3**: Chrome Extension NIM (ノードインスペクタマネージャ) をインストールします:   
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
   
 <!-- 
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+

--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -130,8 +130,6 @@ info on these follows:
   are listed.
 * **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
   (see above) or the --inspect hint text and paste into Chrome.
-* **Option 3**: Install the Chrome Extension NIM (Node Inspector Manager):  
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 -->
 
 ## 인스펙터 클라이언트
@@ -152,8 +150,6 @@ Node 인스펙터에 접속할 수 있는 여러 상용 도구와 오픈소스 �
   Configure 버튼을 눌러서 대상 호스트와 포트 목록을 확인합니다.
 * **방법 2**: `/json/list`(상단 참고)의 출력에서 `devtoolsFrontendUrl`을
   복사하거나 --inspect가 알려준 텍스트에서 복사해서 크롬에 붙여넣기를 합니다.
-* **방법 3**: 크롬 확장프로그램 NIM(Node Inspector Manager)을 설치하세요. 
-  https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
 <!--
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+

--- a/locale/zh-cn/docs/guides/debugging-getting-started.md
+++ b/locale/zh-cn/docs/guides/debugging-getting-started.md
@@ -52,7 +52,6 @@ layout: docs.hbs
 
 * **选项 1**: 在基于 Chromium 内核的浏览器下打开 `chrome://inspect`。点击配置按钮确保你的目标宿主和端口号列入其中。
 * **选项 2**: 从 `/json/list` 中拷贝 `devtoolsFrontendUrl`（见上），或者加上 --inspect 以检查提示文本并粘贴到 Chrome 中。
-* **选项 3**: 安装 Chrome 扩展（Node 监视管理器）：https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj
 
 #### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
 


### PR DESCRIPTION
The only Chrome Extension currently recommended is NiM, there are no
other links to the Chrome webstore. This removes the extension from all
locales.

Fixes: https://github.com/nodejs/nodejs.org/issues/1908