### PR TITLE
fix: correct color contrast for blogpost-meta class in dark mode

### DIFF
--- a/layouts/css/layout/_dark-theme.scss
+++ b/layouts/css/layout/_dark-theme.scss
@@ -3,6 +3,11 @@
     background-image: url("/static/images/light-mode.svg");
   }
 
+  body,
+  .blogpost-meta {
+    color: $white;
+  }
+
   #main {
     background-color: $dark-black;
     p,


### PR DESCRIPTION
The previous blog post byline had inaccessible contrast in dark mode.

Fixes: https://github.com/nodejs/nodejs.org/issues/4196