### PR TITLE
Remove SmartOS from download page

### DIFF
--- a/layouts/partials/secondary-download-matrix.hbs
+++ b/layouts/partials/secondary-download-matrix.hbs
@@ -3,11 +3,6 @@
   <table class="download-matrix full-width">
     <tbody>
       <tr>
-        <th>{{additional.SmartOSBinaries}}</th>
-        <td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-sunos-x64.tar.xz">64-bit</a></td>
-      </tr>
-
-      <tr>
         <th>{{additional.DockerImage}}</th>
         <td><a href="https://hub.docker.com/_/node/">{{additional.officialDockerImage}}</a></td>
       </tr>


### PR DESCRIPTION
We stopped releasing Node.js binaries on SmartOS in Node.js 14 so
the link on both LTS and Curent download pages leads to a 404 page.