### PR TITLE
docs: fix nvs doc typo

### DIFF
--- a/locale/ar/download/package-manager.md
+++ b/locale/ar/download/package-manager.md
@@ -141,7 +141,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -252,7 +252,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/es/download/package-manager.md
+++ b/locale/es/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/fr/download/package-manager.md
+++ b/locale/fr/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ko/download/package-manager.md
+++ b/locale/ko/download/package-manager.md
@@ -282,7 +282,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -129,7 +129,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ro/download/package-manager.md
+++ b/locale/ro/download/package-manager.md
@@ -137,7 +137,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.

--- a/locale/ru/download/package-manager.md
+++ b/locale/ru/download/package-manager.md
@@ -130,7 +130,7 @@ choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installtion steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
 After this you can use `nvs` to switch between different versions of node.


### PR DESCRIPTION
A typo was fixed in the `nvs` documentation.