### PR TITLE
v15.1.0.md: fix wrong syntax highlighting

### DIFF
--- a/locale/en/blog/release/v15.1.0.md
+++ b/locale/en/blog/release/v15.1.0.md
@@ -104,7 +104,7 @@ When generating snapshots, garbage collection may be triggered and bring the hea
 
 Generating V8 snapshots takes time and memory (both memory managed by the V8 heap and native memory outside the V8 heap). The bigger the heap is, the more resources it needs. Node.js will adjust the V8 heap to accommondate the additional V8 heap memory overhead, and try its best to avoid using up all the memory avialable to the process.
 
-```console
+```shell-session
 $ node --max-old-space-size=100 --heapsnapshot-near-heap-limit=3 index.js
 Wrote snapshot to Heap.20200430.100036.49580.0.001.heapsnapshot
 Wrote snapshot to Heap.20200430.100037.49580.0.002.heapsnapshot


### PR DESCRIPTION
So, this is a tricky one.

1. the build errors aren't real errors; the build continued and resulted in wrong highlighting, see for example https://github.com/nodejs/nodejs.org/runs/1896479847#step:6:31. AFAICT this is by design in the metalsmith-prism package: https://github.com/Availity/metalsmith-prism/blob/8db23a433d600b3fd13e33779cbd264e053d7caf/lib/index.js#L41-L47
2. maybe this should be implemented in the changelog maker or something?

Before:

![image](https://user-images.githubusercontent.com/349621/107870370-7dd70b80-6ea0-11eb-95f5-86d43bca648a.png)


After:

![image](https://user-images.githubusercontent.com/349621/107870375-862f4680-6ea0-11eb-99a7-ae0ca237a437.png)

Any of these should do the job: `shell-session`, `sh-session`, `shellsession`
