### PR TITLE
Modified the non-standard expression:“黏贴”=>"粘贴"

### DIFF
--- a/locale/zh-cn/docs/guides/getting-started-guide.md
+++ b/locale/zh-cn/docs/guides/getting-started-guide.md
@@ -6,7 +6,7 @@ layout: docs.hbs
 # 在安装了 Node.js 之后，我怎么开始呢？
 
 一旦你已经安装了 Node，让我们尝试构建第一个 Web 服务器。
-请创建一个“app.js”文件，黏贴以下代码：
+请创建一个“app.js”文件，粘贴以下代码：
 
 ```javascript
 const http = require('http');


### PR DESCRIPTION
此处应表示paste的意思，paste的标准的中文翻译是“粘贴”而不是“黏贴”。“黏贴”只是少数地区的方言，放在官方文档中不合适。
The meaning of paste should be shown here. The standard Chinese translation of paste is "paste" instead of "paste". "Paste" is just a dialect of a few regions and it is inappropriate to put it in official documents.