### PR TITLE
fix broken links

### DIFF
--- a/pages/ar/download/package-manager.md
+++ b/pages/ar/download/package-manager.md
@@ -51,7 +51,7 @@ pacman -S nodejs npm
 
 ## <!--debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages-->التوزيعات المبنية على ديبيان أو اوبنتو، لينكس للمؤسسات / فيدورا و حزم سناب
 
-يتم توفير [الملف الثنائي الرسمي للنود جي اس](https://github.com/nodesource/distributions/blob/master/README.md) من قبل NodeSource.
+يتم توفير [الملف الثنائي الرسمي للنود جي اس](https://github.com/nodesource/distributions) من قبل NodeSource.
 
 ## FreeBSD
 

--- a/pages/en/blog/weekly-updates/weekly-update.2016-11-11.md
+++ b/pages/en/blog/weekly-updates/weekly-update.2016-11-11.md
@@ -20,7 +20,7 @@ layout: blog-post.hbs
 
 * Results for v7.x added to [https://benchmarking.nodejs.org/](https://benchmarking.nodejs.org/)
 * Benchmarks are curently run daily and the updated results published on this page in order to provide visibility and to encourage contributors to look for possible regressions after their commits go in.
-* This page/data is maintained by the [benchmarking working group](https://github.com/nodejs/benchmarking/blob/master/README.md).
+* This page/data is maintained by the [benchmarking working group](https://github.com/nodejs/benchmarking).
 
 ### Daily Code Coverage Results
 

--- a/pages/en/blog/weekly-updates/weekly-update.2016-11-24.md
+++ b/pages/en/blog/weekly-updates/weekly-update.2016-11-24.md
@@ -16,7 +16,7 @@ layout: blog-post.hbs
 
 * Results for v7.x added to [https://benchmarking.nodejs.org/](https://benchmarking.nodejs.org/)
 * Benchmarks are curently run daily and the updated results published on this page in order to provide visibility and to encourage contributors to look for possible regressions after their commits go in.
-* This page/data is maintained by the [benchmarking working group](https://github.com/nodejs/benchmarking/blob/master/README.md).
+* This page/data is maintained by the [benchmarking working group](https://github.com/nodejs/benchmarking).
 
 ### Daily Code Coverage Results
 

--- a/pages/en/download/package-manager.md
+++ b/pages/en/download/package-manager.md
@@ -100,7 +100,7 @@ These resources provide packages compatible with CentOS, Fedora, and RHEL.
 
 ## Debian and Ubuntu based Linux distributions
 
-[Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are available from NodeSource.
+[Node.js binary distributions](https://github.com/nodesource/distributions) are available from NodeSource.
 
 ### Alternatives
 

--- a/pages/es/download/package-manager.md
+++ b/pages/es/download/package-manager.md
@@ -50,7 +50,7 @@ pacman -S nodejs npm
 
 ## Distribuciones Linux basadas en Debian y Ubuntu, paquetes Enterprise Linux / Fedora y Snap
 
-[Las distribuciones de binarios oficiales de Node.js](https://github.com/nodesource/distributions/blob/master/README.md) son proporcinados por NodeSource.
+[Las distribuciones de binarios oficiales de Node.js](https://github.com/nodesource/distributions) son proporcinados por NodeSource.
 
 ## FreeBSD
 

--- a/pages/fr/download/package-manager.md
+++ b/pages/fr/download/package-manager.md
@@ -50,7 +50,7 @@ pacman -S nodejs npm
 
 ## Les distributions Linux basées sur Debian et Ubuntu, Enterprise Linux/Fedora et les paquets Snap
 
-[Les distributions binaires Node.js] (https://github.com/nodesource/distributions/blob/master/README.md) sont disponibles sur NodeSource.
+[Les distributions binaires Node.js] (https://github.com/nodesource/distributions) sont disponibles sur NodeSource.
 
 ## FreeBSD
 

--- a/pages/ja/download/package-manager.md
+++ b/pages/ja/download/package-manager.md
@@ -49,8 +49,8 @@ pacman -S nodejs npm
 
 ## <!--debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages-->Debian と Ubuntu ベースの Linux ディストリビューション、エンタープライズ Linux/Fedora と Snap パッケージ
 
-<!-- [Official Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are provided by NodeSource. -->
-[Node.js 公式のバイナリディストリビューション](https://github.com/nodesource/distributions/blob/master/README.md)が NodeSource によって提供されています。
+<!-- [Official Node.js binary distributions](https://github.com/nodesource/distributions) are provided by NodeSource. -->
+[Node.js 公式のバイナリディストリビューション](https://github.com/nodesource/distributions)が NodeSource によって提供されています。
 
 <!-- ## FreeBSD and OpenBSD -->
 ## FreeBSD と OpenBSD

--- a/pages/ko/download/package-manager.md
+++ b/pages/ko/download/package-manager.md
@@ -100,11 +100,11 @@ pacman -S nodejs npm
 <!--
 ## Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages
 
-[Official Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are provided by NodeSource.
+[Official Node.js binary distributions](https://github.com/nodesource/distributions) are provided by NodeSource.
 -->
 ## <!--debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages-->데비안과 우분투 기반 리눅스 배포판. 엔터프라이즈 리눅스/페도라와 Snap 패키지
 
-[공식 Node.js 바이너리 배포판](https://github.com/nodesource/distributions/blob/master/README.md)은 NodeSource가 제공합니다.
+[공식 Node.js 바이너리 배포판](https://github.com/nodesource/distributions)은 NodeSource가 제공합니다.
 
 <!--
 ## FreeBSD

--- a/pages/nl/download/package-manager.md
+++ b/pages/nl/download/package-manager.md
@@ -100,7 +100,7 @@ Deze bronnen bieden packages aan die compatibel zijn met CentOS, Fedora en RHEL.
 
 ## Debian en Ubuntu gebaseerde Linux-distributies
 
-[Node.js binary-distributies](https://github.com/nodesource/distributions/blob/master/README.md) zijn beschikbaar bij NodeSource.
+[Node.js binary-distributies](https://github.com/nodesource/distributions) zijn beschikbaar bij NodeSource.
 
 ### Alternatieven
 

--- a/pages/pt-br/download/package-manager.md
+++ b/pages/pt-br/download/package-manager.md
@@ -49,7 +49,7 @@ pacman -S nodejs npm
 
 ## Debian e distribuições Linux basedas em Ubuntu, Enterprise Linux/Fedora e pacotes Snap
 
-[Distribuição dos binários oficiais do Node.js](https://github.com/nodesource/distributions/blob/master/README.md) são fornecidos pelo NodeSource.
+[Distribuição dos binários oficiais do Node.js](https://github.com/nodesource/distributions) são fornecidos pelo NodeSource.
 
 ## FreeBSD
 

--- a/pages/ro/download/package-manager.md
+++ b/pages/ro/download/package-manager.md
@@ -50,7 +50,7 @@ pacman -S nodejs npm
 
 ## Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages
 
-[Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are available from NodeSource.
+[Node.js binary distributions](https://github.com/nodesource/distributions) are available from NodeSource.
 
 ## FreeBSD
 

--- a/pages/ru/download/package-manager.md
+++ b/pages/ru/download/package-manager.md
@@ -50,7 +50,7 @@ pacman -S nodejs npm
 
 ## Дистрибутивы Linux на основе Debian и Ubuntu, пакеты Enterprise Linux/Fedora и Snap
 
-[Официальный Node.js бинарный дистрибутив](https://github.com/nodesource/distributions/blob/master/README.md) предоставляемый NodeSource.
+[Официальный Node.js бинарный дистрибутив](https://github.com/nodesource/distributions) предоставляемый NodeSource.
 
 ## FreeBSD
 

--- a/pages/zh-cn/download/package-manager.md
+++ b/pages/zh-cn/download/package-manager.md
@@ -88,7 +88,7 @@ your real title.
 -->
 ## <!--debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages--> 基于 Linux 的 Debian 和 Ubuntu 发行版，Enterprise Linux/Fedora 和 Snap packages
 
-[Node.js 官方二进制发行版](https://github.com/nodesource/distributions/blob/master/README.md) 由 NodeSource 提供。
+[Node.js 官方二进制发行版](https://github.com/nodesource/distributions) 由 NodeSource 提供。
 
 ### 可替换项
 

--- a/pages/zh-tw/download/package-manager.md
+++ b/pages/zh-tw/download/package-manager.md
@@ -53,7 +53,7 @@ pacman -S nodejs npm
 
 ## <!--debian-and-ubuntu-based-linux-distributions-enterprise-linux-fedora-and-snap-packages-->Debian 及 Ubuntu 系列發行版，企業版 Linux/Fedora 和 Snap packages
 
-[官方 Node.js 二進位發行版](https://github.com/nodesource/distributions/blob/master/README.md) 透過 NodeSource 提供.
+[官方 Node.js 二進位發行版](https://github.com/nodesource/distributions) 透過 NodeSource 提供.
 
 ## FreeBSD
 


### PR DESCRIPTION
https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions

![图片](https://user-images.githubusercontent.com/24759802/224004401-27de3043-448d-400f-ae46-76ff65f4705e.png)

`https://github.com/nodesource/distributions/blob/master/README` doesn't exist. But the source md is correct (with .md suffix).