### PR TITLE
Add vnu.jar support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
 
       - run: node --version
       - run: npm --version
+      - run: java -version
 
       - name: Install npm dependencies
         run: npm ci
@@ -27,6 +28,9 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Run HTML validator
+        run: npm run test:html
 
       - name: Run linkinator
         run: npm run test:linkinator

--- a/package-lock.json
+++ b/package-lock.json
@@ -1876,7 +1876,6 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
@@ -7013,6 +7012,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vnu-jar": {
+      "version": "19.9.4",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-19.9.4.tgz",
+      "integrity": "sha512-x91WyaNr1oPJaYZkbyMElRyV60BUaxPuhm3zXXjlFOpW3E2KavPWlyohX0LTf6gX7/tujIMgLE5UGc0jn7o4XQ==",
+      "dev": true
     },
     "ware": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:lint:md": "markdownlint \"**/*.md\" -i \"**/node_modules/**\"",
     "test:lint:stylint": "stylint layouts/css",
     "test:lint": "npm-run-all --parallel test:lint:*",
+    "test:html": "node scripts/vnu-jar.js",
     "test:unit": "tape tests/**/*.test.js | faucet"
   },
   "repository": "nodejs/nodejs.org",
@@ -78,6 +79,7 @@
     "st": "^1.2.2",
     "standard": "^14.3.1",
     "stylint": "^2.0.0",
-    "tape": "^4.11.0"
+    "tape": "^4.11.0",
+    "vnu-jar": "19.9.4"
   }
 }

--- a/scripts/vnu-jar.js
+++ b/scripts/vnu-jar.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const childProcess = require('child_process')
+const vnu = require('vnu-jar')
+
+childProcess.exec('java -version', (error, stdout, stderr) => {
+  if (error) {
+    console.error('Skipping vnu-jar test; Java is missing.')
+    return
+  }
+
+  const is32bitJava = !stderr.match(/64-Bit/)
+
+  // vnu-jar accepts multiple ignores joined with a `|`.
+  // Also note that the ignores are regular expressions.
+  const ignores = [
+    // Low priority warnings
+    'Section lacks heading.*',
+    // This seems to happen due to some Unicode characters
+    'Text run is not in Unicode Normalization Form C.',
+    // These are real errors but hard to tackle.
+    // We should fix them eventually
+    'Table column.*',
+    // These happen due to the commented out English HTML code some translations have...
+    // They should be removed at some point
+    'The document is not mappable to XML 1.0 due to two consecutive hyphens in a comment.'
+  ].join('|')
+
+  const args = [
+    '-jar',
+    vnu,
+    '--asciiquotes',
+    '--skip-non-html',
+    // Ignore the language code warnings
+    '--no-langdetect',
+    '--Werror',
+    '--errors-only',
+    `--filterpattern "${ignores}"`,
+    'build/'
+  ]
+
+  // For the 32-bit Java we need to pass `-Xss512k`
+  if (is32bitJava) {
+    args.splice(0, 0, '-Xss512k')
+  }
+
+  return childProcess.spawn('java', args, {
+    shell: true,
+    stdio: 'inherit'
+  })
+    .on('exit', process.exit)
+})


### PR DESCRIPTION
This is WIP because there are some things that need to be addressed:

1. #2441 needs to be merged
2. #2437 probably needs to be merged too
3. There's a bug in vnu.jar, I have already discussed with sideshowbarker (not CC'ing right now), that causes the build to exit with non-zero.
4. I'd prefer it if we could actually fix the table errors, because these are real issues:
    ```
    "file:/home/travis/build/XhmikosR/nodejs.org/build/en/download/index.html":276.50-277.32: error: Table column 3 established by element "td" has no cells beginning in it.
    "file:/home/travis/build/XhmikosR/nodejs.org/build/en/download/index.html":277.113-278.32: error: Table column 7 established by element "td" has no cells beginning in it.
    ```
5. The license of the new file might need to be adapted for this repo. It's just a simple script so it's OK to change it, especially since I also adapted it to fit our needs

Note that this is how I noticed and fixed many of the issues so far, like https://github.com/nodejs/nodejs.org/commit/bae664a98a772781314b05eae4cdcc57efafd2b0, https://github.com/nodejs/nodejs.org/commit/b533fcddc0deffbf086d229b5f79155d8a21868d, https://github.com/nodejs/nodejs.org/commit/a714afcc90df0283d0cd9006d049a78ce60361fc, https://github.com/nodejs/nodejs.org/commit/ceee600686ae067f439a7ad9230499c442081e12 etc.

IMO this should definitely land as soon as we sort out the above points. Personally I'd remove htmllint too; I'm [having issues with it on Windows](#2459) and it just doesn't seem to catch any real issues.

Marking it as draft for further discussion and tweaks.

vnu.jar: <https://github.com/validator/validator>

Closes #2398 