### PR TITLE
Link fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org/
 
 root = true
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [nodejs.org](https://nodejs.org/)
 
-[![Build Status](https://img.shields.io/travis/nodejs/nodejs.org/master.svg)](http://travis-ci.org/nodejs/nodejs.org)
+[![Build Status](https://img.shields.io/travis/nodejs/nodejs.org/master.svg)](https://travis-ci.org/nodejs/nodejs.org)
 [![Dependency Status](https://img.shields.io/david/nodejs/nodejs.org.svg)](https://david-dm.org/nodejs/nodejs.org)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/layouts/partials/download-list.hbs
+++ b/layouts/partials/download-list.hbs
@@ -1,8 +1,8 @@
 <section>
   <ul>
     <li><a href="https://nodejs.org/dist/{{version.node}}/{{site.download.shasums.link}}">{{site.download.shasums.text}}</a> (<a href="{{site.download.shasums.verify-link}}">{{site.download.shasums.verify-text}}</a>)</li>
-    <li><a href="https://nodejs.org/dist/{{version.node}}">{{site.all-downloads}}</a></li>
-    <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}">{{site.download.package-manager.text}}</a></li>
+    <li><a href="https://nodejs.org/dist/{{version.node}}/">{{site.all-downloads}}</a></li>
+    <li><a href="/{{site.locale}}/{{site.download.package-manager.link}}/">{{site.download.package-manager.text}}</a></li>
     <li><a href="/{{site.locale}}/{{site.download.releases.link}}/">{{site.download.releases.text}}</a></li>
     <li><a href="https://nodejs.org/download/nightly/">{{site.nightly}}</a></li>
     <li><a href="https://nodejs.org/download/chakracore-nightly/">{{site.chakracore-nightly}}</a></li>

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -4,7 +4,7 @@
   <div class="download-hero full-width">
     <ul class="no-padding download-version-toggle">
       <li>
-        <a {{#if versionTypeLts}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}" title="{{downloads.display-hint}} {{downloads.lts}}">
+        <a {{#if versionTypeLts}}class="is-version"{{/if}} href="/{{site.locale}}/{{site.download.link}}/" title="{{downloads.display-hint}} {{downloads.lts}}">
           <div class="title">{{downloads.lts}}</div>
           <div class="tag">{{downloads.tagline-lts}}</div>
         </a>


### PR DESCRIPTION
There are plenty more but being I'm on Windows there's a bug somewhere and it generates invalid links (like `<a href="/en/blog/release\v10.16.2/">Node v10.16.2 (LTS)</a>`) so I need to fix this first before doing this with a tool.

For reference about the missing trailing slashes:

```
C:\Users\XhmikosR\Desktop>curl -ILls https://nodejs.org/en/download/current | findstr location
location: https://nodejs.org/en/download/current/
```