### PR TITLE
Enabled marked's `smartypants` option.

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,7 +40,8 @@ const renderer = new marked.Renderer()
 renderer.heading = anchorMarkdownHeadings
 const markedOptions = {
   langPrefix: 'language-',
-  renderer: renderer
+  renderer: renderer,
+  smartypants: renderer
 }
 
 // This function imports a given language file and uses the default language set


### PR DESCRIPTION
This is something I'm personally in between.

Live preview: <https://affectionate-almeida-a9f620.netlify.com/en/>

Examples comparison:

* https://nodejs.org/en/docs/guides/getting-started-guide/
* https://affectionate-almeida-a9f620.netlify.com/en/docs/guides/getting-started-guide/

---

* https://nodejs.org/en/docs/guides/dont-block-the-event-loop/
* https://affectionate-almeida-a9f620.netlify.com/en/docs/guides/dont-block-the-event-loop/

Usually, I tend to prefer the curly quotes (smart ones), but I guess it's a matter of preference. Note that this only affects pure Markdown (no online HTML AFAICT), and also curly quotes are already being used in some old npm and uncategorized blog posts.

Anyway, let me know your thoughts.