### PR TITLE
change security banner end date

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -164,7 +164,7 @@
   "banners": {
     "index": {
       "startDate": "2021-10-05T16:00:00.000Z",
-      "endDate": "2021-11-05T16:00:00.000Z",
+      "endDate": "2021-10-19T16:00:00.000Z",
       "text": "New security releases now available October 12th, 2021",
       "link": "blog/vulnerability/oct-2021-security-releases/"
     },


### PR DESCRIPTION
With 17.0.0 about to drop and 16.x going LTS, remove two-week old security banner. (We should set those banners to be there for two weeks and not a month. Otherwise there will always be a security banner and people will stop seeing it.)