### PR TITLE
Add missing property for `small`

### DIFF
--- a/layouts/css/_utils.scss
+++ b/layouts/css/_utils.scss
@@ -29,3 +29,12 @@
 .hidden {
   display: none;
 }
+
+.full-width {
+  width: 100%;
+}
+
+small,
+.small {
+  font-size: .7rem;
+}

--- a/layouts/css/styles.scss
+++ b/layouts/css/styles.scss
@@ -106,14 +106,6 @@ article a {
   }
 }
 
-.full-width {
-  width: 100%;
-}
-
-.small {
-  font-size: 10px;
-}
-
 .color-lightgray {
   color: $light-gray;
 }


### PR DESCRIPTION
Also,

* switch to rem
* make the value a little bigger (~11px)
* move the selectors to utils

```
C:\Users\xmr\Desktop\nodejs.org>git grep -rna "<small"
layouts/about-release-schedule.hbs:23:          <small>{{ schedule-footer }}</small>
layouts/download-releases.hbs:56:          <p><small id="ref-1">[<a href="#backref-1">1</a>]: {{{modules}}}</small></p>
layouts/index.hbs:33:            <small>{{ labels.tagline-lts }}</small>
layouts/index.hbs:56:              <small>{{ labels.tagline-current }}</small>
```

The homepage (index.hbs) isn't affected because the selector is overwritten. The https://nodejs.org/en/download/releases/ diff:

| Before | After |
| ------- | ----- |
| <img src="https://user-images.githubusercontent.com/349621/97322777-caa6c000-1878-11eb-9b4b-aef8232c0d84.png" alt="before" width="300"> | <img src="https://user-images.githubusercontent.com/349621/97322742-c2e71b80-1878-11eb-8d0e-288d23865bc6.png" alt="after" width="300"> |

If you all think it's too small, perhaps we should remove the tag in another patch?
