### PR TITLE
doc: update Dec 2019 Sec Announcement

### DIFF
--- a/locale/en/blog/vulnerability/december-2019-security-releases.md
+++ b/locale/en/blog/vulnerability/december-2019-security-releases.md
@@ -9,7 +9,7 @@ author: Michael Dawson
 
 # Summary  
 
-The Node.js project will release new versions of all supported release lines on or shortly after Tuesday December 17, 2019 UTC. The only update in these releases will be an updated version of npm addressing the vulnerability announced in https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli.
+The Node.js project will release new versions of all supported release lines on or shortly after Tuesday December 17, 2019 UTC. For versions 8, 10, and 12 the only update to the runtime in these releases will be an updated version of npm addressing the vulnerability announced in https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli. Version 13, while still being a security release, will include all commits that were scheduled to be included in the originally scheduled release.
 
 In the meantime, users should update to npm 6.13.4 by following the instructions provided in the npm advisory. As a general rule, avoid running npm in production environments.
 


### PR DESCRIPTION
Originally we states only the npm commit would be included. This
expands on that claim to make it clear that other commits not
affecting the runtime will appear on 8 / 10 / 12 and that 13
will be a full release