### PR TITLE
Fix: language menu cover style to show at the top

### DIFF
--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -51,6 +51,7 @@ header {
     list-style-type: none;
     margin: 0;
     padding: 0;
+    z-index: 1;
 
     a {
       color: $light-gray2;


### PR DESCRIPTION
fixes: #3535

Before

<img width="327" alt="Screenshot 2020-11-20 at 1 21 14 PM" src="https://user-images.githubusercontent.com/23723464/99775402-3e18b600-2b35-11eb-8aa8-0ee36cb657c3.png">

After

<img width="359" alt="Screenshot 2020-11-20 at 1 20 56 PM" src="https://user-images.githubusercontent.com/23723464/99775413-4244d380-2b35-11eb-89d3-0b88154578c4.png">
