### PR TITLE
package.json: require Node.js 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Node.js Website Working Group",
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Node.js Website Working Group",
   "license": "MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.12.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
So that we use `mkdir`'s recursive option later.

Or should I make this `>=10.12.0` since that's when it was added? https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback


/CC @phillipj 