### PR TITLE
doc: fix typo in Feb 2021 sec pre-announcement

### DIFF
--- a/locale/en/blog/vulnerability/february-2021-security-releases.md
+++ b/locale/en/blog/vulnerability/february-2021-security-releases.md
@@ -11,9 +11,9 @@ author: Daniel Bevenius
 
 The Node.js project will release new versions of all supported release lines on or shortly after Tuesday, February 23th, 2021.
 
-* One Critical serverity issue
-* One High serverity issue
-* One Low serverity issue
+* One Critical severity issue
+* One High severity issue
+* One Low severity issue
 
 ## Impact
 


### PR DESCRIPTION
Correct `serverity` ➡️ `severity`. Sorry, missed this when reviewing https://github.com/nodejs/nodejs.org/pull/3714.