### PR TITLE
fix Edit on GitHub link leading to wrong URL

### DIFF
--- a/build.js
+++ b/build.js
@@ -90,7 +90,6 @@ function buildLocale(source, locale, opts) {
   const labelForBuild = `[metalsmith] build/${locale} finished`;
   console.time(labelForBuild);
   const metalsmith = Metalsmith(__dirname);
-
   metalsmith
     // Sets global metadata imported from the locale's respective site.json.
     .metadata({
@@ -158,7 +157,14 @@ function buildLocale(source, locale, opts) {
         ]
       })
     )
+    .use(githubLinks({ locale, site: i18nJSON(locale) }))
     .use(markdown(markedOptions))
+    // Set pretty permalinks, we don't want .html suffixes everywhere.
+    .use(
+      permalinks({
+        relative: false
+      })
+    )
     // Generates the feed XML files from their respective collections which were
     // defined earlier on.
     .use(
@@ -188,13 +194,6 @@ function buildLocale(source, locale, opts) {
     .use(hbsReg())
     .use(scriptReg())
     .use(layouts())
-    .use(githubLinks({ locale, site: i18nJSON(locale) }))
-    // Set pretty permalinks, we don't want .html suffixes everywhere.
-    .use(
-      permalinks({
-        relative: false
-      })
-    )
     // Pipes the generated files into their respective subdirectory in the build
     // directory.
     .destination(path.join(__dirname, 'build', locale))

--- a/build.js
+++ b/build.js
@@ -159,12 +159,6 @@ function buildLocale(source, locale, opts) {
       })
     )
     .use(markdown(markedOptions))
-    // Set pretty permalinks, we don't want .html suffixes everywhere.
-    .use(
-      permalinks({
-        relative: false
-      })
-    )
     // Generates the feed XML files from their respective collections which were
     // defined earlier on.
     .use(
@@ -195,6 +189,12 @@ function buildLocale(source, locale, opts) {
     .use(scriptReg())
     .use(layouts())
     .use(githubLinks({ locale, site: i18nJSON(locale) }))
+    // Set pretty permalinks, we don't want .html suffixes everywhere.
+    .use(
+      permalinks({
+        relative: false
+      })
+    )
     // Pipes the generated files into their respective subdirectory in the build
     // directory.
     .destination(path.join(__dirname, 'build', locale))

--- a/build.js
+++ b/build.js
@@ -157,7 +157,6 @@ function buildLocale(source, locale, opts) {
         ]
       })
     )
-    .use(githubLinks({ locale, site: i18nJSON(locale) }))
     .use(markdown(markedOptions))
     // Set pretty permalinks, we don't want .html suffixes everywhere.
     .use(
@@ -194,6 +193,7 @@ function buildLocale(source, locale, opts) {
     .use(hbsReg())
     .use(scriptReg())
     .use(layouts())
+    .use(githubLinks({ locale, site: i18nJSON(locale) }))
     // Pipes the generated files into their respective subdirectory in the build
     // directory.
     .destination(path.join(__dirname, 'build', locale))

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -6,16 +6,18 @@
     <div class="openjsfoundation-footer">
       <p>Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and Node.js contributors. All rights reserved. The <a href="https://openjsf.org">OpenJS Foundation</a> has registered trademarks and uses trademarks.  For a list of trademarks of the <a href="https://openjsf.org">OpenJS Foundation</a>, please see our <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> and <a href="https://trademark-list.openjsf.org">Trademark List</a>.  Trademarks and logos not indicated on the <a href="https://trademark-list.openjsf.org">list of OpenJS Foundation trademarks</a> are trademarks&trade; or registered&reg; trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</p>
       <p class="openjsfoundation-footer-links">
-        <a href="https://openjsf.org">The OpenJS Foundation</a> | 
-        <a href="https://terms-of-use.openjsf.org">Terms of Use</a> | 
-        <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> | 
-        <a href="https://bylaws.openjsf.org">Bylaws</a> | 
-        <a href="https://code-of-conduct.openjsf.org">Code of Conduct</a> | 
-        <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> | 
-        <a href="https://trademark-list.openjsf.org">Trademark List</a> | 
+        <a href="https://openjsf.org">The OpenJS Foundation</a> |
+        <a href="https://terms-of-use.openjsf.org">Terms of Use</a> |
+        <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> |
+        <a href="https://bylaws.openjsf.org">Bylaws</a> |
+        <a href="https://code-of-conduct.openjsf.org">Code of Conduct</a> |
+        <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> |
+        <a href="https://trademark-list.openjsf.org">Trademark List</a> |
         <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a>
       </p>
-        <div class="openjsfoundation-footer-edit"></div>
+         <div class="openjsfoundation-footer-edit">
+              | <a id="editOnGitHubLink" href="#">{{site.editOnGithub}}</a>
+         </div>
     </div>
   </div>
 

--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -15,9 +15,7 @@
         <a href="https://trademark-list.openjsf.org">Trademark List</a> |
         <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a>
       </p>
-         <div class="openjsfoundation-footer-edit">
-              | <a id="editOnGitHubLink" href="#">{{site.editOnGithub}}</a>
-         </div>
+      <div class="openjsfoundation-footer-edit"></div>
     </div>
   </div>
 

--- a/scripts/plugins/githubLinks.js
+++ b/scripts/plugins/githubLinks.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { sep } = require('path');
+const { sep, resolve } = require('path');
+const fs = require('fs');
 // add suffix (".html" or sep for windows test) to each part of regex
 // to ignore possible occurrences in titles (e.g. blog posts)
 const isEditable = `(security|index).html|(about|download|docs|foundation|get-involved|knowledge)\\${sep}`;
@@ -15,13 +16,30 @@ function githubLinks(options) {
       }
 
       const file = files[path];
-      path = path.replace(/\\/g, '/');
+      path = path.replace('.html', '.md').replace(/\\/g, '/');
 
-      console.log(path);
+      const currentFilePath = resolve(
+        __dirname,
+        `../../locale/${options.locale}/${path}`
+      );
+
+      if (!fs.existsSync(currentFilePath)) {
+        path = path.replace('/index.md', '.md');
+      }
+
       const url = `https://github.com/nodejs/nodejs.org/edit/main/locale/${options.locale}/${path}`;
-      const contents =
-        file.contents.toString() +
-        ` <input type = "hidden" id = "editOnGitHubUrl" value="${url}"/> `;
+      const editOnGitHubTrans = options.site.editOnGithub || 'Edit on GitHub';
+      const replCallBack = (match, $1, $2) => {
+        return `<div class="openjsfoundation-footer-edit">
+             | <a href="${url}">${editOnGitHubTrans}</a>
+             </div>`;
+      };
+      const contents = file.contents
+        .toString()
+        .replace(
+          /<div class="openjsfoundation-footer-edit"><\/div>/,
+          replCallBack
+        );
 
       file.contents = Buffer.from(contents);
     });

--- a/scripts/plugins/githubLinks.js
+++ b/scripts/plugins/githubLinks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const sep = require('path').sep;
+const { sep } = require('path');
 // add suffix (".html" or sep for windows test) to each part of regex
 // to ignore possible occurrences in titles (e.g. blog posts)
 const isEditable = `(security|index).html|(about|download|docs|foundation|get-involved|knowledge)\\${sep}`;
@@ -15,20 +15,13 @@ function githubLinks(options) {
       }
 
       const file = files[path];
-      path = path.replace('.html', '.md').replace(/\\/g, '/');
+      path = path.replace(/\\/g, '/');
+
+      console.log(path);
       const url = `https://github.com/nodejs/nodejs.org/edit/main/locale/${options.locale}/${path}`;
-      const editOnGitHubTrans = options.site.editOnGithub || 'Edit on GitHub';
-      const replCallBack = (match, $1, $2) => {
-        return `<div class="openjsfoundation-footer-edit">
-            | <a href="${url}">${editOnGitHubTrans}</a>
-            </div>`;
-      };
-      const contents = file.contents
-        .toString()
-        .replace(
-          /<div class="openjsfoundation-footer-edit"><\/div>/,
-          replCallBack
-        );
+      const contents =
+        file.contents.toString() +
+        ` <input type = "hidden" id = "editOnGitHubUrl" value="${url}"/> `;
 
       file.contents = Buffer.from(contents);
     });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -159,3 +159,23 @@
     winText.textContent = winText.textContent.replace(/x(86|64)/, arch);
   }
 })();
+
+(function () {
+  // This function is used to replace the anchor
+  // link of Edit on GitHub
+
+  var editOnGitHubElement = document.getElementById('editOnGitHubLink');
+  var editOnGitHubUrlElement = document.getElementById('editOnGitHubUrl');
+
+  if (!editOnGitHubElement) {
+    return;
+  }
+
+  if (editOnGitHubUrlElement) {
+    editOnGitHubElement.setAttribute('href', editOnGitHubUrlElement.value);
+  } else {
+    editOnGitHubElement.parentNode.parentNode.removeChild(
+      editOnGitHubElement.parentNode
+    );
+  }
+})();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -159,23 +159,3 @@
     winText.textContent = winText.textContent.replace(/x(86|64)/, arch);
   }
 })();
-
-(function () {
-  // This function is used to replace the anchor
-  // link of Edit on GitHub
-
-  var editOnGitHubElement = document.getElementById('editOnGitHubLink');
-  var editOnGitHubUrlElement = document.getElementById('editOnGitHubUrl');
-
-  if (!editOnGitHubElement) {
-    return;
-  }
-
-  if (editOnGitHubUrlElement) {
-    editOnGitHubElement.setAttribute('href', editOnGitHubUrlElement.value);
-  } else {
-    editOnGitHubElement.parentNode.parentNode.removeChild(
-      editOnGitHubElement.parentNode
-    );
-  }
-})();


### PR DESCRIPTION
From the below video, its seen that most pages are throwing 404 when the Edit on GitHub link is clicked

https://user-images.githubusercontent.com/24433274/195949908-f93a95c6-9ce5-4a78-9776-2be8d8871369.mp4

This PR resolves the issue by moving the call to the permalink plugin after githubLinks and layouts middleware has been called. Below is the result.

https://user-images.githubusercontent.com/24433274/195950002-0f87de4d-552a-4961-b682-1b92410be62f.mp4


