### PR TITLE
fix: make highlight-box text visible in dark mode

### DIFF
--- a/layouts/css/layout/_dark-theme.scss
+++ b/layouts/css/layout/_dark-theme.scss
@@ -82,6 +82,7 @@
     }
 
     .highlight-box {
+      color: $light-gray3;
       background-color: $dark-code-background;
     }
   }


### PR DESCRIPTION
Visit https://nodejs.org/en/blog/npm/peer-dependencies/ in darkmode, scroll to bottom and see the highlight-box appears empty.

In light mode the text color is the same as what's used for the article body in that mode, so for the fix I used the same color that the dark mode article body uses.

## Before 📷:
![before](https://user-images.githubusercontent.com/12915163/139333018-4e959dca-ca2b-464d-9c26-241b3ce750ab.JPG)
-------

## After 📷:
![after](https://user-images.githubusercontent.com/12915163/139333045-9a03b41a-87c2-4cf5-8f9d-2f4305da24cb.JPG)

