### PR TITLE
Specify `word-break: break-word` for article links.

### DIFF
--- a/layouts/css/styles.styl
+++ b/layouts/css/styles.styl
@@ -20,6 +20,9 @@
 @import 'page-modules/_release-schedule'
 @import 'page-modules/_resources'
 
+article a
+  word-break break-word
+
 .intro
   margin-top 140px
   font-size 38px


### PR DESCRIPTION
Without this, the links were not fully showing on mobile if they didn't fit the screen.

Before:

| Before | After |
| ------- | ------ |
| ![1-before](https://user-images.githubusercontent.com/349621/63781872-267f5d00-c8f3-11e9-9f09-67334ae5ee3e.png) | ![2-after](https://user-images.githubusercontent.com/349621/63781889-2ed79800-c8f3-11e9-826a-18f428b9814f.png) |
