### PR TITLE
fix: make Hamburg a separate state

### DIFF
--- a/locale/en/get-involved/node-meetups.md
+++ b/locale/en/get-involved/node-meetups.md
@@ -212,7 +212,7 @@ REQUIREMENTS
 - Organizer name - Valentin Huber
 - Organizer contact info - [Email](mailto:valentin.huber@msg.group)
 
-##### Hamburg
+#### Hamburg
 
 - [Meetup](https://www.meetup.com/node-HH/)
 - Frequency of meetups - monthly and on demand


### PR DESCRIPTION
Hamburg is now a separate state and not a part of Bavaria :slightly_smiling_face: 