### PR TITLE
blog: include info about notarization on 13.12.0

### DIFF
--- a/locale/en/blog/release/v13.12.0.md
+++ b/locale/en/blog/release/v13.12.0.md
@@ -8,6 +8,15 @@ layout: blog-post.hbs
 author: Myles Borins
 ---
 
+### macOS package notarization and a change in builder configuration
+
+The macOS binaries for this release, and future 13.x releases, are now being compiled on
+macOS 10.15 (Catalina) with Xcode 11 to support package notarization, a requirement for
+installing on .pkg files on macOS 10.15 and later. Previous builds of Node.js 13.x were
+compiled on macOS 10.11 (El Capitan) with Xcode 10. As binaries are still being compiled
+to support a minimum of macOS 10.10 (Yosemite) we do not anticipate this having a negative
+impact on Node.js 13.x users with older versions of macOS.
+
 ### Notable Changes
 
 * **build**:


### PR DESCRIPTION
This was missing from 13.12.0 release post