### PR TITLE
fix: correct year for banner dates

### DIFF
--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -139,8 +139,8 @@
   },
   "banners": {
     "index": {
-      "startDate": "2021-09-15T16:00:00.000Z",
-      "endDate": "2021-09-22T16:00:00.000Z",
+      "startDate": "2022-09-15T16:00:00.000Z",
+      "endDate": "2022-09-22T16:00:00.000Z",
       "text": "New security releases to be made available September 22nd, 2022",
       "link": "blog/vulnerability/september-2022-security-releases/"
     },

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -142,7 +142,7 @@
       "startDate": "2022-09-15T16:00:00.000Z",
       "endDate": "2022-09-22T16:00:00.000Z",
       "text": "New security releases to be made available September 22nd, 2022",
-      "link": "blog/vulnerability/september-2022-security-releases/"
+      "link": "https://nodejs.org/en/blog/vulnerability/september-2022-security-releases/"
     },
     "blacklivesmatter": {
       "visible": false,


### PR DESCRIPTION
Banner isn't displaying because the year for the start/end dates was incorrect.

Refs: https://github.com/nodejs/nodejs.org/pull/4822