### PR TITLE
downloads: add macOS ARM64 link for current version.

### DIFF
--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -59,11 +59,12 @@
         <th>{{downloads.MacOSInstaller}} (.pkg)</th>
         <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit</a></td>
       </tr>
-
       <tr>
         <th>{{downloads.MacOSBinary}} (.tar.gz)</th>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
+        <td{{#unless versionTypeCurrent}} colspan="2"{{/unless}}><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
+        {{#if versionTypeCurrent}}<td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-arm64.tar.gz">ARM64</a></td>{{/if}}
       </tr>
+
       <tr>
         <th>{{downloads.LinuxBinaries}} (x64)</th>
         <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-linux-x64.tar.xz">64-bit</a></td>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/349621/116745348-9d8fc180-aa03-11eb-9d40-f5ebf0d28025.png)

Fixes #3811

---

I used `versionTypeCurrent` so this will only show up for Node.js 16.x.