### PR TITLE
Suggested update for the openssl-november-2022.md

### DIFF
--- a/locale/en/blog/vulnerability/openssl-november-2022.md
+++ b/locale/en/blog/vulnerability/openssl-november-2022.md
@@ -23,8 +23,8 @@ the _highest_ severity issue is CRITICAL.
 
 [security policy](https://www.openssl.org/policies/secpolicy.html).
 
-Node.js v18.x and v19.x use OpenSSL v3.
-Therefore these release lines are impacted by this update.
+Node.js v17.x, v18.x and v19.x use OpenSSL v3.
+While Node.js v17.x is no longer supported, the v18.x and v19.x release lines are impacted by this update.
 
 Node.js 14.x and v16.x are not affected by this OpenSSL update.
 

--- a/locale/en/blog/vulnerability/openssl-november-2022.md
+++ b/locale/en/blog/vulnerability/openssl-november-2022.md
@@ -23,8 +23,11 @@ the _highest_ severity issue is CRITICAL.
 
 [security policy](https://www.openssl.org/policies/secpolicy.html).
 
-Node.js v17.x, v18.x and v19.x use OpenSSL v3.
-While Node.js v17.x is no longer supported, the v18.x and v19.x release lines are impacted by this update.
+Node.js v17.x, v18.x, and v19.x use OpenSSL v3.
+
+Node.js v18.x and v19.x will be updated to address this issue.
+
+Support for Node.js v17.x ended in June 2022. It will not be updated. Please migrate to a supported version of Node.js.
 
 Node.js 14.x and v16.x are not affected by this OpenSSL update.
 


### PR DESCRIPTION
Added that Node.js v17.x is also affected by the vulnerabilities. I think it is important to mention even though it is no longer supported to avoid creating a false sense of security for folks still using 17.x. This is especially true since otherwise, users won't know they have OpenSSL 3.x in their environment since it is compiled into node and hence won't be flagged by most scanners/SCA tools.