### PR TITLE
Remove the unused metalsmith-metadata dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4919,14 +4919,6 @@
         }
       }
     },
-    "metalsmith-metadata": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/metalsmith-metadata/-/metalsmith-metadata-0.0.4.tgz",
-      "integrity": "sha1-07ByWcZqDNPGGFDV5jI6JbLBCA4=",
-      "requires": {
-        "js-yaml": "^3.2.7"
-      }
-    },
     "metalsmith-permalinks": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "metalsmith-feed": "^1.0.0",
     "metalsmith-layouts": "^2.3.1",
     "metalsmith-markdown": "^1.3.0",
-    "metalsmith-metadata": "0.0.4",
     "metalsmith-permalinks": "^2.2.0",
     "metalsmith-prism": "^3.1.1",
     "metalsmith-yearly-pagination": "^4.0.2",


### PR DESCRIPTION
Needs another pair of eyes for sure, but it seems this was unused. It might have been used at some point in the past.