### PR TITLE
fix: remove unwanted newline which caused the paragraph to break

### DIFF
--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -164,7 +164,7 @@ to help you figure out how you might want to take part. If you have any question
 want to talk about anything, please reach out to [blacklivesmatter@nodejs.org](mailto:blacklivesmatter@nodejs.org).
 
 Moving forward we plan to offer ongoing support, mentorship, and sponsorship to
-help those from the Black community get involved in our project.
+help those from the Black community get involved in our project. We will
 also be analyzing our existing processes and governance to see what changes
 we can make to make sure our project is the kind of environment that the
 Black community wants to participate in.

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -163,12 +163,7 @@ We have an [orientation guide](https://github.com/openjs-foundation/summit/blob/
 to help you figure out how you might want to take part. If you have any questions or
 want to talk about anything, please reach out to [blacklivesmatter@nodejs.org](mailto:blacklivesmatter@nodejs.org).
 
-Moving forward we plan to offer ongoing support, mentorship, and sponsorship to
-
-help those from the Black community get involved in our project. We will
-aslo be analyzing our existing processes and governance to see what changes
-we can make to make sure our project is the kind of environment that the
-Black community wants to participate in.
+Moving forward we plan to offer ongoing support, mentorship, and sponsorship to help those from the Black community get involved in our project. We will aslo be analyzing our existing processes and governance to see what changes we can make to make sure our project is the kind of environment that the Black community wants to participate in.
 
 Please feel welcome to contact
 [Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee)

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -163,7 +163,11 @@ We have an [orientation guide](https://github.com/openjs-foundation/summit/blob/
 to help you figure out how you might want to take part. If you have any questions or
 want to talk about anything, please reach out to [blacklivesmatter@nodejs.org](mailto:blacklivesmatter@nodejs.org).
 
-Moving forward we plan to offer ongoing support, mentorship, and sponsorship to help those from the Black community get involved in our project. We will aslo be analyzing our existing processes and governance to see what changes we can make to make sure our project is the kind of environment that the Black community wants to participate in.
+Moving forward we plan to offer ongoing support, mentorship, and sponsorship to
+help those from the Black community get involved in our project.
+also be analyzing our existing processes and governance to see what changes
+we can make to make sure our project is the kind of environment that the
+Black community wants to participate in.
 
 Please feel welcome to contact
 [Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee)


### PR DESCRIPTION
Removed newline after "mentorship, and sponsorship to" to fix broken paragraph.