### PR TITLE
feat: Statuspage

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -12,6 +12,7 @@
           <li><a href="https://github.com/nodejs/node/issues">{{site.reportNodeIssue}}</a></li>
           <li><a href="https://github.com/nodejs/nodejs.org/issues">{{site.reportWebsiteIssue}}</a></li>
           <li><a href="https://github.com/nodejs/help/issues">{{site.getHelpIssue}}</a></li>
+          <li><a href="https://status.nodejs.org">{{site.statusPage}}</a></li>
         </ul>
       </div>
 

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -29,3 +29,4 @@
 </footer>
 
 <script src="/static/js/main.js" async defer></script>
+<script src="https://rxy2rhgm8q1n.statuspage.io/embed/script.js" async defer></script>

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -12,7 +12,7 @@
           <li><a href="https://github.com/nodejs/node/issues">{{site.reportNodeIssue}}</a></li>
           <li><a href="https://github.com/nodejs/nodejs.org/issues">{{site.reportWebsiteIssue}}</a></li>
           <li><a href="https://github.com/nodejs/help/issues">{{site.getHelpIssue}}</a></li>
-          <li><a href="https://status.nodejs.org">{{site.statusPage}}</a></li>
+          <li><a href="https://status.nodejs.org/">{{site.statusPage}}</a></li>
         </ul>
       </div>
 

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -9,6 +9,7 @@
   "reportNodeIssue": "Report Node.js issue",
   "reportWebsiteIssue": "Report website issue",
   "getHelpIssue": "Get Help",
+  "statusPage": "Status Page",
   "by": "by",
   "all-downloads": "All download options",
   "nightly": "Nightly builds",


### PR DESCRIPTION
Add the Statuspage embed script to the site, which will automatically show a notification in the bottom right of the screen if there is an active incident or maintenance on the status page site. This also adds a link in the footer to the status page.

![image](https://user-images.githubusercontent.com/12371363/79802626-3521f500-8358-11ea-9a06-03a9699d4cd6.png)

I don't expect this to be merged for a while, access, policies and more for the status page need to be established first (see https://github.com/nodejs/build/issues/2265 & https://github.com/nodejs/build/pull/2299).