### PR TITLE
summary.js: use double quotes in the `a` tag.

### DIFF
--- a/scripts/helpers/summary.js
+++ b/scripts/helpers/summary.js
@@ -30,7 +30,7 @@ module.exports = (contents, locale, path) => {
     .not((i, elem) => IGNORE_SELECTORS.some((selector) => $(elem).is(selector)))
     .each((i, elem) => {
       if (summary.length > SUMMARY_MAX_LENGTH) {
-        summary += `<p><a href='/${locale}/${path.replace(/\\/g, '/')}/'>Read more...</a></p>`
+        summary += `<p><a href="/${locale}/${path.replace(/\\/g, '/')}/">Read more...</a></p>`
         return false
       }
 


### PR DESCRIPTION
No functional change.