### PR TITLE
Add temporary banner for training and cert discounts

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -163,10 +163,10 @@
   },
   "banners": {
     "index": {
-      "startDate": "2021-10-05T16:00:00.000Z",
-      "endDate": "2021-10-19T16:00:00.000Z",
-      "text": "New security releases now available October 12th, 2021",
-      "link": "blog/vulnerability/oct-2021-security-releases/"
+      "startDate": "2021-11-30T00:00:00.000Z",
+      "endDate": "2021-12-07T00:00:00.000Z",
+      "text": "Node.js training and exams discounted through Dec. 6th",
+      "link": "https://openjsf.org/blog/2021/11/29/test-your-skills-how-good-are-you-with-node-js/"
     },
     "blacklivesmatter": {
       "visible": false,


### PR DESCRIPTION
Linux Foundation Training is currently running a number of deep discounts on the Node.js trainings and exams. Looking back at prior years' trends, a lot of folks have signed up during this particular promotion, especially individuals who don't have a corporate training budget and can really use the discounts.

Can we please add a temporary banner to make it more visible? Thanks!

Signed-off-by: Brian Warner <brian@bdwarner.com>