### PR TITLE
Minor CSS cleanup.

### DIFF
--- a/layouts/css/page-modules/_footer.styl
+++ b/layouts/css/page-modules/_footer.styl
@@ -1,7 +1,7 @@
 footer
   margin-top 2em
   background-color $node-gray
-  padding 0 0px
+  padding 0
 
   a,
   a:link,
@@ -13,4 +13,4 @@ footer
     text-decoration underline
 
   &.no-margin-top
-    margin-top 0px
+    margin-top 0

--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -24,7 +24,7 @@ header
     a:hover
       background-color transparent
       text-decoration underline
-  
+
   #lang-picker-toggler
     position absolute
     right 0

--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -42,7 +42,7 @@
 
 .home-banner
   opacity 1
-  transition .2s opacity ease-in-out
+  transition opacity .2s ease-in-out
 
   &:hover
     opacity 0.85
@@ -65,7 +65,7 @@
   font-size 30px
   font-weight 400
 
-  transition .2s background-color ease-in-out
+  transition background-color .2s ease-in-out
 
   &:hover
     background-color $node-green

--- a/layouts/css/styles.styl
+++ b/layouts/css/styles.styl
@@ -76,7 +76,7 @@
       width 100%
       float none
     article
-      margin-left 0px
+      margin-left 0
 
 .full-width
   width 100%
@@ -109,9 +109,9 @@ html[dir="rtl"]
 
       article
         margin-right 220px
-        margin-left 0px
+        margin-left 0
 
     @media screen and (max-width: 480px)
       .has-side-nav
         article
-          margin-right 0px
+          margin-right 0


### PR DESCRIPTION
* simplify padding shorthand
* remove units from 0
* use `property-name | duration | timing function` for transition shorthand
* remove trailing spaces
* add missing EOF