### PR TITLE
Update macOS downloads for new LTS

### DIFF
--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -61,7 +61,7 @@
       </tr>
       <tr>
         <th>{{downloads.MacOSBinary}} (.tar.gz)</th>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
+        <td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
         <td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-arm64.tar.gz">ARM64</a></td>
       </tr>
 

--- a/layouts/partials/primary-download-matrix.hbs
+++ b/layouts/partials/primary-download-matrix.hbs
@@ -57,12 +57,12 @@
 
       <tr>
         <th>{{downloads.MacOSInstaller}} (.pkg)</th>
-        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit{{#if versionTypeCurrent}} / ARM64{{/if}}</a></td>
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}.pkg">64-bit / ARM64</a></td>
       </tr>
       <tr>
         <th>{{downloads.MacOSBinary}} (.tar.gz)</th>
-        <td{{#unless versionTypeCurrent}} colspan="2"{{/unless}}><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
-        {{#if versionTypeCurrent}}<td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-arm64.tar.gz">ARM64</a></td>{{/if}}
+        <td colspan="2"><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-x64.tar.gz">64-bit</a></td>
+        <td><a href="https://nodejs.org/dist/{{version.node}}/node-{{version.node}}-darwin-arm64.tar.gz">ARM64</a></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
Now that Node.js 16 has transitioned to LTS add the ARM64 entries to the LTS download matrix for macOS.

Fixes: https://github.com/nodejs/nodejs.org/issues/4241