### PR TITLE
Blog: v14.15.2 release post patch

### DIFF
--- a/locale/en/blog/release/v14.15.2.md
+++ b/locale/en/blog/release/v14.15.2.md
@@ -10,7 +10,7 @@ author: Bethany Nicolle Griggs
 
 ### Notable Changes
 
-* **deps**:
+* **deps**: 
   * upgrade npm to 6.14.9 (Myles Borins) [#36450](https://github.com/nodejs/node/pull/36450)
   * update acorn to v8.0.4 (Michaël Zasso) [#35791](https://github.com/nodejs/node/pull/35791)
 * **doc**: add release key for Danielle Adams (Danielle Adams) [#35545](https://github.com/nodejs/node/pull/35545)


### PR DESCRIPTION
 #3576 doesn't appear to be being promoted (~40mins later). Previously it has been recommended to push a small patch to force the webhook to refresh. Apologies in advance for the noise.