### PR TITLE
Fix slashes on Windows.

### DIFF
--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -13,7 +13,7 @@
         {{#each pagination.posts}}
           <li>
             <time datetime="{{ strftime post.date '%FT%T%z' }}">{{ strftime post.date "%d %b" }}</time>
-            <a href="/{{ ../site.locale }}/{{ post.path }}/">{{ post.title }}</a>
+            <a href="/{{ ../site.locale }}/{{ slashes post.path }}/">{{ post.title }}</a>
 
             {{#if displaySummary}}
               <div class="summary">

--- a/layouts/category-index.hbs
+++ b/layouts/category-index.hbs
@@ -18,7 +18,7 @@
               {{#if title}}
                 <li>
                   <time datetime="{{ strftime date '%FT%T%z' }}">{{ strftime date "%d %b %y" }}</time>
-                  <a href="/{{../site.locale}}/{{ path }}/">{{ title }}</a>
+                  <a href="/{{../site.locale}}/{{ slashes path }}/">{{ title }}</a>
                 </li>
               {{/if}}
             {{/startswith}}

--- a/layouts/knowledge-base-index.hbs
+++ b/layouts/knowledge-base-index.hbs
@@ -16,7 +16,7 @@
         <ul class="no-padding">
         {{#each collections.knowledgeBase}}
           {{#startswith path 'knowledge/'}}
-            <li><a href="/{{../site.locale}}/{{ path }}/">{{ title }}</a></li>
+            <li><a href="/{{../site.locale}}/{{ slashes path }}/">{{ title }}</a></li>
           {{/startswith}}
         {{/each}}
         </ul>

--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -26,7 +26,7 @@
   <meta name="twitter:image" content="https://nodejs.org/static/images/logo-hexagon-card.png">
   <meta name="twitter:image:alt" content="The Node.js Hexagon Logo">
 
-  <link rel="canonical" href="{{ site.url }}{{#if path}}{{ path }}/{{/if}}">
+  <link rel="canonical" href="{{ site.url }}{{#if path}}{{ slashes path }}/{{/if}}">
   {{#each site.feeds}}
   <link rel="alternate" href="/{{ ../site.locale }}/{{ link }}" title="{{ text }}" type="application/rss+xml">
   {{/each}}

--- a/scripts/helpers/slashes.js
+++ b/scripts/helpers/slashes.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function (str) {
+  return process.platform === 'win32' && str.replace(/\\/g, '/')
+}

--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -30,7 +30,7 @@ module.exports = (contents, locale, path) => {
     .not((i, elem) => IGNORE_SELECTORS.some((selector) => $(elem).is(selector)))
     .each((i, elem) => {
       if (summary.length > SUMMARY_MAX_LENGTH) {
-        summary += `<p><a href='/${locale}/${path}/'>Read more...</a></p>`
+        summary += `<p><a href='/${locale}/${path.replace(/\\/g, '/')}/'>Read more...</a></p>`
         return false
       }
 


### PR DESCRIPTION
There's a bug somewhere which results in backslashes in paths when building on Windows.

Maybe the name should be normalize slashes or something? I just wanted to keep it short here.

Fixes #2396 