### PR TITLE
Remove "x64" from macOS homepage header

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -138,7 +138,7 @@
     switch (os) {
       case 'Mac':
         versionIntoHref(buttons, 'node-%version%.pkg');
-        downloadHead.textContent = dlLocal + ' macOS (x64)';
+        downloadHead.textContent = dlLocal + ' macOS';
         break;
       case 'Win':
         versionIntoHref(buttons, 'node-%version%-' + arch + '.msi');


### PR DESCRIPTION
This simply removes the "(x64)" from the homepage download label when macOS is detected to reduce confusion, since both the LTS and current versions now link to universal Intel/ARM installers.

We could also use "Download for macOS (x64 / ARM64)" (which would match the [download page](https://nodejs.org/en/download/)) or "macOS (Universal)" (which would require new translations, correct?) or something similar. :)