### PR TITLE
Fix `githubLinks()` to work on Windows too.

### DIFF
--- a/build.js
+++ b/build.js
@@ -213,7 +213,7 @@ function withPreserveLocale (preserveLocale) {
 // This middleware adds "Edit on GitHub" links to every editable page
 function githubLinks (options) {
   return (files, m, next) => {
-    // add suffix (".html" or "/") to each part of regex
+    // add suffix (".html" or "/" or "\" for windows) to each part of regex
     // to ignore possible occurrences in titles (e.g. blog posts)
     const isEditable = /security\.html|about(\/|\\)|docs(\/|\\)|foundation(\/|\\)|get-involved(\/|\\)|knowledge(\/|\\)/
 

--- a/build.js
+++ b/build.js
@@ -215,7 +215,7 @@ function githubLinks (options) {
   return (files, m, next) => {
     // add suffix (".html" or "/") to each part of regex
     // to ignore possible occurrences in titles (e.g. blog posts)
-    const isEditable = /security\.html|about\/|docs\/|foundation\/|get-involved\/|knowledge\//
+    const isEditable = /security\.html|about(\/|\\)|docs(\/|\\)|foundation(\/|\\)|get-involved(\/|\\)|knowledge(\/|\\)/
 
     Object.keys(files).forEach((path) => {
       if (!isEditable.test(path)) {


### PR DESCRIPTION
Not sure if there's a better solution, but I think this is the last thing I notice differently on Windows.