### PR TITLE
fix: windows download incorrectly selects 32bit on 64bit machine

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -170,12 +170,8 @@ function initDownloadHyperlink(bitness) {
     // [MSFT](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11)
     navigator.userAgentData
       .getHighEntropyValues(['bitness'])
-      .then(function (ua) {
-        initDownloadHyperlink(ua.bitness);
-      })
-      .catch(function () {
-        // Ignore errors since not every browser supports this API
-      });
+      .then((ua) => initDownloadHyperlink(ua.bitness))
+      .catch();
   } else {
     initDownloadHyperlink('unknown');
   }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -113,10 +113,6 @@
   var userAgent = navigator.userAgent;
   var osMatch = userAgent.match(/(Win|Mac|Linux)/);
   var os = (osMatch && osMatch[1]) || '';
-  var arch =
-    userAgent.match(/x86_64|Win64|WOW64/) || navigator.cpuClass === 'x64'
-      ? 'x64'
-      : 'x86';
   var buttons = document.querySelectorAll('.home-downloadbutton');
   var downloadHead = document.querySelector('#home-downloadhead');
   var dlLocal;
@@ -141,21 +137,13 @@
         downloadHead.textContent = dlLocal + ' macOS';
         break;
       case 'Win':
-        versionIntoHref(buttons, 'node-%version%-' + arch + '.msi');
-        downloadHead.textContent = dlLocal + ' Windows (' + arch + ')';
+        versionIntoHref(buttons, 'node-%version%-x64.msi');
+        downloadHead.textContent = dlLocal + ' Windows (x64)';
         break;
       case 'Linux':
         versionIntoHref(buttons, 'node-%version%-linux-x64.tar.xz');
         downloadHead.textContent = dlLocal + ' Linux (x64)';
         break;
     }
-  }
-
-  // Windows button on download page
-  var winButton = document.querySelector('#windows-downloadbutton');
-  if (winButton && os === 'Win') {
-    var winText = winButton.querySelector('p');
-    winButton.href = winButton.href.replace(/x(86|64)/, arch);
-    winText.textContent = winText.textContent.replace(/x(86|64)/, arch);
   }
 })();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -108,13 +108,15 @@
   });
 })();
 
-(function () {
+function initDownloadHyperlink(bitness) {
   'use strict';
   var userAgent = navigator.userAgent;
   var osMatch = userAgent.match(/(Win|Mac|Linux)/);
   var os = (osMatch && osMatch[1]) || '';
   var arch =
-    userAgent.match(/x86_64|Win64|WOW64/) || navigator.cpuClass === 'x64'
+    bitness === '64' ||
+    userAgent.match(/x86_64|Win64|WOW64/) ||
+    navigator.cpuClass === 'x64'
       ? 'x64'
       : 'x86';
   var buttons = document.querySelectorAll('.home-downloadbutton');
@@ -157,5 +159,24 @@
     var winText = winButton.querySelector('p');
     winButton.href = winButton.href.replace(/x(86|64)/, arch);
     winText.textContent = winText.textContent.replace(/x(86|64)/, arch);
+  }
+}
+
+(function () {
+  'use strict';
+  if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+    // This is necessary to detect Windows 11 on Edge.
+    // [MDN](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
+    // [MSFT](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11)
+    navigator.userAgentData
+      .getHighEntropyValues(['bitness'])
+      .then(function (ua) {
+        initDownloadHyperlink(ua.bitness);
+      })
+      .catch(function () {
+        // Ignore errors since not every browser supports this API
+      });
+  } else {
+    initDownloadHyperlink('unknown');
   }
 })();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -113,6 +113,10 @@
   var userAgent = navigator.userAgent;
   var osMatch = userAgent.match(/(Win|Mac|Linux)/);
   var os = (osMatch && osMatch[1]) || '';
+  var arch =
+    userAgent.match(/x86_64|Win64|WOW64/) || navigator.cpuClass === 'x64'
+      ? 'x64'
+      : 'x86';
   var buttons = document.querySelectorAll('.home-downloadbutton');
   var downloadHead = document.querySelector('#home-downloadhead');
   var dlLocal;
@@ -137,13 +141,21 @@
         downloadHead.textContent = dlLocal + ' macOS';
         break;
       case 'Win':
-        versionIntoHref(buttons, 'node-%version%-x64.msi');
-        downloadHead.textContent = dlLocal + ' Windows (x64)';
+        versionIntoHref(buttons, 'node-%version%-' + arch + '.msi');
+        downloadHead.textContent = dlLocal + ' Windows (' + arch + ')';
         break;
       case 'Linux':
         versionIntoHref(buttons, 'node-%version%-linux-x64.tar.xz');
         downloadHead.textContent = dlLocal + ' Linux (x64)';
         break;
     }
+  }
+
+  // Windows button on download page
+  var winButton = document.querySelector('#windows-downloadbutton');
+  if (winButton && os === 'Win') {
+    var winText = winButton.querySelector('p');
+    winButton.href = winButton.href.replace(/x(86|64)/, arch);
+    winText.textContent = winText.textContent.replace(/x(86|64)/, arch);
   }
 })();


### PR DESCRIPTION
I just installed Windows 11 64 bit and opened Edge to install Node.js and it incorrectly installed the 32 bit version.

User Agent:

```
Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.55
```

Also `navigator.cpuClass` is undefined so we need a new way to detect the the bitness.

- Fixes #5028 