### PR TITLE
chore: Rename default branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The Code of Conduct explains the *bare minimum* behavior
 expectations the Node Foundation requires of its contributors.
-[Please read it before participating](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md).
+[Please read it before participating](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md).
 
 ## Vocabulary
 

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -13,7 +13,7 @@ would like to contribute to the translation of nodejs.org, please refer to the f
 
 All translated and approved content will be pushed to this repo automatically. You don't need to create any PRs with translation. Just keep localization process on Crowdin.
 
-Original source can be found in [/locale/en](https://github.com/nodejs/nodejs.org/tree/master/locale/en). If you find any problem with original source, please create a PR with changes directly to `/locale/en`. Crowdin automatically pull all updates within 24 hours.
+Original source can be found in [/locale/en](https://github.com/nodejs/nodejs.org/tree/main/locale/en). If you find any problem with original source, please create a PR with changes directly to `/locale/en`. Crowdin automatically pull all updates within 24 hours.
 
 ### Can't find my locale on Crowdin
 

--- a/scripts/contributor-list/index.js
+++ b/scripts/contributor-list/index.js
@@ -22,7 +22,7 @@ const github = new GithubGraphQLApi({
 const queryCommits = variables => github.query(`
   query ($repositoryOwner: String!, $repositoryName: String!, $since: GitTimestamp, $historyAfter: String) {
     repository(owner: $repositoryOwner, name: $repositoryName) {
-      ref(qualifiedName: "master") {
+      ref(qualifiedName: "main") {
         target {
           ... on Commit {
             history(first: 100, since: $since, after: $historyAfter) {

--- a/scripts/plugins/githubLinks.js
+++ b/scripts/plugins/githubLinks.js
@@ -16,7 +16,7 @@ function githubLinks (options) {
 
       const file = files[path]
       path = path.replace('.html', '.md').replace(/\\/g, '/')
-      const url = `https://github.com/nodejs/nodejs.org/edit/master/locale/${options.locale}/${path}`
+      const url = `https://github.com/nodejs/nodejs.org/edit/main/locale/${options.locale}/${path}`
 
       const contents = file.contents.toString() +
       ` <input type = "hidden" id = "editOnGitHubUrl" value="${url}"/> `


### PR DESCRIPTION
Related to https://github.com/nodejs/nodejs.org/issues/3761
Marked as draft since the rename will need to happen before the edit and query links will work. I believe after the rename the auto-redirects should still work for the time being