### PR TITLE
Fix the link to BFJ

### DIFF
--- a/locale/en/docs/guides/dont-block-the-event-loop.md
+++ b/locale/en/docs/guides/dont-block-the-event-loop.md
@@ -279,7 +279,7 @@ console.log('JSON.parse took ' + took);
 
 There are npm modules that offer asynchronous JSON APIs. See for example:
 - [JSONStream](https://www.npmjs.com/package/JSONStream), which has stream APIs.
-- [Big-Friendly JSON](https://github.com/philbooth/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
 
 ### Complex calculations without blocking the Event Loop
 Suppose you want to do complex calculations in JavaScript without blocking the Event Loop.

--- a/locale/fa/docs/guides/dont-block-the-event-loop.md
+++ b/locale/fa/docs/guides/dont-block-the-event-loop.md
@@ -279,7 +279,7 @@ console.log('JSON.parse took ' + took);
 
 There are npm modules that offer asynchronous JSON APIs. See for example:
 - [JSONStream](https://www.npmjs.com/package/JSONStream), which has stream APIs.
-- [Big-Friendly JSON](https://github.com/philbooth/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
 
 ### Complex calculations without blocking the Event Loop
 Suppose you want to do complex calculations in JavaScript without blocking the Event Loop.

--- a/locale/it/docs/guides/dont-block-the-event-loop.md
+++ b/locale/it/docs/guides/dont-block-the-event-loop.md
@@ -279,7 +279,7 @@ console.log('JSON.parse took ' + took);
 
 There are npm modules that offer asynchronous JSON APIs. See for example:
 - [JSONStream](https://www.npmjs.com/package/JSONStream), which has stream APIs.
-- [Big-Friendly JSON](https://github.com/philbooth/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
 
 ### Complex calculations without blocking the Event Loop
 Suppose you want to do complex calculations in JavaScript without blocking the Event Loop.

--- a/locale/ja/docs/guides/dont-block-the-event-loop.md
+++ b/locale/ja/docs/guides/dont-block-the-event-loop.md
@@ -279,7 +279,7 @@ console.log('JSON.parse took ' + took);
 
 There are npm modules that offer asynchronous JSON APIs. See for example:
 - [JSONStream](https://www.npmjs.com/package/JSONStream), which has stream APIs.
-- [Big-Friendly JSON](https://github.com/philbooth/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
 
 ### Complex calculations without blocking the Event Loop
 Suppose you want to do complex calculations in JavaScript without blocking the Event Loop.

--- a/locale/ru/docs/guides/dont-block-the-event-loop.md
+++ b/locale/ru/docs/guides/dont-block-the-event-loop.md
@@ -279,7 +279,7 @@ console.log('JSON.parse took ' + took);
 
 There are npm modules that offer asynchronous JSON APIs. See for example:
 - [JSONStream](https://www.npmjs.com/package/JSONStream), which has stream APIs.
-- [Big-Friendly JSON](https://github.com/philbooth/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj), which has stream APIs as well as asynchronous versions of the standard JSON APIs using the partitioning-on-the-Event-Loop paradigm outlined below.
 
 ### Complex calculations without blocking the Event Loop
 Suppose you want to do complex calculations in JavaScript without blocking the Event Loop.

--- a/locale/zh-cn/docs/guides/dont-block-the-event-loop.md
+++ b/locale/zh-cn/docs/guides/dont-block-the-event-loop.md
@@ -280,7 +280,7 @@ console.log('JSON.parse took ' + took);
 
 有一些 npm 的模块提供了异步的 JSON API 函数，参考：
 - [JSONStream](https://www.npmjs.com/package/JSONStream)，有流式操作的 API。
-- [Big-Friendly JSON](https://github.com/philbooth/bfj)，有流式 API 和使用下文所概述的任务拆分思想的异步 JSON 标准 API。
+- [Big-Friendly JSON](https://www.npmjs.com/package/bfj)，有流式 API 和使用下文所概述的任务拆分思想的异步 JSON 标准 API。
 
 ### 不要让复杂的计算阻塞事件循环
 假设你想在 JavaScript 处理一个复杂的计算，而又不想阻塞事件循环。


### PR DESCRIPTION
The documentation mentions Big-Friendly JSON (BFJ), but links to an outdated, archived, GitHub repository (https://github.com/philbooth/bfj).
A better option would be to link to the NPM package page (https://www.npmjs.com/package/bfj), in a similar way to how JSONStream is referenced earlier in the same paragraph.

Closes #2438