### PR TITLE
ui: add padding to nav bar

### DIFF
--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -4,7 +4,7 @@ header {
   position: relative;
 
   >.container {
-    padding-top: 0.5em;
+    padding-top: .5em;
     overflow: visible;
   }
 
@@ -41,6 +41,10 @@ header {
     position: absolute;
     right: 0;
     bottom: 0;
+    top: 0;
+    >button {
+      margin-right: .5em;
+    }
   }
 
   .dark-theme-switcher {
@@ -48,7 +52,6 @@ header {
     border: none;
     color: $light-gray2;
     cursor: pointer;
-    padding: 12px;
     background-image: url("/static/images/dark-mode.svg");
     background-repeat: no-repeat;
   }
@@ -58,7 +61,6 @@ header {
     border: none;
     color: $light-gray2;
     cursor: pointer;
-    padding: 12px;
   }
 
   .lang-picker {

--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -57,6 +57,7 @@ header {
   }
 
   .lang-picker-toggler {
+    margin-top: 0.3em;
     background-color: transparent;
     border: none;
     color: $light-gray2;

--- a/layouts/css/page-modules/_header.scss
+++ b/layouts/css/page-modules/_header.scss
@@ -4,6 +4,7 @@ header {
   position: relative;
 
   >.container {
+    padding-top: 0.5em;
     overflow: visible;
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66859419/215432184-a73d8361-ef10-4089-9de2-485fc399d6e8.png)

The current navigation bar has no margin to the top of the website, which has made it looks pretty weird and ugly to me. So I added a `0.5em` top padding to it to make it looks comfortable and visually balanced to me.

![image](https://user-images.githubusercontent.com/66859419/215436834-9405dba4-455c-4af1-9455-6c6803906e21.png)

This is what it looks like after the change.