### PR TITLE
chore: specify that Node.js is open source and cross-platform

### DIFF
--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -15,4 +15,4 @@ labels:
   version-schedule-prompt-link-text: Long Term Support (LTS) schedule
 ---
 
-Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://v8.dev/).
+Node.js® is an open-source, cross-platform JavaScript runtime environment.


### PR DESCRIPTION
The fact that Node.js is open source and cross-platform is far more important to call out than that it runs on V8 so let's do that.