### PR TITLE
helpers/slashes.js: remove the process check.

### DIFF
--- a/scripts/helpers/slashes.js
+++ b/scripts/helpers/slashes.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = function (str) {
-  return process.platform === 'win32' && str.replace(/\\/g, '/')
+  return str.replace(/\\/g, '/')
 }


### PR DESCRIPTION
Sorry for the regression, my initial patch didn't include the process check, but due to a review comment I added it, which I shouldn't have.

/CC @Trott @MaledongGit please try on nix and merge ASAP.

Fixes #2494 