### PR TITLE
fix: use nav elements with descriptive aria-labels

### DIFF
--- a/layouts/blog-index.hbs
+++ b/layouts/blog-index.hbs
@@ -25,7 +25,7 @@
       </ul>
 
       {{#if pagination}}
-      <nav class="pagination">
+      <nav aria-label="pagination" class="pagination">
         {{#if pagination.prev.path}}
         <a href="/{{ site.locale }}/{{ pagination.prev.path }}/">&lt; Newer</a>
         {{/if}}

--- a/layouts/css/styles.scss
+++ b/layouts/css/styles.scss
@@ -50,7 +50,7 @@ article a {
 }
 
 .has-side-nav {
-  aside {
+  nav {
     width: 200px;
     float: left;
     margin-top: 1.5em;
@@ -95,7 +95,7 @@ article a {
 
 @media screen and (max-width: 480px) {
   .has-side-nav {
-    aside {
+    nav {
       width: 100%;
       float: none;
     }
@@ -139,7 +139,7 @@ a:hover .color-lightgray {
 
 html[dir="rtl"] {
   .has-side-nav {
-    aside {
+    nav {
       float: right;
     }
 

--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -5,7 +5,7 @@
       <img src="/static/images/logo.svg" alt="Node.js" width="122" height="75">
     </a>
 
-    <nav>
+    <nav aria-label="primary">
       <ul class="list-divider-pipe">
         <li {{#equals path ''}} class="active" {{/equals}}>
           <a href="/{{site.locale}}/">{{site.home.text}}</a>

--- a/layouts/partials/navigation.hbs
+++ b/layouts/partials/navigation.hbs
@@ -1,4 +1,4 @@
-<aside>
+<nav aria-label="secondary">
   <ul>
     {{#each nav}}
       {{#equals @key ../key}}
@@ -18,4 +18,4 @@
       {{/equals}}
     {{/each}}
   </ul>
-</aside>
+</nav>


### PR DESCRIPTION
## Description

This PR sets out to make 2 related improvements to the navigation of the site. Please let me know what you think -- thank you!

### 1. Ensure that all navigation components use a `<nav>` element
I noticed that docs page has a secondary navigation wrapped in an `<aside>`.

In this case I believe it would be more helpful to use `<nav>` to more directly signal the purpose of the markup, as it includes navigation links (reference: [`<nav>`: The Navigation Section element via MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)). By comparison, an `<aside>` element is associated with complementary content "indirectly related to the document's main content" (reference: [`<aside>`: The Aside element via MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)).


### 2. Ensure that all `<nav>` elements have descriptive `aria-label` attributes
There are instances where multiple `<nav>`s appear on a page, as is the case with the newly-revised Docs page and the current News page.

Whenever there are multiple `<nav>`, it helps to either point to an existing label (via `aria-labelledby`) or create a label (via `aria-label`). For this PR, I opted to use `aria-label` because I did not see any existing headings that would be ideal to point to with `aria-labelledby`. Related resource: [WCAG 2.1 -- Example using `aria-label` to distinguish between navigation landmarks](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA6#example-1-distinguishing-navigation-landmarks)