### PR TITLE
Fix generating anchors with empty IDs and links.

### DIFF
--- a/scripts/plugins/anchor-markdown-headings.js
+++ b/scripts/plugins/anchor-markdown-headings.js
@@ -35,6 +35,11 @@ module.exports = function anchorMarkdownHeadings (text, level, raw) {
       .replace(/-{2,}/g, '-')
       .replace(/(^-|-$)/g, '')
   }
+
+  if (!anchorTitle) {
+    return `<h${level}>${text}</h${level}>`
+  }
+
   anchorTitle = anchorTitle.toLowerCase()
 
   return '<h' + level + ' id="header-' + anchorTitle + '">' + text + '<a name="' +

--- a/tests/scripts/anchor-mardown-headings.test.js
+++ b/tests/scripts/anchor-mardown-headings.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const test = require('tape')
+const anchorMarkdownHeadings = require('../../scripts/plugins/anchor-markdown-headings')
 
 test('anchorMarkdownHeadings', (t) => {
-  const anchorMarkdownHeadings = require('../../scripts/plugins/anchor-markdown-headings')
+  t.plan(6)
 
-  t.plan(5)
-  t.test('correctly pharses markdown heading without links', (t) => {
+  t.test('correctly parses markdown heading without links', (t) => {
     const text = 'Simple title'
     const level = 1
     const raw = 'Simple title'
@@ -19,7 +19,7 @@ test('anchorMarkdownHeadings', (t) => {
     t.equal(output, expected)
   })
 
-  t.test('correctly pharses markdown heading with a single link', (t) => {
+  t.test('correctly parses markdown heading with a single link', (t) => {
     const text = 'Title with <a href="#">link</a>'
     const level = 3
     const raw = 'Title with [link](#)'
@@ -33,7 +33,7 @@ test('anchorMarkdownHeadings', (t) => {
     t.equal(output, expected)
   })
 
-  t.test('correctly pharses markdown heading with multiple links', (t) => {
+  t.test('correctly parses markdown heading with multiple links', (t) => {
     const text = 'a <a href="b">b</a> c<a href="d">d</a>e'
     const level = 2
     const raw = 'a [b](b) c[d](d)e'
@@ -60,7 +60,7 @@ test('anchorMarkdownHeadings', (t) => {
     t.equal(output, expected)
   })
 
-  t.test('correctly pharses markdown heading with non-English characters', (t) => {
+  t.test('correctly parses markdown heading with non-English characters', (t) => {
     const text = '这是<a href="b">链接</a>的<a href="d">测试！</a>'
     const level = 2
     const raw = '<!-- anchor-With-Non-English-Characters -->这是[链接](b)c[测试！](d)'
@@ -69,6 +69,18 @@ test('anchorMarkdownHeadings', (t) => {
       '这是<a href="b">链接</a>的<a href="d">测试！</a>' +
       '<a name="anchor-with-non-english-characters" class="anchor" href="#anchor-with-non-english-characters" ' +
       'aria-labelledby="header-anchor-with-non-english-characters"></a></h2>'
+
+    t.plan(1)
+    t.equal(output, expected)
+  })
+
+  t.test('does not generate empty anchors', (t) => {
+    const text = 'إنضم إلينا'
+    const level = 2
+    const raw = 'إنضم إلينا'
+    const output = anchorMarkdownHeadings(text, level, raw)
+    const expected = '<h2>إنضم إلينا</h2>'
+
     t.plan(1)
     t.equal(output, expected)
   })


### PR DESCRIPTION
Previously this resulted in duplicate IDs like `header-` and empty `name` attributes in translations.