### PR TITLE
Remove extra semicolons.

### DIFF
--- a/build.js
+++ b/build.js
@@ -321,7 +321,7 @@ function fullBuild (opts) {
     // Executes the build cycle for every locale.
     fs.readdir(path.join(__dirname, 'locale'), (e, locales) => {
       if (e) {
-        throw e;
+        throw e
       }
       const filteredLocales = locales.filter(file => junk.not(file) && (selectedLocales ? selectedLocales.includes(file) : true))
       const localesData = generateLocalesData(filteredLocales)

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ function dynamicallyBuildOnLanguages (source, locale) {
   if (!selectedLocales || selectedLocales.length === 0) {
     fs.readdir(path.join(__dirname, 'locale'), (e, locales) => {
       if (e) {
-        throw e;
+        throw e
       }
       const filteredLocales = locales.filter(file => junk.not(file))
       const localesData = build.generateLocalesData(filteredLocales)


### PR DESCRIPTION
'build.js' has extra semicolons, remove them together.