### PR TITLE
remove foundation link from header

### DIFF
--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -87,19 +87,6 @@ header {
   }
 }
 
-// Special format for external "Foundation" link in main navigation
-.nav-foundation {
-  background-color: $active-green;
-
-  &::before {
-    content: none !important;
-  }
-
-  a {
-    padding: 0 16px !important;
-  }
-}
-
 @media screen and (min-width: 481px) {
   header {
     li {
@@ -131,10 +118,6 @@ header {
     a:active {
       padding: 0 8px;
     }
-  }
-
-  .nav-foundation {
-    margin-left: 8px;
   }
 }
 

--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -12,7 +12,7 @@
         </li>
 
         {{#each nav.main}}
-          <li {{#startswith ../path link}}class="active"{{/startswith}}{{#startswith link 'https://foundation.nodejs.org'}} class="nav-foundation"{{/startswith}}>
+          <li {{#startswith ../path link}}class="active"{{/startswith}}>
             {{#startswith link 'http'}}
               <a href="{{link}}">{{text}}</a>
             {{else}}

--- a/locale/ar/site.json
+++ b/locale/ar/site.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/ar/",
   "locale": "ar",
   "language": "العربية",
@@ -141,10 +141,6 @@
   "blog": {
     "link": "blog",
     "text": "المدونة"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "المؤسسة"
   },
   "releases": {
     "title": "أرشيف الاصدارات",

--- a/locale/ca/site.json
+++ b/locale/ca/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Fundació Node.js",
+  "author": "Node.js",
   "url": "https://nodejs.org/ca/",
   "locale": "ca",
   "language": "Catalan",
@@ -137,10 +137,6 @@
   "blog": {
     "link": "blog",
     "text": "Notícies"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fundació"
   },
   "releases": {
     "title": "Històric de Versions",

--- a/locale/de/site.json
+++ b/locale/de/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/de/",
   "locale": "de",
   "language": "Deutsch",
@@ -119,10 +119,6 @@
   "blog": {
     "link": "blog",
     "text": "Neuigkeiten"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Foundation"
   },
   "releases": {
     "title": "Versionshistorie",

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/en/",
   "locale": "en",
   "language": "English",
@@ -142,10 +142,6 @@
   "blog": {
     "link": "blog",
     "text": "News"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Foundation"
   },
   "releases": {
     "title": "Release History",

--- a/locale/es/site.json
+++ b/locale/es/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Node.js",
   "editOnGithub":"Editar en Github",
-  "author": "Fundación de Node.js",
+  "author": "Node.js",
   "url": "https://nodejs.org/es/",
   "locale": "es",
   "language": "Español",
@@ -138,10 +138,6 @@
   "blog": {
     "link": "blog",
     "text": "Noticias"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fundación"
   },
   "releases": {
     "title": "Histórico de versiones",

--- a/locale/fa/site.json
+++ b/locale/fa/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js بنیاد",
+  "author": "Node.js",
   "url": "https://nodejs.org/fa/",
   "locale": "fa",
   "language": "زبان فارسی",
@@ -138,10 +138,6 @@
   "blog": {
     "link": "blog",
     "text": "بلاگ"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "بنیاد"
   },
   "releases": {
     "title": "تاریخچه انتشارها",

--- a/locale/fr/site.json
+++ b/locale/fr/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/fr/",
   "locale": "fr",
   "language": "Français",
@@ -121,10 +121,6 @@
   "blog": {
     "link": "blog",
     "text": "Actualités"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fondation"
   },
   "releases": {
     "title": "Historique des versions",

--- a/locale/gl/site.json
+++ b/locale/gl/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Fundación de Node.js",
+  "author": "Node.js",
   "url": "https://nodejs.org/gl/",
   "locale": "gl",
   "language": "Galego",
@@ -123,10 +123,6 @@
   "blog": {
     "link": "blog",
     "text": "Noticias"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fundación"
   },
   "releases": {
     "title": "Histórico de versións",

--- a/locale/it/site.json
+++ b/locale/it/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/en/",
   "locale": "it",
   "language": "Italiano",
@@ -114,10 +114,6 @@
   "blog": {
     "link": "blog",
     "text": "Blog"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fondazione"
   },
   "releases": {
     "title": "Cronologia delle Release",

--- a/locale/ja/site.json
+++ b/locale/ja/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Node.js",
   "editOnGithub":"GitHub 上で編集",
-  "author": "Node.js 財団",
+  "author": "Node.js",
   "url": "https://nodejs.org/ja/",
   "locale": "ja",
   "language": "日本語",
@@ -124,10 +124,6 @@
   "blog": {
     "link": "blog",
     "text": "ニュース"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "財団"
   },
   "releases": {
     "title": "過去のリリース",

--- a/locale/ko/site.json
+++ b/locale/ko/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js 재단",
+  "author": "Node.js",
   "url": "https://nodejs.org/ko/",
   "locale": "ko",
   "language": "한국어",
@@ -142,10 +142,6 @@
   "blog": {
     "link": "blog",
     "text": "뉴스"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "재단"
   },
   "releases": {
     "title": "릴리스 이력",

--- a/locale/pt-br/site.json
+++ b/locale/pt-br/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/pt-br/",
   "locale": "pt-br",
   "language": "Português do Brasil",
@@ -137,10 +137,6 @@
   "blog": {
     "link": "blog",
     "text": "Novidades"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Fundação"
   },
   "releases": {
     "title": "Versões Anteriores",

--- a/locale/ru/site.json
+++ b/locale/ru/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/ru/",
   "locale": "ru",
   "language": "Русский",
@@ -142,10 +142,6 @@
   "blog": {
     "link": "blog",
     "text": "Новости"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Организация"
   },
   "releases": {
     "title": "История релизов",

--- a/locale/tr/site.json
+++ b/locale/tr/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/tr/",
   "locale": "tr",
   "language": "Türkçe",
@@ -142,10 +142,6 @@
   "blog": {
     "link": "blog",
     "text": "Haberler"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Vakıf"
   },
   "releases": {
     "title": "Release History",

--- a/locale/uk/site.json
+++ b/locale/uk/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Node.js",
-  "author": "Node.js Foundation",
+  "author": "Node.js",
   "url": "https://nodejs.org/uk/",
   "locale": "uk",
   "language": "Українська",
@@ -137,10 +137,6 @@
   "blog": {
     "link": "blog",
     "text": "Новини"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "Фундація"
   },
   "releases": {
     "title": "Історія релізів",

--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Node.js",
   "editOnGithub":"在 GitHub 上编辑",
-  "author": "Node.js 基金会",
+  "author": "Node.js",
   "url": "https://nodejs.org/zh-cn/",
   "locale": "zh-cn",
   "language": "中文(简体)",
@@ -143,10 +143,6 @@
   "blog": {
     "link": "blog",
     "text": "新闻"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "基金会"
   },
   "releases": {
     "title": "发布历史",

--- a/locale/zh-tw/site.json
+++ b/locale/zh-tw/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Node.js",
   "editOnGithub": "在 GitHub 上編輯",
-  "author": "Node.js 基金會",
+  "author": "Node.js",
   "url": "https://nodejs.org/zh-tw/",
   "locale": "zh-tw",
   "language": "中文 (繁體)",
@@ -133,10 +133,6 @@
   "blog": {
     "link": "blog",
     "text": "部落格"
-  },
-  "foundation": {
-    "link": "https://foundation.nodejs.org/",
-    "text": "基金會"
   },
   "releases": {
     "title": "發佈版歷史",


### PR DESCRIPTION
The Node.js Foundation is no longer. The OpenJS Foundation is linked
from the footer. Let's take this opportunity to streamline our
navigation menu by removing the nav link to the Foundation.