### PR TITLE
scroll to top: specify `display: none`

### DIFF
--- a/layouts/css/page-modules/_scrollToTop.styl
+++ b/layouts/css/page-modules/_scrollToTop.styl
@@ -18,6 +18,7 @@ html
   min-width 20px
   text-align center
   padding 0 5px 1px
+  display none
 
   // Prevent button from flashing on page load
   opacity 0


### PR DESCRIPTION
This is so that when JavaScript is disabled, the button doesn't show up.

BTW the button could work without JS if we targeted an `id` in `body` maybe. It's just that it would always show up regardless of the pageYOffset.