### PR TITLE
Revert "chore: add link to OpenJSF Slack channel"

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -8,9 +8,7 @@ layout: contribute.hbs
 ## Community Discussion
 
 * The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
-* For real-time chat about Node.js development use the OpenJS Foundation Slack or IRC
-  * For Slack, [join the OpenJSF workspace](https://slack-invite.openjsf.org/) and then join the [`#nodejs`](https://openjs-foundation.slack.com/archives/CK9Q4MB53) channel
-  * For IRC, go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
+* For real-time chat about Node.js development go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 * [Node.js Collection](https://medium.com/the-node-js-collection) is a collection of community-curated content on Medium.


### PR DESCRIPTION
This reverts commit c10bb69904ff1b069af4adbe912661f5cfa83cba.

----

Based on discussion from https://github.com/nodejs/community-committee/issues/655, the change was added without appropriate communications and with lack of approval from CommComm (which should be involved in such decisions). Therefore reverting it until further discussion takes place.