### PR TITLE
docs: add nvs docs

### DIFF
--- a/locale/ar/download/package-manager.md
+++ b/locale/ar/download/package-manager.md
@@ -141,7 +141,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ar/download/package-manager.md
+++ b/locale/ar/download/package-manager.md
@@ -17,6 +17,7 @@ title: تثبيت Node.js عن طريق مدير الحزم
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE و SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -124,6 +125,51 @@ nvm use 8
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -22,6 +22,7 @@ title: Installing Node.js via package manager
 * [NetBSD](#netbsd)
 * [Nodenv](#nodenv)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [SmartOS and illumos](#smartos-and-illumos)
@@ -235,6 +236,51 @@ from source:
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -252,7 +252,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -17,6 +17,7 @@ title: Instalando Node.js utilizando un gestor de paquetes
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE y SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -120,6 +121,51 @@ Once the official release is out you will want to uninstall the version built fr
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/fr/download/package-manager.md
+++ b/locale/fr/download/package-manager.md
@@ -17,6 +17,7 @@ title: Installing Node.js via package manager
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -120,6 +121,51 @@ Once the official release is out you will want to uninstall the version built fr
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/fr/download/package-manager.md
+++ b/locale/fr/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -44,6 +44,7 @@ title: 패키지 매니저로 Node.js 설치하기
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE 와 SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -265,6 +266,51 @@ nvm use 8
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 <!--

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -282,7 +282,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -16,6 +16,7 @@ title: Instalando Node.js via gerenciador pacotes
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE e SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -112,6 +113,51 @@ a partir do código fonte:
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -129,7 +129,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ro/download/package-manager.md
+++ b/locale/ro/download/package-manager.md
@@ -17,6 +17,7 @@ title: Installing Node.js via package manager
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE and SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -120,6 +121,51 @@ Once the official release is out you will want to uninstall the version built fr
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/ro/download/package-manager.md
+++ b/locale/ro/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ru/download/package-manager.md
+++ b/locale/ru/download/package-manager.md
@@ -16,6 +16,7 @@ title: Установка Node.js через пакетный менеджер
 * [Gentoo](#gentoo)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE и SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -113,6 +114,51 @@ nvm use 8
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/ru/download/package-manager.md
+++ b/locale/ru/download/package-manager.md
@@ -130,7 +130,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/zh-cn/download/package-manager.md
+++ b/locale/zh-cn/download/package-manager.md
@@ -19,6 +19,7 @@ title: 通过包管理器安装 Node.js
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE 和 SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -172,6 +173,51 @@ nvm use 8
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/zh-cn/download/package-manager.md
+++ b/locale/zh-cn/download/package-manager.md
@@ -178,35 +178,35 @@ nvm uninstall 8
 ## nvs
 
 #### Windows
-The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+`nvs`版本管理器是一个跨平台，可用于 Windows、macOS 以及形如 Unix 的操作系统。
 
-To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+在 Windows 上安装 `nvs`，请到此 [发布页](https://github.com/jasongin/nvs/releases) 下载最新发布的 MSI 安装源。
 
-You can also use `chocolatey` to install it:
+你也可以使用 `chocolatey` 进行安装：
 
 ```bash
 choco install nvs
 ```
 
-#### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+#### macOS，UnixLike
+你可以在 [此处](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux) 找到关于在 macOS / 形如 Unix 操作系统的安装步骤文档。
 
-#### Usage
-After this you can use `nvs` to switch between different versions of node.
+#### 使用方法
+安装完成后，你可以使用 `nvs` 在不同版本的 node 中来回切换。
 
-To add the latest version of node:
+添加最新版本的 node：
 
 ```bash
 nvs add latest
 ```
 
-Or to add the latest LTS version of node:
+添加最新 LTS 版本的 node：
 
 ```bash
 nvs add lts
 ```
 
-Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+然后运行 `nvs use` ，为当前脚本的 `PATH` 路径下添加一个 node 版本：
 
 ```bash
 $ nvs use lts
@@ -214,7 +214,7 @@ PATH -= %LOCALAPPDATA%\nvs\default
 PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
 ```
 
-To add it to `PATH` permanently, use `nvs link`:
+如果需要永久在 `PATH` 里添加，使用 `nvs link`：
 
 ```bash
 nvs link lts

--- a/locale/zh-tw/download/package-manager.md
+++ b/locale/zh-tw/download/package-manager.md
@@ -17,6 +17,7 @@ title: 使用套件管理器安裝 Node.js
 * [IBM i](#ibm-i)
 * [NetBSD](#netbsd)
 * [nvm](#nvm)
+* [nvs](#nvs)
 * [OpenBSD](#openbsd)
 * [openSUSE 及 SLE](#opensuse-and-sle)
 * [macOS](#macos)
@@ -124,6 +125,51 @@ nvm use 8
 
 ```bash
 nvm uninstall 8
+```
+
+## nvs
+
+#### Windows
+The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+
+To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+
+You can also use `chocolatey` to install it:
+
+```bash
+choco install nvs
+```
+
+#### macOS,UnixLike
+You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+
+#### Usage
+After this you can use `nvs` to switch between different versions of node.
+
+To add the latest version of node:
+
+```bash
+nvs add latest
+```
+
+Or to add the latest LTS version of node:
+
+```bash
+nvs add lts
+```
+
+Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+
+```bash
+$ nvs use lts
+PATH -= %LOCALAPPDATA%\nvs\default
+PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
+```
+
+To add it to `PATH` permanently, use `nvs link`:
+
+```bash
+nvs link lts
 ```
 
 ## OpenBSD

--- a/locale/zh-tw/download/package-manager.md
+++ b/locale/zh-tw/download/package-manager.md
@@ -130,35 +130,35 @@ nvm uninstall 8
 ## nvs
 
 #### Windows
-The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+`nvs`版本管理器是一個跨平台，可用於 Windows、macOS 以及形如 Unix 的操作系統。
 
-To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+在 Windows 上安裝 `nvs`，請到此 [發布頁](https://github.com/jasongin/nvs/releases) 下載最新發布的 MSI 安裝源。
 
-You can also use `chocolatey` to install it:
+你也可以使用 `chocolatey` 進行安裝：
 
 ```bash
 choco install nvs
 ```
 
-#### macOS,UnixLike
-You can find the documentation regarding the instaltion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+#### macOS，UnixLike
+你可以在 [此處](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux) 找到關於在 macOS / 形如 Unix 操作系統的安裝步驟文檔。
 
-#### Usage
-After this you can use `nvs` to switch between different versions of node.
+#### 使用方法
+安裝完成後，你可以使用 `nvs` 在不同版本的 node 中來回切換。
 
-To add the latest version of node:
+添加最新版本的 node：
 
 ```bash
 nvs add latest
 ```
 
-Or to add the latest LTS version of node:
+添加最新 LTS 版本的 node：
 
 ```bash
 nvs add lts
 ```
 
-Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+然後運行 `nvs use` ，為當前腳本的 `PATH` 路徑下添加一個 node 版本：
 
 ```bash
 $ nvs use lts
@@ -166,7 +166,7 @@ PATH -= %LOCALAPPDATA%\nvs\default
 PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
 ```
 
-To add it to `PATH` permanently, use `nvs link`:
+如果需要永久在 `PATH` 裡添加，使用 `nvs link`：
 
 ```bash
 nvs link lts


### PR DESCRIPTION
Added docs for `nvs`.

Issue: #3873 

Since the official certification [OpenJS Node.js Services Developer (JSNSD)](https://training.linuxfoundation.org/certification/jsnsd/) recommends using the `nvs` in windows machines but it lacks the in the `package manager` docs. 

After the changes (sample):
![image](https://user-images.githubusercontent.com/26359740/118400770-ad083f00-b680-11eb-8347-fb06755cf30e.png)
