### PR TITLE
fix: remove incorrect name

### DIFF
--- a/layouts/black-lives-matter.hbs
+++ b/layouts/black-lives-matter.hbs
@@ -193,7 +193,6 @@
       <li>Michael Dean</li>
       <li>Mike Ramos</li>
       <li>Miles Hall</li>
-      <li>Natosha McDade</li>
       <li>Patrick Harmon</li>
       <li>Philando Castile</li>
       <li>Quintonio LeGrier</li>


### PR DESCRIPTION
Removes the incorrect name for someone who was killed. Their correct name is already on the list.

Thank you to the person who DM'ed us at @nodejs on Twitter to let us know ❤️