### PR TITLE
fix: add page title to <title> tag if possible

### DIFF
--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -14,9 +14,15 @@ const HtmlHead = ({ frontMatter }: HeaderProps) => {
   const pageTitle = frontMatter.title || siteConfig.title;
   const canonicalLink = `https://nodejs.org${route}`;
 
+  // "{pageTitle} | {siteConfig.title}" if pageTitle is defined
+  const title =
+    // avoid "Node.js | Node.js" title
+    pageTitle && pageTitle !== siteConfig.title
+      ? `${pageTitle} | ${siteConfig.title}`
+      : siteConfig.title;
   return (
     <Head>
-      <title>{siteConfig.title}</title>
+      <title>{title}</title>
 
       <meta name="theme-color" content={siteConfig.accentColor}></meta>
 


### PR DESCRIPTION
This PR make `<title>` to "{pageTitle} | {siteConfig.title}" if pageTitle is defined.

```
Node.js
http://localhost:3000/en/

About | Node.js
http://localhost:3000/en/about/

Download | Node.js
http://localhost:3000/en/download/

Documentation | Node.js
http://localhost:3000/en/docs/

Get involved | Node.js
http://localhost:3000/en/get-involved/

Node.js
http://localhost:3000/en/blog/

Node v19.8.0 (Current) | Node.js
http://localhost:3000/en/blog/release/v19.8.0
```


fix #5141 