### PR TITLE
remove banner

### DIFF
--- a/build.js
+++ b/build.js
@@ -271,11 +271,6 @@ function getSource (callback) {
           current: latestVersion.current(versions),
           lts: latestVersion.lts(versions)
         },
-        blacklivesmatter: {
-          visible: true,
-          text: '#BlackLivesMatter',
-          link: '/en/black-lives-matter/'
-        },
         banner: {
           visible: true,
           text: 'The OpenJS World CFP is open until Feb 15 - submit your talk ideas!',


### PR DESCRIPTION
coding and activists do not go together
many people trying to download nodejs binaries are not looking to see this banner jammed down their throat
if viewers care so much, they can go to any other site
the element of the website is not essential whatsoever