### PR TITLE
fix: broken ci badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [nodejs.org](https://nodejs.org/)
 
-[![CI Status](https://github.com/nodejs/nodejs.org/actions/workflows/ci.yml/badge.svg)](https://github.com/nodejs/nodejs.org/actions/workflows/ci.yml?query=branch%3Amain)
+[![CI Status](https://github.com/nodejs/nodejs.org/actions/workflows/github-pages.yml/badge.svg)](https://github.com/nodejs/nodejs.org/actions/workflows/github-pages.yml?query=branch%3Amain)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Crowdin](https://badges.crowdin.net/nodejs-website/localized.svg)](https://crowdin.com/project/nodejs-website)
 


### PR DESCRIPTION
there is no ci file named `ci.yml` inside the workflows folder, thus the badge wouldn't show. i replaced it with the `github-pages.yml` workflow

before:

![image](https://user-images.githubusercontent.com/68690233/224286058-2a445e0d-0a85-484a-97c5-407046398952.png)


after:
![image](https://user-images.githubusercontent.com/68690233/224286155-69635252-f86b-468a-a274-f58cebf8da95.png)

