### PR TITLE
chore: Remove modernizr linting glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "standard": {
     "ignore": [
-      "static/js/modernizr.custom.js",
       "static/legacy/*",
       "external"
     ]


### PR DESCRIPTION
Remove no longer existent standard ignore

modernizr was removed in #2813