### PR TITLE
Add "server-side"

### DIFF
--- a/locale/en/about/index.md
+++ b/locale/en/about/index.md
@@ -5,10 +5,11 @@ trademark: Trademark
 ---
 # About Node.js&reg;
 
-As an asynchronous event driven JavaScript runtime, Node is designed to build
-scalable network applications. In the following "hello world" example, many
-connections can be handled concurrently. Upon each connection the callback is
-fired, but if there is no work to be done, Node will sleep.
+As an asynchronous event driven JavaScript server-side runtime, Node is 
+designed to build scalable network applications. In the following "hello 
+world" example, many connections can be handled concurrently. Upon each 
+connection the callback is fired, but if there is no work to be done, 
+Node will sleep.
 
 ```javascript
 const http = require('http');


### PR DESCRIPTION
Complete Node.js neophytes (like myself) might not immediately understand that Node.js is a server-side tool, since the lion's share of JavaScript uses are client-side (i.e. browser-based).  Added "server-side" to the initial sentence to clear that possible misunderstanding up right away.