### PR TITLE
remove timeframe from security.md

### DIFF
--- a/locale/en/security.md
+++ b/locale/en/security.md
@@ -16,8 +16,7 @@ handling your submission.
 After the initial reply to your report, the security team will endeavor to keep
 you informed of the progress being made towards a fix and full announcement,
 and may ask for additional information or guidance surrounding the reported
-issue. These updates will be sent at least every five days; in practice, this
-is more likely to be every 24-48 hours.
+issue.
 
 ### Node.js Bug Bounty Program
 


### PR DESCRIPTION
We don't provide updates to reporters with the frequency specified.
Remove the guarantee.

@nodejs/security 