### PR TITLE
backpressuring-in-streams: fix wrong syntax highlighting.

### DIFF
--- a/locale/en/docs/guides/backpressuring-in-streams.md
+++ b/locale/en/docs/guides/backpressuring-in-streams.md
@@ -185,8 +185,7 @@ and instead with the replaced `return true;`.
 Let's take a look at a quick benchmark. Using the same example from above, we
 ran a few time trials to get a median time for both binaries.
 
-<!-- eslint-skip -->
-```javascript
+```
    trial (#)  | `node` binary (ms) | modified `node` binary (ms)
 =================================================================
       1       |      56924         |           55011
@@ -206,8 +205,7 @@ collector.
 The GC (garbage collector) measured time indicates the intervals of a full cycle
 of a single sweep done by the garbage collector:
 
-<!-- eslint-skip -->
-```javascript
+```
 approx. time (ms) | GC (ms) | modified GC (ms)
 =================================================
           0       |    0    |      0
@@ -253,8 +251,7 @@ individually.
 
 This is the output on the normal binary:
 
-<!-- eslint-skip -->
-```javascript
+```
 Respecting the return value of .write()
 =============================================
 real        58.88
@@ -281,8 +278,7 @@ The maximum byte size occupied by virtual memory turns out to be approximately
 
 And now changing the [return value][] of the [`.write()`][] function, we get:
 
-<!-- eslint-skip -->
-```javascript
+```
 Without respecting the return value of .write():
 ==================================================
 real        54.48
@@ -370,8 +366,7 @@ To achieve a better understanding of backpressure, here is a flow-chart on the
 lifecycle of a [`Readable`][] stream being [piped][] into a [`Writable`][]
 stream:
 
-<!-- eslint-skip -->
-```javascript
+```
                                                      +===================+
                          x-->  Piping functions   +-->   src.pipe(dest)  |
                          x     are set up during     |===================|

--- a/locale/zh-cn/docs/guides/backpressuring-in-streams.md
+++ b/locale/zh-cn/docs/guides/backpressuring-in-streams.md
@@ -135,8 +135,7 @@ inp.pipe(gzip).pipe(outputFile);
 
 让我们来看一个快速的基准。使用上面的同一个例子，我们进行两次试验以获得两个二进制文件的中位时间。
 
-<!-- eslint-skip -->
-```javascript
+```
    trial (#)  | `node` binary (ms) | modified `node` binary (ms)
 =================================================================
       1       |      56924         |           55011
@@ -152,8 +151,7 @@ average time: |      55299         |           55975
 
 GC（垃圾回收器）测量表明一个完整的周期间隔一个由垃圾回收器进行扫描：
 
-<!-- eslint-skip -->
-```javascript
+```
 approx. time (ms) | GC (ms) | modified GC (ms)
 =================================================
           0       |    0    |      0
@@ -187,8 +185,7 @@ approx. time (ms) | GC (ms) | modified GC (ms)
 
 这是普通程序输出结果：
 
-<!-- eslint-skip -->
-```javascript
+```
 Respecting the return value of .write()
 =============================================
 real        58.88
@@ -214,8 +211,7 @@ sys          8.79
 
 现在改变 [`.write()`][] 方法的 [返回值][]，我们得到以下结果：
 
-<!-- eslint-skip -->
-```javascript
+```
 Without respecting the return value of .write():
 ==================================================
 real        54.48
@@ -271,8 +267,7 @@ sys          7.43
 
 为了对积压有一个更好的理解，这里有一副 [`Readable`][] 流正通过 [piped][] 流入 [`Writable`][] 流的整个生命周期图：
 
-<!-- eslint-skip -->
-```javascript
+```
                                                      +===================+
                          x-->  Piping functions   +-->   src.pipe(dest)  |
                          x     are set up during     |===================|


### PR DESCRIPTION
These aren't JavaScript snippets.