### PR TITLE
feat(title): add proper title to pages

### DIFF
--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -11,12 +11,15 @@ const HtmlHead = ({ frontMatter }: HeaderProps) => {
   const siteConfig = useSiteConfig();
   const { route, basePath } = useRouter();
 
-  const pageTitle = frontMatter.title || siteConfig.title;
   const canonicalLink = `https://nodejs.org${route}`;
+
+  const pageTitle = frontMatter.title
+    ? `${frontMatter.title} | ${siteConfig.title}`
+    : siteConfig.title;
 
   return (
     <Head>
-      <title>{siteConfig.title}</title>
+      <title>{pageTitle}</title>
 
       <meta name="theme-color" content={siteConfig.accentColor}></meta>
 

--- a/pages/en/blog/index.md
+++ b/pages/en/blog/index.md
@@ -1,4 +1,5 @@
 ---
 layout: blog-index.hbs
+title: News
 paginate: blog
 ---

--- a/scripts/next-data/generatePreBuildFiles.mjs
+++ b/scripts/next-data/generatePreBuildFiles.mjs
@@ -20,7 +20,7 @@ const publicFeedPath = join(__dirname, '../../public/en/feed');
 const createBlogYearFile = year =>
   writeFile(
     join(blogPath, `year-${year}.md`),
-    `---\nlayout: blog-index.hbs\npaginate: blog\n---\n`
+    `---\nlayout: blog-index.hbs\ntitle: News from ${year}\npaginate: blog\n---\n`
   );
 
 export const generateBlogYearPages = cachedBlogData =>


### PR DESCRIPTION
This PR adds the prior behaviour of showing the frontmatter title as the page title, as it has been done.

It also adds a title for the blog index, and the blog year indexes.

This PR overall fixes a regression.

Closes #5141