### PR TITLE
Fix language picker height

### DIFF
--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -65,8 +65,6 @@ header {
     right: 0;
     top: 100%;
     min-height: 100%;
-    max-height: 200%;
-    overflow: auto;
     background: $node-gray;
     list-style-type: none;
     margin: 0;


### PR DESCRIPTION
The language picker in main navigation opens at a very small height, and it isn't obvious that it can be scrolled, so it feels broken. Suggested change allows the dropdown to expand to fix content, making all languages easily discoverable. This change is for desktop viewports only, the mobile behaviour is unchanged (which already shows all languages). 

## Before:

![Screenshot 2023-01-23 at 14 06 47@2x](https://user-images.githubusercontent.com/120485/214116117-183b9957-9de7-41f4-86c0-7735532f7c40.png)


## After:

![Screenshot 2023-01-23 at 14 06 20@2x](https://user-images.githubusercontent.com/120485/214116056-1902ee3d-0f47-4e22-b0ac-b52fafd63f53.png)
