### PR TITLE
doc: remove BLM TODO

### DIFF
--- a/layouts/css/page-modules/_home.scss
+++ b/layouts/css/page-modules/_home.scss
@@ -88,7 +88,6 @@
 
 /**
  * BLM CTA button styles.
- * TODO: Remove at conclusion of natural course (days to weeks).
  */
 
 .home-blacklivesmatterblock {


### PR DESCRIPTION
When I originally reviewed the PR for upgrading styles I did not
notice this additional TODO which makes a time commitment
for removing the BLM banner.

This is not something I would have signed off on and as such
I think we should revert this line.

Refs: https://github.com/nodejs/nodejs.org/commit/d29ad75d0ef679a7186c48efc892fa2513fe0343#diff-0eb67dac6cfdc75724b04f6a2c4eaf5d