### PR TITLE
blog: clarify CVE applicability in security announce

### DIFF
--- a/locale/en/blog/vulnerability/aug-2021-security-releases2.md
+++ b/locale/en/blog/vulnerability/aug-2021-security-releases2.md
@@ -7,28 +7,27 @@ layout: blog-post.hbs
 author: Daniel Bevenius
 ---
 
-## _(Update 31-Aug-2021)_ Security releases available
+## _(Update 6-Dec-2021)_ Security releases available
 Updates are now available for v14.x, and v12.x Node.js release lines for the
 following issues.
 
-### npm 6 update - node-tar, arborist, npm cli modules
-These are vulnerabilities in the node-tar, arborist, and npm cli modules which
+### npm 6 update - node-tar
+
+There are vulnerabilities in the node-tar which
 are related to the initial reports and subsequent remediation of node-tar
 vulnerabilities [CVE-2021-32803](https://github.com/advisories/GHSA-r628-mhmh-qjhw)
 and [CVE-2021-32804](https://github.com/advisories/GHSA-3jfq-g458-7qm9).
 Subsequent internal security review of node-tar and additional external bounty
-reports have resulted in another 5 CVE being remediated in core npm CLI
-dependencies including node-tar, and npm arborist.
+reports have resulted in the following further CVEs being remediated in node-tar:
 
-You can read more about it in:
 * [CVE-2021-37701](https://github.com/npm/node-tar/security/advisories/GHSA-9r2w-394v-53qc)
 * [CVE-2021-37712](https://github.com/npm/node-tar/security/advisories/GHSA-qq89-hq3f-393p)
 * [CVE-2021-37713](https://github.com/npm/node-tar/security/advisories/GHSA-5955-9wpr-37jh)
-* [CVE-2021-39134](https://github.com/npm/arborist/security/advisories/GHSA-2h3h-q99f-3fhc)
-* [CVE-2021-39135](https://github.com/npm/arborist/security/advisories/GHSA-gmw6-94gg-2rc2)
 
 Impacts:
 * All versions of the 14.x, and 12.x releases lines
+
+**Note**: [CVE-2021-39134](https://github.com/npm/arborist/security/advisories/GHSA-2h3h-q99f-3fhc) and [CVE-2021-39135](https://github.com/npm/arborist/security/advisories/GHSA-gmw6-94gg-2rc2) previously mentioned in this annoucement do not apply to Node.js 12 and 14 as npm@6 does not depend on the `@npm/arborist` module. These vulnerabilities applied to Node.js 16 and have been fixed via the npm 7.21.0 update which was shipped in [Node.js v16.8.0 (Current)](https://nodejs.org/en/blog/release/v16.8.0/).
 
 ## Downloads and release details
 


### PR DESCRIPTION
I've had some feedback that it was confusing to see CVE-2021-39134 / CVE-2021-39135 listed in this announce as they do not apply to Node.js 12/14.  Updating with an additional note. 

