### PR TITLE
fix: add commits section to Gallium release post

### DIFF
--- a/locale/en/blog/release/v16.13.0.md
+++ b/locale/en/blog/release/v16.13.0.md
@@ -15,6 +15,10 @@ with the codename 'Gallium'. The 16.x release line now moves into "Active LTS"
 and will remain so until October 2022. After that time, it will move into
 "Maintenance" until end of life in April 2024.
 
+### Commits
+
+* [[`40ecd56011`](https://github.com/nodejs/node/commit/40ecd56011)] - v16.13.0 release proposal (Richard Lau) [#40536](https://github.com/nodejs/node/pull/40536)
+
 Windows 32-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x86.msi<br>
 Windows 64-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x64.msi<br>
 Windows 32-bit Binary: https://nodejs.org/dist/v16.13.0/win-x86/node.exe<br>


### PR DESCRIPTION
Adds the &ldquo;Commits&rdquo; section that was missing from the Gallium release post.

/cc @richardlau @BethGriggs @targos @danielleadams 