### PR TITLE
chore(portuguese): introduce localised strings for `nvs`

### DIFF
--- a/locale/pt-br/download/package-manager.md
+++ b/locale/pt-br/download/package-manager.md
@@ -118,35 +118,35 @@ nvm uninstall 8
 ## nvs
 
 #### Windows
-The `nvs` version manager is cross-platform and can be used on Windows, macOS, and Unix-like systems
+O gerenciador de versões `nvs` é multi-plataformal e pode ser utilizado no Windows, macOS e Sistemas baseadoes em UNIX
 
-To install `nvs` on Windows go to the [release page](https://github.com/jasongin/nvs/releases) here and download the MSI installer file of the latest release.
+Para instalar o `nvs` no Windows, visite a [página de versões](https://github.com/jasongin/nvs/releases) e baixe o instalador no formato MSI da última versão disponível.
 
-You can also use `chocolatey` to install it:
+Você também pode usar `chocolatey` para instalar o `nvs`:
 
 ```bash
 choco install nvs
 ```
 
 #### macOS,UnixLike
-You can find the documentation regarding the installation steps of `nvs` in macOS/Unix-like systems [here](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
+Você pode encontrar a documentação sobre as etapas de instalação do `nvs` para macOS/Sistemas baseados em UNIX [nesta página](https://github.com/jasongin/nvs/blob/master/doc/SETUP.md#mac-linux)
 
 #### Usage
-After this you can use `nvs` to switch between different versions of node.
+Após a instalação você pode utilizar o `nvs` para alternar entre diferentes versões do Node.
 
-To add the latest version of node:
+Para adicionar a última versão do node:
 
 ```bash
 nvs add latest
 ```
 
-Or to add the latest LTS version of node:
+Ou para adicionar a última versão LTS do node:
 
 ```bash
 nvs add lts
 ```
 
-Then run the `nvs use` command to add a version of node to your `PATH` for the current shell:
+Após execute o comando `nvs use` para introduzir a versão instalada do node no seu `PATH` para a sessão atual do seu shell:
 
 ```bash
 $ nvs use lts
@@ -154,7 +154,7 @@ PATH -= %LOCALAPPDATA%\nvs\default
 PATH += %LOCALAPPDATA%\nvs\node\14.17.0\x64
 ```
 
-To add it to `PATH` permanently, use `nvs link`:
+Para adicionar-lo ao `PATH` de forma permanente, use `nvs link`
 
 ```bash
 nvs link lts


### PR DESCRIPTION
This PR introduces localised strings in Portuguese (Brazil) for the `nvs` installation steps for Node.js.

Note.: The translated bags use a technical-free terminology. This is done to allow a more general audience to understand better the installation steps.