### PR TITLE
Further fix `Edit on GitHub` slashes on Windows.

### DIFF
--- a/build.js
+++ b/build.js
@@ -223,7 +223,7 @@ function githubLinks (options) {
       }
 
       const file = files[path]
-      const url = `https://github.com/nodejs/nodejs.org/edit/master/locale/${options.locale}/${path.replace('.html', '.md')}`
+      const url = `https://github.com/nodejs/nodejs.org/edit/master/locale/${options.locale}/${path.replace('.html', '.md').replace(/\\/g, '/')}`
       const editText = options.site.editOnGithub || 'Edit on GitHub'
 
       const contents = file.contents.toString().replace(/<h1(.*?)>(.*?)<\/h1>/, (match, $1, $2) => {


### PR DESCRIPTION
This was visible with nested pages like `/get-involved/node-meetups/` which resulted in `https://github.com/nodejs/nodejs.org/edit/master/locale/en/get-involved\node-meetups.md`