### PR TITLE
Fix constrast issue in code highlighting upto WCAG AA standards

### DIFF
--- a/layouts/css/vendor/prism-tomorrow.css
+++ b/layouts/css/vendor/prism-tomorrow.css
@@ -6,7 +6,7 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-	color: #ccc;
+	color: #ddd;
 	font-family: Consolas, Monaco, 'Andale Mono', monospace;
 	direction: ltr;
 	text-align: left;
@@ -49,7 +49,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #999;
+	color: #9d9d9d;
 }
 
 .token.punctuation {


### PR DESCRIPTION
See https://github.com/nodejs/nodejs.org/pull/4225#issuecomment-962275874 
Fixes (contrast ratio: 4.45):
![image](https://user-images.githubusercontent.com/58736240/140702169-d498c19c-4c0c-4d5a-b7b7-8ff7c6bb7a9c.png)

To (contrast ratio: 4.68, WCAG AA standard > 4.5):
![Screenshot from 2021-11-08 13-13-31](https://user-images.githubusercontent.com/58736240/140702801-4a3474ca-bdbb-4335-8d8f-9dce402c61f8.png)


