### PR TITLE
Fix typo Debate => Donate

### DIFF
--- a/layouts/black-lives-matter.hbs
+++ b/layouts/black-lives-matter.hbs
@@ -188,7 +188,7 @@
     <ul>
       <li>Donate to the <a href="https://www.gofundme.com/f/georgefloyd">Official George Floyd Memorial Fund</a>.</li>
       <li>Donate to the <a href="https://www.gofundme.com/f/i-run-with-maud">I Run With Maud</a> fundraiser for Ahmaud Arbery.</li>
-      <li>Debate to the <a href="https://www.gofundme.com/f/justice-for-mike-ramos">Justice for Mike Ramos</a> fundraiser.</li>
+      <li>Donate to the <a href="https://www.gofundme.com/f/justice-for-mike-ramos">Justice for Mike Ramos</a> fundraiser.</li>
       <li>Find and donate to bail fund via the <a href="https://www.communityjusticeexchange.org/nbfn-directory">National Bail Fund Network</a>.</li>
       <li><a href="https://www.facebook.com/reclaimtheblock/">Reclaim the Block</a> has published a <a href="https://docs.google.com/document/d/1yLWGTQIe3967hdc9RSxBq5s6KKZHe-3_mWp5oemd7OA/preview?pru=AAABcpUiX3k*Y6Q4I6UBtkH3lLz9GVLg0A">Google Doc of organizations to donate to.</a></li>
     </ul>


### PR DESCRIPTION
There appears to be a typo on the homepage. I think "Debate" should be "Donate".