### PR TITLE
Blog: fix release posts for Node.js 14

### DIFF
--- a/locale/en/blog/release/v14.0.0.md
+++ b/locale/en/blog/release/v14.0.0.md
@@ -299,7 +299,6 @@ Linux 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-arm64.tar.xz<br>
 Source Code: https://nodejs.org/dist/v14.0.0/node-v14.0.0.tar.gz<br>

--- a/locale/en/blog/release/v14.1.0.md
+++ b/locale/en/blog/release/v14.1.0.md
@@ -127,7 +127,6 @@ Linux 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-arm64.tar.xz<br>
 Source Code: https://nodejs.org/dist/v14.1.0/node-v14.1.0.tar.gz<br>

--- a/locale/en/blog/release/v14.2.0.md
+++ b/locale/en/blog/release/v14.2.0.md
@@ -178,10 +178,9 @@ Linux 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-x64.tar.
 Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-ppc64le.tar.xz<br>
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-s390x.tar.xz<br>
 AIX 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: *Coming soon*<br>
 ARMv7 32-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-armv7l.tar.xz<br>
 ARMv8 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-arm64.tar.xz<br>
-Source Code: *Coming soon*<br>
+Source Code: https://nodejs.org/dist/v14.2.0/node-v14.2.0.tar.gz<br>
 Other release files: https://nodejs.org/dist/v14.2.0/<br>
 Documentation: https://nodejs.org/docs/v14.2.0/api/
 

--- a/scripts/helpers/downloads.js
+++ b/scripts/helpers/downloads.js
@@ -160,6 +160,12 @@ const resolveDownloads = (version) => {
     )
   }
 
+  if (semver.satisfies(version, '>= 14.0.0')) {
+    downloads = downloads.filter(ver =>
+      ver.title !== 'SmartOS 64-bit Binary'
+    )
+  }
+
   return downloads
 }
 


### PR DESCRIPTION
We do not build SmartOS releases anymore.
The link for the source code of v14.2.0 wasn't included by the script.

@nodejs/releasers 