### PR TITLE
Replace `i` with `em`.

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -18,7 +18,7 @@
       "div", "span", "p",
       "table", "th", "tr", "td",
       "code", "pre",
-      "i", "strong", "em",
+      "strong", "em",
       "sup"
     ]
   },

--- a/locale/ar/docs/guides/debugging-getting-started.md
+++ b/locale/ar/docs/guides/debugging-getting-started.md
@@ -113,12 +113,12 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td><span dir="ltr">--inspect=<i>[host:port]</i></span></td>
+    <td><span dir="ltr">--inspect=<em>[host:port]</em></span></td>
     <td>
       <ul>
         <li>يقوم بتمكين عميل التدقيق</li>
-        <li>يحدد عنوانا أو  إسم مضيف <i>host</i> (افتراضيا: 127.0.0.1)</li>
-        <li>يشتغل على المنفذ <i>port</i> (افتراضيا: 9229)</li>
+        <li>يحدد عنوانا أو  إسم مضيف <em>host</em> (افتراضيا: 127.0.0.1)</li>
+        <li>يشتغل على المنفذ <em>port</em> (افتراضيا: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -133,18 +133,18 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td><span dir="ltr">--inspect-brk=<i>[host:port]</i><span></td>
+    <td><span dir="ltr">--inspect-brk=<em>[host:port]</em><span></td>
     <td>
       <ul>
         <li>يقوم بتمكين عميل التدقيق</li>
-        <li>يحدد عنوانا قيمته <i>host</i> (افتراضيا: 127.0.0.1)</li>
-        <li>يشتغل على المنفذ <i>port</i> (افتراضيا: 9229)</li>
+        <li>يحدد عنوانا قيمته <em>host</em> (افتراضيا: 127.0.0.1)</li>
+        <li>يشتغل على المنفذ <em>port</em> (افتراضيا: 9229)</li>
         <li>يتوقف قبل بدء تنفيذ شيفرة المستخدم</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><span dir="ltr"><code>node inspect <i>script.js</i></code></span></td>
+    <td><span dir="ltr"><code>node inspect <em>script.js</em></code></span></td>
     <td>
       <ul>
         <li>يخبر العمليات الفرعية بتنفيذ السكربت الخاص بالمستخدم تحت علم <span dir="ltr">--inspect</span> مع استعمال العملية الرئيسية لتشغيل مصحح الأخطاء من سطر الأوامر.</li>
@@ -152,11 +152,11 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td><span dir="ltr"><code>node inspect --port=xxxx <i>script.js</i></code><span></td>
+    <td><span dir="ltr"><code>node inspect --port=xxxx <em>script.js</em></code><span></td>
     <td>
       <ul>
         <li>يخبر العمليات الفرعية بتنفيذ السكربت الخاص بالمستخدم تحت علم <span dir="ltr">--inspect</span> مع استعمال العملية الرئيسية لتشغيل مصحح الأخطاء من سطر الأوامر.</li>
-        <li>يشتغل عبر المنفذ <i>port</i> (افتراضيا: 9229)</li>
+        <li>يشتغل عبر المنفذ <em>port</em> (افتراضيا: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -132,12 +132,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -152,18 +152,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -172,12 +172,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/fa/docs/guides/debugging-getting-started.md
+++ b/locale/fa/docs/guides/debugging-getting-started.md
@@ -127,12 +127,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -147,18 +147,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -167,12 +167,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/it/docs/guides/debugging-getting-started.md
+++ b/locale/it/docs/guides/debugging-getting-started.md
@@ -145,12 +145,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -165,18 +165,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -185,12 +185,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/ja/docs/guides/debugging-getting-started.md
+++ b/locale/ja/docs/guides/debugging-getting-started.md
@@ -257,12 +257,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -277,18 +277,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -297,12 +297,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -327,12 +327,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>インスペクタエージェントを有効にする</li>
-        <li>アドレスまたはホスト名 <i>host</i> にバインド (デフォルト: 127.0.0.1)</li>
-        <li><i>port</i> ポートで待ち受ける (デフォルト: 9229)</li>
+        <li>アドレスまたはホスト名 <em>host</em> にバインド (デフォルト: 127.0.0.1)</li>
+        <li><em>port</em> ポートで待ち受ける (デフォルト: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -347,18 +347,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>インスペクタエージェントを有効にする</li>
-        <li>アドレスまたはホスト名 <i>host</i> にバインド (デフォルト: 127.0.0.1)</li>
-        <li><i>port</i> ポートで待ち受ける (デフォルト: 9229)</li>
+        <li>アドレスまたはホスト名 <em>host</em> にバインド (デフォルト: 127.0.0.1)</li>
+        <li><em>port</em> ポートで待ち受ける (デフォルト: 9229)</li>
         <li>ユーザーコードが始まる前に中断する</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>--inspect フラグの下でユーザのスクリプトを実行するための子プロセスを生成します。そして CLI デバッガを動かすのに主要なプロセスを使用します</li>
@@ -366,11 +366,11 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>--inspect フラグの下でユーザのスクリプトを実行するための子プロセスを生成します。そして CLI デバッガを動かすのに主要なプロセスを使用します</li>
-        <li><i>port</i> ポートで待ち受ける (デフォルト: 9229)</li>
+        <li><em>port</em> ポートで待ち受ける (デフォルト: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/ko/docs/guides/debugging-getting-started.md
+++ b/locale/ko/docs/guides/debugging-getting-started.md
@@ -223,12 +223,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -243,18 +243,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -263,12 +263,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -293,12 +293,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>인스펙터 에이전트 활성화</li>
-        <li>주소 또는 호스트 이름 <i>host</i>에 바인딩 (기본값: 127.0.0.1)</li>
-        <li><i>port</i> 포트에서 수신 (기본값: 9229)</li>
+        <li>주소 또는 호스트 이름 <em>host</em>에 바인딩 (기본값: 127.0.0.1)</li>
+        <li><em>port</em> 포트에서 수신 (기본값: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -313,18 +313,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>인스펙터 에이전트 활성화</li>
-        <li>주소 또는 호스트 이름 <i>host</i>에 바인딩 (기본값: 127.0.0.1)</li>
-        <li><i>port</i> 포트에서 수신 (기본값: 9229)</li>
+        <li>주소 또는 호스트 이름 <em>host</em>에 바인딩 (기본값: 127.0.0.1)</li>
+        <li><em>port</em> 포트에서 수신 (기본값: 9229)</li>
         <li>사용자 코드 시작 전 멈춤</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>사용자의 스크립트를 --inspect 플래그로 실행하는 자식 프로세스를 생성하고 CLI 디버거 실행에 메인 프로세스를 사용합니다.</li>
@@ -332,11 +332,11 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>사용자의 스크립트를 --inspect 플래그로 실행하는 자식 프로세스를 생성하고 CLI 디버거 실행에 메인 프로세스를 사용합니다.</li>
-        <li><i>port</i> 포트에서 수신 (기본값: 9229)</li>
+        <li><em>port</em> 포트에서 수신 (기본값: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/pt-br/docs/guides/debugging-getting-started.md
+++ b/locale/pt-br/docs/guides/debugging-getting-started.md
@@ -185,12 +185,12 @@ Abaixo temos a lista de todas as flags que impactam a linha de comando enquanto 
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:porta]</i></td>
+    <td>--inspect=<em>[host:porta]</em></td>
     <td>
       <ul>
         <li>Ativa o agente do inspetor</li>
-        <li>Faz a conexão com o endereço ou hostname descrito em <i>host</i> (padrão: 127.0.0.1)</li>
-        <li>Ouve a porta descrita em <i>porta</i> (padrão: 9229)</li>
+        <li>Faz a conexão com o endereço ou hostname descrito em <em>host</em> (padrão: 127.0.0.1)</li>
+        <li>Ouve a porta descrita em <em>porta</em> (padrão: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -205,18 +205,18 @@ Abaixo temos a lista de todas as flags que impactam a linha de comando enquanto 
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Ativa o agente do inspetor</li>
-        <li>Faz a conexão com o endereço ou hostname descrito em <i>host</i> (default: 127.0.0.1)</li>
-        <li>Ouve na porta descrita por <i>porta</i> (padrão: 9229)</li>
+        <li>Faz a conexão com o endereço ou hostname descrito em <em>host</em> (default: 127.0.0.1)</li>
+        <li>Ouve na porta descrita por <em>porta</em> (padrão: 9229)</li>
         <li>Pausa antes do código do usuário iniciar</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Inicia um child process para executar um script do usuário sob a flag --inspect; e usa o processo principal para executar o CLI do debugger.</li>
@@ -224,11 +224,11 @@ Abaixo temos a lista de todas as flags que impactam a linha de comando enquanto 
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Inicia um child process para executar um script do usuário sob a flag --inspect; e usa o processo principal para executar o CLI do debugger.</li>
-        <li>Ouve na porta descrita por <i>porta</i> (padrão: 9229)</li>
+        <li>Ouve na porta descrita por <em>porta</em> (padrão: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/ru/docs/guides/debugging-getting-started.md
+++ b/locale/ru/docs/guides/debugging-getting-started.md
@@ -127,12 +127,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>
@@ -147,18 +147,18 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>Enable inspector agent</li>
-        <li>Bind to address or hostname <i>host</i> (default: 127.0.0.1)</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Bind to address or hostname <em>host</em> (default: 127.0.0.1)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
         <li>Break before user code starts</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>node inspect <i>script.js</i></code></td>
+    <td><code>node inspect <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
@@ -167,12 +167,12 @@ The following table lists the impact of various runtime flags on debugging:
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>Spawn child process to run user's script under --inspect flag;
             and use main process to run CLI debugger.</li>
-        <li>Listen on port <i>port</i> (default: 9229)</li>
+        <li>Listen on port <em>port</em> (default: 9229)</li>
       </ul>
     </td>
   </tr>

--- a/locale/zh-cn/docs/guides/debugging-getting-started.md
+++ b/locale/zh-cn/docs/guides/debugging-getting-started.md
@@ -96,12 +96,12 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td>--inspect=<i>[host:port]</i></td>
+    <td>--inspect=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>启用监视器代理</li>
-        <li>绑定地址或主机名<i>宿主</i> （默认：127.0.0.1）</li>
-        <li>监听<i>端口</i> （默认：9229）</li>
+        <li>绑定地址或主机名<em>宿主</em> （默认：127.0.0.1）</li>
+        <li>监听<em>端口</em> （默认：9229）</li>
       </ul>
     </td>
   </tr>
@@ -116,18 +116,18 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td>--inspect-brk=<i>[host:port]</i></td>
+    <td>--inspect-brk=<em>[host:port]</em></td>
     <td>
       <ul>
         <li>启用监视器代理</li>
-        <li>绑定地址和主机名<i>宿主</i>（默认：127.0.0.1）</li>
-        <li>监听<i>端口</i>（默认：9229）</li>
+        <li>绑定地址和主机名<em>宿主</em>（默认：127.0.0.1）</li>
+        <li>监听<em>端口</em>（默认：9229）</li>
         <li>在用户代码启动前终止</li>
       </ul>
     </td>
   </tr>
   <tr>
-    <td><code>Node 监视<i>script.js</i></code></td>
+    <td><code>Node 监视<em>script.js</em></code></td>
     <td>
       <ul>
         <li>通过 --inspect 标志生成一个新的子进程，使用主进程运行 CLI 调试器。</li>
@@ -135,11 +135,11 @@ layout: docs.hbs
     </td>
   </tr>
   <tr>
-    <td><code>node inspect --port=xxxx <i>script.js</i></code></td>
+    <td><code>node inspect --port=xxxx <em>script.js</em></code></td>
     <td>
       <ul>
         <li>通过 --inspect 标志生成一个新的子进程，使用主进程运行 CLI 调试器。</li>
-        <li>监听<i>端口</i>（默认：9229）</li>
+        <li>监听<em>端口</em>（默认：9229）</li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
Mostly for consistency and being more schematically correct.