### PR TITLE
zh-CN: Add '环境' to clearify the meaning of Nodejs

### DIFF
--- a/locale/zh-cn/index.md
+++ b/locale/zh-cn/index.md
@@ -17,4 +17,4 @@ labels:
   version-schedule-prompt-link-text: LTS 日程。
 ---
 
-Node.js® 是一个基于 [Chrome V8 引擎](https://v8.dev/) 的 JavaScript 运行时。
+Node.js® 是一个基于 [Chrome V8 引擎](https://v8.dev/) 的 JavaScript 运行时环境。


### PR DESCRIPTION
For English, we can say "运行时" directly, however to be more clear, it would be better to say "运行时环境" in Chinese.