### PR TITLE
fix: scroll to top button on small viewports

### DIFF
--- a/styles/page-modules/_scrollToTop.scss
+++ b/styles/page-modules/_scrollToTop.scss
@@ -41,10 +41,4 @@ html {
       opacity: 1;
     }
   }
-
-  @media (max-width: 600px) {
-    span {
-      display: none;
-    }
-  }
 }


### PR DESCRIPTION
Resolves https://github.com/nodejs/nodejs.org/issues/5090

Looking at this CSS rule, perhaps the original intention was to hide the button on mobile. I don't think there's any harm to show it for now. This rule does not hide it completely in any event, so I think overall this PR is an improvement.