### PR TITLE
Update Node.js trademark notices

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -10,7 +10,7 @@
         </a>
       </div>
     <p>© OpenJS Foundation. All Rights Reserved. Portions of this site originally © Joyent.</p>
-    <p>Node.js is a trademark of Joyent, Inc. and is used with its permission. Please review the <a
+    <p>Node.js is a trademark of the OpenJS Foundation. Please review the <a
         href="https://trademark-list.openjsf.org">Trademark List</a> and <a
         href="https://trademark-policy.openjsf.org">Trademark Guidelines</a> of the <a href="https://openjsf.org">OpenJS
         Foundation</a>.</p>


### PR DESCRIPTION
In February 2022, Joyent and the OpenJS Foundation completed an agreement that transfers ownership of the Node.js trademarks from Joyent to the OpenJS Foundation. Effective immediately, the OpenJS Foundation will take on the ongoing management and maintenance of the Node.js trademarks. The rules governing usage of the Node.js trademarks will now be consistent with all of the other OpenJS Foundation projects' trademarks. For contributors, nothing will change.

This commit updates the trademark notice. Please note that any projects using the prior footer may make this change as well. If you have any questions, please reach out to trademark@openjsf.org.

Signed-off-by: Robin Ginn <rginn@linuxfoundation.org>