### PR TITLE
en: Fixed typo in package manager page

### DIFF
--- a/locale/en/download/package-manager.md
+++ b/locale/en/download/package-manager.md
@@ -197,7 +197,7 @@ cd pkgsrc/lang/nodejs && bmake install
 or select from a menu of previously downloaded versions. The versions are installed system-wide or user-wide, and for more
 targeted use you can run a version directly from the cached downloads.
 
-See the [homepage](https://github.com/tj/n) for install methods (boostrap, npm, Homebrew, third-party), and all the usage details.
+See the [homepage](https://github.com/tj/n) for install methods (bootstrap, npm, Homebrew, third-party), and all the usage details.
 
 If you already have `npm` then installing `n` and then the newest LTS `node` version is as simple as:
 


### PR DESCRIPTION
### Changes:
* Changed `boostrap` to `bootstrap`. 