### PR TITLE
Specify image dimensions in the HTML.

### DIFF
--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -131,14 +131,10 @@ header
 
 #logo
   display block
-  border none
 
   &:hover
     background-color transparent
     text-decoration underline
 
   img
-    display block
     margin 0.5em auto 0
-    max-height 75px
-    max-width 180px

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -6,7 +6,7 @@
     <div class="linuxfoundation-footer">
       <div class="issue-link-container">
         <a class="linuxfoundation-logo" href="http://collabprojects.linuxfoundation.org">
-          <img alt="Linux Foundation Collaborative Projects" src="/static/images/lfcp.png">
+          <img alt="Linux Foundation Collaborative Projects" src="/static/images/lfcp.png" width="416" height="15">
         </a>
         <ul class="list-divider-pipe issue-link">
           <li><a href="https://github.com/nodejs/node/issues">{{site.reportNodeIssue}}</a></li>

--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -2,7 +2,7 @@
   <div class="container">
 
     <a href="/{{site.locale}}/" id="logo">
-      <img src="/static/images/logo.svg" alt="node.js">
+      <img src="/static/images/logo.svg" alt="node.js" width="180" height="75">
     </a>
 
     <nav>


### PR DESCRIPTION
This avoids potential reflows since the HTML is parsed first.
