### PR TITLE
Allow inexact filtering and filtering by LTS

### DIFF
--- a/static/js/previousVersion.js
+++ b/static/js/previousVersion.js
@@ -5,7 +5,7 @@ $(function () {
     pagination: true,
     perPage: 10,
     globalSearch: true,
-    exactMatch: "auto",
+    exactMatch: 'auto',
     globalSearchExcludeColumns: [3, 4, 6, 7],
     sortable: false, // We don't allow sorting because it will make orders at mass
     inputPlaceholder:

--- a/static/js/previousVersion.js
+++ b/static/js/previousVersion.js
@@ -5,8 +5,8 @@ $(function () {
     pagination: true,
     perPage: 10,
     globalSearch: true,
-    exactMatch: true,
-    globalSearchExcludeColumns: [2, 3, 4, 6, 7],
+    exactMatch: "auto",
+    globalSearchExcludeColumns: [3, 4, 6, 7],
     sortable: false, // We don't allow sorting because it will make orders at mass
     inputPlaceholder:
       "Type versions of Node.js or npm to search (e.g: 'Node.js 14.17.5' or '6.14.14' ...)"


### PR DESCRIPTION
Right now it is not possible to filter by, e.g. `16`, or `Gallium`.
This would be useful to take a quick glance at just a single major release.
The `"auto"` setting allows for exact matches to be performed by quoting the input, e.g. `"Node.js 16.13.2"`.