### PR TITLE
Fix tiny typo in security release blog post

### DIFF
--- a/locale/en/blog/vulnerability/oct-2021-security-releases.md
+++ b/locale/en/blog/vulnerability/oct-2021-security-releases.md
@@ -16,7 +16,7 @@ following issues.
 The http parser accepts requests with a space (SP) right after the header name before the colon. This can lead to HTTP Request Smuggling (HRS).
 More details will be available at [CVE-2021-22959](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22959) after publication.
 
-THe fix for this is included in llhttp v2.1.4 and v6.0.6.
+The fix for this is included in llhttp v2.1.4 and v6.0.6.
 
 Thanks to Mattias Grenfeldt (https://grenfeldt.dev/) and Asta Olofsson for reporting this vulnerability.
 


### PR DESCRIPTION
Small typo I've found reading the recent security release blog post. This is pretty tiny but probably worth fixing?

CC @danielleadams @BethGriggs  :]