### PR TITLE
Remove links to 3rd-party tools with Privacy issues.

### DIFF
--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -77,37 +77,9 @@ info on these follows:
 * The latest version can also be installed independently (e.g. `npm install -g node-inspect`)
   and used with `node-inspect myscript.js`.
 
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **Option 1**: Open `chrome://inspect` in a Chromium-based
-  browser. Click the Configure button and ensure your target host and port
-  are listed.
-* **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
-  (see above) or the --inspect hint text and paste into Chrome.
-
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* In the Debug panel, click the settings icon to open `.vscode/launch.json`.
-  Select "Node.js" for initial setup.
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* Choose "Debug > Start Debugging" from the menu or hit F5.
-* [Detailed instructions](https://github.com/Microsoft/nodejstools/wiki/Debugging).
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ and other JetBrains IDEs
-
-* Create a new Node.js debug configuration and hit Debug. `--inspect` will be used
-  by default for Node.js 7+. To disable uncheck `js.debugger.node.use.inspect` in
-  the IDE Registry.
-
 #### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
 * Library to ease connections to Inspector Protocol endpoints.
-
-#### [Gitpod](https://www.gitpod.io)
-
-* Start a Node.js debug configuration from the `Debug` view or hit `F5`. [Detailed instructions](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
 
 ---
 
@@ -205,8 +177,7 @@ $ ssh -L 9221:localhost:9229 user@remote.example.com
 
 This starts a ssh tunnel session where a connection to port 9221 on your local
 machine will be forwarded to port 9229 on remote.example.com. You can now attach
-a debugger such as Chrome DevTools or Visual Studio Code to localhost:9221,
-which should be able to debug as if the Node.js application was running locally.
+a debugger to localhost:9221, which should be able to debug as if the Node.js application was running locally.
 
 ---
 
@@ -229,12 +200,6 @@ Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
 the `--debug-brk` option, and the initial Node process runs the `_debugger.js`
 script and connects to your target.
-
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
-protocol used in Node.js.
 
 <!-- refs -->
 

--- a/locale/fa/docs/guides/debugging-getting-started.md
+++ b/locale/fa/docs/guides/debugging-getting-started.md
@@ -77,37 +77,9 @@ info on these follows:
 * The latest version can also be installed independently (e.g. `npm install -g node-inspect`)
   and used with `node-inspect myscript.js`.
 
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **Option 1**: Open `chrome://inspect` in a Chromium-based
-  browser. Click the Configure button and ensure your target host and port
-  are listed.
-* **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
-  (see above) or the --inspect hint text and paste into Chrome.
-  
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* In the Debug panel, click the settings icon to open `.vscode/launch.json`.
-  Select "Node.js" for initial setup.
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* Choose "Debug > Start Debugging" from the menu or hit F5.
-* [Detailed instructions](https://github.com/Microsoft/nodejstools/wiki/Debugging).
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ and other JetBrains IDEs
-
-* Create a new Node.js debug configuration and hit Debug. `--inspect` will be used
-  by default for Node.js 7+. To disable uncheck `js.debugger.node.use.inspect` in
-  the IDE Registry.
-
 #### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
 * Library to ease connections to Inspector Protocol endpoints.
-
-#### [Gitpod](https://www.gitpod.io)
-
-* Start a Node.js debug configuration from the `Debug` view or hit `F5`. [Detailed instructions](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
 
 ---
 
@@ -205,7 +177,7 @@ $ ssh -L 9221:localhost:9229 user@remote.example.com
 
 This starts a ssh tunnel session where a connection to port 9221 on your local
 machine will be forwarded to port 9229 on remote.example.com. You can now attach
-a debugger such as Chrome DevTools or Visual Studio Code to localhost:9221,
+a debugger to localhost:9221,
 which should be able to debug as if the Node.js application was running locally.
 
 ---
@@ -229,12 +201,6 @@ Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
 the `--debug-brk` option, and the initial Node process runs the `_debugger.js`
 script and connects to your target.
-
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
-protocol used in Node.js.
 
 <!-- refs -->
 

--- a/locale/it/docs/guides/debugging-getting-started.md
+++ b/locale/it/docs/guides/debugging-getting-started.md
@@ -99,30 +99,6 @@ info on these follows:
 * The latest version can also be installed independently (e.g. `npm install -g node-inspect`)
   and used with `node-inspect myscript.js`.
 
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **Option 1**: Open `chrome://inspect` in a Chromium-based
-  browser. Click the Configure button and ensure your target host and port
-  are listed.
-* **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
-  (see above) or the --inspect hint text and paste into Chrome.
-
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* In the Debug panel, click the settings icon to open `.vscode/launch.json`.
-  Select "Node.js" for initial setup.
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* Choose "Debug > Start Debugging" from the menu or hit F5.
-* [Detailed instructions](https://github.com/Microsoft/nodejstools/wiki/Debugging).
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ and other JetBrains IDEs
-
-* Create a new Node.js debug configuration and hit Debug. `--inspect` will be used
-  by default for Node.js 7+. To disable uncheck `js.debugger.node.use.inspect` in
-  the IDE Registry.
-
 #### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
 * Library to ease connections to Inspector Protocol endpoints.
@@ -223,7 +199,7 @@ $ ssh -L 9221:localhost:9229 user@remote.example.com
 
 This starts a ssh tunnel session where a connection to port 9221 on your local
 machine will be forwarded to port 9229 on remote.example.com. You can now attach
-a debugger such as Chrome DevTools or Visual Studio Code to localhost:9221,
+a debugger to localhost:9221,
 which should be able to debug as if the Node.js application was running locally.
 
 ---
@@ -247,12 +223,6 @@ Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
 the `--debug-brk` option, and the initial Node process runs the `_debugger.js`
 script and connects to your target.
-
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
-protocol used in Node.js.
 
 <!-- refs -->
 

--- a/locale/ja/docs/guides/debugging-getting-started.md
+++ b/locale/ja/docs/guides/debugging-getting-started.md
@@ -166,77 +166,9 @@ info on these follows:
 * バージョンは Node にバンドルされており、`node inspect myscript.js`と一緒に使うことができます
 * 最新バージョンは独立してインストールすることもでき (例えば `npm install -g node-inspect`)、 `node-inspect myscript.js` と一緒に使うことができます
 
-<!-- 
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **Option 1**: Open `chrome://inspect` in a Chromium-based
-  browser. Click the Configure button and ensure your target host and port
-  are listed.
-* **Option 2**: Copy the `devtoolsFrontendUrl` from the output of `/json/list`
-  (see above) or the --inspect hint text and paste into Chrome.
-
- -->
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **オプション 1**: Chromium ベースのブラウザで `chrome://inspect` を開きます。設定ボタンをクリックして、ターゲットホストとポートが表示されていることを確認します。
-* **オプション 2**: `/json/list`の出力 (上記を参照) または --inspect ヒントテキストから `devtoolsFrontendUrl` をコピーして Chrome に貼り付けます
-  
-<!-- 
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* In the Debug panel, click the settings icon to open `.vscode/launch.json`.
-  Select "Node.js" for initial setup.
-
- -->
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* デバッグパネルで、設定アイコンをクリックして `.vscode/launch.json` を開きます。初期設定は "Node.js" を選択してください
-
-<!-- 
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* Choose "Debug > Start Debugging" from the menu or hit F5.
-* [Detailed instructions](https://github.com/Microsoft/nodejstools/wiki/Debugging).
-
- -->
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* メニューから "デバッグ > デバッグの開始" を選択するか、F5 を押します
-* [詳しい説明](https://github.com/Microsoft/nodejstools/wiki/Debugging)
-
-<!-- 
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ and other JetBrains IDEs
-
-* Create a new Node.js debug configuration and hit Debug. `--inspect` will be used
-  by default for Node.js 7+. To disable uncheck `js.debugger.node.use.inspect` in
-  the IDE Registry.
-
- -->
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ と他の JetBrains IDE
-
-* 新しい Node.js デバッグ設定を作成して Debug をクリックします。Node.js 7 以降の場合、`--inspect` がデフォルトで使用されます。IDE レジストリで `js.debugger.node.use.inspect` のチェックを外します
-
-<!-- 
-#### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
-
-* Library to ease connections to Inspector Protocol endpoints.
-
- -->
 #### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
 * Inspector Protocol エンドポイントへの接続を容易にするためのライブラリ
-
-<!-- 
-#### [Gitpod](https://www.gitpod.io)
-
-* Start a Node.js debug configuration from the `Debug` view or hit `F5`. [Detailed instructions](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
-
----
-
- -->
-#### [Gitpod](https://www.gitpod.io)
-
-* `Debug` ビュー から Node.js デバッグ設定を開始するか、`F5` を押します。[詳しい説明](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
 
 ---
 
@@ -404,7 +336,7 @@ $ ssh -L 9221:localhost:9229 user@remote.example.com
 
 This starts a ssh tunnel session where a connection to port 9221 on your local
 machine will be forwarded to port 9229 on remote.example.com. You can now attach
-a debugger such as Chrome DevTools or Visual Studio Code to localhost:9221,
+a debugger to localhost:9221,
 which should be able to debug as if the Node.js application was running locally.
 
 ---
@@ -484,20 +416,6 @@ Node の組み込みコマンドラインデバッガの下でスクリプトを
 `node debug script_name.js` を起動します。
 スクリプトは `--debug-brk` オプションで開始された別のノードプロセスで開始され、
 最初のノードプロセスは `_debugger.js` スクリプトを実行してターゲットに接続します。
-
-<!-- 
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
-protocol used in Node.js.
-
- -->
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Chromium で使用されるインスペクタプロトコルを 
-Node.js で使用される V8 デバッガプロトコルに変換する中間プロセスを使用して、
-Chrome DevTools で Node.js アプリケーションをデバッグします。
 
 <!-- refs -->
 

--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -144,65 +144,9 @@ Node 인스펙터에 접속할 수 있는 여러 상용 도구와 오픈소스 �
 * 최신 버전을 별도로 설치할 수 있고(예시: `npm install -g node-inspect`)
   `node-inspect myscript.js`로 사용할 수 있습니다.
 
-#### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **방법 1**: 크로미움에 기반을 둔 브라우저에서 `chrome://inspect`를 엽니다.
-  Configure 버튼을 눌러서 대상 호스트와 포트 목록을 확인합니다.
-* **방법 2**: `/json/list`(상단 참고)의 출력에서 `devtoolsFrontendUrl`을
-  복사하거나 --inspect가 알려준 텍스트에서 복사해서 크롬에 붙여넣기를 합니다.
-
-<!--
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* In the Debug panel, click the settings icon to open `.vscode/launch.json`.
-  Select "Node.js" for initial setup.
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* Choose "Debug > Start Debugging" from the menu or hit F5.
-* [Detailed instructions](https://github.com/Microsoft/nodejstools/wiki/Debugging).
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ and other JetBrains IDEs
-
-* Create a new Node.js debug configuration and hit Debug. `--inspect` will be used
-  by default for Node.js 7+. To disable uncheck `js.debugger.node.use.inspect` in
-  the IDE Registry.
-
-#### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
-
-* Library to ease connections to Inspector Protocol endpoints.
-
-#### [Gitpod](https://www.gitpod.io)
-
-* Start a Node.js debug configuration from the `Debug` view or hit `F5`. [Detailed instructions](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
-
----
--->
-
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* Debug 패널에서 설정 아이콘을 클릭해서 `.vscode/launch.json`을 엽니다.
-  초기 설정으로 "Node.js"를 선택하세요.
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* 메뉴에서 "Debug > Start Debugging"을 선택하거나 F5를 누르세요.
-* [상세한 설명](https://github.com/Microsoft/nodejstools/wiki/Debugging)
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+와 다른 JetBrains IDE
-
-* 새로운 Node.js 디버그 설정을 생성하고 Debug를 누르세요. Node.js 7+에서는
-  기본적으로 `--inspect`를 사용할 것입니다. 비활성화하려면 IDE 레지스트리에서
-  `js.debugger.node.use.inspect`의 체크를 해제하세요.
-
 #### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
 * 인스펙터 프로토콜 엔드포인트로의 연결을 쉽게 하는 라이브러리입니다.
-
-#### [Gitpod](https://www.gitpod.io)
-
-* `Debug` 뷰에서 Node.js 디버그 설정을 실행하거나 `F5` 키를 누르세요.
-  [자세한 방법은 여기를 참고하세요.](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
 
 ---
 
@@ -380,10 +324,10 @@ $ ssh -L 9221:localhost:9229 user@remote.example.com
 <!--
 This starts a ssh tunnel session where a connection to port 9221 on your local
 machine will be forwarded to port 9229 on remote.example.com. You can now attach
-a debugger such as Chrome DevTools or Visual Studio Code to localhost:9221,
+a debugger to localhost:9221,
 which should be able to debug as if the Node.js application was running locally.
 -->
-그러면 로컬 시스템의 9221 포트에서 remote.example.com의 9229 포트로 전달되는 ssh 터널 세션이 시작됩니다. Chrome DevTools 또는 Visual Studio Code 등의 디버거로 localhost:9221에 연결 할 수 있으며 Node.js 애플리케이션이 로컬에서 실행 중인 것처럼 디버깅할 수 있습니다.
+그러면 로컬 시스템의 9221 포트에서 remote.example.com의 9229 포트로 전달되는 ssh 터널 세션이 시작됩니다. 등의 디버거로 localhost:9221에 연결 할 수 있으며 Node.js 애플리케이션이 로컬에서 실행 중인 것처럼 디버깅할 수 있습니다.
 
 ---
 
@@ -420,12 +364,6 @@ Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
 the `--debug-brk` option, and the initial Node process runs the `_debugger.js`
 script and connects to your target.
-
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
-protocol used in Node.js.
 -->
 
 #### [내장 디버거](https://nodejs.org/dist/latest-v6.x/docs/api/debugger.html)
@@ -433,11 +371,6 @@ protocol used in Node.js.
 Node의 내장 명령형 디버거로 스크립트를 실행하려면 `node debug script_name.js`로 실행하세요.
 스크립트가 다른 Node 프로세스에서 `--debug-brk` 옵션으로 시작되고 원래의 Node 프로세스는
 `_debugger.js`를 실행해서 대상에 접속합니다.
-
-#### [node-inspector](https://github.com/node-inspector/node-inspector)
-
-크로미움에서 사용하는 인스펙터 프로토콜을 Node.js가 사용하는 V8 디버거 프로토콜로 변환하는
-중간 프로세스를 사용해서 크롬 개발자도구로 Node.js 애플리케이션을 디버깅합니다.
 
 <!-- refs -->
 

--- a/locale/zh-cn/docs/guides/debugging-getting-started.md
+++ b/locale/zh-cn/docs/guides/debugging-getting-started.md
@@ -48,31 +48,9 @@ layout: docs.hbs
 * 和 Node 绑定在一起的版本，并且可以使用 `node inspect myscript.js`。
 * 最新的版本同样可以单独通过（例如 `npm install -g node-inspect`）方式安装，并使用 `node-inspect myscript.js`。
 
-#### [Chrome 开发工具 ](https://github.com/ChromeDevTools/devtools-frontend) 55+
-
-* **选项 1**: 在基于 Chromium 内核的浏览器下打开 `chrome://inspect`。点击配置按钮确保你的目标宿主和端口号列入其中。
-* **选项 2**: 从 `/json/list` 中拷贝 `devtoolsFrontendUrl`（见上），或者加上 --inspect 以检查提示文本并粘贴到 Chrome 中。
-
-#### [Visual Studio Code](https://github.com/microsoft/vscode) 1.10+
-
-* 在 Debug 面板中，点击设置按钮打开 `.vscode/launch.json`，选择 "Node.js" 进行初始化构建。
-
-#### [Visual Studio](https://github.com/Microsoft/nodejstools) 2017
-
-* 从菜单中或者单击 F5， "Debug > Start Debugging"。
-* [详细指导](https://github.com/Microsoft/nodejstools/wiki/Debugging)
-
-#### [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) 2017.1+ 以及其它版本
-
-* 创建一个新的 Node.js 调试配置，点击调试。在 Node.js 7 版本上默认会加上 `--inspect` 开关。禁用 uncheck `js.debugger.node.use.inspect` IDE 注册表。
-
 #### [chrome 远程接口](https://github.com/cyrus-and/chrome-remote-interface)
 
 * 简化对检查器协议终端连接的库。
-
-#### [Gitpod](https://www.gitpod.io)
-
-* 你可以通过 `Debug` 视图，或者按下 `F5` 启动 Node.js 调试。[查看详细教程](https://medium.com/gitpod/debugging-node-js-applications-in-theia-76c94c76f0a1)
 
 ---
 
@@ -159,7 +137,7 @@ $ node --inspect server.js
 $ ssh -L 9221:localhost:9229 user@remote.example.com
 ```
 
-ssh 管道启动，在你机器上连接到 9221 端口将被重定向到 9229 的 remote.example.com 地址上。你可以附加一个调试器，例如 Chrome 开发工具或者是指向 localhost:9221 的 Visual Studio Code。如果 Node.js 本地正在运行，应该可以调试了。
+ssh 管道启动，在你机器上连接到 9221 端口将被重定向到 9229 的 remote.example.com 地址上。你可以附加一个调试器 localhost:9221 的。如果 Node.js 本地正在运行，应该可以调试了。
 
 ---
 
@@ -174,10 +152,6 @@ V8 调试协议再也不维护或是归档了。
 #### [ 内置调试器 ](https://nodejs.org/dist/latest-v6.x/docs/api/debugger.html)
 
 在 Node.js 内置命令行调试器中 用 `node debug script_name.js` 启动你的脚本。你的脚本就在 Node 另外一个进程中随着 `--debug-brk` 启动了起来，并且初始化的 Node 进程运行 `_debugger.js` 脚本连接上你的目标。
-
-#### [node 监视器](https://github.com/node-inspector/node-inspector)
-
-用 Chrome 开发工具，通过 Node.js 的中间进程把 Chromium 中的检查器协议转换成 V8 调试器协议进行程序调试。
 
 <!-- refs -->
 


### PR DESCRIPTION
Keeping with the spirit of the most recent privacy concerns raised, this PR is being opened to address additional privacy issues:

> Gathering information about users is a real concern some of our consumers have.

# 1. Chrome DevTools 55+
Ignoring the obvious (like this [#1 Google search result article](https://www.cnet.com/news/google-alphabet-earnings-fourth-quarter-2018/)), the Chrome DevTools has analytics baked into the code:
https://github.com/ChromeDevTools/devtools-frontend/blob/aa1532c2f8bdc37c9886255644ed90ad01c61c77/front_end/audits/lighthouse/template.html#L52-L56

Further upon startup following the instructions [from the link](https://github.com/ChromeDevTools/devtools-frontend):

```
Clone the repo
Go to repo root and run: npm start
This launches Chrome Canary and starts the dev server with 1 command
```

This is all of the content that is pulled from Google servers and more (survey.g.doubleclick.net, youtube.com, google-analytics.com, googleads.g.doubleclick.net...)

![Capture6](https://user-images.githubusercontent.com/11353590/59726638-473a8080-91e7-11e9-8b99-dbbe4aed586a.JPG)

And the following test was verified on a freshly installed VM so I'm certain this behavior is the default.  Because DevTools is so tightly integrated with Chrome the browser, privacy concerns related to DevTools should be considered at parity with that of Chrome itself... that is to say [A HUGE ISSUE](https://www.wired.com/story/google-tracks-you-privacy/).

# 2. Visual Studio Code 1.10+, and Visual Studio 2017
Wide open issues on GitHub about telemetry data being collected by default, possible VSCode extension issues, etc.

https://github.com/microsoft/vscode/issues/47284
https://github.com/microsoft/vscode/issues/34503
https://github.com/microsoft/vscode/issues/31891

# 3. JetBrains WebStorm 2017.1+ and other JetBrains IDEs
Whilst just installing Jetbrains, I'm faced with the following notice which basically tells me that my personal data is going to be used including my "email address".  In fact I can't continue without accepting the terms.

![jetbrains](https://user-images.githubusercontent.com/11353590/59721809-ff136200-91d6-11e9-9445-ebcd4ba84ed8.jpg)

# 4. Gitpod
Whilst just now trying to use Gitpod, I'm faced with another notice, requiring none other than my "email address".
![Capture1](https://user-images.githubusercontent.com/11353590/59721957-5580a080-91d7-11e9-871e-8dbeab17f4e9.JPG)

Outside of node-inspect which is part of the Node project, [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface) remains because no obvious privacy concerns were visible to me.  However I [will bring attention to this issue](https://github.com/cyrus-and/chrome-remote-interface/issues/391) which I found rather timely/untimely, and I would caution the author of going down the extension route as it relates to the Node ecosystem.

The overarching theme here is that privacy issues remain with these other links, and as such they ought to be removed immediately and without delay.



