### PR TITLE
chore: update banner expiration

### DIFF
--- a/locale/zh-cn/site.json
+++ b/locale/zh-cn/site.json
@@ -162,7 +162,7 @@
   "banners": {
     "index": {
       "startDate": "2021-07-01T16:00:00.000Z",
-      "endDate": "2021-07-30T16:00:00.000Z",
+      "endDate": "2021-07-13T16:00:00.000Z",
       "text": "对 16.x, 14.x, and 12.x 版本的最新安全修复可下载",
       "link": "blog/vulnerability/july-2021-security-releases"
     }


### PR DESCRIPTION
There has been a new release of 16.x so it's probably time to remove the
banner about the previous release being a "new" security release.