### PR TITLE
fix(dark): classname cannot be applied to itself

### DIFF
--- a/styles/layout/_dark-theme.scss
+++ b/styles/layout/_dark-theme.scss
@@ -1,3 +1,8 @@
+body.dark {
+  background-color: $dark-black;
+  color: $white;
+}
+
 .dark {
   color-scheme: dark;
 
@@ -5,11 +10,6 @@
     background-image: url('/static/images/light-mode.svg');
   }
 
-  body {
-    background-color: $dark-black;
-  }
-
-  body,
   .blogpost-meta {
     color: $white;
   }


### PR DESCRIPTION
This PR fixes the bug that was introduced on #5079 because class names when applied to the own element cannot use the same connotation as before.

Explanation: If you apply a class name to "body", to apply styling when that classname is applied, you should use "body.classname" not ".classname body", the second approach only works for children elements.