### PR TITLE
docs: Update OpenJs World CFP deadline to date listed on the OpenJS site

### DIFF
--- a/build.js
+++ b/build.js
@@ -278,7 +278,7 @@ function getSource (callback) {
         },
         banner: {
           visible: true,
-          text: 'The OpenJS World CFP is open until Feb 15 - submit your talk ideas!',
+          text: 'The OpenJS World CFP is open until Feb 22 - submit your talk ideas!',
           link: 'https://openjsworld.com/'
         }
       }


### PR DESCRIPTION
The site (https://openjsf.org/openjs-world-2021/) has a different deadline.