### PR TITLE
fix(blog): point v10.19.0 to the correct URL

### DIFF
--- a/locale/en/blog/vulnerability/february-2020-security-releases.md
+++ b/locale/en/blog/vulnerability/february-2020-security-releases.md
@@ -35,7 +35,7 @@ Increase the strictness of HTTP header parsing. There are no known vulnerabiliti
 
 ## Downloads & release details
 
-* [Node.js v10.19.0 (LTS)](https://nodejs.org/en/blog/release/v10.19.1/)
+* [Node.js v10.19.0 (LTS)](https://nodejs.org/en/blog/release/v10.19.0/)
 * [Node.js v12.15.0 (LTS)](https://nodejs.org/en/blog/release/v12.15.0/)
 * [Node.js v13.8.0 (LTS)](https://nodejs.org/en/blog/release/v13.8.0/)
 


### PR DESCRIPTION
URL for v10.19.0 changelog was broken (pointing to unreleased v10.19.1).