### PR TITLE
fix typo event-loop-timers-and-nexttick.md

### DIFF
--- a/locale/en/docs/guides/event-loop-timers-and-nexttick.md
+++ b/locale/en/docs/guides/event-loop-timers-and-nexttick.md
@@ -155,7 +155,7 @@ more events.
 
 This phase executes callbacks for some system operations such as types
 of TCP errors. For example if a TCP socket receives `ECONNREFUSED` when
-attempting to connect, some \*nix systems want to wait to report the
+attempting to connect, some unix systems want to wait to report the
 error. This will be queued to execute in the **pending callbacks** phase.
 
 ### poll


### PR DESCRIPTION
change \*nix to unix for typo mistake