### PR TITLE
blog: postpone Sept security release

### DIFF
--- a/locale/en/blog/vulnerability/september-2022-security-releases.md
+++ b/locale/en/blog/vulnerability/september-2022-security-releases.md
@@ -7,6 +7,12 @@ layout: blog-post.hbs
 author: Vladimir de Turckheim
 ---
 
+## _(Update 22-July-2022)_ Security releases postponed
+
+Some fixes of the security releases have been recently updated and the Node.js security team still needs an extra day of work to ensure the binaries are ready to release.
+We would like to thank you for your patience and understanding.
+The releases are now planned for September 23rd 2022.
+
 # Summary
 
 The Node.js project will release new versions of the 14.x, 16.x, and 18.x

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -137,7 +137,7 @@
     "index": {
       "startDate": "2022-09-15T16:00:00.000Z",
       "endDate": "2022-09-22T16:00:00.000Z",
-      "text": "New security releases to be made available September 22nd, 2022",
+      "text": "New security releases to be made available September 23rd, 2022",
       "link": "https://nodejs.org/en/blog/vulnerability/september-2022-security-releases/"
     },
     "blacklivesmatter": {


### PR DESCRIPTION
The security release planned for today has to be postponed for reasons detailed in the blog update.