### PR TITLE
package.json: add `--continue-on-error` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "load-schedule": "curl -sS https://raw.githubusercontent.com/nodejs/Release/master/schedule.json -o source/schedule.json",
     "start": "npm run serve",
     "test": "npm-run-all test:lint test:unit",
-    "test:lint": "npm-run-all --parallel --aggregate-output test:lint:*",
+    "test:lint": "npm-run-all --parallel --aggregate-output --continue-on-error test:lint:*",
     "test:lint:js": "eslint .",
     "test:lint:md": "remark -qf .",
     "test:lint:stylelint": "stylelint \"layouts/css/**/*.{css,scss}\" --report-needless-disables",


### PR DESCRIPTION
This should allow the `test:lint` script to finish and not just exit immediately if one of the subscripts fails. The script will still fail, just not immediately without the other scripts finishing first.