### PR TITLE
Fix font-display for Google Fonts

### DIFF
--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -31,5 +31,5 @@
   <link rel="alternate" href="/{{ ../site.locale }}/{{ link }}" title="{{ text }}" type="application/rss+xml">
   {{/each}}
   <link rel="stylesheet" href="/layouts/css/styles.css" media="all">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&display=fallback">
 </head>


### PR DESCRIPTION
Google Fonts shipped the display flag in May: https://addyosmani.com/blog/google-fonts-font-display/

This PR makes use of that new feature to add `font-display: fallback` in Google Fonts CSS via the `display=fallback` query param.

This will remove the following error under `Diagnostics` in Google PageSpeed Inisghts: https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fnodejs.org%2Fen%2F

![Screenshot 2019-09-18 at 15 09 59](https://user-images.githubusercontent.com/181959/65156412-f8d79080-da26-11e9-838d-8f86af72f3e3.jpg)