### PR TITLE
blm: increase link contrast

### DIFF
--- a/layouts/partials/blm-styles.hbs
+++ b/layouts/partials/blm-styles.hbs
@@ -4,6 +4,10 @@
     color: #fff;
     font-family: system-ui, sans-serif;
   }
+  
+  a, a:link {
+    color: #72ba55;
+  }
 
   p, ul {
     padding-left: 2rem;


### PR DESCRIPTION
The current implementation has contrast issues with links on the landing page. Use a brighter green (derived from Node.js logo) for links

Fixes: https://github.com/nodejs/nodejs.org/issues/3257