### PR TITLE
improved grammar

### DIFF
--- a/locale/en/knowledge/javascript-conventions/what-is-json.md
+++ b/locale/en/knowledge/javascript-conventions/what-is-json.md
@@ -65,7 +65,7 @@ There are a few rules to remember when dealing with data in JSON
 format. There are several gotchas that can produce invalid JSON as well.
 
 * Empty objects and arrays are okay
-* Strings can contain any unicode character, this includes object properties
+* Strings can contain any unicode character (this also applies to object properties)
 * `null` is a valid JSON value on it's own
 * All object properties should always be double quoted
 * Object property values must be one of the following: String, Number, Boolean, Object, Array, null


### PR DESCRIPTION
Changed comma to parentheses to make it clear that what previously followed the comma is a side-note, not a separate statement with equal weight

Changed "includes" to "also applies to" to remove grammatical ambiguity which allowed for the following interpretation: "strings can contain object properties"