### PR TITLE
Add njs download link to blm layout at the bottom

### DIFF
--- a/layouts/black-lives-matter.hbs
+++ b/layouts/black-lives-matter.hbs
@@ -281,7 +281,7 @@
   </section>
 
   <section id="temporary">
-    If you're looking for docs, they're <a href="https://nodejs.org/docs">still available</a>. If you're looking for information on the most recent security release, please see <a href="https://nodejs.org/en/blog/vulnerability/june-2020-security-releases/">the security release blog post</a>.
+    If you're looking for docs, they're <a href="https://nodejs.org/docs">still available</a> and so are <a href="https://nodejs.org/en/download/">the downloads</a>. If you're looking for information on the most recent security release, please see <a href="https://nodejs.org/en/blog/vulnerability/june-2020-security-releases/">the security release blog post</a>.
   </section>
 
   <footer>


### PR DESCRIPTION
This adds a link to the downloads where the docs are linked. This will help people find them. I am fully open to changes if it doesn't fit the wording or location where to link to them.