### PR TITLE
feature: hide current release when LTS release is more recent

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,6 +23,7 @@ const postcss = require('postcss')
 const sass = require('node-sass')
 const ncp = require('ncp')
 const junk = require('junk')
+const semver = require('semver')
 
 const githubLinks = require('./scripts/plugins/githubLinks')
 const navigation = require('./scripts/plugins/navigation')
@@ -293,6 +294,11 @@ function getSource (callback) {
           link: '/en/blog/vulnerability/february-2019-security-releases/'
         }
       }
+    }
+
+    if (semver.gt(source.project.latestVersions.lts.node, source.project.latestVersions.current.node)) {
+      // If LTS is higher than Current hide it from the main page
+      source.project.latestVersions.hideCurrent = true
     }
 
     callback(err, source)

--- a/build.js
+++ b/build.js
@@ -295,7 +295,6 @@ function getSource (callback) {
         }
       }
     }
-
     if (semver.gt(source.project.latestVersions.lts.node, source.project.latestVersions.current.node)) {
       // If LTS is higher than Current hide it from the main page
       source.project.latestVersions.hideCurrent = true

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -42,7 +42,7 @@
         </div>
 
         {{#if project.latestVersions.current.node}}
-        {{#if project.latestVersions.current.hideCurrent}}
+        {{#unless project.latestVersions.hideCurrent}}
           <div class="home-downloadblock">
 
             <a href="https://nodejs.org/dist/{{ project.latestVersions.current.node }}/" class="home-downloadbutton"  title="{{ labels.download }} {{stripv project.latestVersions.current.node }} {{ labels.current }}"  data-version="{{ project.latestVersions.current.node }}">
@@ -63,7 +63,7 @@
             </ul>
 
           </div>
-        {{/if}}
+        {{/unless}}
         {{/if}}
         <p>
           {{{ labels.version-schedule-prompt }}} <a href="https://nodejs.org/{{site.locale}}/about/releases/">{{ labels.version-schedule-prompt-link-text }}</a>

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -42,6 +42,7 @@
         </div>
 
         {{#if project.latestVersions.current.node}}
+        {{#if project.latestVersions.current.hideCurrent}}
           <div class="home-downloadblock">
 
             <a href="https://nodejs.org/dist/{{ project.latestVersions.current.node }}/" class="home-downloadbutton"  title="{{ labels.download }} {{stripv project.latestVersions.current.node }} {{ labels.current }}"  data-version="{{ project.latestVersions.current.node }}">
@@ -62,6 +63,7 @@
             </ul>
 
           </div>
+        {{/if}}
         {{/if}}
         <p>
           {{{ labels.version-schedule-prompt }}} <a href="https://nodejs.org/{{site.locale}}/about/releases/">{{ labels.version-schedule-prompt-link-text }}</a>


### PR DESCRIPTION
This is an edge case we hit today. The latest Current release is 12.12.0,
the latest LTS release is 12.13.0. This leads to a confusing landing page.

This adds an additional semver comparison and hides the current release
from the main page on days like today when it shouldn't be shown.

Refs: https://github.com/nodejs/Release/issues/495