### PR TITLE
chore(workflows): run linting job on windows too

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,8 +17,9 @@ concurrency:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build for GitHub Pages
     runs-on: ubuntu-latest
+
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,12 @@ env:
 jobs:
   lint:
     name: Lint on ${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Git Checkout
@@ -55,7 +60,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: |
-            ${{ github.workspace }}/.next/cache
+            .next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build Next.js
@@ -67,5 +72,5 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
-            ${{ github.workspace }}/.next/cache
+            .next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('.next/cache/eslint') }}


### PR DESCRIPTION
This PR simply makes the linting job run on Windows too, so we can ensure that both build and linting work on both OSs.