### PR TITLE
chore: improve "We're here for you" callout on Black Lives Matter page

### DIFF
--- a/layouts/black-lives-matter.hbs
+++ b/layouts/black-lives-matter.hbs
@@ -242,7 +242,25 @@
   <section id="our-support">
 
     <p>It would be wrong for us to ignore the unearned privilege that exists in Node.js: much of the project leadership is white, and a majority are men. We are and have been systematically complicit in perpetuating the issues that led to where we are now. We can't change how we've built out the project's leadership to date, but we can change how we build it moving forward. We are dedicated to being a part of the solution by actively centering the Black community with our collective platforms to uplift Black voices, share projects founded and built by Black community members, and actively hold ourselves accountable to our promises and make changes as needed. While it is our responsibility and it is not the work of the community to hold us accountable, we welcome you to share ways that we can do better by emailing <a href="mailto:blacklivesmatter@nodejs.org">blacklivesmatter@nodejs.org</a> or reaching out individually to any of our project leaders.</p>
-    <p>The labor to dismantle white supremacy does not fall on Black community; it falls on the rest of us. If there are Black folks looking for collaboration, amplification, mentorship, guidance, or any sort of support, we're here for you (see below).</p>
+
+    <p>
+      The responsibility to dismantle white supremacy does not fall on the Black
+      community. It falls on the rest of us.
+    </p>
+
+    <p>
+      To Black folks looking for access or collaboration: We're here for you.
+    </p>
+
+    <p>
+      To Black people looking for  amplification or mentorship: We're here for
+      you.
+    </p>
+
+    <p>
+      To Black members of our community seeking guidance or any sort of support:
+      We're here for you.
+    </p>
 
  <p>Beginning with our upcoming Collaborator Summit event, and extending beyond, we will be offering mentorship to Black members of the community who wish to become contributors to the Node.js project. If you are interested in this, please send us an email at <a href="mailto:blacklivesmatter@nodejs.org">blacklivesmatter@nodejs.org</a> or direct message us at <a href="https://twitter.com/nodejs">@nodejs</a> on Twitter. We will post more information on how we will be proceeding with this effort as we finalize the details both for the period of the Collaborator summit and beyond that single event.</p>
 


### PR DESCRIPTION
Improve the text and format of the "We're here for you" paragraph by
splitting it into multiple sentences/paragraphs. Shorter sentences and
repeated structure improve impact. Also added "access" as something
Black folks may be seeking rather than limiting it to guidance,
mentorship, etc. This was inspired by
https://twitter.com/NotNikyatu/status/1268661305843552263.