### PR TITLE
Revert "Re-style release schedule table in both light & dark mode"

### DIFF
--- a/layouts/css/_variables.scss
+++ b/layouts/css/_variables.scss
@@ -2,7 +2,7 @@ $body-max-width: 980px;
 
 $black: #000;
 $white: #fff;
-$white-alpha-b3: #ffffffb3;
+
 $node-green: #43853d;
 //$bright-green: #028a00;
 $light-green: #eaf5e9;
@@ -14,14 +14,10 @@ $light-gray: #999;
 $gray: #666;
 $node-gray: #333;
 $home-secondary-links-color: #51744e;
-$black-alpha-80: #00000080;
-$black-alpha-12: #00000012;
-$black-alpha-0f: #0000000f;
 
 // for dark-theme
 $dark-black: #090c15;
 $dark-black2: #233056;
-$dark-black3: #23305671;
 $dark-gray: #242424;
 $dark-green: #2c372a;
 $dark-green2: #84ba64;

--- a/layouts/css/layout/_dark-theme.scss
+++ b/layouts/css/layout/_dark-theme.scss
@@ -65,16 +65,12 @@
     }
 
     table {
-      background-color: $dark-black3;
       th {
-        color: $white-alpha-b3;
-      }
-      td {
         color: $white;
       }
-      tr:only-child,
-      tr:nth-child(even) {
+      tr:nth-child(odd) {
         background-color: $dark-black2 !important;
+        color: $light-gray3;
       }
     }
 

--- a/layouts/css/page-modules/_release-schedule.scss
+++ b/layouts/css/page-modules/_release-schedule.scss
@@ -1,26 +1,26 @@
 table.release-schedule {
   width: 100%;
   font-size: 1rem;
-  border-radius: 4px;
-  box-shadow: 0 4px 3px $black-alpha-12, 0 2px 2px $black-alpha-0f;
-  border-collapse: separate;
-  border-spacing: 0;
-  overflow: hidden;
+  border: 1px solid $light-gray2;
 
-
-  td,
-  th {
-    padding: 10px 6px;
+  td {
+    padding: 5px;
   }
 
-  > thead tr {
-    color: $black-alpha-80;
-    text-transform: uppercase;
-    font-size: smaller;
-    font-weight: 700;
+  > thead {
+    font-weight: 600;
+    text-align: left;
   }
-  tr:only-child,
-  tr:nth-child(even) {
-    background-color: $light-gray3;
+
+  > tbody {
+    border-top: 1px solid $light-gray2;
+
+    tr:nth-child(odd) {
+      background-color: $light-gray3;
+    }
+
+    tr:nth-child(even) {
+      background-color: $white;
+    }
   }
 }


### PR DESCRIPTION
Reverts nodejs/nodejs.org#4200

I have decided to revert since we need a quick fix to address the a11y problem, which is more pressing than the cosmetic feature implementation that somehow was not tested on dark mode, which several people (like myself) have set as the default. 