### PR TITLE
Address issue in file system security knowledge base article (directory traversing)

### DIFF
--- a/locale/en/knowledge/file-system/security/introduction.md
+++ b/locale/en/knowledge/file-system/security/introduction.md
@@ -39,14 +39,14 @@ Directory traversal means that an attacker tries to access files outside of the 
 This example assumes that you already checked the `userSuppliedFilename` variable as described in the "Poison Null Bytes" section above.
 
 ```javascript
-var rootDirectory = '/var/www/';
+const rootDirectory = '/var/www/';
 ```
 
 Make sure that you have a slash at the end of the allowed folders name - you don't want people to be able to access `/var/www-secret/`, do you?.
 
 ```javascript
-var path = require('path');
-var filename = path.join(rootDirectory, userSuppliedFilename);
+const path = require('path');
+const filename = path.join(rootDirectory, userSuppliedFilename);
 ```
 
 Now `filename` contains an absolute path and doesn't contain `..` sequences anymore - `path.join` takes care of that. However, it might be something like `/etc/passwd` now, so you have to check whether it starts with the `rootDirectory`:

--- a/locale/en/knowledge/file-system/security/introduction.md
+++ b/locale/en/knowledge/file-system/security/introduction.md
@@ -52,7 +52,7 @@ const filename = path.join(rootDirectory, userSuppliedFilename);
 Now `filename` contains an absolute path and doesn't contain `..` sequences anymore - `path.join` takes care of that. However, it might be something like `/etc/passwd` now, so you have to check whether it starts with the `rootDirectory`:
 
 ```javascript
-if (filename.indexOf(rootDirectory) !== 0) {
+if (!filename.startsWith(rootDirectory)) {
   return respond('trying to sneak out of the web root?');
 }
 ```


### PR DESCRIPTION
The [fs security intro article](https://nodejs.org/en/knowledge/file-system/security/introduction/) suggests preventing directory traversal by checking whether the requested directory starts with the pre-defined root directory. However, the code suggested only checks if the pre-defined root directory is part of the path (could be anywhere in the path).

Old code:
```js
var rootDirectory = '/var/www/';
var filename = path.join(rootDirectory, userSuppliedFilename);
if (filename.indexOf(rootDirectory) !== 0) {
  return respond('trying to sneak out of the web root?');
}
```
This allows traversing to any path as long as `/var/www` is present anywhere. This complicates the attack but does not prevent it.

This PR suggests using `if (!filename.startsWith(rootDirectory))` to ensure only files inside `/var/www` are accessed, disallowing paths like `/etc/traversed/directory/var/www/secret_file`. Secondarily, this PR proposes the use of ES6 syntax.