### PR TITLE
disable banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -283,7 +283,7 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: true,
+          visible: false,
           text: 'New security releases now available for all release lines',
           link: '/en/blog/vulnerability/december-2019-security-releases/'
         }


### PR DESCRIPTION
Time to take down the security banner. Don't want to leave it up too
long lest people get used to not noticing it when it appears again.