### PR TITLE
CI: make use of `actions/setup-node`'s cache option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - run: java -version
 


### PR DESCRIPTION
Arguably, on Windows it might not speed things up at all, but on Linux it's definitely faster.