### PR TITLE
fix: address "coming soon" 404 cache hit problem

### DIFF
--- a/scripts/release-post.js
+++ b/scripts/release-post.js
@@ -151,7 +151,8 @@ function findAuthorLogin (version, section) {
 }
 
 function urlOrComingSoon (binary) {
-  return sendRequest({ url: binary.url, method: 'HEAD' }).then(
+  const url = binary.url.replace('nodejs.org', 'direct.nodejs.org')
+  return sendRequest({ url: url, method: 'HEAD' }).then(
     () => `${binary.title}: ${binary.url}`,
     () => {
       console.log(`\x1B[32m "${binary.title}" is Coming soon...\x1B[39m`)

--- a/tests/scripts/release-post.test.js
+++ b/tests/scripts/release-post.test.js
@@ -45,7 +45,7 @@ test('verifyDownloads(<version>)', (t) => {
   })
 
   t.test('resolves to "<binary title>: url" when HEAD request succeed', (t) => {
-    const nodejsorg = nock('https://nodejs.org')
+    const nodejsorg = nock('https://direct.nodejs.org')
       .head('/dist/v4.1.1/node-v4.1.1.tar.gz')
       .reply(200, 'OK')
 
@@ -60,7 +60,7 @@ test('verifyDownloads(<version>)', (t) => {
   })
 
   t.test('resolves to "<binary title>: *Coming soon*" when HEAD request fails', (t) => {
-    const nodejsorg = nock('https://nodejs.org')
+    const nodejsorg = nock('https://direct.nodejs.org')
       .head('/dist/v4.1.1/node-v4.1.1-linux-armv6l.tar.gz')
       .reply(404, 'Not found')
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/2751

This is entirely untested (and I'm editing this in my browser too) but this might be a way of addressing the problem. I'm not super happy about exposing this address but it exists and shouldn't suffer from the hard-cache problem that seems to be causing https://github.com/nodejs/build/issues/2751; it'll give accurate results wrt what's actually available on the server, not just what the edge cache has.