### PR TITLE
Remove "on Linux" from binary archive install link

### DIFF
--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -82,7 +82,7 @@
       "verify-text": "Com verificar-ho"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -72,7 +72,7 @@
       "text": "Signierte SHASUMS für die Versionsdateien"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -83,7 +83,7 @@
       "verify-text": "How to verify"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -83,7 +83,7 @@
       "verify-text": "Cómo verificarlo"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/fa/site.json
+++ b/locale/fa/site.json
@@ -83,7 +83,7 @@
       "verify-text": "چگونه راستی‌آزمایی کنیم؟"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/fr/site.json
+++ b/locale/fr/site.json
@@ -74,7 +74,7 @@
       "text": "SHASUMS signés pour les fichiers des versions"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/gl/site.json
+++ b/locale/gl/site.json
@@ -76,7 +76,7 @@
       "text": "Firmas SHASUMS para os arquivos de versións"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -67,7 +67,7 @@
       "text": "Installa Node.js con un gestore di pacchetti"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -73,7 +73,7 @@
       "text": "リリースファイルのための SHASUM 署名"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {

--- a/locale/pt-br/site.json
+++ b/locale/pt-br/site.json
@@ -82,7 +82,7 @@
       "verify-text": "Como verificar"
     },
     "install-on-linux": {
-      "text": "Instalando Node.js via arquivo binário no Linux."
+      "text": "Instalando Node.js via arquivo binário."
     }
   },
   "docs": {

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -82,7 +82,7 @@
       "verify-text": "Як перевірити"
     },
     "install-on-linux": {
-      "text": "Installing Node.js via binary archive on Linux"
+      "text": "Installing Node.js via binary archive"
     }
   },
   "docs": {


### PR DESCRIPTION
The Installation wiki page is not specific to Linux. Remove the text
from the website, for the languages I read well enough to change.

See:
- https://github.com/nodejs/help/wiki/Installation
- https://nodejs.org/en/download/