### PR TITLE
fix(docs): remove deprecated usage of npm ci --only

### DIFF
--- a/pages/en/docs/guides/nodejs-docker-webapp.md
+++ b/pages/en/docs/guides/nodejs-docker-webapp.md
@@ -109,7 +109,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 
 Note that, rather than copying the entire working directory, we are only copying
@@ -156,7 +156,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # Bundle app source
 COPY . .

--- a/pages/id/docs/guides/nodejs-docker-webapp.md
+++ b/pages/id/docs/guides/nodejs-docker-webapp.md
@@ -89,7 +89,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 
 Perhatikan bahwa, daripada menyalin seluruh direktori kerja, kami hanya menyalin berkas `package.json`. Ini memungkinkan kami untuk memanfaatkan Docker yang di-cache lapisan. bitJudo memiliki penjelasan yang bagus tentang ini [di sini](http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/). Selanjutnya, perintah `npm ci`, yang ditentukan dalam komentar, membantu menyediakan build yang lebih cepat, andal, dan dapat direproduksi untuk lingkungan produksi. Anda dapat membaca lebih lanjut tentang ini [di sini](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable).
@@ -128,7 +128,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # Bundle app source
 COPY . .

--- a/pages/ko/docs/guides/nodejs-docker-webapp.md
+++ b/pages/ko/docs/guides/nodejs-docker-webapp.md
@@ -201,7 +201,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 -->
 
@@ -225,7 +225,7 @@ COPY package*.json ./
 
 RUN npm install
 # 프로덕션을 위한 코드를 빌드하는 경우
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 
 <!--
@@ -296,7 +296,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # Bundle app source
 COPY . .
@@ -328,7 +328,7 @@ COPY package*.json ./
 
 RUN npm install
 # 프로덕션을 위한 코드를 빌드하는 경우
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # 앱 소스 추가
 COPY . .

--- a/pages/ru/docs/guides/nodejs-docker-webapp.md
+++ b/pages/ru/docs/guides/nodejs-docker-webapp.md
@@ -111,7 +111,7 @@ COPY package*.json ./
 
 RUN npm install
 # Если вы создаете сборку для продакшн
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 
 Обратите внимание, что вместо того, чтобы копировать весь рабочий каталог,
@@ -161,7 +161,7 @@ COPY package*.json ./
 
 RUN npm install
 # Если вы создаете сборку для продакшн
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # копируем исходный код
 COPY . .

--- a/pages/zh-cn/docs/guides/nodejs-docker-webapp.md
+++ b/pages/zh-cn/docs/guides/nodejs-docker-webapp.md
@@ -90,7 +90,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 ```
 
 请注意，我们只是拷贝了 `package.json` 文件而非整个工作目录。这允许我们利用缓存 Docker 层的优势。bitJudo 对此有一个很好的解释，请[见此](http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/)。
@@ -130,7 +130,7 @@ COPY package*.json ./
 
 RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+# RUN npm ci --omit=dev
 
 # Bundle app source
 COPY . .


### PR DESCRIPTION
this is the npm output when you using `npm ci --only=production` 

npm version: 8.19.0

```
Step 4/7 : RUN npm ci --only=production
 ---> Running in bfc1319afc62
npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.

```