### PR TITLE
Work around the blog/index.md in the first year.

### DIFF
--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -31,11 +31,17 @@
         {{/if}}
 
         {{#if pagination.prev.path}}{{#if pagination.next.path}}
+        {{#equals (slashes pagination.next.path) 'blog/index.md'}}
+        {{else}}
         |
+        {{/equals}}
         {{/if}}{{/if}}
 
         {{#if pagination.next.path}}
+        {{#equals (slashes pagination.next.path) 'blog/index.md'}}
+        {{else}}
         <a href="/{{ site.locale }}/{{ pagination.next.path }}/">Older &gt;</a>
+        {{/equals}}
         {{/if}}
       </nav>
       {{/if}}


### PR DESCRIPTION
This is quite hacky, but I don't know the root cause, so I couldn't think of a better way.

Regardless, this fixes the issue. I just point to the blog index page when year is 2011. Alternatively we could hide the older button completely, but the `|` separator makes it complex.

Requires #2563.

Fixes #2422.