### PR TITLE
AR : Fix missing part & some translate in site.json

### DIFF
--- a/locale/ar/site.json
+++ b/locale/ar/site.json
@@ -87,7 +87,7 @@
   },
   "docs": {
     "link": "docs",
-    "text": "التوثيق",
+    "text": "المستندات",
     "es6": {
       "link": "docs/es6",
       "text": "ES6 وما بعدها"
@@ -104,6 +104,10 @@
     "guides": {
       "link": "docs/guides",
       "text": "إرشادات"
+    },
+    "dependencies": {
+      "link": "docs/meta/topics/dependencies",
+      "text": "تبعيات"
     }
   },
   "getinvolved": {
@@ -127,7 +131,7 @@
     },
     "node-meetups": {
       "link": "get-involved/node-meetups",
-      "text": "Node.js لقاءات"
+      "text": "Node.js مُلْتَقَيات"
     }
   },
   "security": {

--- a/locale/ar/site.json
+++ b/locale/ar/site.json
@@ -87,7 +87,7 @@
   },
   "docs": {
     "link": "docs",
-    "text": "المستندات",
+    "text": "التوثيق",
     "es6": {
       "link": "docs/es6",
       "text": "ES6 وما بعدها"


### PR DESCRIPTION
Some details :
1. I've added a part that is in the English version and is missing here ; 
```
    "dependencies": {
      "link": "docs/meta/topics/dependencies",
      "text": "Dependencies"
    }
  <!-- from `Dependencies` to `تبعيات` -->
```
2. Fix translation of meetups ; from `لقاءات` to `مُلْتَقَيات` .. 
3.  ~~Fix translation of docs ; from `التوثيق` to `المستندات` ..~~
