### PR TITLE
Fix wrong option name in en/blog/release/v12.12.0.md

### DIFF
--- a/locale/en/blog/release/v12.12.0.md
+++ b/locale/en/blog/release/v12.12.0.md
@@ -19,7 +19,7 @@ author: Ruben Bridgewater
 * **fs**:
   * Introduce `opendir()` and `fs.Dir` to iterate through directories [#29349](https://github.com/nodejs/node/pull/29349)
 * **process**:
-  * Add source-map support to stack traces by using `--source-map-support`[#29564](https://github.com/nodejs/node/pull/29564)
+  * Add source-map support to stack traces by using `--enable-source-maps`[#29564](https://github.com/nodejs/node/pull/29564)
 * **tls**:
   * Honor `pauseOnConnect` option [#29635](https://github.com/nodejs/node/pull/29635)
   * Add option for private keys for OpenSSL engines [#28973](https://github.com/nodejs/node/pull/28973)


### PR DESCRIPTION
I found the option name in the blog post is wrong.

```
$ node --source-map-support
C:\Program Files (x86)\Nodist/v-x64/12.12.0/node.exe: bad option: --source-map-support

$ node --enable-source-maps
Welcome to Node.js v12.12.0.
Type ".help" for more information.
>