### PR TITLE
disable the banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -272,7 +272,7 @@ function getSource (callback) {
           lts: latestVersion.lts(versions)
         },
         banner: {
-          visible: true,
+          visible: false,
           text: 'New security releases now available for all release lines',
           link: '/en/blog/vulnerability/february-2020-security-releases/'
         }


### PR DESCRIPTION
~20 days passed since the security releases. I'm fine with closing/waiting if we want to keep the banner visible for some more time.