### PR TITLE
blog: improve title of sep 2019 sec pre-release

### DIFF
--- a/locale/en/blog/vulnerability/september-2019-openssl-updates.md
+++ b/locale/en/blog/vulnerability/september-2019-openssl-updates.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-09-05T15:34:35.000Z
 category: vulnerability
-title: OpenSSL upgrade low-severity Node.js security fixes
+title: OpenSSL security releases may require Node.js security releases
 slug: openssl-and-low-severity-fixes-sep-2019
 layout: blog-post.hbs
 author: Sam Roberts


### PR DESCRIPTION
While mirroring the blog to the nodejs-sec mailing list, I realized I hadn't updated the title very well.

This improves it.