### PR TITLE
Minor lint tweaks

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,7 +40,7 @@ const renderer = new marked.Renderer()
 renderer.heading = anchorMarkdownHeadings
 const markedOptions = {
   langPrefix: 'language-',
-  renderer: renderer
+  renderer
 }
 
 // This function imports a given language file and uses the default language set
@@ -133,7 +133,7 @@ function buildLocale (source, locale, opts) {
       })
     }))
     .use(markdown(markedOptions))
-    .use(githubLinks({ locale: locale, site: i18nJSON(locale) }))
+    .use(githubLinks({ locale, site: i18nJSON(locale) }))
     .use(prism())
     // Set pretty permalinks, we don't want .html suffixes everywhere.
     .use(permalinks({
@@ -190,7 +190,7 @@ function buildLocale (source, locale, opts) {
 function withPreserveLocale (preserveLocale) {
   return (files, m, next) => {
     if (preserveLocale) {
-      var path = m.path('locale/en')
+      const path = m.path('locale/en')
       m.read(path, (err, newfiles) => {
         if (err) {
           console.error(err)

--- a/scripts/helpers/slashes.js
+++ b/scripts/helpers/slashes.js
@@ -1,5 +1,3 @@
 'use strict'
 
-module.exports = function (str) {
-  return str.replace(/\\/g, '/')
-}
+module.exports = (str) => str.replace(/\\/g, '/')

--- a/scripts/plugins/filter-stylus-partials.js
+++ b/scripts/plugins/filter-stylus-partials.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const Path = require('path')
+const path = require('path')
 
 module.exports = function filterStylusPartials () {
   return (files, metalsmith, done) => {
     Object.keys(files).forEach((filename) => {
-      const isPartial = (/^_.*\.styl(us)?/).test(Path.basename(filename))
+      const isPartial = (/^_.*\.styl(us)?/).test(path.basename(filename))
       if (isPartial) {
         delete files[filename]
       }

--- a/tests/scripts/anchor-mardown-headings.test.js
+++ b/tests/scripts/anchor-mardown-headings.test.js
@@ -92,7 +92,7 @@ test('anchorMarkdownHeadings', (t) => {
     renderer.heading = anchorMarkdownHeadings
 
     const text = '# Title\n# Title'
-    const output = marked(text, { renderer: renderer })
+    const output = marked(text, { renderer })
     const expected = '<h1 id="header-title">Title' +
       '<a id="title" class="anchor" ' +
       'href="#title" aria-labelledby="header-title"></a></h1>' +


### PR DESCRIPTION
* use the object shorthand
* use const
* lowercase a variable

We should look into using the same config us the upstream repo IMO, see #2523.