### PR TITLE
Revert "Update dont-block-the-event-loop.md (#2479)"

### DIFF
--- a/locale/en/docs/guides/dont-block-the-event-loop.md
+++ b/locale/en/docs/guides/dont-block-the-event-loop.md
@@ -362,7 +362,7 @@ A CPU-intensive task only makes progress when its Worker is scheduled, and the W
 If you have 4 logical cores and 5 Workers, one of these Workers cannot make progress.
 As a result, you are paying overhead (memory and scheduling costs) for this Worker and getting no return for it.
 
-I/O-intensive tasks involve querying an external service provider ([DNS](https://hosting.review/web-hosting-glossary/#9), file system, etc.) and waiting for its response.
+I/O-intensive tasks involve querying an external service provider (DNS, file system, etc.) and waiting for its response.
 While a Worker with an I/O-intensive task is waiting for its response, it has nothing else to do and can be de-scheduled by the operating system, giving another Worker a chance to submit their request.
 Thus, *I/O-intensive tasks will be making progress even while the associated thread is not running*.
 External service providers like databases and file systems have been highly optimized to handle many pending requests concurrently.


### PR DESCRIPTION
This reverts commit 5455032a9727aad9194eb101d6c2316d94d68a5f.

My reasoning is simple (I think).

1. first of all DNS isn't only mentioned in this page, so why add it specifically here? If we go with this, then we'd need to link to hundreds of things per page
2. secondly and most important, I don't think we should link to such sites. I don't have anything against this specific site, I just believe we should only link to sources everyone (or most people) trust like Wikipedia

I commented in #2479 but I don't think this was discussed enough, especially with #1971 open and pending.

/CC @phillipj @Trott @fhemberger 