### PR TITLE
blog: add blog for dec security releases

### DIFF
--- a/build.js
+++ b/build.js
@@ -290,9 +290,9 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: false,
-          text: 'New security releases now available for all release lines',
-          link: '/en/blog/vulnerability/february-2019-security-releases/'
+          visible: true,
+          text: 'New security releases to be made available Dec 17, 2019',
+          link: '/en/blog/vulnerability/december-2019-security-releases/'
         }
       }
     }

--- a/locale/en/blog/vulnerability/december-2019-security-releases.md
+++ b/locale/en/blog/vulnerability/december-2019-security-releases.md
@@ -1,0 +1,28 @@
+---
+date: 2019-12-12T18:R2047.733Z
+category: vulnerability
+title: December 2019 Security Releases
+slug: december-2019-security-releases
+layout: blog-post.hbs
+author: Michael Dawson 
+---
+
+# Summary  
+
+The Node.js project will release new versions of all supported release lines on or shortly after Tuesday December 17, 2019 UTC. The only update in these releases will be an updated version of npm addressing the vulnerability announced in https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli.
+
+In the meantime, users should update to npm 6.13.4 by following the instructions provided in the npm advisory. As a general rule, avoid running npm in production environments.
+
+# Impact
+
+All versions of Node.js are vulnerable including the LTS and current releases: Node.js 8 (LTS "Carbon"), Node.js 10 (LTS "Dubnium") , Node.js 12 (LTS "Erbium"), and Node.js 13.
+
+# Release timing 
+
+Releases will be available at, or shortly after, Tuesday, December 17, 2019 UTC.
+
+#  Contact and future updates  
+
+The current Node.js security policy can be found at https://nodejs.org/en/security/.   Please follow the process outlined in https://github.com/nodejs/node/blob/master/SECURITY.md if you wish to report a vulnerability in Node.js.  
+
+Subscribe to the low-volume announcement-only nodejs-sec mailing list at https://groups.google.com/forum/#!forum/nodejs-sec to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization. 

--- a/locale/en/blog/vulnerability/december-2019-security-releases.md
+++ b/locale/en/blog/vulnerability/december-2019-security-releases.md
@@ -1,5 +1,5 @@
 ---
-date: 2019-12-12T18:R2047.733Z
+date: 2019-12-12T18:20:47.733Z
 category: vulnerability
 title: December 2019 Security Releases
 slug: december-2019-security-releases


### PR DESCRIPTION
Add blog and make visible in main banner.

The same announcement has already been made via the nodejs-sec mailing list.