### PR TITLE
chore: add libera for community support

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -9,6 +9,7 @@ layout: contribute.hbs
 
 * The [GitHub issues list](https://github.com/nodejs/node/issues) is the place for discussion of Node.js core features.
 * For real-time chat about Node.js development use one of the platforms below
+  * For IRC, go to `irc.libera.chat` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [a web client](https://kiwiirc.com/nextclient/)
   * For Slack, there are two options:
     * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community. Some Working Groups have discussion channels there.
     * The [OpenJSF Slack](https://slack-invite.openjsf.org/) is a Foundation run Slack with several Node.js channels (channels prefixed by `#nodejs-` are related to the project). Some Working Groups have discussion channels there.


### PR DESCRIPTION
This wasn't pulled in before #3923 was landed.

libera.chat is moderated by node staff and the moderation team, and is where the majority of those on freenode have already migrated.