### PR TITLE
chore(crowdin): ignore the knowledgebase

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,6 +10,7 @@ files:
         pt-BR: pt-br
         zh-CN: zh-cn
         zh-TW: zh-tw
+        es-ES: es
   - source: /locale/en/**/*.json
     translation: /locale/%two_letters_code%/**/%original_file_name%
     ignore:
@@ -19,3 +20,4 @@ files:
         pt-BR: pt-br
         zh-CN: zh-cn
         zh-TW: zh-tw
+        es-ES: es

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,7 @@ files:
     content_segmentation: 0
     ignore:
       - /locale/en/blog/**/*.md
+      - /locale/en/knowledge/**/*.md
     languages_mapping:
       two_letters_code:
         pt-BR: pt-br


### PR DESCRIPTION
This PR removes the Knowledge base from being indexed by Crowdin as they are legacy pages and going to be removed in the close future.