### PR TITLE
chore(infra): remove unused config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,10 +20,5 @@ const withNextra = nextra({
 export default withNextra({
   trailingSlash: true,
   images: { unoptimized: true },
-  swcMinify: true,
   outputFileTracing: false,
-  experimental: {
-    sharedPool: true,
-    newNextLinkBehavior: true,
-  },
 });


### PR DESCRIPTION
I suspect some of these config options were added to `next.config.mjs` awhile ago because the latest version (Next.js 13) changed these to the default values:

- `swcMinify: true` in https://github.com/vercel/next.js/pull/41506
- `sharedPool: true` in https://github.com/vercel/next.js/pull/30110
- `newNextLinkBehavior: true` in https://github.com/vercel/next.js/pull/41459

You can also verify the the latest default values in [next/src/server/config-shared.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config-shared.ts).