### PR TITLE
Banner: remove Unhandled Rejections Survey

### DIFF
--- a/build.js
+++ b/build.js
@@ -277,7 +277,7 @@ function getSource (callback) {
           link: '/en/black-lives-matter/'
         },
         banner: {
-          visible: true,
+          visible: false,
           text: 'Help us decide the future of Unhandled Rejections',
           link: 'https://www.surveymonkey.com/r/FTJM7YD'
         }


### PR DESCRIPTION

The survey ends on Aug 24th, remove the banner so folks don't try to
respond to it after it closes.