### PR TITLE
fix: allowing release schedule table to be responsive

### DIFF
--- a/layouts/css/page-modules/_release-schedule.scss
+++ b/layouts/css/page-modules/_release-schedule.scss
@@ -6,6 +6,8 @@ table.release-schedule {
   border-collapse: separate;
   border-spacing: 0;
   overflow: hidden;
+  display: block;
+  overflow-x: scroll;
 
 
   td,


### PR DESCRIPTION
adjusting styling for release schedule table to allow for responsiveness

**Before (mobile): table heading cannot scroll**
![before](https://user-images.githubusercontent.com/11414958/173136138-4e6a0d2d-0cd4-4348-ae04-b4c239cca6bd.png)


**After (mobile): table heading is now scrolled to the end**
![after](https://user-images.githubusercontent.com/11414958/173136161-6df6d3fd-2fe8-467c-b762-bfe865998704.png)


**After (desktop): table heading is now scrolled to the end**
![desktop-after](https://user-images.githubusercontent.com/11414958/173136196-723cd7c5-2e61-408f-9fab-f25251d945be.png)


closes #[4628](https://github.com/nodejs/nodejs.org/issues/4628)