### PR TITLE
Optimizing load time of website 🛩

### DIFF
--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -2,8 +2,8 @@
   <meta charset="utf-8">
   <title>{{#if title}}{{ title }} | {{/if}}{{ site.title }}</title>
 
-  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&display=fallback">
   <link rel="stylesheet" href="/static/css/styles.css">
@@ -35,5 +35,5 @@
   <link rel="alternate" href="/{{ ../site.locale }}/{{ link }}" title="{{ text }}" type="application/rss+xml">
   {{/each}}
 
-  <script src="/static/js/themeSwitcher.js"></script>
+  <script src="/static/js/themeSwitcher.js" defer></script>
 </head>


### PR DESCRIPTION
Optimizing the load performance.
---

> 1. [Preconnecting](https://web.dev/uses-rel-preconnect) to google fonts for faster loading of fonts.
> 2. Defering the script load and moving it to head tag (Fetching scripts without blocking the rendering of `HTML`).