### PR TITLE
doc: update links to collaborator guide

### DIFF
--- a/locale/ar/about/governance.md
+++ b/locale/ar/about/governance.md
@@ -23,7 +23,7 @@ layout: about.hbs
 
 يتم قيادة المشروع بشكل مشترك من قبل كل من [لجنة التوجيه التقني (TSC)][] المسؤولة عن القيادة العليا للمشروع و [لجنة المجتمع (CommComm)][] المسؤولة عن توسيع مجتمع النود جي اس.
 
-[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md
+[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md
 [لجنة المجتمع (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [منهج الإجماع في إتخاذ القرارات]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members

--- a/locale/en/about/governance.md
+++ b/locale/en/about/governance.md
@@ -29,7 +29,7 @@ which is responsible for high-level guidance of the project, and the
 [Community Committee (CommComm)][] which is responsible for guiding and
 extending the Node.js community.
 
-[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md
+[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md
 [Community Committee (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members

--- a/locale/es/about/governance.md
+++ b/locale/es/about/governance.md
@@ -1,4 +1,4 @@
--
+---
 title: Dirección del Proyecto
 layout: about.hbs
 ---

--- a/locale/es/about/governance.md
+++ b/locale/es/about/governance.md
@@ -1,4 +1,4 @@
----
+-
 title: Dirección del Proyecto
 layout: about.hbs
 ---
@@ -17,7 +17,7 @@ Las personas que hacen contribuciones significativas y valiosas se convierten en
 
 Para ver la lista actual de Colaboradores, consulte el [README.md](https://github.com/nodejs/node/blob/master/README.md#current-project-team-members) del proyecto.
 
-Se mantiene una guía para Colaboradores en [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md).
+Se mantiene una guía para Colaboradores en [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md).
 
 ## Comités de nivel superior
 

--- a/locale/ko/about/governance.md
+++ b/locale/ko/about/governance.md
@@ -105,7 +105,7 @@ For the current list of Collaborators, see the project
 [README.md](https://github.com/nodejs/node/blob/master/README.md#current-project-team-members).
 
 A guide for Collaborators is maintained in
-[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md).
+[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md).
 -->
 협업자는 TSC에서 논의하려고 풀 리퀘스트나 이슈에 ***tsc-agenda*** 태그를 할당함으로써 중요하거나
 논쟁이 되는 수정사항이나 합의점을 찾지 못한 수정사항을 개선하려고 할 수도 있습니다.
@@ -116,7 +116,7 @@ TSC는 필요한 경우 최종 중재자가 되어야 합니다.
 볼 수 있습니다.
 
 협업자 가이드는
-[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md)에서
+[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md)에서
 관리되어 있습니다.
 
 <!--

--- a/locale/pt-br/about/governance.md
+++ b/locale/pt-br/about/governance.md
@@ -58,7 +58,7 @@ O projeto é governado de forma conjunta pelo _[Technical Steering Committee (TS
 responsável pelas diretrizes do projeto, e pelo _[Community Committee (CommComm)][]_
 responsável por orientar e ampliar a comunidade Node.js.
 
-[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md
+[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md
 [Community Committee (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [Busca por Consenso]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members

--- a/locale/ro/about/governance.md
+++ b/locale/ro/about/governance.md
@@ -17,7 +17,7 @@ Individuals making significant and valuable contributions are made Collaborators
 
 For the current list of Collaborators, see the project's [README.md](https://github.com/nodejs/node/blob/master/README.md#current-project-team-members).
 
-A guide for Collaborators is maintained at [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md).
+A guide for Collaborators is maintained at [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md).
 
 ## Top Level Committees
 

--- a/locale/ru/about/governance.md
+++ b/locale/ru/about/governance.md
@@ -17,7 +17,7 @@ layout: about.hbs
 
 Текущий список Коллабораторов можно найти в [README.md](https://github.com/nodejs/node/blob/master/README.md#current-project-team-members) проекта.
 
-Руководство для Коллабораторов находится по адресу [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md).
+Руководство для Коллабораторов находится по адресу [collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md).
 
 ## Комитеты высшего уровня
 

--- a/locale/uk/about/governance.md
+++ b/locale/uk/about/governance.md
@@ -61,7 +61,7 @@ _Процес пошуку консенсусу_ нижче для додатк�
 [README.md](https://github.com/nodejs/node/blob/master/README.md#current-project-team-members) проекту.
 
 Керівництво для співавторів знаходиться у
-[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md).
+[collaborator-guide.md](https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md).
 
 ## Членство в TSC
 

--- a/locale/zh-cn/about/governance.md
+++ b/locale/zh-cn/about/governance.md
@@ -23,7 +23,7 @@ Node.js 项目遵循[一致协商][]的工作模式。
 
 本项目由[技术指导委员会（TSC）][]和[社区委员会（CommComm）][]共同管理。前者对于项目中高级别的技术负责指导，后者则对指导和扩展社区进行负责。
 
-[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md
+[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md
 [社区委员会（CommComm）]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [一致协商]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members

--- a/locale/zh-tw/about/governance.md
+++ b/locale/zh-tw/about/governance.md
@@ -23,7 +23,7 @@ Node.js 專案遵循 [Consensus Seeking][]（尋求共識）的決策模式。
 
 此專案由 [TSC][] 及 [CommComm][]（Community Committee）聯合治理，前者負責此專案較高層級的指導，後者則負責一般指導及擴展 Node.js 社群。
 
-[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/guides/collaborator-guide.md
+[collaborator-guide.md]: https://github.com/nodejs/node/blob/master/doc/contributing/collaborator-guide.md
 [CommComm]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/master/README.md#current-project-team-members


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/41408

Found one more link that needs fixing up.

Signed-off-by: Michael Dawson <mdawson@devrus.com>