### PR TITLE
Update metalsmith-markdown to v1.3.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4519,12 +4519,12 @@
       }
     },
     "metalsmith-markdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-1.2.0.tgz",
-      "integrity": "sha512-YAZZ1G4Y+AfnlJEoba6sr8zGBxg2xiAetf2xvGCTOpUR5CKV6G+X3Oq0BcS1aKBLYf86rWmm6Nu0Wq/5O2CEMQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-1.3.0.tgz",
+      "integrity": "sha512-wStYRbJIYwNTDtHmVfb6RjNfFB+DkloIoQr600pXT2QRnbqMsdnAdSVfPjXX+vP7upCulZmp/xlcYzfDxKpx1w==",
       "requires": {
         "debug": "^4.1.1",
-        "marked": "^0.6.1"
+        "marked": "^0.7.0"
       },
       "dependencies": {
         "debug": {
@@ -4534,11 +4534,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "marked": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-          "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
         },
         "ms": {
           "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "metalsmith-discover-partials": "^0.1.2",
     "metalsmith-feed": "^1.0.0",
     "metalsmith-layouts": "^2.3.1",
-    "metalsmith-markdown": "^1.2.0",
+    "metalsmith-markdown": "^1.3.0",
     "metalsmith-metadata": "0.0.4",
     "metalsmith-permalinks": "^2.2.0",
     "metalsmith-prism": "^3.1.1",


### PR DESCRIPTION
Fixes the remaining npm vulnerability.

https://github.com/segmentio/metalsmith-markdown/blob/master/History.md#130---2019-10-30