### PR TITLE
Deprecated platform detection

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -242,11 +242,11 @@
 })()
 ;(function () {
   'use strict'
-
-  var osMatch = navigator.platform.match(/(Win|Mac|Linux)/)
+  var userAgent = navigator.userAgent
+  var osMatch = userAgent.match(/(Win|Mac|Linux)/)
   var os = (osMatch && osMatch[1]) || ''
   var arch =
-    navigator.userAgent.match(/x86_64|Win64|WOW64/) ||
+    userAgent.match(/x86_64|Win64|WOW64/) ||
     navigator.cpuClass === 'x64'
       ? 'x64'
       : 'x86'


### PR DESCRIPTION
In ./static/js/main.js there is a usage of navigator.platform to detect the user platform and display the download buttons accordingly. Now that Web API is deprecated and MDN docs suggests to avoid it. I replaced the detection through the User Agent which was also used to detect Windows architecture.