### PR TITLE
Fix broken link in docs to «How to publish N-API package» article

### DIFF
--- a/locale/ru/docs/guides/index.md
+++ b/locale/ru/docs/guides/index.md
@@ -27,5 +27,5 @@ layout: docs.hbs
 * [Working with Different Filesystems](/en/docs/guides/working-with-different-filesystems/)
 * [Backpressuring in Streams](/en/docs/guides/backpressuring-in-streams/)
 * [Domain Module Postmortem](/en/docs/guides/domain-postmortem/)
-* [How to publish N-API package]/en/docs/guides/(publishing-napi-modules/)
+* [How to publish N-API package](/en/docs/guides/publishing-napi-modules/)
 * [ABI Stability](/en/docs/guides/abi-stability/)


### PR DESCRIPTION
Current look of the page:

![image](https://user-images.githubusercontent.com/6977652/68744715-4c6cf180-0606-11ea-8d05-93a04d5513fd.png)
