### PR TITLE
chore: remove newsletter links

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -68,11 +68,6 @@
         <p>
           {{{ labels.version-schedule-prompt }}} <a href="/{{site.locale}}/about/releases/">{{ labels.version-schedule-prompt-link-text }}</a>
         </p>
-        {{#if labels.newsletter }}
-        <p>
-          {{{ labels.newsletter-prefix }}} <a href="https://newsletter.nodejs.org/">Node.js Everywhere</a>{{{ labels.newsletter-postfix }}}
-        </p>
-        {{/if}}
       </div>
 
     </div>

--- a/locale/ar/get-involved/index.md
+++ b/locale/ar/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * لأجل الانخراط في دردشة آنية عن تطوير الـ Node.js، تفضل بزيارة `irc.freenode.net` على قناة `#node.js` باستعمال [أحد برامج IRC](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) أو اتصل بواسطة متصفحك باستعمال خدمة الشات الخاصة بـ [freenode](https://webchat.freenode.net/#node.js)
 * الحساب الرسمي للـ Node.js على تويتر هو [nodejs](https://twitter.com/nodejs)
 * [رزنامة مؤسسة الـ Node.js](https://nodejs.org/calendar) تحتوي على تواريخ لقاءات جميع الفرق العامة.
-* [Node.js Everywhere](https://newsletter.nodejs.org) و تمثل الرسالة الإخبارية الشهرية للـ Node.js.
 * [Node.js Collection](https://medium.com/the-node-js-collection) وهي مجموعة من المحتوى المكتوب من طرف مجتمعنا على موقع medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) و هي تمثل لجنة ذات مستوى عالٍ في مؤسسة الـ Node.js و تركز على الجهود الخاصة بالمجتمع.
 

--- a/locale/ar/index.md
+++ b/locale/ar/index.md
@@ -15,9 +15,6 @@ labels:
   api: API Docs
   version-schedule-prompt: أو انظر إلى
   version-schedule-prompt-link-text: أجندة LTS.
-  newsletter: نعم
-  newsletter-prefix: قم بالانضمام الى
-  newsletter-postfix: " الرسالة الإخبارية الشّهريّة عن Node.js "
 ---
 
 Node.js® هو إطار عمل مبني على محرك [Chrome V8](https://v8.dev/).

--- a/locale/ca/get-involved/index.md
+++ b/locale/ca/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * Per xatejar en temps real sobre el desenvolupament de Node.js vagi a `irc.freenode.net` al canal `#node.js` fent servir un [client d'IRC](https://es.wikipedia.org/wiki/Anexo:Clientes_IRC) o connecti's amb el seu navegador al canal usant [WebChat de freenode](https://webchat.freenode.net/#node.js).
 * El compte de Twitter oficial de Node.js és [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) és el Butlletí oficial mensual de Node.js.
 * [Node.js Collection](https://medium.com/the-node-js-collection) és una col·lecció de contingut comissat per la comunitat a Medium.
 * La [Community Committee](https://github.com/nodejs/community-committee) és una comissió de primer nivell a la Fundació Node.js centrada en els esforços que afronta la comunitat.
 

--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -15,9 +15,6 @@ labels:
   api: API Docs
   version-schedule-prompt: Or have a look at the
   version-schedule-prompt-link-text: Long Term Support (LTS) schedule.
-  newsletter: true
-  newsletter-prefix: Sign up for
-  newsletter-postfix: ", the official Node.js Monthly Newsletter."
 ---
 
 Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://v8.dev/).

--- a/locale/es/index.md
+++ b/locale/es/index.md
@@ -15,9 +15,6 @@ labels:
   api: Documentación del API
   version-schedule-prompt: O eche un vistazo a la
   version-schedule-prompt-link-text: agenda LTS.
-  newsletter: true
-  newsletter-prefix: Regístrese en
-  newsletter-postfix: ", la Newsletter Mensual de Node.js."
 ---
 
 Node.js® es un entorno de ejecución para JavaScript construido con el [motor de JavaScript V8 de Chrome](https://v8.dev/).

--- a/locale/fa/index.md
+++ b/locale/fa/index.md
@@ -15,9 +15,6 @@ labels:
   api: مستندات API
   version-schedule-prompt: یا نگاهی بیاندازید به
   version-schedule-prompt-link-text: زمان بندی پشتیبانی طولانی مدت
-  newsletter: درست
-  newsletter-prefix: نام‌نویسی برای
-  newsletter-postfix: "، خبرنامهٔ رسمی NodeJs.org"
 ---
 
 Node.js® چارچوبی است برای اجرای جاوااسکریپت ساخته شده بر روی [موتور جاوااسکریپت کروم](https://v8.dev/).

--- a/locale/fr/get-involved/index.md
+++ b/locale/fr/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community.

--- a/locale/fr/index.md
+++ b/locale/fr/index.md
@@ -15,9 +15,6 @@ labels:
   api: Documentation API
   version-schedule-prompt: Ou regardez le
   version-schedule-prompt-link-text: Planning LTS.
-  newsletter: true
-  newsletter-prefix: Sign up for
-  newsletter-postfix: ", the official Node.js Monthly Newsletter."
 ---
 
 Node.js® est un environnement d’exécution JavaScript construit sur le [moteur JavaScript V8 de Chrome](https://v8.dev/).

--- a/locale/it/get-involved/index.md
+++ b/locale/it/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * La chat relativa allo sviluppo di Node.js è disponibile su `irc.freenode.net` nel canale `#node.js` usando il [client IRC](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) o connettendosi tramite web browser usando [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * L'account Twitter ufficiale di Node.js é [nodejs](https://twitter.com/nodejs).
 * Il [calendario della Node.js Foundation](https://nodejs.org/calendar) con tutti i meeting pubblici del team.
-* [Node.js Everywhere](https://newsletter.nodejs.org) é la Newsletter ufficiale di Node.js.
 * [Node.js Collection](https://medium.com/the-node-js-collection) é una collezione di contenuti curati dalla comunità e presenti su Medium.
 * Il [Comitato della Comunità](https://github.com/nodejs/community-committee) é un comitato di livello più alto della Node.js Foundation concentrato sugli sforzi della comunità.
 * [Node Slackers](https://www.nodeslackers.com/) è la comunità Slack di Node.js.

--- a/locale/it/index.md
+++ b/locale/it/index.md
@@ -15,9 +15,6 @@ labels:
   api: Documentazione API
   version-schedule-prompt: Dai un'occhiata alla
   version-schedule-prompt-link-text: tabella di marcia LTS.
-  newsletter: true
-  newsletter-prefix: Iscriviti a
-  newsletter-postfix: ", la newsletter mensile di Node.js"
 ---
 
 Node.js® è un runtime JavaScript costruito sul [motore JavaScript V8 di Chrome](https://v8.dev/).

--- a/locale/ja/get-involved/index.md
+++ b/locale/ja/get-involved/index.md
@@ -12,7 +12,6 @@ layout: contribute.hbs
 * For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 
@@ -25,7 +24,6 @@ layout: contribute.hbs
 * Node.js 開発についてのリアルタイムチャットは、[IRC クライアント](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) を使って `#node.js` チャンネルで `irc.freenode.net` に行くか、または [freenode's WebChat](https://webchat.freenode.net/#node.js) を使ってあなたの Web ブラウザでそのチャンネルに接続してください。
 * Node.js 公式 Twitter アカウントは [nodejs](https://twitter.com/nodejs) です。
 * [Node.js Foundation calendar](https://nodejs.org/calendar) とすべての公開チームミーティング。
-* [Node.js Everywhere](https://newsletter.nodejs.org) は、公式の Node.js マンスリーニュースレターです。
 * [Node.js Collection](https://medium.com/the-node-js-collection) は、Medium 上のコミュニティキュレーションコンテンツのコレクションです。
 * [Community Committee](https://github.com/nodejs/community-committee) は、Node.js Foundation のトップレベルの委員会で、コミュニティに向けた取り組みに焦点を当てています。
 

--- a/locale/ja/index.md
+++ b/locale/ja/index.md
@@ -15,9 +15,6 @@ labels:
   api: API ドキュメント
   version-schedule-prompt: または、
   version-schedule-prompt-link-text: LTSのリリーススケジュールをご覧ください。
-  newsletter: true
-  newsletter-prefix: "公式 Node.js ニュースレター"
-  newsletter-postfix: "を購読しましょう。"
 ---
 
 Node.js® は、[Chrome の V8 JavaScript エンジン](https://v8.dev/) で動作する JavaScript 環境です。

--- a/locale/ko/get-involved/index.md
+++ b/locale/ko/get-involved/index.md
@@ -15,7 +15,6 @@ layout: contribute.hbs
 * For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 -->
@@ -25,7 +24,6 @@ layout: contribute.hbs
 * Node.js 개발에 대해 실시간으로 이야기하고 싶다면 [IRC 클라이언트](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients)나 [freenode의 웹챗](https://webchat.freenode.net/#node.js)을 이용해 `irc.freenode.net`의 `#node.js` 채널에 가보세요.
 * Node.js의 공식 트위터 계정은 [nodejs](https://twitter.com/nodejs)입니다.
 * [Node.js 재단 캘린더](https://nodejs.org/calendar)에 모든 공개 팀 미팅 일정이 포함되어 있습니다.
-* [Node.js Everywhere](https://newsletter.nodejs.org)는 공식 Node.js 월간 뉴스레터입니다.
 * [Node.js 컬렉션](https://medium.com/the-node-js-collection)은 커뮤니티에서 선별한 콘텐츠를 Medium에 모아놓은 곳입니다.
 * [커뮤니티 위원회](https://github.com/nodejs/community-committee)는 Node.js 재단에서 커뮤니티와 관련한 것에 집중하는 최상위 위원회입니다.
 

--- a/locale/pt-br/get-involved/index.md
+++ b/locale/pt-br/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * Para conversar sobre o desenvolvimento do Node.js, em tempo real, entre em `irc.freenode.net` no canal `#node.js` com um [cliente IRC](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) ou conecte-se através do navegador usando o [WebChat do freenode](https://webchat.freenode.net/#node.js).
 * A conta oficial do Node.js no Twitter é [nodejs](https://twitter.com/nodejs).
 * O [calendário da Fundação Node.js](https://nodejs.org/calendar) contém todas as reuniões dos times públicos
-* [Node.js Everywhere](https://newsletter.nodejs.org) é o boletim oficial do Node.js.
 * [Node.js Collection](https://medium.com/the-node-js-collection) é uma coleção de conteúdos, com curadoria da comunidade, disponível no Medium.
 * O [Community Committee](https://github.com/nodejs/community-committee) é um dos principais comitês na Fundação Node.js, focado nos esforços da comunidade.
 

--- a/locale/pt-br/index.md
+++ b/locale/pt-br/index.md
@@ -15,9 +15,6 @@ labels:
   api: Documentação da API
   version-schedule-prompt: Ou verifique o
   version-schedule-prompt-link-text: Cronograma de versões LTS.
-  newsletter: true
-  newsletter-prefix: Inscreva-se para
-  newsletter-postfix: ", o boletim oficial de atualizações do Node.js."
 ---
 
 Node.js® é um runtime JavaScript desenvolvido com o [Chrome's V8 JavaScript engine](https://v8.dev/).

--- a/locale/ro/get-involved/index.md
+++ b/locale/ro/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
-* [Node.js Everywhere](https://newsletter.nodejs.org) is the official Node.js Monthly Newsletter.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.
 * The [Community Committee](https://github.com/nodejs/community-committee) is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community.

--- a/locale/ro/index.md
+++ b/locale/ro/index.md
@@ -15,9 +15,6 @@ labels:
   api: API Docs
   version-schedule-prompt: Or have a look at the
   version-schedule-prompt-link-text: Long Term Support (LTS) schedule.
-  newsletter: true
-  newsletter-prefix: Sign up for
-  newsletter-postfix: ", the official Node.js Monthly Newsletter."
 ---
 
 Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://v8.dev/).

--- a/locale/ru/get-involved/index.md
+++ b/locale/ru/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * Для чата в реальном времени о разработке Node.js перейдите на `irc.freenode.net` в канале`#node.js` с [IRC-клиентом](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) или подключитесь в своем веб-браузере к каналу с помощью [веб-чата freenode](https://webchat.freenode.net/#node.js).
 * Официальный аккаунт Node.js в Твиттере ― [nodejs](https://twitter.com/nodejs).
 * [Календарь Фонда Node.js](https://nodejs.org/calendar) со всеми общественными встречами.
-* [Node.js Everywhere](https://newsletter.nodejs.org) официальный ежемесячный блог Node.js
 * [Node.js](https://medium.com/the-node-js-collection) контент, создаваемый сообществом Medium.
 * [Community Committee](https://github.com/nodejs/community-committee) является комитетом высшего уровня в Фонде Node.js, ориентированным на развитие сообщества.
 

--- a/locale/ru/index.md
+++ b/locale/ru/index.md
@@ -15,9 +15,6 @@ labels:
   api: Документация
   version-schedule-prompt: Или смотрите на
   version-schedule-prompt-link-text: график LTS.
-  newsletter: true
-  newsletter-prefix: Подпишитесь на
-  newsletter-postfix: ", официальный ежемесячный информационный бюллетень Node.js."
 ---
 
 Node.js® — это JavaScript-окружение построенное на движке [Chrome V8](https://v8.dev/).

--- a/locale/tr/index.md
+++ b/locale/tr/index.md
@@ -15,9 +15,6 @@ labels:
   api: API Belgeleri
   version-schedule-prompt: Ya da
   version-schedule-prompt-link-text: Uzun Süreli Destek (LTS) takvimine bakın.
-  newsletter: true
-  newsletter-prefix: Resmi Node.js aylık bülteni
-  newsletter-postfix: "'e kaydolun."
 ---
 
 Node.js® [Chrome'un V8 JavaScript motoru](https://v8.dev/) üzerine inşa edilmiş bir JavaScript çalışma ortamıdır.

--- a/locale/zh-cn/get-involved/index.md
+++ b/locale/zh-cn/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * 关于 Node.js 开发的实时对话，请使用 [IRC 客户端](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) 或 [freenode 网页聊天室](https://webchat.freenode.net/#node.js)转到 `irc.freenode.net` 中的 `#node.js` 頻道。
 * Node.js 官方的 Twitter 账号：[nodejs](https://twitter.com/nodejs).
 * [Node.js Foundation calendar](https://nodejs.org/calendar) 是有关于所有 Node.js 团队会议的相关日程安排。
-* [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月报。
 * [Node.js Collection](https://medium.com/the-node-js-collection) 是一堆在媒体上的社区策划内容集合。
 * [Community Committee](https://github.com/nodejs/community-committee) 是 Node.js 基金会中的高级委员会，专注于社区事务。
 

--- a/locale/zh-cn/index.md
+++ b/locale/zh-cn/index.md
@@ -15,9 +15,6 @@ labels:
   api: API 文档
   version-schedule-prompt: 可参考
   version-schedule-prompt-link-text: LTS 日程。
-  newsletter: true
-  newsletter-prefix: 订阅
-  newsletter-postfix: ，Node.js 官方的新闻月报。
 ---
 
 Node.js® 是一个基于 [Chrome V8 引擎](https://v8.dev/) 的 JavaScript 运行时。

--- a/locale/zh-tw/get-involved/index.md
+++ b/locale/zh-tw/get-involved/index.md
@@ -11,7 +11,6 @@ layout: contribute.hbs
 * 關於 Node.js 開發的即時對話請使用 [IRC 用戶端](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) 或 [freenode 網頁聊天室](https://webchat.freenode.net/#node.js) 連線至 `irc.freenode.net` 中的 `#node.js` 頻道。
 * Node.js 官方的 Twitter 帳號是 [nodejs](https://twitter.com/nodejs)。
 * [Node.js Foundation 行事曆](https://nodejs.org/calendar) 中列出了所有的公開團隊會議。
-* [Node.js Everywhere](https://newsletter.nodejs.org) 是 Node.js 官方的月報。
 * [Node.js Collection](https://medium.com/the-node-js-collection) 是個由社群策劃的 Medium 文章合集。
 * [Community Committee](https://github.com/nodejs/community-committee) 是 Node.js 基金會中的高級委員會，專責社群事務。
 

--- a/locale/zh-tw/index.md
+++ b/locale/zh-tw/index.md
@@ -15,9 +15,6 @@ labels:
   api: API 文件
   version-schedule-prompt: 或參考
   version-schedule-prompt-link-text: LTS（長期維護版）時程
-  newsletter: true
-  newsletter-prefix: 訂閱
-  newsletter-postfix: "：Node.js 官方的新聞月報。"
 ---
 
 Node.js® 是款基於 [Chrome V8 引擎](https://v8.dev/)的 JavaScript 執行環境。


### PR DESCRIPTION
The newsletter has not been a thing for many months now, and the email
list associated with it has not been used since December. If it ever
becomes a regular active thing again, we can add it again, but unless
and until that happens, it's best not to use up valuable front-page real
estate directing people to it.