### PR TITLE
doc: correct the type of attack for CVE-2021-22884

### DIFF
--- a/locale/en/blog/vulnerability/february-2021-security-releases.md
+++ b/locale/en/blog/vulnerability/february-2021-security-releases.md
@@ -22,7 +22,7 @@ Thank you to OMICRON electronics for reporting this vulnerability.
 
 ### DNS rebinding in --inspect (CVE-2021-22884)
 
-Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes “localhost6”. When “localhost6” is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the “localhost6” domain. As long as the attacker uses the “localhost6” domain, they can still apply the attack described in CVE-2018-7160. 
+Affected Node.js versions are vulnerable to a DNS rebinding attack when the whitelist includes “localhost6”. When “localhost6” is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the “localhost6” domain. As long as the attacker uses the “localhost6” domain, they can still apply the attack described in CVE-2018-7160. 
 
 Impacts:
 * All versions of the 15.x, 14.x, 12.x and 10.x releases lines


### PR DESCRIPTION
This commit corrects an error in the description of the DNS rebinding
attack which should not be described as a denial of service attack.