### PR TITLE
Fix typo about Node.js v12’s maintenance start

### DIFF
--- a/locale/en/blog/release/v12.13.0.md
+++ b/locale/en/blog/release/v12.13.0.md
@@ -10,7 +10,7 @@ author: Michaël Zasso
 
 This release marks the transition of Node.js 12.x into Long Term Support (LTS)
 with the codename 'Erbium'. The 12.x release line now moves into "Active LTS"
-and will remain so until October 2020. After that time, it will move into
+and will remain so until October 2021. After that time, it will move into
 "Maintenance" until end of life in April 2022.
 
 ### Notable changes


### PR DESCRIPTION
See [Release schedule](https://github.com/nodejs/Release/blob/886be32f3f6bef1cf96d9551331fa145346a38a5/README.md#release-schedule) over at nodejs/Release.