### PR TITLE
remove "International" list from Get Involved

### DIFF
--- a/locale/en/get-involved/index.md
+++ b/locale/en/get-involved/index.md
@@ -25,13 +25,3 @@ layout: contribute.hbs
 * [Stack Overflow Node.js tag](https://stackoverflow.com/questions/tagged/node.js) collects new information every day.
 * [The DEV Community Node.js tag](https://dev.to/t/node) is a place to share Node.js projects, articles and tutorials as well as start discussions and ask for feedback on Node.js-related topics. Developers of all skill-levels are welcome to take part.
 * [Nodeiflux](https://discordapp.com/invite/vUsrbjd) is a friendly community of Node.js backend developers supporting each other on Discord.
-
-## International community sites and projects
-
-* [Chinese community](https://cnodejs.org/)
-* [Hungarian (Magyar) community](https://nodehun.blogspot.com/)
-* [Israeli Facebook group for Node.js](https://www.facebook.com/groups/node.il/)
-* [Japanese user group](https://nodejs.jp/)
-* [Spanish language Facebook group for Node.js](https://www.facebook.com/groups/node.es/)
-* [Vietnamese Node.js community](https://www.facebook.com/nodejs.vn/)
-* [Uzbekistan group for Node.js](https://t.me/nodejs_uz)


### PR DESCRIPTION
* We don't vet any of these groups and have little idea of their quality or values.
* Calling it "International" is a very U.S./English-language-centered approach.
* Many of these groups appear to have not been active for some time.
* We can't possibly list all groups, but listing some invites everyone else to want their group listed.
* The Node.js website is simply not the place for this content.

Much of the remainder of the page needs to be removed or edited too, but I'm starting at the bottom of the page.