### PR TITLE
Added flags : 'a' option to fs.createWriteStream

### DIFF
--- a/locale/en/knowledge/advanced/streams/how-to-use-fs-create-write-stream.md
+++ b/locale/en/knowledge/advanced/streams/how-to-use-fs-create-write-stream.md
@@ -10,6 +10,7 @@ layout: knowledge-post.hbs
 ---
 
 The function `fs.createWriteStream()` creates a writable stream in a very simple manner. After a call to `fs.createWriteStream()` with the filepath, you have a writeable stream to work with. It turns out that the response (as well as the request) objects are streams. So we will stream the `POST` data to the file `output`. Since the code is simple enough, it is pretty easy just to read through it and comment why each line is necessary.
+Note: With the default `flags`:`w` option, the `fs.createWriteStream()` function opens a file for writing. The file is created (if it does not exist) or truncated (if it exists). Since most browsers send more than one request to a server at a time, each new request, and therefore each new `fs.createWriteStream()` call deletes any existing data from the `output` file. So, to ensure that no possible subsequent requests remove data written by the `POST` request with the data from the `<form>` element, the `flags`:`a` option is added to the `fs.createWriteStream()` call, which then opens a file for appending data (any existing data remains unaffected).
 
 ```javascript
 var http = require('http');

--- a/locale/en/knowledge/advanced/streams/how-to-use-fs-create-write-stream.md
+++ b/locale/en/knowledge/advanced/streams/how-to-use-fs-create-write-stream.md
@@ -17,7 +17,7 @@ var fs = require('fs');
 
 http.createServer(function(req, res) {
   // This opens up the writeable stream to `output`
-  var writeStream = fs.createWriteStream('./output');
+  var writeStream = fs.createWriteStream('./output', {flags:'a'});
 
   // This pipes the POST data to the file
   req.pipe(writeStream);


### PR DESCRIPTION
Without flags : 'a' option, nothing is saved in output.txt file.