### PR TITLE
fix: do not remove `Edit on GitHub` if it does not exist

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -166,6 +166,10 @@
   var editOnGitHubElement = document.getElementById('editOnGitHubLink');
   var editOnGitHubUrlElement = document.getElementById('editOnGitHubUrl');
 
+  if (!editOnGitHubElement) {
+    return;
+  }
+
   if (editOnGitHubUrlElement) {
     editOnGitHubElement.setAttribute('href', editOnGitHubUrlElement.value);
   } else {


### PR DESCRIPTION
Do not attempt to remove `#editOnGitHubLink`'s `.parentNode` if it doesn't exist on the page.

For example, this element does not exist on 404 page: https://nodejs.org/amNotExist