### PR TITLE
chore: remove freenode (community safety concerns)

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -9,7 +9,6 @@ layout: contribute.hbs
 
 * The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 * For real-time chat about Node.js development use one of the platforms below
-  * For IRC, go to `irc.freenode.net` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
   * For Slack, there are two options:
     * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community. Some Working Groups have discussion channels there.
     * The [OpenJSF Slack](https://slack-invite.openjsf.org/) is a Foundation run Slack with several Node.js channels (channels prefixed by `#nodejs-` are related to the project). Some Working Groups have discussion channels there.


### PR DESCRIPTION
removes freenode for community safety concerns, including the platform's leadership [calling a project member a slur](https://github.com/nodejs/TSC/issues/1031#issuecomment-860812817).

I don't expect immediate merge on this, but wanted to go ahead and put it up (ref: https://github.com/nodejs/TSC/issues/1031)