### PR TITLE
fix null check for invalid lang

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,11 +20,13 @@
     }
   })
 
-  langPickerTogglerElement.setAttribute('title', currentLangElement.textContent)
+  if (currentLangElement) {
+    langPickerTogglerElement.setAttribute('title', currentLangElement.textContent)
 
-  // Remove the current selected language item, because we don't need to choose it
-  // any more unless we want to switch to a new language
-  langPickerElement.removeChild(currentLangElement.parentNode)
+    // Remove the current selected language item, because we don't need to choose it
+    // any more unless we want to switch to a new language
+    langPickerElement.removeChild(currentLangElement.parentNode)
+  }
 
   langPickerTogglerElement.addEventListener('click', function () {
     langPickerElement.classList.toggle('hidden')


### PR DESCRIPTION
`null` check is missing before accessing the child props of `currentLangElement`.

Error Screenshot:
![image](https://user-images.githubusercontent.com/26359740/116302938-67620000-a7bf-11eb-95c6-c50c4792f627.png)

Impact:
There will be no impact on the current application behavior. Instead, it will fix an issue caused due to missing null checks. 