### PR TITLE
Update Dockerizing guide to adhere to best practice

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -80,11 +80,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -144,7 +144,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -195,7 +195,7 @@ $ docker images
 
 # Example
 REPOSITORY                      TAG        ID              CREATED
-node                            8          1934b0b038d1    5 days ago
+node                            10         1934b0b038d1    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 

--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -134,11 +134,10 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -162,7 +161,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 ## .dockerignore file

--- a/locale/fa/docs/guides/nodejs-docker-webapp.md
+++ b/locale/fa/docs/guides/nodejs-docker-webapp.md
@@ -82,11 +82,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -144,7 +144,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/locale/fa/docs/guides/nodejs-docker-webapp.md
+++ b/locale/fa/docs/guides/nodejs-docker-webapp.md
@@ -134,11 +134,10 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -162,7 +161,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 ## .dockerignore file

--- a/locale/it/docs/guides/nodejs-docker-webapp.md
+++ b/locale/it/docs/guides/nodejs-docker-webapp.md
@@ -82,11 +82,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -144,7 +144,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/locale/it/docs/guides/nodejs-docker-webapp.md
+++ b/locale/it/docs/guides/nodejs-docker-webapp.md
@@ -134,11 +134,10 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -162,7 +161,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 ## .dockerignore file

--- a/locale/ja/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ja/docs/guides/nodejs-docker-webapp.md
@@ -155,11 +155,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -217,7 +217,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -251,10 +251,10 @@ touch Dockerfile
 
 最初にしなければならないことは、どのイメージから構築したいかを定義することです。
 ここでは[Docker Hub](https://hub.docker.com/)から入手できる
-`node` の最新の LTS (long term support) バージョン `8` を使います。
+`node` の最新の LTS (long term support) バージョン `10` を使います。
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 次に、イメージ内にアプリケーションコードを入れるディレクトリを作成します。
@@ -312,7 +312,7 @@ CMD [ "npm", "start" ]
 `Dockerfile` はこのようになっているはずです。
 
 ```docker
-FROM node:8
+FROM node:10
 
 # アプリケーションディレクトリを作成する
 WORKDIR /usr/src/app

--- a/locale/ja/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ja/docs/guides/nodejs-docker-webapp.md
@@ -207,11 +207,10 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -235,7 +234,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
  -->
@@ -306,7 +305,7 @@ EXPOSE 8080
 基本的な `npm start` を使います：
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 `Dockerfile` はこのようになっているはずです。
@@ -330,7 +329,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 <!-- 

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -151,11 +151,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 -->
 
@@ -171,10 +171,10 @@ touch Dockerfile
 
 가장 먼저 해야 할 것은 어떤 이미지를 사용해서 빌드할 것인지를 정의하는 것입니다. 여기서는
 [Docker Hub](https://hub.docker.com/)에 있는
-`node`의 최신 LTS(장기 지원) 버전인 `8`을 사용할 것입니다.
+`node`의 최신 LTS(장기 지원) 버전인 `10`을 사용할 것입니다.
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 <!--
@@ -283,7 +283,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -315,7 +315,7 @@ CMD [ "npm", "start" ]
 `Dockerfile`은 다음과 같아야 합니다.
 
 ```docker
-FROM node:8
+FROM node:10
 
 # 앱 디렉터리 생성
 WORKDIR /usr/src/app

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -273,11 +273,10 @@ EXPOSE 8080
 
 <!--
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -301,7 +300,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 -->
 
@@ -309,7 +308,7 @@ CMD [ "npm", "start" ]
 여기서는 서버를 구동하도록 `node server.js`을 실행하는 기본 `npm start`을 사용할 것입니다.
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 `Dockerfile`은 다음과 같아야 합니다.
@@ -333,7 +332,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 <!--

--- a/locale/ru/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ru/docs/guides/nodejs-docker-webapp.md
@@ -136,11 +136,10 @@ EXPOSE 8080
 ```
 
 Last but not least, define the command to run your app using `CMD` which defines
-your runtime. Here we will use the basic `npm start` which will run
-`node server.js` to start your server:
+your runtime. Here we will use `node server.js` to start your server:
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 Your `Dockerfile` should now look like this:
@@ -164,7 +163,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 ## .dockerignore file

--- a/locale/ru/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ru/docs/guides/nodejs-docker-webapp.md
@@ -82,11 +82,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `8` of `node`
+Here we will use the latest LTS (long term support) version `10` of `node`
 available from the [Docker Hub](https://hub.docker.com/):
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -146,7 +146,7 @@ CMD [ "npm", "start" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
+++ b/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
@@ -112,7 +112,7 @@ EXPOSE 8080
 最后但同样重要的事是，使用定义运行时的 `CMD` 定义命令来运行应用程序。这里我们使用最简单的 `npm start` 命令，它将运行 `node server.js` 启动你的服务器：
 
 ```docker
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 你的 `Dockerfile` 现在看上去是这个样子：
@@ -136,7 +136,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]
 ```
 
 ## .dockerignore 文件

--- a/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
+++ b/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
@@ -67,10 +67,10 @@ touch Dockerfile
 
 用你最喜欢的文本编辑器打开这个 `Dockerfile`。
 
-我们要做的第一件事是定义我们需要从哪个镜像进行构建。这里我们将使用最新的 LTS（长期服务器支持版），`Node` 的版本号为 `8`。你可以从 [Docker 站点](https://hub.docker.com/) 获取相关镜像：
+我们要做的第一件事是定义我们需要从哪个镜像进行构建。这里我们将使用最新的 LTS（长期服务器支持版），`Node` 的版本号为 `10`。你可以从 [Docker 站点](https://hub.docker.com/) 获取相关镜像：
 
 ```docker
-FROM node:8
+FROM node:10
 ```
 
 下一步在镜像中创建一个文件夹存放应用程序代码，这将是你的应用程序工作目录：
@@ -118,7 +118,7 @@ CMD [ "npm", "start" ]
 你的 `Dockerfile` 现在看上去是这个样子：
 
 ```docker
-FROM node:8
+FROM node:10
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
Hey y'all,

#### TL;DR - This PR updates the [Dockerizing a Node.js web app guide](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/) to adhere to an official best practice of using `node server.js` instead of `npm start` inside of a Docker container.

#### Longer version:

The current [Dockerizing a Node.js web app](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/) guide links to the official [Node.js Docker Best Practices Guide](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md) that [currently recommends](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#cmd) avoiding the use of `npm start` for two reasons:

1. Reduces the number of processes running inside of your container.
2. Enable exit signals such as `SIGTERM` and `SIGINT` to be received by the Node.js process instead of npm swallowing them.

There are currently [~54,000 public `Dockerfile`s on GitHub](https://github.com/search?q=%22CMD+%5B+%5C%22npm%5C%22%2C+%5C%22start%5C%22+%5D%22+filename%3ADockerfile&type=Code) not following this practice.

This PR updates the former guide to adhere to latter guide's best practice.

Additionally, the guide references "latest LTS" that points to `8`, this updates that to `10`

#### Additional Question:

How should I handle translations? The translation guide in this repo doesn't seem to apply to the guides pages, so I didn't update the corresponding paragraph of text for the locales that weren't already english.
