### PR TITLE
chore: Drop IE 10

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,4 @@
 # https://github.com/browserslist/browserslist#readme
 
 defaults
-Explorer >= 10
+Explorer 11


### PR DESCRIPTION

Support end January 31st 2020
https://support.microsoft.com/en-us/help/4488955/support-ending-for-internet-explorer-10