### PR TITLE
fix: replaced url

### DIFF
--- a/locale/en/docs/guides/security/index.md
+++ b/locale/en/docs/guides/security/index.md
@@ -426,7 +426,7 @@ functionality isn't securely stable. Although, feedback is highly appreciated.
 [RFC7230]: https://datatracker.ietf.org/doc/html/rfc7230#section-3
 [policy mechanism]: https://nodejs.org/api/permissions.html#policies
 [typosquatting]: https://en.wikipedia.org/wiki/Typosquatting
-[Mitigations for lockfile poisoning]: https://securenodejsguidelines.ulisesgascon.com/attacks/lockfile-posioned#mitigation
+[Mitigations for lockfile poisoning]: https://blog.ulisesgascon.com/lockfile-posioned
 [`npm ci`]: https://docs.npmjs.com/cli/v8/commands/npm-ci
 [secure-heap documentation]: https://nodejs.org/dist/latest-v18.x/docs/api/cli.html#--secure-heapn
 [CVE-2022-21824]: https://www.cvedetails.com/cve/CVE-2022-21824/


### PR DESCRIPTION
I just [deprecated the project](https://github.com/UlisesGascon/secure-nodejs-guidelines) and relocated the article to [the blog](https://blog.ulisesgascon.com/lockfile-posioned). It is the same content 😉

cc: @RafaelGSS 

**Note:** Once this is merged, this will affect #4929 (cc @MaledongGit) and #4932 