### PR TITLE
Update Docker example to use most recent LTS

### DIFF
--- a/locale/en/docs/guides/nodejs-docker-webapp.md
+++ b/locale/en/docs/guides/nodejs-docker-webapp.md
@@ -80,11 +80,11 @@ touch Dockerfile
 Open the `Dockerfile` in your favorite text editor
 
 The first thing we need to do is define from what image we want to build from.
-Here we will use the latest LTS (long term support) version `14` of `node`
+Here we will use the latest LTS (long term support) version `16` of `node`
 available from the [Docker Hub](https://hub.docker.com/_/node):
 
 ```docker
-FROM node:14
+FROM node:16
 ```
 
 Next we create a directory to hold the application code inside the image, this
@@ -143,7 +143,7 @@ CMD [ "node", "server.js" ]
 Your `Dockerfile` should now look like this:
 
 ```docker
-FROM node:14
+FROM node:16
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -194,7 +194,7 @@ $ docker images
 
 # Example
 REPOSITORY                      TAG        ID              CREATED
-node                            14         1934b0b038d1    5 days ago
+node                            16         3b66eb585643    5 days ago
 <your username>/node-web-app    latest     d64d3505b0d2    1 minute ago
 ```
 


### PR DESCRIPTION
Update node LTS version for the guide for docerizing node applications.

I happened to read the guide at the moment when the new LTS was swapped over to 16. My first intention was to actually suggest changing the output of `docker ps` which included `npm start` in the command column, which will not be the output if this guide is followed, but I don't think it's much of an issue. Or?

Related: https://github.com/nodejs/nodejs.org/pull/2983, https://github.com/nodejs/nodejs.org/pull/2953, https://github.com/nodejs/nodejs.org/issues/2988