### PR TITLE
Fix up list of version affected.

### DIFF
--- a/locale/en/blog/vulnerability/openssl-november-2022.md
+++ b/locale/en/blog/vulnerability/openssl-november-2022.md
@@ -23,7 +23,7 @@ the _highest_ severity issue is CRITICAL.
 
 [security policy](https://www.openssl.org/policies/secpolicy.html).
 
-Node.js v16.x, v18.x and v19.x use OpenSSL v3.
+Node.js v18.x and v19.x use OpenSSL v3.
 Therefore all active LTS release lines are impacted by this update.
 
 At this stage, due to embargo, the exact nature of these defects is uncertain


### PR DESCRIPTION
OpenSSL 3 is not used in the 16.x line