### PR TITLE
chore(banners): use absolute path for image

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -162,7 +162,7 @@
       "startDate": "2022-07-29T16:00:00.000Z",
       "endDate": "2022-08-11T16:00:00.000Z",
       "text": null,
-      "html": "<img alt='Grace Hopper Celebration' src='/static/images/ghc-banner.png' />",
+      "html": "<img alt='Grace Hopper Celebration' src='https://nodejs.org/static/images/ghc-banner.png' />",
       "link": "https://anitab-org.github.io/open-source-day/open-source-day/"
     },
     "blacklivesmatter": {


### PR DESCRIPTION
This PR simply uses an absolute path for the Nodejs.org Banners metadata. As Nodejs.dev pulls the data and would consume this image. Without the need to copy the file.