### PR TITLE
blm: change references for police violence

### DIFF
--- a/layouts/black-lives-matter.hbs
+++ b/layouts/black-lives-matter.hbs
@@ -219,7 +219,7 @@
       <li>William Green</li>
       <li>Willie McCoy</li>
       <li>Yassin Mohamed</li>
-      <li>&hellip;<a href="https://mappingpoliceviolence.org/unarmed">and</a> <a href="https://mappingpoliceviolence.org/unarmed2014">countless</a> <a href="https://apps.npr.org/documents/document.html?id=6933593-NPR-CodeSwitch-Saytheirnameslistv3">more</a> <a href="https://ebwiki.org/">lives</a> not listed here, taken by violence and brutality.</li>
+      <li>&hellip;<a href="https://mappingpoliceviolence.org/">and</a> <a href="https://twitter.com/samswey/status/1259254114606886913">countless</a> <a href="https://apps.npr.org/documents/document.html?id=6933593-NPR-CodeSwitch-Saytheirnameslistv3">more</a> <a href="https://ebwiki.org/">lives</a> not listed here, taken by violence and brutality.</li>
     </ul>
     <p>
       White supremacy and police brutality are global problems. Every Black life


### PR DESCRIPTION
Privately received feedback regarding the links we currently have showing policy violence.

This PR updates the links. Specifically changing 

https://mappingpoliceviolence.org/unarmed -> https://mappingpoliceviolence.org/

Reasoning: The statistics included on the "unarmed" page are from 2015, the statistics on the main landing page are from 2019

https://mappingpoliceviolence.org/unarmed2014 -> https://twitter.com/samswey/status/1259254114606886913

Reasoning: That statistics from this specific landing page are from 2014. The twitter thread is a summary of many years of data presented in a thoughtful way.

Thoughts?