### PR TITLE
blog: create nodejs-trademarks-transferred-to-openjs-foundation

### DIFF
--- a/locale/en/blog/announcements/nodejs-trademarks-transferred-to-openjs-foundation
+++ b/locale/en/blog/announcements/nodejs-trademarks-transferred-to-openjs-foundation
@@ -7,7 +7,7 @@ layout: blog-post.hbs
 author: Joe Sepi
 ---
 
-Exciting news today for the Node.js project — Joyent has transferred ownership of 
+Exciting news today for the Node.js project: Joyent has transferred ownership of 
 its trademarks to the OpenJS Foundation. Nothing will change for contributors, but 
 the OpenJS Foundation will become the steward of the trademarks that help protect 
 the work of the Node.js collaborators.

--- a/locale/en/blog/announcements/nodejs-trademarks-transferred-to-openjs-foundation
+++ b/locale/en/blog/announcements/nodejs-trademarks-transferred-to-openjs-foundation
@@ -1,0 +1,15 @@
+---
+date: 2022-02-14T17:00:00Z
+category: Announcements
+title: Node.js Trademarks Transferred to OpenJS Foundation
+slug: nodejs-trademarks-transferred-to-openjs-foundation
+layout: blog-post.hbs
+author: Joe Sepi
+---
+
+Exciting news today for the Node.js project — Joyent has transferred ownership of 
+its trademarks to the OpenJS Foundation. Nothing will change for contributors, but 
+the OpenJS Foundation will become the steward of the trademarks that help protect 
+the work of the Node.js collaborators.
+
+Read more on the [OpenJS blog](https://openjsf.org/blog/2022/02/14/node-js-trademarks-transferred-to-openjs-foundation/)


### PR DESCRIPTION
Point to announcement on OpenJS blog about the Node.js trademarks being transferred from Samsung to OpenJS