### PR TITLE
Configuration file for Crowdin integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,3 +9,8 @@ files:
         zh-TW: zh-tw
   - source: /locale/en/**/*.json
     translation: /locale/%two_letters_code%/**/%original_file_name%
+    languages_mapping:
+      two_letters_code:
+        pt-BR: pt-br
+        zh-CN: zh-cn
+        zh-TW: zh-tw

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,3 @@
+files:
+  - source: /locale/en/**/*.md
+    translation: /locale/%two_letters_code%/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,11 @@
 files:
   - source: /locale/en/**/*.md
     translation: /locale/%two_letters_code%/**/%original_file_name%
+    content_segmentation: 0
+    languages_mapping:
+      two_letters_code:
+        pt-BR: pt-br
+        zh-CN: zh-cn
+        zh-TW: zh-tw
+  - source: /locale/en/**/*.json
+    translation: /locale/%two_letters_code%/**/%original_file_name%


### PR DESCRIPTION
You already have translations for Markdown files, so importing .md files with `content_segmentation: 0` is a good idea, it will segment content by paragraphs and integration will automatically import existing translations to Crowdin (e.g. 1st paragraph in translated file is imported to the 1st paragraph in the source file).

A bit customized language codes are used for Portuguese, Brazilian and Chinese, thus languages mapping was added to fit your current folder names (e.g. `pt-br`).

Hope it helps to start faster!