### PR TITLE
Add v12 link to the "latest release" section on "Previous releases".

### DIFF
--- a/locale/en/download/releases.md
+++ b/locale/en/download/releases.md
@@ -11,6 +11,7 @@ Releases 1.x through 3.x were called "io.js" as they were part of the io.js fork
 
 #### Looking for latest release of a version branch?
 
+* [Node.js 12.x](https://nodejs.org/dist/latest-v12.x/)
 * [Node.js 10.x](https://nodejs.org/dist/latest-v10.x/)
 * [Node.js 8.x](https://nodejs.org/dist/latest-v8.x/)
 * [Node.js 6.x](https://nodejs.org/dist/latest-v6.x/)


### PR DESCRIPTION
This adds a link to the v12 `/dist/` directory for quick access to the "latest" releases.

This existing section is a bit confusing to me, since even the latest releases are available on this (very useful) page titled _Previous releases_, but it seems like a strange omission to not link the v12 release in this list of bullet-points.

Happy to adjust, but thought I'd fly by with this as I'm frequently on this page and often realizing that I need to scroll down to find what I most often want for the _current_ v12 release whereas v10, v8, etc. are the first links I see.