### PR TITLE
doc-improvement: change the dot of `docker build` command to middle

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -184,7 +184,7 @@ build the Docker image. The `-t` flag lets you tag your image so it's easier to
 find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:

--- a/locale/es/docs/guides/nodejs-docker-webapp.md
+++ b/locale/es/docs/guides/nodejs-docker-webapp.md
@@ -153,7 +153,7 @@ This will prevent your local modules and debug logs from being copied onto your 
 Go to the directory that has your `Dockerfile` and run the following command to build the Docker image. The `-t` flag lets you tag your image so it's easier to find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:

--- a/locale/fr/docs/guides/nodejs-docker-webapp.md
+++ b/locale/fr/docs/guides/nodejs-docker-webapp.md
@@ -153,7 +153,7 @@ This will prevent your local modules and debug logs from being copied onto your 
 Go to the directory that has your `Dockerfile` and run the following command to build the Docker image. The `-t` flag lets you tag your image so it's easier to find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:

--- a/locale/ja/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ja/docs/guides/nodejs-docker-webapp.md
@@ -368,7 +368,7 @@ build the Docker image. The `-t` flag lets you tag your image so it's easier to
 find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:
@@ -390,7 +390,7 @@ node                            12         1934b0b038d1    5 days ago
 後で `docker images` コマンドを使って見つけやすくなります。
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 あなたのイメージは Docker によって表示されます。

--- a/locale/ko/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ko/docs/guides/nodejs-docker-webapp.md
@@ -370,7 +370,7 @@ build the Docker image. The `-t` flag lets you tag your image so it's easier to
 find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:
@@ -392,7 +392,7 @@ node                            8          1934b0b038d1    5 days ago
 쉽게 찾을 수 있습니다.
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Docker가 당신이 빌드한 이미지를 보여줄 것입니다.

--- a/locale/ro/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ro/docs/guides/nodejs-docker-webapp.md
@@ -153,7 +153,7 @@ This will prevent your local modules and debug logs from being copied onto your 
 Go to the directory that has your `Dockerfile` and run the following command to build the Docker image. The `-t` flag lets you tag your image so it's easier to find later using the `docker images` command:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Your image will now be listed by Docker:

--- a/locale/ru/docs/guides/nodejs-docker-webapp.md
+++ b/locale/ru/docs/guides/nodejs-docker-webapp.md
@@ -190,7 +190,7 @@ npm-debug.log
 `docker images`:
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Созданный образ теперь будет отображаться в списке всех образов:

--- a/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
+++ b/locale/zh-cn/docs/guides/nodejs-docker-webapp.md
@@ -154,7 +154,7 @@ npm-debug.log
 进入到 `Dockerfile` 所在的那个目录中，运行以下命令构建 Docker 镜像。开关符 `-t` 让你标记你的镜像，以至于让你以后很容易地用 `docker images` 找到它。
 
 ```bash
-docker build -t <your username>/node-web-app .
+docker build . -t <your username>/node-web-app
 ```
 
 Docker 现在将给出你的镜像列表：


### PR DESCRIPTION
Placing the dot at the end of command is sometimes misleading. Readers may confuse it with a full stop notation