### PR TITLE
feat: add slider for cyber week

### DIFF
--- a/layouts/partials/header.hbs
+++ b/layouts/partials/header.hbs
@@ -1,3 +1,8 @@
+<!-- Needed for OpenJS slider -->
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MLXTDP3"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 <header>
   <div class="container">
 

--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -36,4 +36,13 @@
   {{/each}}
 
   <script src="/static/js/themeSwitcher.js"></script>
+  <!-- Needed for OpenJS slider -->
+  <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/3b49aaa9-15ab-4d47-a8fb-96cc25b5543c/osano.js"></script>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MLXTDP3');</script>
+  <!-- End Google Tag Manager -->
 </head>


### PR DESCRIPTION
Given our avoidance of even basic analytics tracking (e.g., Google Analytics) on privacy grounds, I'm going to guess that this will give people pause. But maybe not because there's a GDPR-compliant cookie tracker config thingy? I don't know. Let's find out! @nodejs/website 