### PR TITLE
Added Nodenv to package-manager list

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -128,6 +128,12 @@ from source:
 nvm uninstall 8
 ```
 
+## Nodenv
+
+`nodenv` is a lightweight node version manager, similar to `nvm`. It's simple and predictable. A rich plugin ecosystem lets you tailor it to suit your needs. Use `nodenv` to pick a Node version for your application and guarantee that your development environment matches production. 
+
+Nodenv installation instructions are maintained [on its Github page](https://github.com/nodenv/nodenv#installation). Please visit that page to ensure you're following the latest version of the installation steps.
+
 ## OpenBSD
 
 Node.js is available through the ports system.

--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -17,6 +17,7 @@ title: Installing Node.js via package manager
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [Nodenv](#nodenv)
 * [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)


### PR DESCRIPTION
Nodenv is an alternative to NVM, and is used fairly widely. See https://github.com/nodenv/nodenv. Would like to have it added to the package-managers list as per https://github.com/nodenv/nodenv/issues/157