### PR TITLE
CI: use the git tag for `actions/setup-node`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
 


### PR DESCRIPTION
Dependabot will try to update it if there's a new version, but it shouldn't. Not sure how to prevent this from happening, but we are better off just using the tag.