### PR TITLE
docs(security): typo-squirting => typosquatting

### DIFF
--- a/locale/en/docs/guides/security/index.md
+++ b/locale/en/docs/guides/security/index.md
@@ -20,7 +20,7 @@ to Node.js, if you are looking for something broad, consider
 * Attacks explained: illustrate and document in plain English with some code
 example (if possible) the attacks that we are mentioning in the threat model.
 * Third-Party Libraries: define threats
-(typo-squirting attacks, malicious packages...) and best practices regarding
+(typosquatting attacks, malicious packages...) and best practices regarding
 node modules dependencies, etc...
 
 ## Threat List


### PR DESCRIPTION
Google produced zero relevant results for 'typo-squirting', so I assume that was just a typo.