### PR TITLE
docs: fix code comment of someAsyncApiCall example

### DIFF
--- a/locale/en/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/en/docs/guides/event-loop-timers-and-nexttick.md
@@ -341,9 +341,9 @@ let bar;
 // this has an asynchronous signature, but calls callback synchronously
 function someAsyncApiCall(callback) { callback(); }
 
-// the callback is called before `someAsyncApiCall` completes.
+// the callback is called before someAsyncApiCall completes.
 someAsyncApiCall(() => {
-  // since someAsyncApiCall has completed, bar hasn't been assigned any value
+  // since someAsyncApiCall hasn't completed, bar hasn't been assigned any value
   console.log('bar', bar); // undefined
 });
 

--- a/locale/en/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/en/docs/guides/event-loop-timers-and-nexttick.md
@@ -341,7 +341,7 @@ let bar;
 // this has an asynchronous signature, but calls callback synchronously
 function someAsyncApiCall(callback) { callback(); }
 
-// the callback is called before someAsyncApiCall completes.
+// the callback is called before `someAsyncApiCall` completes.
 someAsyncApiCall(() => {
   // since someAsyncApiCall hasn't completed, bar hasn't been assigned any value
   console.log('bar', bar); // undefined


### PR DESCRIPTION
Just fixed a comment of `someAsyncApiCall` example code in this [section](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#why-would-that-be-allowed).