### PR TITLE
doc: use sentence case consistently in headers

### DIFF
--- a/locale/en/docs/index.md
+++ b/locale/en/docs/index.md
@@ -1,11 +1,11 @@
 ---
-title: Docs
+title: Documentation
 layout: docs.hbs
 labels:
   lts: LTS
 ---
 
-# About Docs
+# About documentation
 
 There are several types of documentation available on this website:
 
@@ -13,7 +13,7 @@ There are several types of documentation available on this website:
 * ES6 features
 * Guides
 
-## API Reference Documentation
+## API reference documentation
 
 The [API reference documentation](https://nodejs.org/api/) provides detailed information about a function or object in Node.js. This documentation indicates what arguments a method accepts, the return value of that method, and what errors may be related to that method. It also indicates which methods are available for different versions of Node.js.
 
@@ -39,7 +39,7 @@ This documentation describes the built-in modules provided by Node.js. It does n
 
 </div>
 
-## ES6 Features
+## ES6 features
 
 The [ES6 section](/en/docs/es6/) describes the three ES6 feature groups, and details which features are enabled by default in Node.js, alongside explanatory links. It also shows how to find which version of V8 shipped with a particular Node.js release.
 


### PR DESCRIPTION
Use sentence case consistently. Also, use "documentation" rather than "docs" which, for me at least, makes me think of "doctors" rather than "documentation"... Maybe I'm unusual in that regard...