### PR TITLE
fix: node-inspect is no longer externally updated

### DIFF
--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -98,7 +98,7 @@ Several commercial and open source tools can also connect to the Node.js Inspect
 
 ### [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface)
 
-* Library to ease connections to Inspector Protocol endpoints.
+* Library to ease connections to [Inspector Protocol][] endpoints.
 
 ### [Gitpod](https://www.gitpod.io)
 
@@ -233,7 +233,7 @@ script and connects to your target.
 ### [node-inspector](https://github.com/node-inspector/node-inspector)
 
 Debug your Node.js app with Chrome DevTools by using an intermediary process
-which translates the Inspector Protocol used in Chromium to the V8 Debugger
+which translates the [Inspector Protocol][] used in Chromium to the V8 Debugger
 protocol used in Node.js.
 
 <!-- refs -->

--- a/locale/en/docs/guides/debugging-getting-started.md
+++ b/locale/en/docs/guides/debugging-getting-started.md
@@ -67,15 +67,8 @@ either the IP address or by using ssh tunnels as described below.
 
 ## Inspector Clients
 
-Several commercial and open source tools can connect to the Node.js Inspector.
-Basic info on these follows:
-
-### [node-inspect](https://github.com/nodejs/node-inspect)
-
-* CLI Debugger supported by the Node.js Foundation which uses the [Inspector Protocol][].
-* A version is bundled with Node.js and can be used with `node inspect myscript.js`.
-* The latest version can also be installed independently (e.g. `npm install -g node-inspect`)
-  and used with `node-inspect myscript.js`.
+A minimal CLI debugger is available with `node inspect myscript.js`.
+Several commercial and open source tools can also connect to the Node.js Inspector.
 
 ### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) 55+, [Microsoft Edge](https://www.microsoftedgeinsider.com)
 


### PR DESCRIPTION
node-inspect is entirely developed within Node.js core.