### PR TITLE
doc: fix peerDependencies behavior for npm 7

### DIFF
--- a/locale/en/blog/npm/peer-dependencies.md
+++ b/locale/en/blog/npm/peer-dependencies.md
@@ -123,7 +123,7 @@ Now, when installing `chai-as-promised`, the `chai` package will come along with
 another Chai plugin that only works with 0.x versions of Chai, you'll get an error. Nice!
 
 <div class="highlight-box">
-  <strong>UPDATE:</strong> npm versions 1 and 2 will automatically install peerDependencies if they are not explicitly depended upon higher in the dependency tree. For all following versions of npm (starting with npm@3), this will no longer be the case. You will receive a warning that the peerDependency is not installed instead.
+  <strong>UPDATE:</strong> npm versions 1, 2, and 7 will automatically install peerDependencies if they are not explicitly depended upon higher in the dependency tree. For npm versions 3 through 6, you will receive a warning that the peerDependency is not installed instead.
 </div>
 
 One piece of advice: peer dependency requirements, unlike those for regular dependencies, *should be lenient*. You


### PR DESCRIPTION
See announcement here: https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies

This whole page might need to be rewritten but this PR will at least mention the behavior for each version.