### PR TITLE
docs: Fix arabic es6 page layout to rtl

### DIFF
--- a/locale/ar/docs/es6.md
+++ b/locale/ar/docs/es6.md
@@ -3,7 +3,7 @@ title: ECMAScript 2015 (ES6) و ما بعدها
 layout: docs.hbs
 ---
 
-# ECMAScript 2015 (ES6) و ما بعدها
+# نسخة ECMAScript 2015 (ES6) و ما بعدها
 
 تم بناء الـ Node.js باستعمال نسخ حديثة من الـ [V8](https://v8.dev/docs/profile)، وهذا يضمن إتاحة آخر المميزات الخاصة بالجافاسكريبت والموافقة لـ [مواصفات JavaScript ECMA-262](http://www.ecma-international.org/publications/standards/Ecma-262.htm) للمطورين في الوقت المناسب، إضافة إلى التحسينات المستمرة في الأداء والثبات.
 


### PR DESCRIPTION
The article direction is set to "auto" , which detect the direction based on the first content. The first content of the page was ES6 which is in latin letters, the page direction is set to "ltr" automatically. I added the word "نسخة" which is the arabic equivalent of "version". It keeps the meaning the same but fixes the layout.