### PR TITLE
chore: add link for nodejs Mastodon verification

### DIFF
--- a/layouts/partials/footer.hbs
+++ b/layouts/partials/footer.hbs
@@ -21,6 +21,9 @@
 
 </footer>
 
+<!-- Verification of official Mastodon profile. -->
+<a rel="me" href="https://social.lfx.dev/@nodejs"></a>
+
 <script src="/static/js/main.js" async defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js" integrity="sha512-BNc7saQYlxCL10lykUYhFBcnzdKMnjx5fp5s5wPucDyZ7rKNwCoqJh1GwEAIhuePEK4WM9askJBRsu7ma0Rzvg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script>hljs.highlightAll();</script>


### PR DESCRIPTION
We should find the right place for this on the page but right now, I'm putting it after the footer with no link text so that we can get the official Mastodon account verified as the owner of the site.