### PR TITLE
Remove Google Plus

### DIFF
--- a/locale/ar/get-involved/index.md
+++ b/locale/ar/get-involved/index.md
@@ -29,7 +29,6 @@ layout: contribute.hbs
 
 - [مجموعة الفيسبوك للـ Node.js بالعربية](https://www.facebook.com/groups/node.ar)
 - [مجتمع Node.js الصيني](http://cnodejs.org)
-- [المجتمع الفرنسي للـ Node.js لمستخدمي Google+](https://plus.google.com/communities/113346206415381691435)
 - [المجتمع المجري (المجرية)](http://nodehun.blogspot.com/)
 - [مجموعة الفيسبوك الإسرائيلية للـ Node.js](https://www.facebook.com/groups/node.il/)
 - [مجموعة المستخدمين اليابانية](http://nodejs.jp/)

--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -27,7 +27,6 @@ layout: contribute.hbs
 ## Llocs de la comunitat internacional i projectes
 
 - [Comunitat Xinesa de Node.js](http://cnodejs.org)
-- [Comunitat en Google+ d'usuaris Francesos de Node.js](https://plus.google.com/communities/113346206415381691435)
 - [Comunitat d'Hongria(Magyar)](http://nodehun.blogspot.com/)
 - [Grup de Facebook israelià per Node.js](https://www.facebook.com/groups/node.il/)
 - [Grup d'usuaris de Japó](http://nodejs.jp/)

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -26,7 +26,6 @@ layout: contribute.hbs
 ## International community sites and projects
 
 - [Chinese community](http://cnodejs.org)
-- [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)

--- a/locale/es/get-involved/index.md
+++ b/locale/es/get-involved/index.md
@@ -25,7 +25,6 @@ layout: contribute.hbs
 ## Sitios de la comunidad internacional y proyectos
 
 - [Comunidad China](http://cnodejs.org)
-- [Comunidad en Google+ de usuarios Franceses de Node.js](https://plus.google.com/communities/113346206415381691435)
 - [Comunidad de Hungría (Magyar)](http://nodehun.blogspot.com/)
 - [Comunidad en Facebook de usuarios Israelí de Node.js](https://www.facebook.com/groups/node.il/)
 - [Grupo de usuarios de Japón](http://nodejs.jp/)

--- a/locale/fa/get-involved/index.md
+++ b/locale/fa/get-involved/index.md
@@ -26,7 +26,6 @@ layout: contribute.hbs
 ## International community sites and projects
 
 - [Chinese community](http://cnodejs.org)
-- [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -40,7 +40,6 @@ layout: contribute.hbs
 ## Site et projets des commuanutés internationales
 
 - [communauté chinoise](http://cnodejs.org)
-- [communauté française Google+ des utilisateurs Node.js](https://plus.google.com/communities/113346206415381691435)
 - [communauté hongroise (Magyar)](http://nodehun.blogspot.com/)
 - [communauté israelienne sur Facebook](https://www.facebook.com/groups/node.il/)
 - [communauté japonaise](http://nodejs.jp/)

--- a/locale/it/get-involved/index.md
+++ b/locale/it/get-involved/index.md
@@ -26,7 +26,6 @@ layout: contribute.hbs
 ## International community sites and projects
 
 - [Chinese community](http://cnodejs.org)
-- [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)

--- a/locale/ja/get-involved/index.md
+++ b/locale/ja/get-involved/index.md
@@ -63,7 +63,6 @@ layout: contribute.hbs
 ## インターナショナルコミュニティサイトとプロジェクト
 
 - [中国コミュニティ](http://cnodejs.org)
-- [フランスの Node.js ユーザ Google+ コミュニティ](https://plus.google.com/communities/113346206415381691435)
 - [ハンガリー (マジャール) コミュニティ](http://nodehun.blogspot.com/)
 - [Node.js のイスラエル Facebook グループ](https://www.facebook.com/groups/node.il/)
 - [日本のユーザグループ](http://nodejs.jp/)

--- a/locale/ko/get-involved/index.md
+++ b/locale/ko/get-involved/index.md
@@ -61,7 +61,6 @@ layout: contribute.hbs
 ## 국제 커뮤니티 사이트 및 프로젝트
 
 - [중국 커뮤니티](http://cnodejs.org)
-- [프랑스 Google+ Node.js 사용자 커뮤니티](https://plus.google.com/communities/113346206415381691435)
 - [헝가리(마자르) 커뮤니티](http://nodehun.blogspot.com/)
 - [이스라엘 Facebook Node.js 그룹](https://www.facebook.com/groups/node.il/)
 - [일본 사용자 그룹](http://nodejs.jp/)

--- a/locale/pt-br/get-involved/index.md
+++ b/locale/pt-br/get-involved/index.md
@@ -27,7 +27,6 @@ layout: contribute.hbs
 ## Sites e projetos internacionais da comunidade
 
 - [Comunidade Chinesa](http://cnodejs.org)
-- [Comunidade Francesa de usuários Node.js no Google+](https://plus.google.com/communities/113346206415381691435)
 - [Comunidade Húngara(Magyar)](http://nodehun.blogspot.com/)
 - [Grupo Node.js Israelense no Facebook](https://www.facebook.com/groups/node.il/)
 - [Grupo de usuários Japoneses](http://nodejs.jp/)

--- a/locale/ru/get-involved/index.md
+++ b/locale/ru/get-involved/index.md
@@ -29,7 +29,6 @@ layout: contribute.hbs
 ## Международные общественные сайты и проекты
 
 - [Китайское сообщество](http://cnodejs.org)
-- [Французское сообщество Google+ пользователей Node.js](https://plus.google.com/communities/113346206415381691435)
 - [Венгерское (мадьярское) сообщество](http://nodehun.blogspot.com/)
 - [Израильская группа Facebook для Node.js](https://www.facebook.com/groups/node.il/)
 - [Японская группа пользователей](http://nodejs.jp/)

--- a/locale/uk/get-involved/index.md
+++ b/locale/uk/get-involved/index.md
@@ -25,7 +25,6 @@ layout: contribute.hbs
 ## Сайти міжнародних спільнот та проекти
 
 - [Chinese community](http://cnodejs.org)
-- [French Google+ Community of Node.js users](https://plus.google.com/communities/113346206415381691435)
 - [Hungarian (Magyar) community](http://nodehun.blogspot.com/)
 - [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
 - [Japanese user group](http://nodejs.jp/)

--- a/locale/zh-cn/get-involved/index.md
+++ b/locale/zh-cn/get-involved/index.md
@@ -27,7 +27,6 @@ layout: contribute.hbs
 ## 国际化社区站点及项目
 
 - [汉语社团](http://cnodejs.org)
-- [Google+ 上的法语 Node.js 用户组](https://plus.google.com/communities/113346206415381691435)
 - [匈牙利（马札尔人）语社团](http://nodehun.blogspot.com/)
 - [Facebook 上以色列语 Node.js 用户组](https://www.facebook.com/groups/node.il/)
 - [日本语用户组](http://nodejs.jp/)

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -28,7 +28,6 @@ layout: contribute.hbs
 ## 國際性社群網站及專案
 
 - [漢語社群](http://cnodejs.org)
-- [Google+ 上的法語 Node.js 用戶組](https://plus.google.com/communities/113346206415381691435)
 - [匈牙利（馬劄爾人）語社群](http://nodehun.blogspot.com/)
 - [Facebook 上以色列語 Node.js 用戶組](https://www.facebook.com/groups/node.il/)
 - [日本語使用者組](http://nodejs.jp/)


### PR DESCRIPTION
Google+ was shut down on April 2, 2019.