### PR TITLE
package-manager.md: fix non-existent syntax highlighting

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -358,7 +358,7 @@ Download the [Windows Installer](https://nodejs.org/en/#home-downloadhead) direc
 
 Using **[Winget](https://aka.ms/winget-cli)**:
 
-```console
+```bash
 winget install OpenJS.NodeJS
 # or for LTS
 winget install OpenJS.NodeJS.LTS


### PR DESCRIPTION
Prism does not include `console`