### PR TITLE
Remove term "simply" from package manager docs

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -160,7 +160,7 @@ zypper install nodejs4
 
 ## macOS
 
-Simply download the [macOS Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
+Download the [macOS Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
 
 _If you want to download the package with bash:_
 
@@ -231,7 +231,7 @@ xbps-install -Sy nodejs
 
 ## Windows
 
-Simply download the [Windows Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
+Download the [Windows Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
 
 ### Alternatives
 


### PR DESCRIPTION
The word "simply" does not add anything useful to the instructions. And in cases where a user encounters trouble, users may infer negative things about themselves that they were unable to "simply" perform the necessary task.