### PR TITLE
docs: tweak wording on deb, rpm, and snap section

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -49,7 +49,7 @@ pacman -S nodejs npm
 
 ## Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages
 
-[Official Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are provided by NodeSource.
+[Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are available from NodeSource.
 
 ## FreeBSD
 


### PR DESCRIPTION
Updates the confusing/misleading wording in the Package Manager section that contradicts what's asserted at the top of the page.