### PR TITLE
typo: pratfalls -> pitfalls

### DIFF
--- a/locale/en/docs/guides/backpressuring-in-streams.md
+++ b/locale/en/docs/guides/backpressuring-in-streams.md
@@ -490,7 +490,7 @@ class MyReadable extends Readable {
 }
 ```
 
-Additionally, from outside the custom stream, there are pratfalls for ignoring
+Additionally, from outside the custom stream, there are pitfalls for ignoring
 backpressure. In this counter-example of good practice, the application's code
 forces data through whenever it is available (signaled by the
 [`'data'` event][]):

--- a/locale/es/docs/guides/backpressuring-in-streams.md
+++ b/locale/es/docs/guides/backpressuring-in-streams.md
@@ -364,7 +364,7 @@ class MyReadable extends Readable {
 }
 ```
 
-Additionally, from outside the custom stream, there are pratfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
+Additionally, from outside the custom stream, there are pitfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
 
 ```javascript
 // This ignores the backpressure mechanisms Node.js has set in place,

--- a/locale/fr/docs/guides/backpressuring-in-streams.md
+++ b/locale/fr/docs/guides/backpressuring-in-streams.md
@@ -364,7 +364,7 @@ class MyReadable extends Readable {
 }
 ```
 
-Additionally, from outside the custom stream, there are pratfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
+Additionally, from outside the custom stream, there are pitfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
 
 ```javascript
 // This ignores the backpressure mechanisms Node.js has set in place,

--- a/locale/ro/docs/guides/backpressuring-in-streams.md
+++ b/locale/ro/docs/guides/backpressuring-in-streams.md
@@ -364,7 +364,7 @@ class MyReadable extends Readable {
 }
 ```
 
-Additionally, from outside the custom stream, there are pratfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
+Additionally, from outside the custom stream, there are pitfalls for ignoring backpressure. In this counter-example of good practice, the application's code forces data through whenever it is available (signaled by the [`'data'` event][]):
 
 ```javascript
 // This ignores the backpressure mechanisms Node.js has set in place,


### PR DESCRIPTION
typo: pratfalls -> pitfalls

Interestingly "pratfalls" is defined by google as:
```
noun informal
 a fall on to one's buttocks.
    "he took a pratfall into the sand"
 an embarrassing failure or mistake.
     "the first political pratfalls of the new administration"
```

which kind of works in the current context, but I'm sure "pitfalls" was the intended word and I'm certain is more widely understood.