### PR TITLE
fix: add missing 12.x & 13.x links

### DIFF
--- a/locale/ar/docs/index.md
+++ b/locale/ar/docs/index.md
@@ -23,6 +23,8 @@ labels:
 
 ### تبحث عن توثيق لنسخة سابقة؟
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/ca/docs/index.md
+++ b/locale/ca/docs/index.md
@@ -25,6 +25,8 @@ També descriu els mòduls inclosos que proporciona Node.js, mes no documenta el
 
 ### Buscant la referència de l'API per a una versió anterior?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/de/docs/index.md
+++ b/locale/de/docs/index.md
@@ -28,6 +28,8 @@ von der Community zur Verfügung gestellt werden, sind dort nicht dokumentiert.
 
 ### Du suchst nach API Referenzen für ältere Versionen?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -23,6 +23,8 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
 ### Looking for API docs of previous releases?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/es/docs/index.md
+++ b/locale/es/docs/index.md
@@ -25,6 +25,8 @@ También describe los módulos incluidos que proporciona Node.js, pero no docume
 
 ### ¿Buscando la referencia de la API de versiones anteriores?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/ja/docs/index.md
+++ b/locale/ja/docs/index.md
@@ -30,6 +30,8 @@ labels:
 
 ### 以前のバージョンの API リファレンスをお探しですか？
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/ko/docs/index.md
+++ b/locale/ko/docs/index.md
@@ -44,6 +44,8 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
 ### 이전 버전에 대한 API 문서가 필요한가요?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/pt-br/docs/index.md
+++ b/locale/pt-br/docs/index.md
@@ -23,6 +23,8 @@ Esta documentação descreve os módulos embarcados (built-in) providos pelo Nod
 
 ### Procurando por documentações de API de versões antigas?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/ru/docs/index.md
+++ b/locale/ru/docs/index.md
@@ -26,6 +26,8 @@ labels:
 
 ### Нужна документация API предыдущих версий?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/tr/docs/index.md
+++ b/locale/tr/docs/index.md
@@ -23,6 +23,8 @@ Bu belgede, Node.js. tarafından sağlanan yerleşik modüller açıklanmaktadı
 
 ### Önceki sürümler için API dokümanlarını mı arıyorsunuz?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/uk/docs/index.md
+++ b/locale/uk/docs/index.md
@@ -23,6 +23,8 @@ labels:
 
 ### Шукаєте документацію про API для попередніх релізів?
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/zh-cn/docs/index.md
+++ b/locale/zh-cn/docs/index.md
@@ -23,6 +23,8 @@ labels:
 
 ### 在寻找先前发布的 API 函数接口文档吗？
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)

--- a/locale/zh-tw/docs/index.md
+++ b/locale/zh-tw/docs/index.md
@@ -23,6 +23,8 @@ labels:
 
 ### 在找舊版的 API 文件嗎？
 
+* [Node.js 13.x](https://nodejs.org/docs/latest-v13.x/api/)
+* [Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/)
 * [Node.js 11.x](https://nodejs.org/docs/latest-v11.x/api/)
 * [Node.js 10.x](https://nodejs.org/docs/latest-v10.x/api/)
 * [Node.js 9.x](https://nodejs.org/docs/latest-v9.x/api/)


### PR DESCRIPTION
Fixes an issue with missing 12.x & 13.x links on the primary API reference page.