### PR TITLE
fix(release-blog-posts): follow commonmark spec and include new lines

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,13 @@
 import nextra from 'nextra';
 
+import remarkGfm from 'remark-gfm';
 import getNextData from './next.data.mjs';
 
 const withNextra = nextra({
   theme: 'theme.tsx',
   flexsearch: false,
   codeHighlight: false,
-  mdxOptions: { format: 'detect' },
+  mdxOptions: { format: 'detect', remarkPlugins: [remarkGfm] },
   transform: getNextData,
   transformPageOpts: pageOpts => {
     delete pageOpts.pageMap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intl": "^6.2.10",
+        "remark-gfm": "^3.0.1",
         "sass": "^1.59.2",
         "semver": "^7.3.8",
         "strftime": "^0.10.1",
@@ -962,9 +963,9 @@
       }
     },
     "node_modules/@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.0.tgz",
+      "integrity": "sha512-EcSqmgm/xJwH8CcJPy9AHNypp/j58CYga3nWdl93/wLxX6OH+rSD3aAj75NQazcZd1YKHJ/pjNZ9qmgVajggwQ==",
       "dependencies": {
         "@types/trusted-types": "*"
       }
@@ -1039,9 +1040,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.15.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.1.tgz",
-      "integrity": "sha512-U2TWca8AeHSmbpi314QBESRk7oPjSZjDsR+c+H4ECC1l+kFgpZf8Ydhv3SJpPy51VyZHHqxlb6mTTqYNNRVAIw==",
+      "version": "18.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1107,14 +1108,14 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
-      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
+      "integrity": "sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.1",
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1134,13 +1135,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
+      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1"
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1151,9 +1152,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1164,13 +1165,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1191,12 +1192,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1355,6 +1356,18 @@
       "dev": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes": {
@@ -1647,9 +1660,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
+      "version": "1.0.30001466",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz",
+      "integrity": "sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1998,26 +2011,16 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
-    },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "rrweb-cssom": "^0.6.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -2031,16 +2034,16 @@
       "dev": true
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^12.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/debug": {
@@ -2390,17 +2393,17 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -2408,8 +2411,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -2417,11 +2420,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -4121,9 +4125,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
-      "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -4675,11 +4679,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.1.0.tgz",
-      "integrity": "sha512-F753oJdEsnEHRPBLBqyuRkm0CpyrwBOtAh8I449gxfknQrKSvVYMY34aObe+tQ9HT7Hi47+Sn3MWjhSXQQpqWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.2.0.tgz",
+      "integrity": "sha512-WAQMvW1ZGLFz3nF8byWLiuBjAakUcMYq9rs2uCDmriVEDaQ69wTZt0q0DfBIVbZtSgC/WTRHxd0A/E10Uv1JaA==",
       "dependencies": {
-        "@types/dompurify": "^2.4.0",
+        "@types/dompurify": "^3.0.0",
         "dompurify": "^3.0.1",
         "jsdom": "^21.1.0"
       }
@@ -4711,17 +4715,16 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
-      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
+      "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
       "dependencies": {
         "abab": "^2.0.6",
-        "acorn": "^8.8.1",
+        "acorn": "^8.8.2",
         "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
@@ -4730,7 +4733,8 @@
         "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.2",
@@ -4738,8 +4742,8 @@
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -5045,9 +5049,9 @@
       }
     },
     "node_modules/mdast-comment-marker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-2.1.1.tgz",
-      "integrity": "sha512-ktFfySmbRfOPiWoLkRKqkkyYkDnBVX5b5FqXwnvV1TmgVOl49ETsYK4hPKqrlM15y7AtxNDKIKwJRkZa3TWkng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-2.1.2.tgz",
+      "integrity": "sha512-HED3ezseRVkBzZ0uK4q6RJMdufr/2p3VfVZstE3H1N9K8bwtspztWo6Xd7rEatuGNoCXaBna8oEqMwUn0Ve1bw==",
       "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -7968,9 +7972,9 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.2.10.tgz",
-      "integrity": "sha512-l2TpskkFR0OzQnq7ChiJ5ZX23USZSzpKOcaR9MYC4UOHE9bT4kQ5JXXolgkq3tiOlvseEOzUCerlzn886AX9Yg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.3.0.tgz",
+      "integrity": "sha512-3hNuLecjy2IwAYbkeI2CRi5RyFN/ucBvHBnmDdePaJt/sTGa1aw2s+0QaW/reL9uTKP/O84O23wO3qZxx3FonQ==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/icu-messageformat-parser": "2.3.0",
@@ -8117,9 +8121,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9431,6 +9435,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9502,9 +9511,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.2.tgz",
-      "integrity": "sha512-jJyO6SmbzkJexF8MUorHx5tAilcgabioYxT/BHbY4+OvoqmbHxsYlrjZ8Adhqcgl6Zqwie0TgMXLCAmPFxXOuw==",
+      "version": "1.59.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.3.tgz",
+      "integrity": "sha512-QCq98N3hX1jfTCoUAsF3eyGuXLsY7BCnCEg9qAact94Yc21npG2/mVOqoDvE0fCbWDqiM4WlcJQla0gWG2YlxQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -9812,9 +9821,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -9890,6 +9899,22 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.4.tgz",
       "integrity": "sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10155,9 +10180,9 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.4.0.tgz",
-      "integrity": "sha512-Qy66a+/30aylFhPmUArHhVsHOun1qrO93LGT15uzLuLjWS7hKDfpFm34mYo1ndR4MCo8W4bEZM1+AlJRJORaaw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.5.0.tgz",
+      "integrity": "sha512-/+rQ8FePOiwT5xblOHkujYzRYfSjmE6HYhLpqJShL+9wH6/HaAVj4mWpXlpEsM3ZgIpOblG9Y+/BycSJzWgjNw==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -10527,14 +10552,14 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/trim-lines": {
@@ -11112,15 +11137,15 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/which": {
@@ -11228,9 +11253,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^6.2.10",
+    "remark-gfm": "^3.0.1",
     "sass": "^1.59.2",
     "semver": "^7.3.8",
     "strftime": "^0.10.1",

--- a/pages/en/blog/release/v0.10.41.md
+++ b/pages/en/blog/release/v0.10.41.md
@@ -62,19 +62,19 @@ This is the first v0.10 release made with the new build infrastructure operated 
 * [[`517986c2f4`](https://github.com/nodejs/node/commit/517986c2f4)] - **win**: backport bringing back xp/2k3 support (Bert Belder) [nodejs/node-v0.x-archive#25569](https://github.com/nodejs/node-v0.x-archive/pull/25569)
 * [[`10f251e8dd`](https://github.com/nodejs/node/commit/10f251e8dd)] - **win**: backport set env before generating projects (Alexis Campailla) [nodejs/node-v0.x-archive#25569](https://github.com/nodejs/node-v0.x-archive/pull/25569)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.41/node-v0.10.41-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.41/x64/node-v0.10.41-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.41/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.41/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.41/node-v0.10.41.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.41/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.41/node-v0.10.41-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.41/x64/node-v0.10.41-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.41/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.41/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.41/node-v0.10.41.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.41/ \
 Documentation: https://nodejs.org/docs/v0.10.41/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.42.md
+++ b/pages/en/blog/release/v0.10.42.md
@@ -37,19 +37,19 @@ This is an important security release. For full details see https://nodejs.org/e
 * [df80e856c6] - src: add --security-revert command line flag (James M Snell)
 * [ff58dcdd74] - tools: backport tools/install.py for headers (Richard Lau) https://github.com/nodejs/node/pull/4149
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.42/node-v0.10.42-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.42/x64/node-v0.10.42-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.42/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.42/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.42/node-v0.10.42.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.42/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.42/node-v0.10.42-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.42/x64/node-v0.10.42-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.42/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.42/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.42/node-v0.10.42.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.42/ \
 Documentation: https://nodejs.org/docs/v0.10.42/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.43.md
+++ b/pages/en/blog/release/v0.10.43.md
@@ -33,19 +33,19 @@ Commits:
 * [[`563c359f5c`](https://github.com/nodejs/node/commit/563c359f5c)] - **domains**: fix handling of uncaught exceptions (Julien Gilli) [#3887](https://github.com/nodejs/node/pull/3887)
 * [[`e483f3fd26`](https://github.com/nodejs/node/commit/e483f3fd26)] - **test**: fix hanging http obstext test (Ben Noordhuis) [#5511](https://github.com/nodejs/node/pull/5511)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.43/x64/node-v0.10.43-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.43/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.43/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.43/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.43/x64/node-v0.10.43-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.43/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.43/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.43/node-v0.10.43.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.43/ \
 Documentation: https://nodejs.org/docs/v0.10.43/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.44.md
+++ b/pages/en/blog/release/v0.10.44.md
@@ -28,19 +28,19 @@ Commits:
 * [6bb86e727a] - test: change tls tests not to use LOW cipher (Shigeki Ohtsu) https://github.com/nodejs/node/pull/5712
 * [905bec29ad] - win,build: support Visual C++ Build Tools 2015 (João Reis) https://github.com/nodejs/node/pull/5627
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.44/node-v0.10.44-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.44/x64/node-v0.10.44-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.44/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.44/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.44/node-v0.10.44.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.44/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.44/node-v0.10.44-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.44/x64/node-v0.10.44-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.44/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.44/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.44/node-v0.10.44.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.44/ \
 Documentation: https://nodejs.org/docs/v0.10.44/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.45.md
+++ b/pages/en/blog/release/v0.10.45.md
@@ -30,19 +30,19 @@ Commits:
 * [[`61ccc27b54`](https://github.com/nodejs/node/commit/61ccc27b54)] - **deps**: upgrade openssl sources to 1.0.1t (Shigeki Ohtsu) [#6553](https://github.com/nodejs/node/pull/6553)
 * [[`aa02438274`](https://github.com/nodejs/node/commit/aa02438274)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [joyent/node#25654](https://github.com/joyent/node/
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.45/node-v0.10.45-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.45/x64/node-v0.10.45-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.45/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.45/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.45/node-v0.10.45.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.45/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.45/node-v0.10.45-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.45/x64/node-v0.10.45-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.45/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.45/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.45/node-v0.10.45.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.45/ \
 Documentation: https://nodejs.org/docs/v0.10.45/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.46.md
+++ b/pages/en/blog/release/v0.10.46.md
@@ -24,19 +24,19 @@ This is a security release. All Node.js users should consult the security releas
 * [3374f57973] - deps: update libuv to 0.10.37 (Saúl Ibarra Corretgé) https://github.com/nodejs/node/pull/7293
 * [fcb9145e29] - deps: backport 3a9bfec from v8 upstream (Myles Borins) https://github.com/nodejs/node-private/pull/43
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.46/node-v0.10.46-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.46/x64/node-v0.10.46-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.46/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.46/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.46/node-v0.10.46.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.46/node-v0.10.46.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.46/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.46/node-v0.10.46-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.46/x64/node-v0.10.46-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.46/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.46/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.46/node-v0.10.46.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.46/node-v0.10.46-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.46/node-v0.10.46.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.46/ \
 Documentation: https://nodejs.org/docs/v0.10.46/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.47.md
+++ b/pages/en/blog/release/v0.10.47.md
@@ -40,19 +40,19 @@ author: Rod Vagg
 * [88dcc7f5bb] - v8: fix -Wsign-compare warning in Zone::New() (Ben Noordhuis) https://github.com/nodejs/node-private/pull/62
 * [fd8ac56c75] - v8: fix build errors with g++ 6.1.1 (Ben Noordhuis) https://github.com/nodejs/node-private/pull/62
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.47/node-v0.10.47-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.47/x64/node-v0.10.47-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.47/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.47/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.47/node-v0.10.47.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.47/node-v0.10.47.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.47/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.47/node-v0.10.47-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.47/x64/node-v0.10.47-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.47/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.47/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.10.47/node-v0.10.47.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.47/node-v0.10.47-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.47/node-v0.10.47.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.47/ \
 Documentation: https://nodejs.org/docs/v0.10.47/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.10.48.md
+++ b/pages/en/blog/release/v0.10.48.md
@@ -24,19 +24,19 @@ This is a security release. All Node.js users should consult the security releas
 * [b798f598af] - tls: fix minor jslint failure (Rod Vagg) https://github.com/nodejs/node/pull/9107
 * [92b232ba01] - win,build: try multiple timeservers when signing (Rod Vagg) https://github.com/nodejs/node/pull/9155
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.10.48/node-v0.10.48-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.10.48/x64/node-v0.10.48-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.10.48/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.10.48/x64/node.exe<br>
-macOS Universal Installer: https://nodejs.org/dist/v0.10.48/node-v0.10.48.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x64.tar.gz<br>
-macOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.10.48/node-v0.10.48.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.10.48/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.10.48/node-v0.10.48-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.10.48/x64/node-v0.10.48-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.10.48/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.10.48/x64/node.exe \
+macOS Universal Installer: https://nodejs.org/dist/v0.10.48/node-v0.10.48.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x64.tar.gz \
+macOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.10.48/node-v0.10.48-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.10.48/node-v0.10.48.tar.gz \
+Other release files: https://nodejs.org/dist/v0.10.48/ \
 Documentation: https://nodejs.org/docs/v0.10.48/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v0.12.10.md
+++ b/pages/en/blog/release/v0.12.10.md
@@ -37,19 +37,19 @@ Commits:
 * [23bced1fb3] - src: add --security-revert command line flag (James M Snell)
 * [f41a3c73e7] - tools: backport tools/install.py for headers (Richard Lau) https://github.com/nodejs/node/pull/4149
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.10/node-v0.12.10-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.10/x64/node-v0.12.10-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.10/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.10/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.10/node-v0.12.10.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.10/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.10/node-v0.12.10-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.10/x64/node-v0.12.10-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.10/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.10/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.10/node-v0.12.10.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.10/ \
 Documentation: https://nodejs.org/docs/v0.12.10/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.11.md
+++ b/pages/en/blog/release/v0.12.11.md
@@ -38,19 +38,19 @@ Commits:
 * [[`be39f30447`](https://github.com/nodejs/node/commit/be39f30447)] - **test**: add test-domain-exit-dispose-again back (Julien Gilli) [#4278](https://github.com/nodejs/node/pull/4278)
 * [[`da66166b9a`](https://github.com/nodejs/node/commit/da66166b9a)] - **test**: fix test-domain-exit-dispose-again (Julien Gilli) [#3991](https://github.com/nodejs/node/pull/3991)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.11/node-v0.12.11-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.11/x64/node-v0.12.11-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.11/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.11/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.11/node-v0.12.11.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.11/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.11/node-v0.12.11-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.11/x64/node-v0.12.11-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.11/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.11/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.11/node-v0.12.11.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.11/ \
 Documentation: https://nodejs.org/docs/v0.12.11/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.12.md
+++ b/pages/en/blog/release/v0.12.12.md
@@ -18,19 +18,19 @@ Commits:
 
 * [[`dbfc9d9241`](https://github.com/nodejs/node/commit/dbfc9d9241)] - **crypto,tls**: remove SSLv2 support (Ben Noordhuis) [#5536](https://github.com/nodejs/node/pull/5536)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.12/node-v0.12.12-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.12/x64/node-v0.12.12-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.12/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.12/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.12/node-v0.12.12.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.12/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.12/node-v0.12.12-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.12/x64/node-v0.12.12-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.12/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.12/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.12/node-v0.12.12.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.12/ \
 Documentation: https://nodejs.org/docs/v0.12.12/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.13.md
+++ b/pages/en/blog/release/v0.12.13.md
@@ -32,19 +32,19 @@ Commits:
 * [154098a3dc] - test: bp fix for test-http-get-pipeline-problem.js (Michael Dawson) https://github.com/nodejs/node/pull/3013
 * [ff2bed6e86] - win,build: support Visual C++ Build Tools 2015 (João Reis) https://github.com/nodejs/node/pull/5627
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.13/node-v0.12.13-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.13/x64/node-v0.12.13-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.13/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.13/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.13/node-v0.12.13.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.13/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.13/node-v0.12.13-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.13/x64/node-v0.12.13-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.13/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.13/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.13/node-v0.12.13.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.13/ \
 Documentation: https://nodejs.org/docs/v0.12.13/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.14.md
+++ b/pages/en/blog/release/v0.12.14.md
@@ -28,19 +28,19 @@ author: Rod Vagg
 * [[`f5a961ab13`](https://github.com/nodejs/node/commit/f5a961ab13)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [joyent/node#25654](https://github.com/joyent/node/pull/25654)
 * [[`810fb211a7`](https://github.com/nodejs/node/commit/810fb211a7)] - **tools**: remove obsolete npm test-legacy command (Kat Marchán) [#5988](https://github.com/nodejs/node/pull/5988)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.14/node-v0.12.14-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.14/x64/node-v0.12.14-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.14/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.14/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.14/node-v0.12.14.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.14/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.14/node-v0.12.14-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.14/x64/node-v0.12.14-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.14/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.14/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.14/node-v0.12.14.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.14/ \
 Documentation: https://nodejs.org/docs/v0.12.14/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.15.md
+++ b/pages/en/blog/release/v0.12.15.md
@@ -29,19 +29,19 @@ This is a security release. All Node.js users should consult the security releas
 * [a113e02f16] - deps: backport 3a9bfec from v8 upstream (Ben Noordhuis)
 * [8138055c88] - test: fix test failure due to expired certificates (Ben Noordhuis) https://github.com/nodejs/node/pull/7195
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.15/node-v0.12.15-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.15/x64/node-v0.12.15-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.15/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.15/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.15/node-v0.12.15.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.15/node-v0.12.15.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.15/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.15/node-v0.12.15-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.15/x64/node-v0.12.15-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.15/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.15/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.15/node-v0.12.15.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.15/node-v0.12.15-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.15/node-v0.12.15.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.15/ \
 Documentation: https://nodejs.org/docs/v0.12.15/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.16.md
+++ b/pages/en/blog/release/v0.12.16.md
@@ -40,19 +40,19 @@ author: Rod Vagg
 * [9dbde2fc88] - lib: make tls.checkServerIdentity() more strict (Ben Noordhuis) https://github.com/nodejs/node-private/pull/61
 * [db80592071] - openssl: fix keypress requirement in apps on win32 (Shigeki Ohtsu) https://github.com/nodejs/node-v0.x-archive/pull/25654
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.16/node-v0.12.16-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.16/x64/node-v0.12.16-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.16/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.16/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.16/node-v0.12.16.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.16/node-v0.12.16.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.16/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.16/node-v0.12.16-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.16/x64/node-v0.12.16-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.16/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.16/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.16/node-v0.12.16.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.16/node-v0.12.16-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.16/node-v0.12.16.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.16/ \
 Documentation: https://nodejs.org/docs/v0.12.16/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.17.md
+++ b/pages/en/blog/release/v0.12.17.md
@@ -22,19 +22,19 @@ This is a security release. All Node.js users should consult the security releas
 
 * [c5b095ecf8] - deps: avoid single-byte buffer overwrite (Daniel Stenberg) https://github.com/nodejs/node/pull/8849
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.17/node-v0.12.17-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.17/x64/node-v0.12.17-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.17/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.17/x64/node.exe<br>
-macOS Universal Installer: https://nodejs.org/dist/v0.12.17/node-v0.12.17.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x64.tar.gz<br>
-macOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.17/node-v0.12.17.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.17/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.17/node-v0.12.17-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.17/x64/node-v0.12.17-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.17/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.17/x64/node.exe \
+macOS Universal Installer: https://nodejs.org/dist/v0.12.17/node-v0.12.17.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x64.tar.gz \
+macOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.17/node-v0.12.17-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.17/node-v0.12.17.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.17/ \
 Documentation: https://nodejs.org/docs/v0.12.17/api/
 
 Shasums (GPG signing hash: SHA256, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.18.md
+++ b/pages/en/blog/release/v0.12.18.md
@@ -29,18 +29,18 @@ author: Rod Vagg
 * [d8e27ec30a] - test: mark dgram-multicast-multi-process as flaky (Rod Vagg) https://github.com/nodejs/node/pull/9150
 * [c722335ead] - tls: fix minor jslint failure (Rod Vagg) https://github.com/nodejs/node/pull/9107
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.18/node-v0.12.18-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.18/x64/node-v0.12.18-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.18/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.18/x64/node.exe<br>
-macOS Universal Installer: https://nodejs.org/dist/v0.12.18/node-v0.12.18.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x64.tar.gz<br>
-macOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-sunos-x86.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.18/node-v0.12.18.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.18/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.18/node-v0.12.18-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.18/x64/node-v0.12.18-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.18/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.18/x64/node.exe \
+macOS Universal Installer: https://nodejs.org/dist/v0.12.18/node-v0.12.18.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x64.tar.gz \
+macOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.18/node-v0.12.18-sunos-x86.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.18/node-v0.12.18.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.18/ \
 Documentation: https://nodejs.org/docs/v0.12.18/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v0.12.8.md
+++ b/pages/en/blog/release/v0.12.8.md
@@ -92,19 +92,19 @@ This is the first v0.12 release made with the new build infrastructure operated 
 * [[`53b6a615a5`](https://github.com/nodejs/node/commit/53b6a615a5)] - Documentation update about Buffer initialization (Sarath) [nodejs/node-v0.x-archive#25591](https://github.com/nodejs/node-v0.x-archive/pull/25591)
 * [[`b8d47a7b6f`](https://github.com/nodejs/node/commit/b8d47a7b6f)] - fix (Fedor Indutny) [nodejs/node-v0.x-archive#25739](https://github.com/nodejs/node-v0.x-archive/pull/25739)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.8/x64/node-v0.12.8-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.8/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.8/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.8/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.8/x64/node-v0.12.8-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.8/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.8/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.8/node-v0.12.8.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.8/ \
 Documentation: https://nodejs.org/docs/v0.12.8/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v0.12.9.md
+++ b/pages/en/blog/release/v0.12.9.md
@@ -20,19 +20,19 @@ author: Rod Vagg
 * [[`8d24a14f2c`](https://github.com/nodejs/node/commit/8d24a14f2c)] - **deps**: upgrade to openssl 1.0.1q (Ben Noordhuis) [#4133](https://github.com/nodejs/node/pull/4133)
 * [[`dfc6f4a9af`](https://github.com/nodejs/node/commit/dfc6f4a9af)] - **http**: fix pipeline regression (Fedor Indutny)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v0.12.9/node-v0.12.9-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v0.12.9/x64/node-v0.12.9-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v0.12.9/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v0.12.9/x64/node.exe<br>
-Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.9/node-v0.12.9.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x64.tar.gz<br>
-Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x86.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz<br>
-Other release files: https://nodejs.org/dist/v0.12.9/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v0.12.9/node-v0.12.9-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v0.12.9/x64/node-v0.12.9-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v0.12.9/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v0.12.9/x64/node.exe \
+Mac OS X Universal Installer: https://nodejs.org/dist/v0.12.9/node-v0.12.9.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x64.tar.gz \
+Mac OS X 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x86.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz \
+Source Code: https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz \
+Other release files: https://nodejs.org/dist/v0.12.9/ \
 Documentation: https://nodejs.org/docs/v0.12.9/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v10.0.0.md
+++ b/pages/en/blog/release/v10.0.0.md
@@ -923,22 +923,22 @@ The following APIs have been deprecated in Node.js 10.0.0
 * [[`7bc5151d5e`](https://github.com/nodejs/node/commit/7bc5151d5e)] - **zlib**: fix windowBits validation to allow 0 for decompression mode (Anand Suresh) [#19686](https://github.com/nodejs/node/pull/19686)
 * [[`e765257283`](https://github.com/nodejs/node/commit/e765257283)] - **zlib,stream**: use “official” util.types typechecks (Anna Henningsen) [#19602](https://github.com/nodejs/node/pull/19602)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.0.0/node-v10.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.0.0/node-v10.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.0.0/node-v10.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.0.0/ \
 Documentation: https://nodejs.org/docs/v10.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.1.0.md
+++ b/pages/en/blog/release/v10.1.0.md
@@ -196,22 +196,22 @@ author: Myles Borins
 * [[`e854c953fd`](https://github.com/nodejs/node/commit/e854c953fd)] - **util**: improve spliceOne perf (Anatoli Papirovski) [#20453](https://github.com/nodejs/node/pull/20453)
 * [[`3962c734ae`](https://github.com/nodejs/node/commit/3962c734ae)] - **util**: fix isInsideNodeModules inside error (Anatoli Papirovski) [#20266](https://github.com/nodejs/node/pull/20266)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.1.0/node-v10.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.1.0/node-v10.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.1.0/node-v10.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.1.0/ \
 Documentation: https://nodejs.org/docs/v10.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.10.0.md
+++ b/pages/en/blog/release/v10.10.0.md
@@ -259,22 +259,22 @@ author: Michaël Zasso
 * [[`887c43ffa7`](https://github.com/nodejs/node/commit/887c43ffa7)] - **worker**: remove redundant function call to `setupPortReferencing` (Ouyang Yadong) [#22298](https://github.com/nodejs/node/pull/22298)
 * [[`8e542eaf5f`](https://github.com/nodejs/node/commit/8e542eaf5f)] - **zlib**: fix memory leak for invalid input (Anna Henningsen) [#22713](https://github.com/nodejs/node/pull/22713)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.10.0/node-v10.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.10.0/node-v10.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.10.0/node-v10.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.10.0/ \
 Documentation: https://nodejs.org/docs/v10.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.11.0.md
+++ b/pages/en/blog/release/v10.11.0.md
@@ -131,22 +131,22 @@ author: Michaël Zasso
 * [[`8cfa88aa5c`](https://github.com/nodejs/node/commit/8cfa88aa5c)] - **(SEMVER-MINOR)** **util**: add util.types.isBoxedPrimitive (Ruben Bridgewater) [#22620](https://github.com/nodejs/node/pull/22620)
 * [[`a96a8468d6`](https://github.com/nodejs/node/commit/a96a8468d6)] - **worker**: correct (de)initialization order (Anna Henningsen) [#22773](https://github.com/nodejs/node/pull/22773)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.11.0/node-v10.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.11.0/node-v10.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.11.0/node-v10.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.11.0/ \
 Documentation: https://nodejs.org/docs/v10.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.12.0.md
+++ b/pages/en/blog/release/v10.12.0.md
@@ -322,22 +322,22 @@ author: Michaël Zasso
 * [[`e749a28c55`](https://github.com/nodejs/node/commit/e749a28c55)] - **zlib**: use common owner symbol to access JS wrapper (Anna Henningsen) [#23189](https://github.com/nodejs/node/pull/23189)
 * [[`a6b55c73b0`](https://github.com/nodejs/node/commit/a6b55c73b0)] - **zlib**: move, rename, document internal params() cb (Anna Henningsen) [#23187](https://github.com/nodejs/node/pull/23187)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.12.0/node-v10.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.12.0/node-v10.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.12.0/node-v10.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.12.0/ \
 Documentation: https://nodejs.org/docs/v10.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.13.0.md
+++ b/pages/en/blog/release/v10.13.0.md
@@ -24,22 +24,22 @@ This release only includes minimal changes necessary to fix known regressions pr
 * [[`2cd68be69d`](https://github.com/nodejs/node/commit/2cd68be69d)] - **build**: spawn `make test-ci` with `-j1` (Refael Ackermann) [#23733](https://github.com/nodejs/node/pull/23733)
 * [[`1003f4c975`](https://github.com/nodejs/node/commit/1003f4c975)] - **deps**: fix wrong default for v8 handle zapping (Refael Ackermann) [#23801](https://github.com/nodejs/node/pull/23801)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.13.0/node-v10.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.13.0/node-v10.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.13.0/node-v10.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.13.0/ \
 Documentation: https://nodejs.org/docs/v10.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.14.0.md
+++ b/pages/en/blog/release/v10.14.0.md
@@ -36,22 +36,22 @@ Fixes for the following CVEs are included in this release:
 * [[`eb43bc04b1`](https://github.com/nodejs/node/commit/eb43bc04b1)] - **(SEMVER-MINOR)** **http,https**: protect against slow headers attack (Matteo Collina) [nodejs-private/node-private#150](https://github.com/nodejs-private/node-private/pull/150)
 * [[`8b1405ee01`](https://github.com/nodejs/node/commit/8b1405ee01)] - **url**: avoid hostname spoofing w/ javascript protocol (Matteo Collina) [nodejs-private/node-private#145](https://github.com/nodejs-private/node-private/pull/145)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.14.0/node-v10.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.14.0/node-v10.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.14.0/node-v10.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.14.0/ \
 Documentation: https://nodejs.org/docs/v10.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.14.1.md
+++ b/pages/en/blog/release/v10.14.1.md
@@ -18,22 +18,22 @@ author: Myles Borins
 * [[`589f0d2192`](https://github.com/nodejs/node/commit/589f0d2192)] - **win**: clarify Boxstarter behavior on install tools (Rob Reynolds) [#23987](https://github.com/nodejs/node/pull/23987)
 * [[`9e293c1328`](https://github.com/nodejs/node/commit/9e293c1328)] - ***Revert*** "**win,msi**: install tools for native modules" (Refael Ackermann) [#24344](https://github.com/nodejs/node/pull/24344)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.14.1/node-v10.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.14.1/node-v10.14.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.14.1/node-v10.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.14.1/ \
 Documentation: https://nodejs.org/docs/v10.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.14.2.md
+++ b/pages/en/blog/release/v10.14.2.md
@@ -395,22 +395,22 @@ author: Myles Borins
 * [[`bae674ee5d`](https://github.com/nodejs/node/commit/bae674ee5d)] - **zlib**: refactor zlib internals (Anna Henningsen) [#23360](https://github.com/nodejs/node/pull/23360)
 * [[`0763d256dc`](https://github.com/nodejs/node/commit/0763d256dc)] - **zlib**: generate error code names in C++ (Anna Henningsen) [#23413](https://github.com/nodejs/node/pull/23413)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.14.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.14.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.14.2/node-v10.14.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.14.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.14.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.14.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.14.2/node-v10.14.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.14.2/node-v10.14.2.tar.gz \
+Other release files: https://nodejs.org/dist/v10.14.2/ \
 Documentation: https://nodejs.org/docs/v10.14.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.15.0.md
+++ b/pages/en/blog/release/v10.15.0.md
@@ -31,22 +31,22 @@ a missing CLI flag to adjust the max header size of the http parser.
 * [[`728bc631e5`](https://github.com/nodejs/node/commit/728bc631e5)] - **test**: fix expectation in test-bootstrap-modules (Ali Ijaz Sheikh) [#25112](https://github.com/nodejs/node/pull/25112)
 * [[`3e14212f0e`](https://github.com/nodejs/node/commit/3e14212f0e)] - **test**: remove magic numbers in test-gc-http-client-onerror (Rich Trott) [#24943](https://github.com/nodejs/node/pull/24943)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.15.0/node-v10.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.15.0/node-v10.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.15.0/node-v10.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.15.0/ \
 Documentation: https://nodejs.org/docs/v10.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.15.1.md
+++ b/pages/en/blog/release/v10.15.1.md
@@ -240,22 +240,22 @@ author: Shelley Vohr
 * [[`7576a518b8`](https://github.com/nodejs/node/commit/7576a518b8)] - **util**: deleted unreachable code from util.inspect (kiyomizumia) [#24187](https://github.com/nodejs/node/pull/24187)
 * [[`c6a43fa2ef`](https://github.com/nodejs/node/commit/c6a43fa2ef)] - **zlib**: do not leak on destroy (Mathias Buus) [#23734](https://github.com/nodejs/node/pull/23734)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.15.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.15.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.15.1/node-v10.15.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.15.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.15.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.15.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.15.1/node-v10.15.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.15.1/node-v10.15.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.15.1/ \
 Documentation: https://nodejs.org/docs/v10.15.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.15.2.md
+++ b/pages/en/blog/release/v10.15.2.md
@@ -22,22 +22,22 @@ A fix for the following CVE is included in this release:
 
 * [[`1a7302bd48`](https://github.com/nodejs/node/commit/1a7302bd48)] - **http**: prevent slowloris with keepalive connections (Matteo Collina) [nodejs-private/node-private#158](https://github.com/nodejs-private/node-private/pull/158)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.15.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.15.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.15.2/node-v10.15.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.15.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.15.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.15.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.15.2/node-v10.15.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.15.2/node-v10.15.2.tar.gz \
+Other release files: https://nodejs.org/dist/v10.15.2/ \
 Documentation: https://nodejs.org/docs/v10.15.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.15.3.md
+++ b/pages/en/blog/release/v10.15.3.md
@@ -229,22 +229,22 @@ author: Bethany Nicolle Griggs
 * [[`595bdc7603`](https://github.com/nodejs/node/commit/595bdc7603)] - **win, build**: skip building cctest by default (Bartosz Sosnowski) [#21408](https://github.com/nodejs/node/pull/21408)
 * [[`483ff7bcc7`](https://github.com/nodejs/node/commit/483ff7bcc7)] - **worker**: drain messages from internal message port (Yael Hermon) [#24932](https://github.com/nodejs/node/pull/24932)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.15.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.15.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.15.3/node-v10.15.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.15.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.15.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.15.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.15.3/node-v10.15.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.15.3/node-v10.15.3.tar.gz \
+Other release files: https://nodejs.org/dist/v10.15.3/ \
 Documentation: https://nodejs.org/docs/v10.15.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.16.0.md
+++ b/pages/en/blog/release/v10.16.0.md
@@ -375,22 +375,22 @@ author: Bethany Nicolle Griggs
 * [[`53e9c8508c`](https://github.com/nodejs/node/commit/53e9c8508c)] - **(SEMVER-MINOR)** **zlib**: add brotli support (Anna Henningsen) [#24938](https://github.com/nodejs/node/pull/24938)
 * [[`dd8d1dabd7`](https://github.com/nodejs/node/commit/dd8d1dabd7)] - **zlib**: split JS code as prep for non-zlib-backed streams (Anna Henningsen) [#24939](https://github.com/nodejs/node/pull/24939)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.16.0/node-v10.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.16.0/node-v10.16.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.16.0/node-v10.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.16.0/ \
 Documentation: https://nodejs.org/docs/v10.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.16.1.md
+++ b/pages/en/blog/release/v10.16.1.md
@@ -49,22 +49,22 @@ author: Bethany Nicolle Griggs
 * [[`4a607fab49`](https://github.com/nodejs/node/commit/4a607fab49)] - **tools**: replace rollup with ncc (Rich Trott) [#24813](https://github.com/nodejs/node/pull/24813)
 * [[`14090b59fc`](https://github.com/nodejs/node/commit/14090b59fc)] - **worker**: fix nullptr deref after MessagePort deser failure (Anna Henningsen) [#25076](https://github.com/nodejs/node/pull/25076)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.16.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.16.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.16.1/node-v10.16.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.16.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.16.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.16.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.16.1/node-v10.16.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.16.1/node-v10.16.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.16.1/ \
 Documentation: https://nodejs.org/docs/v10.16.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.16.2.md
+++ b/pages/en/blog/release/v10.16.2.md
@@ -16,22 +16,22 @@ This release patches a [regression](https://github.com/nodejs/node/issues/28932)
 
 * [[`894a9dd230`](https://github.com/nodejs/node/commit/894a9dd230)] - **deps**: cherry-pick c19c5a6 from openssl upstream (Ali Ijaz Sheikh) [#28983](https://github.com/nodejs/node/pull/28983)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.16.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.16.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.16.2/node-v10.16.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.16.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.16.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.16.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.16.2/node-v10.16.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.16.2/node-v10.16.2.tar.gz \
+Other release files: https://nodejs.org/dist/v10.16.2/ \
 Documentation: https://nodejs.org/docs/v10.16.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.16.3.md
+++ b/pages/en/blog/release/v10.16.3.md
@@ -49,22 +49,22 @@ Vulnerabilities fixed:
 * [[`a0a14c809f`](https://github.com/nodejs/node/commit/a0a14c809f)] - **src**: pass along errors from http2 object creation (Anna Henningsen) [#25822](https://github.com/nodejs/node/pull/25822)
 * [[`d85e4006ab`](https://github.com/nodejs/node/commit/d85e4006ab)] - **test**: apply test-http2-max-session-memory-leak from v12.x (Anna Henningsen) [#29122](https://github.com/nodejs/node/pull/29122)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.16.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.16.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.16.3/node-v10.16.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.16.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.16.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.16.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.16.3/node-v10.16.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.16.3/node-v10.16.3.tar.gz \
+Other release files: https://nodejs.org/dist/v10.16.3/ \
 Documentation: https://nodejs.org/docs/v10.16.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.17.0.md
+++ b/pages/en/blog/release/v10.17.0.md
@@ -77,22 +77,22 @@ author: Bethany Nicolle Griggs
 * [[`2eae030a4b`](https://github.com/nodejs/node/commit/2eae030a4b)] - **(SEMVER-MINOR)** **worker**: add missing return value in case of fatal exceptions (Ruben Bridgewater) [#29036](https://github.com/nodejs/node/pull/29036)
 * [[`e8c90bf4d1`](https://github.com/nodejs/node/commit/e8c90bf4d1)] - **zlib**: do not coalesce multiple `.flush()` calls (Anna Henningsen) [#28520](https://github.com/nodejs/node/pull/28520)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.17.0/node-v10.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.17.0/node-v10.17.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.17.0/node-v10.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.17.0/ \
 Documentation: https://nodejs.org/docs/v10.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.18.0.md
+++ b/pages/en/blog/release/v10.18.0.md
@@ -17,22 +17,22 @@ author: Myles Borins
 * [[`54a466a865`](https://github.com/nodejs/node/commit/54a466a865)] - **build,win**: add test-ci-native and test-ci-js (João Reis) [#30724](https://github.com/nodejs/node/pull/30724)
 * [[`f9b31edb25`](https://github.com/nodejs/node/commit/f9b31edb25)] - **deps**: update npm to 6.13.4 (Isaac Z. Schlueter) [#30904](https://github.com/nodejs/node/pull/30904)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.18.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.18.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.18.0/node-v10.18.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.18.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.18.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.18.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.18.0/node-v10.18.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.18.0/node-v10.18.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.18.0/ \
 Documentation: https://nodejs.org/docs/v10.18.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.18.1.md
+++ b/pages/en/blog/release/v10.18.1.md
@@ -32,22 +32,22 @@ author: Bethany Nicolle Griggs
 * [[`4ae8d204cb`](https://github.com/nodejs/node/commit/4ae8d204cb)] - **tools**: move python code out of jenkins shell (Sam Roberts) [#28458](https://github.com/nodejs/node/pull/28458)
 * [[`4879b80d87`](https://github.com/nodejs/node/commit/4879b80d87)] - **tools**: fix v8 testing with devtoolset on ppcle (Sam Roberts) [#28458](https://github.com/nodejs/node/pull/28458)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.18.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.18.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.18.1/node-v10.18.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.18.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.18.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.18.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.18.1/node-v10.18.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.18.1/node-v10.18.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.18.1/ \
 Documentation: https://nodejs.org/docs/v10.18.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.19.0.md
+++ b/pages/en/blog/release/v10.19.0.md
@@ -34,22 +34,22 @@ http option. Using the insecure HTTP parser should be avoided.
 * [[`e2c8f89b75`](https://github.com/nodejs/node/commit/e2c8f89b75)] - **test**: using TE to smuggle reqs is not possible (Sam Roberts) [nodejs-private/node-private#192](https://github.com/nodejs-private/node-private/pull/192)
 * [[`d616722f65`](https://github.com/nodejs/node/commit/d616722f65)] - **test**: check that --insecure-http-parser works (Sam Roberts) [#31253](https://github.com/nodejs/node/pull/31253)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.19.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.19.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.19.0/node-v10.19.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.19.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.19.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.19.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.19.0/node-v10.19.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.19.0/node-v10.19.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.19.0/ \
 Documentation: https://nodejs.org/docs/v10.19.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.2.0.md
+++ b/pages/en/blog/release/v10.2.0.md
@@ -239,22 +239,22 @@ author: Myles Borins
 * [[`740bf783e5`](https://github.com/nodejs/node/commit/740bf783e5)] - **vm,trace_events**: add node.vm.script trace events category (James M Snell) [#20728](https://github.com/nodejs/node/pull/20728)
 * [[`d5db576d15`](https://github.com/nodejs/node/commit/d5db576d15)] - **zlib**: reduce number of static internal methods (Anna Henningsen) [#20674](https://github.com/nodejs/node/pull/20674)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.2.0/node-v10.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.2.0/node-v10.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.2.0/node-v10.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.2.0/ \
 Documentation: https://nodejs.org/docs/v10.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.2.1.md
+++ b/pages/en/blog/release/v10.2.1.md
@@ -18,22 +18,22 @@ This is a follow up release to fix two regressions that were introduced in v10.2
 * [[`0b1ba20fc0`](https://github.com/nodejs/node/commit/0b1ba20fc0)] - **src**: re-integrate headers into node.h (Anna Henningsen) [#20939](https://github.com/nodejs/node/pull/20939)
 * [[`52f21fbfbc`](https://github.com/nodejs/node/commit/52f21fbfbc)] - **test**: mark test-zlib.zlib-binding.deflate as flaky (Matheus Marchini) [#20935](https://github.com/nodejs/node/pull/20935)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.2.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.2.1/node-v10.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.2.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.2.1/node-v10.2.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.2.1/node-v10.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.2.1/ \
 Documentation: https://nodejs.org/docs/v10.2.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.20.0.md
+++ b/pages/en/blog/release/v10.20.0.md
@@ -95,22 +95,22 @@ As binaries are still being compiled to support a minimum of macOS 10.7
 * [[`4390674624`](https://github.com/nodejs/node/commit/4390674624)] - **url**: handle quasi-WHATWG URLs in urlToOptions() (Colin Ihrig) [#26226](https://github.com/nodejs/node/pull/26226)
 * [[`dc61e09feb`](https://github.com/nodejs/node/commit/dc61e09feb)] - **v8**: fix load elimination liveness checks (Ben Noordhuis) [#31613](https://github.com/nodejs/node/pull/31613)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.20.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.20.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.20.0/node-v10.20.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.20.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.20.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.20.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.20.0/node-v10.20.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.20.0/node-v10.20.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.20.0/ \
 Documentation: https://nodejs.org/docs/v10.20.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.20.1.md
+++ b/pages/en/blog/release/v10.20.1.md
@@ -19,22 +19,22 @@ add-ons or where compiling Node.js from source is involved.
 Node.js v10.20.1 is a clean release with the correct sources and is
 strongly recommended in place of v10.20.0.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.20.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.20.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.20.1/node-v10.20.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.20.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.20.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.20.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.20.1/node-v10.20.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.20.1/node-v10.20.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.20.1/ \
 Documentation: https://nodejs.org/docs/v10.20.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.21.0.md
+++ b/pages/en/blog/release/v10.21.0.md
@@ -26,22 +26,22 @@ Vulnerabilities fixed:
 * [[`881c244a4e`](https://github.com/nodejs/node/commit/881c244a4e)] - **(SEMVER-MINOR)** **http2**: implement support for max settings entries (James M Snell) [nodejs-private/node-private#204](https://github.com/nodejs-private/node-private/pull/204)
 * [[`cd9827f105`](https://github.com/nodejs/node/commit/cd9827f105)] - **napi**: fix memory corruption vulnerability (Tobias Nießen) [nodejs-private/node-private#203](https://github.com/nodejs-private/node-private/pull/203)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.21.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.21.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.21.0/node-v10.21.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.21.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.21.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.21.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.21.0/node-v10.21.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.21.0/node-v10.21.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.21.0/ \
 Documentation: https://nodejs.org/docs/v10.21.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.22.0.md
+++ b/pages/en/blog/release/v10.22.0.md
@@ -42,22 +42,22 @@ This release was prepared by Richard Lau ([@richardlau](https://github.com/richa
 * [[`543656928c`](https://github.com/nodejs/node/commit/543656928c)] - **test**: flaky test-stdout-close-catch on freebsd (Sam Roberts) [#32849](https://github.com/nodejs/node/pull/32849)
 * [[`74b00cca64`](https://github.com/nodejs/node/commit/74b00cca64)] - **tls**: allow empty subject even with altNames defined (Jason Macgowan) [#22906](https://github.com/nodejs/node/pull/22906)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.22.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.22.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.22.0/node-v10.22.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.22.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.22.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.22.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.22.0/node-v10.22.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.22.0/node-v10.22.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.22.0/ \
 Documentation: https://nodejs.org/docs/v10.22.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.22.1.md
+++ b/pages/en/blog/release/v10.22.1.md
@@ -20,22 +20,22 @@ Vulnerabilities fixed:
 
 * [[`57badcf93e`](https://github.com/nodejs/node/commit/57badcf93e)] - **deps**: libuv: cherry-pick 0e6e8620 (Colin Ihrig) [libuv/libuv#2966](https://github.com/libuv/libuv/pull/2966)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.22.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.22.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.22.1/node-v10.22.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.22.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.22.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.22.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.22.1/node-v10.22.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.22.1/node-v10.22.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.22.1/ \
 Documentation: https://nodejs.org/docs/v10.22.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.23.0.md
+++ b/pages/en/blog/release/v10.23.0.md
@@ -33,22 +33,22 @@ author: Richard Lau
 * [[`21b86d7f19`](https://github.com/nodejs/node/commit/21b86d7f19)] - **test,v8**: skip less and stabilize test-linux-perf.js (Refael Ackermann) [#27364](https://github.com/nodejs/node/pull/27364)
 * [[`ee11ab50a7`](https://github.com/nodejs/node/commit/ee11ab50a7)] - **tools**: add debug entitlements for macOS 10.15+ (Gabriele Greco) [#34378](https://github.com/nodejs/node/pull/34378)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.23.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.23.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.23.0/node-v10.23.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.23.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.23.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.23.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.23.0/node-v10.23.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.23.0/node-v10.23.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.23.0/ \
 Documentation: https://nodejs.org/docs/v10.23.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.23.1.md
+++ b/pages/en/blog/release/v10.23.1.md
@@ -47,22 +47,22 @@ https://www.openssl.org/news/secadv/20201208.txt
 * [[`7f178663eb`](https://github.com/nodejs/node/commit/7f178663eb)] - **src**: use unique\_ptr for WriteWrap (Daniel Bevenius) [nodejs-private/node-private#238](https://github.com/nodejs-private/node-private/pull/238)
 * [[`357e2857c8`](https://github.com/nodejs/node/commit/357e2857c8)] - **test**: add test-tls-use-after-free-regression (Daniel Bevenius) [nodejs-private/node-private#238](https://github.com/nodejs-private/node-private/pull/238)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.23.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.23.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.23.1/node-v10.23.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.23.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.23.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.23.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.23.1/node-v10.23.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.23.1/node-v10.23.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.23.1/ \
 Documentation: https://nodejs.org/docs/v10.23.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.23.2.md
+++ b/pages/en/blog/release/v10.23.2.md
@@ -25,22 +25,22 @@ Release keys have been synchronized with the main branch.
 * [[`ac49d415b0`](https://github.com/nodejs/node/commit/ac49d415b0)] - **doc**: add release key for Ruy Adorno (Ruy Adorno) [#34628](https://github.com/nodejs/node/pull/34628)
 * [[`b8426ae3ce`](https://github.com/nodejs/node/commit/b8426ae3ce)] - **doc**: add release key for Richard Lau (Richard Lau) [#34397](https://github.com/nodejs/node/pull/34397)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.23.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.23.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.23.2/node-v10.23.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.23.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.23.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.23.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.23.2/node-v10.23.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.23.2/node-v10.23.2.tar.gz \
+Other release files: https://nodejs.org/dist/v10.23.2/ \
 Documentation: https://nodejs.org/docs/v10.23.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.23.3.md
+++ b/pages/en/blog/release/v10.23.3.md
@@ -19,22 +19,22 @@ The update to npm 6.14.11 has been relanded so that npm correctly reports its ve
 * [[`7b7fb43b8a`](https://github.com/nodejs/node/commit/7b7fb43b8a)] - ***Revert*** "**deps**: upgrade npm to 6.14.11" (Richard Lau) [#37278](https://github.com/nodejs/node/pull/37278)
 * [[`1c6fbd6ffe`](https://github.com/nodejs/node/commit/1c6fbd6ffe)] - **test**: add test that verifies crypto stream pipeline (Evan Lucas) [#37009](https://github.com/nodejs/node/pull/37009)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.23.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.23.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.23.3/node-v10.23.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.23.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.23.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.23.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.23.3/node-v10.23.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.23.3/node-v10.23.3.tar.gz \
+Other release files: https://nodejs.org/dist/v10.23.3/ \
 Documentation: https://nodejs.org/docs/v10.23.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.24.0.md
+++ b/pages/en/blog/release/v10.24.0.md
@@ -26,22 +26,22 @@ Vulnerabilities fixed:
 * [[`3f2e9dc40c`](https://github.com/nodejs/node/commit/3f2e9dc40c)] - **(SEMVER-MINOR)** **http2**: add unknownProtocol timeout (Daniel Bevenius) [nodejs-private/node-private#246](https://github.com/nodejs-private/node-private/pull/246)
 * [[`d1cf6a9b0f`](https://github.com/nodejs/node/commit/d1cf6a9b0f)] - **src**: drop localhost6 as allowed host for inspector (Matteo Collina) [nodejs-private/node-private#244](https://github.com/nodejs-private/node-private/pull/244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.24.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.24.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.24.0/node-v10.24.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.24.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.24.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.24.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.24.0/node-v10.24.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.24.0/node-v10.24.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.24.0/ \
 Documentation: https://nodejs.org/docs/v10.24.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.24.1.md
+++ b/pages/en/blog/release/v10.24.1.md
@@ -31,22 +31,22 @@ Vulerabilties fixed:
 * [[`781cb6df5c`](https://github.com/nodejs/node/commit/781cb6df5c)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37940](https://github.com/nodejs/node/pull/37940)
 * [[`5db0a05a90`](https://github.com/nodejs/node/commit/5db0a05a90)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37940](https://github.com/nodejs/node/pull/37940)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.24.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.24.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.24.1/node-v10.24.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.24.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.24.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.24.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.24.1/node-v10.24.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.24.1/ \
 Documentation: https://nodejs.org/docs/v10.24.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.3.0.md
+++ b/pages/en/blog/release/v10.3.0.md
@@ -64,22 +64,22 @@ author: Myles Borins
 * [[`b62cbe106c`](https://github.com/nodejs/node/commit/b62cbe106c)] - **tools**: update tools/doc/package-lock.json (Rich Trott) [#20970](https://github.com/nodejs/node/pull/20970)
 * [[`46e7cec7a5`](https://github.com/nodejs/node/commit/46e7cec7a5)] - **tools**: fix sorting in doc/type-parser.js (Vse Mozhet Byt) [#20976](https://github.com/nodejs/node/pull/20976)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.3.0/node-v10.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.3.0/node-v10.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.3.0/node-v10.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.3.0/ \
 Documentation: https://nodejs.org/docs/v10.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.4.0.md
+++ b/pages/en/blog/release/v10.4.0.md
@@ -110,22 +110,22 @@ author: Myles Borins
 * [[`ec058193a8`](https://github.com/nodejs/node/commit/ec058193a8)] - **v8**: backport 9fb02b526f1cd3b859a530a01adb08bc0d089f4f (Gus Caplan) [#20575](https://github.com/nodejs/node/pull/20575)
 * [[`48aa4c32d0`](https://github.com/nodejs/node/commit/48aa4c32d0)] - **zlib**: removed extra util require (ErnestoSalazar) [#21069](https://github.com/nodejs/node/pull/21069)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.4.0/node-v10.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.4.0/node-v10.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.4.0/node-v10.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.4.0/ \
 Documentation: https://nodejs.org/docs/v10.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.4.1.md
+++ b/pages/en/blog/release/v10.4.1.md
@@ -35,22 +35,22 @@ author: Evan Lucas
 * [[`eea2bce58d`](https://github.com/nodejs/node/commit/eea2bce58d)] - **tls**: fix SSL write error handling (Anna Henningsen) [nodejs-private/node-private#127](https://github.com/nodejs-private/node-private/pull/127)
 * [[`1e49eadd68`](https://github.com/nodejs/node/commit/1e49eadd68)] - **tools,gyp**: fix regex for version matching (Rich Trott) [#21216](https://github.com/nodejs/node/pull/21216)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.4.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.4.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.4.1/node-v10.4.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.4.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.4.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.4.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.4.1/node-v10.4.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.4.1/node-v10.4.1.tar.gz \
+Other release files: https://nodejs.org/dist/v10.4.1/ \
 Documentation: https://nodejs.org/docs/v10.4.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.5.0.md
+++ b/pages/en/blog/release/v10.5.0.md
@@ -174,22 +174,22 @@ author: Michaël Zasso
 * [[`529d24e3e8`](https://github.com/nodejs/node/commit/529d24e3e8)] - ***Revert*** "**workers,trace_events**: set thread name for workers" (James M Snell) [#21363](https://github.com/nodejs/node/pull/21363)
 * [[`dfb5cf6963`](https://github.com/nodejs/node/commit/dfb5cf6963)] - **workers,trace_events**: set thread name for workers (James M Snell) [#21246](https://github.com/nodejs/node/pull/21246)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.5.0/node-v10.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.5.0/node-v10.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.5.0/node-v10.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.5.0/ \
 Documentation: https://nodejs.org/docs/v10.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.6.0.md
+++ b/pages/en/blog/release/v10.6.0.md
@@ -144,22 +144,22 @@ author: Michaël Zasso
 * [[`49706b44b7`](https://github.com/nodejs/node/commit/49706b44b7)] - **workers**: replace message types string by constants (Weijia Wang) [#21537](https://github.com/nodejs/node/pull/21537)
 * [[`fb2592ff12`](https://github.com/nodejs/node/commit/fb2592ff12)] - **workers,trace_events**: set thread name for workers (James M Snell) [#21246](https://github.com/nodejs/node/pull/21246)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.6.0/node-v10.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.6.0/node-v10.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.6.0/node-v10.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.6.0/ \
 Documentation: https://nodejs.org/docs/v10.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.7.0.md
+++ b/pages/en/blog/release/v10.7.0.md
@@ -149,22 +149,22 @@ author: Michaël Zasso
 * [[`dae7130929`](https://github.com/nodejs/node/commit/dae7130929)] - **zlib**: track memory allocated by zlib (Anna Henningsen) [#21608](https://github.com/nodejs/node/pull/21608)
 * [[`96dae83713`](https://github.com/nodejs/node/commit/96dae83713)] - **zlib**: fix memory leak for unused zlib instances (Anna Henningsen) [#21607](https://github.com/nodejs/node/pull/21607)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.7.0/node-v10.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.7.0/node-v10.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.7.0/node-v10.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.7.0/ \
 Documentation: https://nodejs.org/docs/v10.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.8.0.md
+++ b/pages/en/blog/release/v10.8.0.md
@@ -121,22 +121,22 @@ author: Michaël Zasso
 * [[`d7edee4954`](https://github.com/nodejs/node/commit/d7edee4954)] - **trace_events**: add more process metadata (James M Snell) [#21785](https://github.com/nodejs/node/pull/21785)
 * [[`9a88fe4d5e`](https://github.com/nodejs/node/commit/9a88fe4d5e)] - **vm**: rename vm.Module to vm.SourceTextModule (Gus Caplan) [#22007](https://github.com/nodejs/node/pull/22007)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.8.0/node-v10.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.8.0/node-v10.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.8.0/node-v10.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.8.0/ \
 Documentation: https://nodejs.org/docs/v10.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v10.9.0.md
+++ b/pages/en/blog/release/v10.9.0.md
@@ -187,22 +187,22 @@ author: Rod Vagg
 * [[`677d10cdd1`](https://github.com/nodejs/node/commit/677d10cdd1)] - **worker**: fix deadlock when calling terminate from exit handler (Anna Henningsen) [#22073](https://github.com/nodejs/node/pull/22073)
 * [[`4b0d2de5f4`](https://github.com/nodejs/node/commit/4b0d2de5f4)] - **zlib**: remove unused parameters (MaleDong) [#22115](https://github.com/nodejs/node/pull/22115)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v10.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v10.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v10.9.0/node-v10.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v10.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v10.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v10.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v10.9.0/node-v10.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v10.9.0/node-v10.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v10.9.0/ \
 Documentation: https://nodejs.org/docs/v10.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.0.0.md
+++ b/pages/en/blog/release/v11.0.0.md
@@ -516,22 +516,22 @@ focus primarily on improving internals, performance, and an update to V8 7.0.
 * [[`188ffcb960`](https://github.com/nodejs/node/commit/188ffcb960)] - **zlib**: refactor zlib internals (Anna Henningsen) [#23360](https://github.com/nodejs/node/pull/23360)
 * [[`e0828635c5`](https://github.com/nodejs/node/commit/e0828635c5)] - **zlib**: generate error code names in C++ (Anna Henningsen) [#23413](https://github.com/nodejs/node/pull/23413)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.0.0/node-v11.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.0.0/node-v11.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.0.0/node-v11.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.0.0/node-v11.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.0.0/ \
 Documentation: https://nodejs.org/docs/v11.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.1.0.md
+++ b/pages/en/blog/release/v11.1.0.md
@@ -103,22 +103,22 @@ author: Michaël Zasso
 * [[`c20eb4f2bd`](https://github.com/nodejs/node/commit/c20eb4f2bd)] - **(SEMVER-MINOR)** **tools, icu**: actually failover if there are multiple URLs (Steven R. Loomis) [#23715](https://github.com/nodejs/node/pull/23715)
 * [[`b07cb4810c`](https://github.com/nodejs/node/commit/b07cb4810c)] - **zlib**: do not leak on destroy (Mathias Buus) [#23734](https://github.com/nodejs/node/pull/23734)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.1.0/node-v11.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.1.0/node-v11.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.1.0/node-v11.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.1.0/node-v11.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.1.0/ \
 Documentation: https://nodejs.org/docs/v11.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.10.0.md
+++ b/pages/en/blog/release/v11.10.0.md
@@ -249,22 +249,22 @@ author: Michaël Zasso
 * [[`55c270253b`](https://github.com/nodejs/node/commit/55c270253b)] - **worker**: throw for duplicates in transfer list (Anna Henningsen) [#25815](https://github.com/nodejs/node/pull/25815)
 * [[`c959d60242`](https://github.com/nodejs/node/commit/c959d60242)] - **worker,etw**: only enable ETW on the main thread (Anna Henningsen) [#25907](https://github.com/nodejs/node/pull/25907)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.10.0/node-v11.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.10.0/node-v11.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.10.0/node-v11.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.10.0/ \
 Documentation: https://nodejs.org/docs/v11.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.10.1.md
+++ b/pages/en/blog/release/v11.10.1.md
@@ -22,22 +22,22 @@ A fix for the following CVE is included in this release:
 
 * [[`05534a24ca`](https://github.com/nodejs/node/commit/05534a24ca)] - **http**: prevent slowloris with keepalive connections (Matteo Collina) [nodejs-private/node-private#158](https://github.com/nodejs-private/node-private/pull/158)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.10.1/node-v11.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.10.1/node-v11.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.10.1/node-v11.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v11.10.1/ \
 Documentation: https://nodejs.org/docs/v11.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.11.0.md
+++ b/pages/en/blog/release/v11.11.0.md
@@ -232,22 +232,22 @@ author: Ruben Bridgewater
 * [[`77a944cdee`](https://github.com/nodejs/node/commit/77a944cdee)] - **worker**: use fake MessageEvent for port.onmessage (Anna Henningsen) [#26082](https://github.com/nodejs/node/pull/26082)
 * [[`851a691678`](https://github.com/nodejs/node/commit/851a691678)] - **zlib**: report premature ends earlier (Anna Henningsen) [#26363](https://github.com/nodejs/node/pull/26363)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.11.0/node-v11.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.11.0/node-v11.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.11.0/node-v11.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.11.0/ \
 Documentation: https://nodejs.org/docs/v11.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.12.0.md
+++ b/pages/en/blog/release/v11.12.0.md
@@ -180,22 +180,22 @@ author: Ruben Bridgewater
 * [[`62801b9320`](https://github.com/nodejs/node/commit/62801b9320)] - **worker**: release native Worker object earlier (Anna Henningsen) [#26542](https://github.com/nodejs/node/pull/26542)
 * [[`73370b4584`](https://github.com/nodejs/node/commit/73370b4584)] - **worker**: remove `ERR_CLOSED_MESSAGE_PORT` (Anna Henningsen) [#26487](https://github.com/nodejs/node/pull/26487)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.12.0/node-v11.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.12.0/node-v11.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.12.0/node-v11.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.12.0/ \
 Documentation: https://nodejs.org/docs/v11.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.13.0.md
+++ b/pages/en/blog/release/v11.13.0.md
@@ -194,22 +194,22 @@ author: Michaël Zasso
 * [[`4314dbfce9`](https://github.com/nodejs/node/commit/4314dbfce9)] - **worker**: create per-Environment message port after bootstrap (Joyee Cheung) [#26593](https://github.com/nodejs/node/pull/26593)
 * [[`3c6f12c965`](https://github.com/nodejs/node/commit/3c6f12c965)] - **(SEMVER-MINOR)** **worker**: implement worker.moveMessagePortToContext() (Anna Henningsen) [#26497](https://github.com/nodejs/node/pull/26497)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.13.0/node-v11.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.13.0/node-v11.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.13.0/node-v11.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.13.0/node-v11.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.13.0/ \
 Documentation: https://nodejs.org/docs/v11.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.14.0.md
+++ b/pages/en/blog/release/v11.14.0.md
@@ -155,22 +155,22 @@ author: Bethany Nicolle Griggs
 * [[`5d9f819a14`](https://github.com/nodejs/node/commit/5d9f819a14)] - **worker**: remove usage of require('util') in worker\_thread.js (toshi1127) [#26814](https://github.com/nodejs/node/pull/26814)
 * [[`44450efa6b`](https://github.com/nodejs/node/commit/44450efa6b)] - **worker**: remove usage of require('util') (toshi1127) [#26810](https://github.com/nodejs/node/pull/26810)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.14.0/node-v11.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.14.0/node-v11.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.14.0/node-v11.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.14.0/node-v11.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.14.0/ \
 Documentation: https://nodejs.org/docs/v11.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.15.0.md
+++ b/pages/en/blog/release/v11.15.0.md
@@ -37,22 +37,22 @@ author: Shelley Vohr
 * [[`8e14859459`](https://github.com/nodejs/node/commit/8e14859459)] - **(SEMVER-MINOR)** **tls**: revert change to invalid protocol error type (Sam Roberts) [#26951](https://github.com/nodejs/node/pull/26951)
 * [[`00688b6042`](https://github.com/nodejs/node/commit/00688b6042)] - **(SEMVER-MINOR)** **tls**: add code for ERR\_TLS\_INVALID\_PROTOCOL\_METHOD (Sam Roberts) [#24729](https://github.com/nodejs/node/pull/24729)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.15.0/node-v11.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.15.0/node-v11.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.15.0/node-v11.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.15.0/node-v11.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.15.0/ \
 Documentation: https://nodejs.org/docs/v11.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.2.0.md
+++ b/pages/en/blog/release/v11.2.0.md
@@ -278,22 +278,22 @@ author: Ruben Bridgewater
 * [[`57a2b957de`](https://github.com/nodejs/node/commit/57a2b957de)] - **win**: add prompt to tools installation script (João Reis) [#23987](https://github.com/nodejs/node/pull/23987)
 * [[`df1ca0fd82`](https://github.com/nodejs/node/commit/df1ca0fd82)] - **win**: clarify Boxstarter behavior on install tools (Rob Reynolds) [#23987](https://github.com/nodejs/node/pull/23987)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.2.0/node-v11.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.2.0/node-v11.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.2.0/node-v11.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.2.0/ \
 Documentation: https://nodejs.org/docs/v11.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.3.0.md
+++ b/pages/en/blog/release/v11.3.0.md
@@ -39,22 +39,22 @@ Fixes for the following CVEs are included in this release:
 * [[`315ee2e626`](https://github.com/nodejs/node/commit/315ee2e626)] - **(SEMVER-MINOR)** **http,https**: protect against slow headers attack (Matteo Collina) [nodejs-private/node-private#144](https://github.com/nodejs-private/node-private/pull/144)
 * [[`d7504324e1`](https://github.com/nodejs/node/commit/d7504324e1)] - **url**: avoid hostname spoofing w/ javascript protocol (Matteo Collina) [nodejs-private/node-private#145](https://github.com/nodejs-private/node-private/pull/145)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.3.0/node-v11.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.3.0/node-v11.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.3.0/node-v11.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.3.0/ \
 Documentation: https://nodejs.org/docs/v11.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.4.0.md
+++ b/pages/en/blog/release/v11.4.0.md
@@ -350,22 +350,22 @@ author: Ruben Bridgewater
 * [[`4d9a2650b2`](https://github.com/nodejs/node/commit/4d9a2650b2)] - **win**: do not use Boxstarter to install tools (João Reis) [#24677](https://github.com/nodejs/node/pull/24677)
 * [[`899e7c30b0`](https://github.com/nodejs/node/commit/899e7c30b0)] - **win, build**: skip building cctest by default (Bartosz Sosnowski) [#21408](https://github.com/nodejs/node/pull/21408)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.4.0/node-v11.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.4.0/node-v11.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.4.0/node-v11.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.4.0/node-v11.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.4.0/ \
 Documentation: https://nodejs.org/docs/v11.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.5.0.md
+++ b/pages/en/blog/release/v11.5.0.md
@@ -106,22 +106,22 @@ author: Bethany Nicolle Griggs
 * [[`117e99121c`](https://github.com/nodejs/node/commit/117e99121c)] - **(SEMVER-MINOR)** **util**: add inspection getter option (Ruben Bridgewater) [#24852](https://github.com/nodejs/node/pull/24852)
 * [[`331f6044b9`](https://github.com/nodejs/node/commit/331f6044b9)] - **worker**: drain messages from internal message port (Yael Hermon) [#24932](https://github.com/nodejs/node/pull/24932)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.5.0/node-v11.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.5.0/node-v11.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.5.0/node-v11.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.5.0/node-v11.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.5.0/ \
 Documentation: https://nodejs.org/docs/v11.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.6.0.md
+++ b/pages/en/blog/release/v11.6.0.md
@@ -83,22 +83,22 @@ author: Myles Borins
 * [[`74e08c0458`](https://github.com/nodejs/node/commit/74e08c0458)] - **vm**: simplify Script constructor options validation (cjihrig) [#25054](https://github.com/nodejs/node/pull/25054)
 * [[`4f28da883f`](https://github.com/nodejs/node/commit/4f28da883f)] - **worker**: fix nullptr deref after MessagePort deser failure (Anna Henningsen) [#25076](https://github.com/nodejs/node/pull/25076)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.6.0/node-v11.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.6.0/node-v11.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.6.0/node-v11.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.6.0/node-v11.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.6.0/ \
 Documentation: https://nodejs.org/docs/v11.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.7.0.md
+++ b/pages/en/blog/release/v11.7.0.md
@@ -274,22 +274,22 @@ author: Ruben Bridgewater
 * [[`7edf8c7e74`](https://github.com/nodejs/node/commit/7edf8c7e74)] - **(SEMVER-MINOR)** **zlib**: add brotli support (Anna Henningsen) [#24938](https://github.com/nodejs/node/pull/24938)
 * [[`e534dcd75e`](https://github.com/nodejs/node/commit/e534dcd75e)] - **zlib**: split JS code as prep for non-zlib-backed streams (Anna Henningsen) [#24939](https://github.com/nodejs/node/pull/24939)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.7.0/node-v11.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.7.0/node-v11.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.7.0/node-v11.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.7.0/node-v11.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.7.0/ \
 Documentation: https://nodejs.org/docs/v11.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.8.0.md
+++ b/pages/en/blog/release/v11.8.0.md
@@ -116,22 +116,22 @@ author: Myles Borins
 * [[`338f456107`](https://github.com/nodejs/node/commit/338f456107)] - **util**: fix iterable types with special prototype (Ruben Bridgewater) [#25457](https://github.com/nodejs/node/pull/25457)
 * [[`219b1b8ce1`](https://github.com/nodejs/node/commit/219b1b8ce1)] - **(SEMVER-MINOR)** **worker**: enable passing command line flags (Yael Hermon) [#25467](https://github.com/nodejs/node/pull/25467)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.8.0/node-v11.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.8.0/node-v11.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.8.0/node-v11.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.8.0/ \
 Documentation: https://nodejs.org/docs/v11.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v11.9.0.md
+++ b/pages/en/blog/release/v11.9.0.md
@@ -96,22 +96,22 @@ author: Michaël Zasso
 * [[`bc81fef988`](https://github.com/nodejs/node/commit/bc81fef988)] - **vm**: mark scripts as shareable cross-origin (Jeremy Apthorp) [#25380](https://github.com/nodejs/node/pull/25380)
 * [[`fb69b2bf14`](https://github.com/nodejs/node/commit/fb69b2bf14)] - **worker**: export workerData to ESM workers (Anna Henningsen) [#25768](https://github.com/nodejs/node/pull/25768)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v11.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v11.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v11.9.0/node-v11.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v11.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v11.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v11.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v11.9.0/node-v11.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v11.9.0/node-v11.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v11.9.0/ \
 Documentation: https://nodejs.org/docs/v11.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.0.0.md
+++ b/pages/en/blog/release/v12.0.0.md
@@ -550,21 +550,21 @@ author: Bethany Nicolle Griggs
 * [[`d070f5d965`](https://github.com/nodejs/node/commit/d070f5d965)] - **worker**: improve coverage (Ruben Bridgewater) [#27230](https://github.com/nodejs/node/pull/27230)
 * [[`5450e48f69`](https://github.com/nodejs/node/commit/5450e48f69)] - **worker**: simplify filename checks (Ruben Bridgewater) [#27233](https://github.com/nodejs/node/pull/27233)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.0.0/node-v12.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.0.0/node-v12.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.0.0/node-v12.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.0.0/ \
 Documentation: https://nodejs.org/docs/v12.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.1.0.md
+++ b/pages/en/blog/release/v12.1.0.md
@@ -67,21 +67,21 @@ author: Michaël Zasso
 * [[`8f3442809a`](https://github.com/nodejs/node/commit/8f3442809a)] - **util**: rename setIteratorBraces to getIteratorBraces (Ruben Bridgewater) [#27342](https://github.com/nodejs/node/pull/27342)
 * [[`973d705aa9`](https://github.com/nodejs/node/commit/973d705aa9)] - **util**: improve `Symbol.toStringTag` handling (Ruben Bridgewater) [#27342](https://github.com/nodejs/node/pull/27342)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.1.0/node-v12.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.1.0/node-v12.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.1.0/node-v12.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.1.0/ \
 Documentation: https://nodejs.org/docs/v12.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.10.0.md
+++ b/pages/en/blog/release/v12.10.0.md
@@ -104,21 +104,21 @@ author: Ruben Bridgewater
 * [[`eceebd3ef1`](https://github.com/nodejs/node/commit/eceebd3ef1)] - **tools**: fix Python 3 issues in gyp/generator/make.py (cclauss) [#29214](https://github.com/nodejs/node/pull/29214)
 * [[`5abbd51c60`](https://github.com/nodejs/node/commit/5abbd51c60)] - **util**: do not throw when inspecting detached ArrayBuffer (Anna Henningsen) [#29318](https://github.com/nodejs/node/pull/29318)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.10.0/node-v12.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.10.0/node-v12.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.10.0/node-v12.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.10.0/ \
 Documentation: https://nodejs.org/docs/v12.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.11.0.md
+++ b/pages/en/blog/release/v12.11.0.md
@@ -180,21 +180,21 @@ author: Ruben Bridgewater
 * [[`53f23715df`](https://github.com/nodejs/node/commit/53f23715df)] - **worker**: prevent event loop starvation through MessagePorts (Anna Henningsen) [#29315](https://github.com/nodejs/node/pull/29315)
 * [[`d2b0568890`](https://github.com/nodejs/node/commit/d2b0568890)] - **worker**: make transfer list behave like web MessagePort (Anna Henningsen) [#29319](https://github.com/nodejs/node/pull/29319)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.11.0/node-v12.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.11.0/node-v12.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.11.0/node-v12.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.11.0/ \
 Documentation: https://nodejs.org/docs/v12.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.11.1.md
+++ b/pages/en/blog/release/v12.11.1.md
@@ -51,21 +51,21 @@ author: Michaël Zasso
 * [[`ef033d046a`](https://github.com/nodejs/node/commit/ef033d046a)] - **worker**: fix process.\_fatalException return type (Ruben Bridgewater) [#29706](https://github.com/nodejs/node/pull/29706)
 * [[`04df7dbadb`](https://github.com/nodejs/node/commit/04df7dbadb)] - **worker**: keep allocators for transferred SAB instances alive longer (Anna Henningsen) [#29637](https://github.com/nodejs/node/pull/29637)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.11.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.11.1/node-v12.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.11.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.11.1/node-v12.11.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.11.1/node-v12.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.11.1/ \
 Documentation: https://nodejs.org/docs/v12.11.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.12.0.md
+++ b/pages/en/blog/release/v12.12.0.md
@@ -91,21 +91,21 @@ author: Ruben Bridgewater
 * [[`6d88f0fef7`](https://github.com/nodejs/node/commit/6d88f0fef7)] - **vm**: refactor SourceTextModule (Gus Caplan) [#29776](https://github.com/nodejs/node/pull/29776)
 * [[`a7113048e3`](https://github.com/nodejs/node/commit/a7113048e3)] - **worker**: do not use two-arg NewIsolate (Shelley Vohr) [#29850](https://github.com/nodejs/node/pull/29850)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.12.0/node-v12.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.12.0/node-v12.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.12.0/node-v12.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.12.0/ \
 Documentation: https://nodejs.org/docs/v12.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.13.0.md
+++ b/pages/en/blog/release/v12.13.0.md
@@ -38,21 +38,21 @@ supports Python 3 for building native modules.
 * [[`44c581ef0b`](https://github.com/nodejs/node/commit/44c581ef0b)] - **test**: add more recursive fs.rmdir() tests (Maria Paktiti) [#29815](https://github.com/nodejs/node/pull/29815)
 * [[`fc5334513c`](https://github.com/nodejs/node/commit/fc5334513c)] - **test**: remove unnecessary --expose-internals flags (Anna Henningsen) [#29886](https://github.com/nodejs/node/pull/29886)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.13.0/node-v12.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.13.0/node-v12.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.13.0/node-v12.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.13.0/ \
 Documentation: https://nodejs.org/docs/v12.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.13.1.md
+++ b/pages/en/blog/release/v12.13.1.md
@@ -118,21 +118,21 @@ author: Michaël Zasso
 * [[`59033f618a`](https://github.com/nodejs/node/commit/59033f618a)] - **tools**: fix GYP MSVS solution generator for Python 3 (Michaël Zasso) [#29897](https://github.com/nodejs/node/pull/29897)
 * [[`41430bea3c`](https://github.com/nodejs/node/commit/41430bea3c)] - **tools**: port Python 3 compat patches from node-gyp to gyp (Michaël Zasso) [#29897](https://github.com/nodejs/node/pull/29897)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.13.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.13.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.13.1/node-v12.13.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.13.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.13.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.13.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.13.1/node-v12.13.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.13.1/node-v12.13.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.13.1/ \
 Documentation: https://nodejs.org/docs/v12.13.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.14.0.md
+++ b/pages/en/blog/release/v12.14.0.md
@@ -17,21 +17,21 @@ author: Myles Borins
 * [[`f01959a616`](https://github.com/nodejs/node/commit/f01959a616)] - **build,win**: add test-ci-native and test-ci-js (João Reis) [#30724](https://github.com/nodejs/node/pull/30724)
 * [[`d586682b0b`](https://github.com/nodejs/node/commit/d586682b0b)] - **deps**: update npm to 6.13.4 (Ruy Adorno) [#30904](https://github.com/nodejs/node/pull/30904)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.14.0/node-v12.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.14.0/node-v12.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.14.0/node-v12.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.14.0/ \
 Documentation: https://nodejs.org/docs/v12.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.14.1.md
+++ b/pages/en/blog/release/v12.14.1.md
@@ -242,21 +242,21 @@ author: Bethany Nicolle Griggs
 * [[`3f24a87f41`](https://github.com/nodejs/node/commit/3f24a87f41)] - **v8**: mark serdes API as stable (Anna Henningsen) [#30234](https://github.com/nodejs/node/pull/30234)
 * [[`2994976ec7`](https://github.com/nodejs/node/commit/2994976ec7)] - **v8**: inspect unserializable objects (Anna Henningsen) [#30167](https://github.com/nodejs/node/pull/30167)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.14.1/node-v12.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.14.1/node-v12.14.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.14.1/node-v12.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.14.1/ \
 Documentation: https://nodejs.org/docs/v12.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.15.0.md
+++ b/pages/en/blog/release/v12.15.0.md
@@ -36,21 +36,21 @@ http option. Using the insecure HTTP parser should be avoided.
 * [[`9cd155eb4a`](https://github.com/nodejs/node/commit/9cd155eb4a)] - **test**: using TE to smuggle reqs is not possible (Sam Roberts) [nodejs-private/node-private#192](https://github.com/nodejs-private/node-private/pull/192)
 * [[`ab1fcb89cb`](https://github.com/nodejs/node/commit/ab1fcb89cb)] - **test**: check that --insecure-http-parser works (Sam Roberts) [#31253](https://github.com/nodejs/node/pull/31253)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.15.0/node-v12.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.15.0/node-v12.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.15.0/node-v12.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.15.0/ \
 Documentation: https://nodejs.org/docs/v12.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.16.0.md
+++ b/pages/en/blog/release/v12.16.0.md
@@ -706,21 +706,21 @@ Colin Ihrig [#30258](https://github.com/nodejs/node/pull/30258).
 * [[`a2fa0318be`](https://github.com/nodejs/node/commit/a2fa0318be)] - **zlib**: use for...of (Trivikram Kamat) [#31051](https://github.com/nodejs/node/pull/31051)
 * [[`7cad756e0c`](https://github.com/nodejs/node/commit/7cad756e0c)] - **zlib**: allow writes after readable 'end' to finish (Anna Henningsen) [#31082](https://github.com/nodejs/node/pull/31082)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.16.0/node-v12.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.16.0/node-v12.16.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.16.0/node-v12.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.16.0/ \
 Documentation: https://nodejs.org/docs/v12.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.16.1.md
+++ b/pages/en/blog/release/v12.16.1.md
@@ -68,21 +68,21 @@ hook exists. The fix to this bug has been included in this release.
 * [[`43d02e20e0`](https://github.com/nodejs/node/commit/43d02e20e0)] - **src**: keep main-thread Isolate attached to platform during Dispose (Anna Henningsen) [#31795](https://github.com/nodejs/node/pull/31795)
 * [[`7a5954ef26`](https://github.com/nodejs/node/commit/7a5954ef26)] - **src**: fix -Winconsistent-missing-override warning (Colin Ihrig) [#30549](https://github.com/nodejs/node/pull/30549)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.16.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.16.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.16.1/node-v12.16.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.16.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.16.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.16.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.16.1/node-v12.16.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.16.1/node-v12.16.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.16.1/ \
 Documentation: https://nodejs.org/docs/v12.16.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.16.2.md
+++ b/pages/en/blog/release/v12.16.2.md
@@ -412,21 +412,21 @@ The macOS binaries for this release, and future 12.x releases, are now being com
 * [[`0697f65f70`](https://github.com/nodejs/node/commit/0697f65f70)] - **worker**: reset `Isolate` stack limit after entering `Locker` (Anna Henningsen) [#31593](https://github.com/nodejs/node/pull/31593)
 * [[`5500521804`](https://github.com/nodejs/node/commit/5500521804)] - **worker**: remove redundant closing of child port (aaccttrr) [#31555](https://github.com/nodejs/node/pull/31555)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.16.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.16.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.16.2/node-v12.16.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.16.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.16.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.16.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.16.2/node-v12.16.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.16.2/node-v12.16.2.tar.gz \
+Other release files: https://nodejs.org/dist/v12.16.2/ \
 Documentation: https://nodejs.org/docs/v12.16.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.16.3.md
+++ b/pages/en/blog/release/v12.16.3.md
@@ -210,21 +210,21 @@ author: Michaël Zasso
 * [[`aeea7d9c1f`](https://github.com/nodejs/node/commit/aeea7d9c1f)] - **worker**: do not emit 'exit' events during process.exit() (Anna Henningsen) [#32546](https://github.com/nodejs/node/pull/32546)
 * [[`28cb7e78ff`](https://github.com/nodejs/node/commit/28cb7e78ff)] - **worker**: improve MessagePort performance (Anna Henningsen) [#31605](https://github.com/nodejs/node/pull/31605)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.16.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.16.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.16.3/node-v12.16.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.16.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.16.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.16.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.16.3/node-v12.16.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.16.3/node-v12.16.3.tar.gz \
+Other release files: https://nodejs.org/dist/v12.16.3/ \
 Documentation: https://nodejs.org/docs/v12.16.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.17.0.md
+++ b/pages/en/blog/release/v12.17.0.md
@@ -650,21 +650,21 @@ Contributed by Tim Costa - [#30071](https://github.com/nodejs/node/pull/30071).
 * [[`576a62688f`](https://github.com/nodejs/node/commit/576a62688f)] - **tools**: decrease timeout in test.py (Anna Henningsen) [#32868](https://github.com/nodejs/node/pull/32868)
 * [[`9cf9cb436b`](https://github.com/nodejs/node/commit/9cf9cb436b)] - **tools**: remove prefer-common-expectserror lint rule (Colin Ihrig) [#31147](https://github.com/nodejs/node/pull/31147)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.17.0/node-v12.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.17.0/node-v12.17.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.17.0/node-v12.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.17.0/ \
 Documentation: https://nodejs.org/docs/v12.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.18.0.md
+++ b/pages/en/blog/release/v12.18.0.md
@@ -26,21 +26,21 @@ Vulnerabilities fixed:
 * [[`0932309af2`](https://github.com/nodejs/node/commit/0932309af2)] - **tls**: emit `session` after verifying certificate (Fedor Indutny) [nodejs-private/node-private#200](https://github.com/nodejs-private/node-private/pull/200)
 * [[`c392d3923f`](https://github.com/nodejs/node/commit/c392d3923f)] - **tools**: update certdata.txt (AshCripps) [#33682](https://github.com/nodejs/node/pull/33682)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.18.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.18.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.18.0/node-v12.18.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.18.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.18.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.18.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.18.0/node-v12.18.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.18.0/node-v12.18.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.18.0/ \
 Documentation: https://nodejs.org/docs/v12.18.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.18.1.md
+++ b/pages/en/blog/release/v12.18.1.md
@@ -106,21 +106,21 @@ author: Shelley Vohr
 * [[`8a926982e5`](https://github.com/nodejs/node/commit/8a926982e5)] - **worker**: call CancelTerminateExecution() before exiting Locker (Anna Henningsen) [#33347](https://github.com/nodejs/node/pull/33347)
 * [[`631e433cf5`](https://github.com/nodejs/node/commit/631e433cf5)] - **zlib**: reject windowBits=8 when mode=GZIP (Ben Noordhuis) [#33045](https://github.com/nodejs/node/pull/33045)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.18.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.18.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.18.1/node-v12.18.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.18.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.18.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.18.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.18.1/node-v12.18.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.18.1/node-v12.18.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.18.1/ \
 Documentation: https://nodejs.org/docs/v12.18.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.18.2.md
+++ b/pages/en/blog/release/v12.18.2.md
@@ -20,21 +20,21 @@ author: Bethany Nicolle Griggs
 * [[`97a3f7b702`](https://github.com/nodejs/node/commit/97a3f7b702)] - **deps**: V8: backport fb26d0bb1835 (Matheus Marchini) [#33573](https://github.com/nodejs/node/pull/33573)
 * [[`30b0339061`](https://github.com/nodejs/node/commit/30b0339061)] - **src**: use symbol to store `AsyncWrap` resource (Anna Henningsen) [#31745](https://github.com/nodejs/node/pull/31745)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.18.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.18.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.18.2/node-v12.18.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.18.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.18.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.18.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.18.2/node-v12.18.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.18.2/node-v12.18.2.tar.gz \
+Other release files: https://nodejs.org/dist/v12.18.2/ \
 Documentation: https://nodejs.org/docs/v12.18.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.18.3.md
+++ b/pages/en/blog/release/v12.18.3.md
@@ -196,21 +196,21 @@ author: Shelley Vohr
 * [[`1c64bc5e34`](https://github.com/nodejs/node/commit/1c64bc5e34)] - **worker**: perform initial port.unref() before preload modules (Anna Henningsen) [#33455](https://github.com/nodejs/node/pull/33455)
 * [[`c502384ab7`](https://github.com/nodejs/node/commit/c502384ab7)] - **worker**: use \_writev in internal communication (Anna Henningsen) [#33454](https://github.com/nodejs/node/pull/33454)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.18.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.18.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.18.3/node-v12.18.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.18.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.18.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.18.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.18.3/node-v12.18.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.18.3/node-v12.18.3.tar.gz \
+Other release files: https://nodejs.org/dist/v12.18.3/ \
 Documentation: https://nodejs.org/docs/v12.18.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.18.4.md
+++ b/pages/en/blog/release/v12.18.4.md
@@ -23,21 +23,21 @@ Vulnerabilities fixed:
 * [[`65415049af`](https://github.com/nodejs/node/commit/65415049af)] - **deps**: update llhttp to 2.1.2 (Fedor Indutny) [nodejs-private/node-private#219](https://github.com/nodejs-private/node-private/pull/219)
 * [[`edad52e243`](https://github.com/nodejs/node/commit/edad52e243)] - **test**: modify tests to support the latest llhttp (Fedor Indutny) [nodejs-private/node-private#219](https://github.com/nodejs-private/node-private/pull/219)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.18.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.18.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.18.4/node-v12.18.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.18.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.18.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.18.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.18.4/node-v12.18.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.18.4/node-v12.18.4.tar.gz \
+Other release files: https://nodejs.org/dist/v12.18.4/ \
 Documentation: https://nodejs.org/docs/v12.18.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.19.0.md
+++ b/pages/en/blog/release/v12.19.0.md
@@ -524,21 +524,21 @@ author: Shelley Vohr
 * [[`cda459ecb0`](https://github.com/nodejs/node/commit/cda459ecb0)] - **zlib**: replace usage of internal stream state with public api (Denys Otrishko) [#34884](https://github.com/nodejs/node/pull/34884)
 * [[`d60b13f2e3`](https://github.com/nodejs/node/commit/d60b13f2e3)] - **zlib**: switch to lazy init for zlib streams (Andrey Pechkurov) [#34048](https://github.com/nodejs/node/pull/34048)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.19.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.19.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.19.0/node-v12.19.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.19.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.19.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.19.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.19.0/node-v12.19.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.19.0/node-v12.19.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.19.0/ \
 Documentation: https://nodejs.org/docs/v12.19.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.19.1.md
+++ b/pages/en/blog/release/v12.19.1.md
@@ -20,21 +20,21 @@ Vulnerabilities fixed:
 
 * [[`022899e1d5`](https://github.com/nodejs/node/commit/022899e1d5)] - **deps**: cherry-pick 0d252eb from upstream c-ares (Michael Dawson) [nodejs-private/node-private#231](https://github.com/nodejs-private/node-private/pull/231)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.19.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.19.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.19.1/node-v12.19.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.19.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.19.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.19.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.19.1/node-v12.19.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.19.1/node-v12.19.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.19.1/ \
 Documentation: https://nodejs.org/docs/v12.19.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.2.0.md
+++ b/pages/en/blog/release/v12.2.0.md
@@ -145,21 +145,21 @@ author: Michaël Zasso
 * [[`52d4f1febf`](https://github.com/nodejs/node/commit/52d4f1febf)] - **util**: improve function inspection (Ruben Bridgewater) [#27227](https://github.com/nodejs/node/pull/27227)
 * [[`caab7d4664`](https://github.com/nodejs/node/commit/caab7d4664)] - **util**: better number formatters (Ruben Bridgewater) [#27499](https://github.com/nodejs/node/pull/27499)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.2.0/node-v12.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.2.0/node-v12.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.2.0/node-v12.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.2.0/ \
 Documentation: https://nodejs.org/docs/v12.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.20.0.md
+++ b/pages/en/blog/release/v12.20.0.md
@@ -162,21 +162,21 @@ author: Myles Borins
 * [[`f29717437f`](https://github.com/nodejs/node/commit/f29717437f)] - **tools,doc**: enforce alphabetical order for md refs (Antoine du Hamel) [#35244](https://github.com/nodejs/node/pull/35244)
 * [[`11b10d7d1f`](https://github.com/nodejs/node/commit/11b10d7d1f)] - **tools,doc**: upgrade dependencies (Antoine du Hamel) [#35244](https://github.com/nodejs/node/pull/35244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.20.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.20.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.20.0/node-v12.20.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.20.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.20.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.20.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.20.0/node-v12.20.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.20.0/node-v12.20.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.20.0/ \
 Documentation: https://nodejs.org/docs/v12.20.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.20.1.md
+++ b/pages/en/blog/release/v12.20.1.md
@@ -45,21 +45,21 @@ https://www.openssl.org/news/secadv/20201208.txt
 * [[`92d430917a`](https://github.com/nodejs/node/commit/92d430917a)] - **http**: unset `F_CHUNKED` on new `Transfer-Encoding` (Fedor Indutny) [nodejs-private/node-private#236](https://github.com/nodejs-private/node-private/pull/236)
 * [[`5b00de7d67`](https://github.com/nodejs/node/commit/5b00de7d67)] - **src**: retain pointers to WriteWrap/ShutdownWrap (James M Snell) [nodejs-private/node-private#230](https://github.com/nodejs-private/node-private/pull/230)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.20.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.20.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.20.1/node-v12.20.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.20.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.20.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.20.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.20.1/node-v12.20.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.20.1/node-v12.20.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.20.1/ \
 Documentation: https://nodejs.org/docs/v12.20.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.20.2.md
+++ b/pages/en/blog/release/v12.20.2.md
@@ -20,21 +20,21 @@ author: Ruy Adorno
 * [[`cd9a8106be`](https://github.com/nodejs/node/commit/cd9a8106be)] - **http**: do not loop over prototype in Agent (Michaël Zasso) [#36410](https://github.com/nodejs/node/pull/36410)
 * [[`4ac8f37800`](https://github.com/nodejs/node/commit/4ac8f37800)] - **http2**: check write not scheduled in scope destructor (David Halls) [#36241](https://github.com/nodejs/node/pull/36241)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.20.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.20.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.20.2/node-v12.20.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.20.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.20.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.20.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.20.2/node-v12.20.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.20.2/node-v12.20.2.tar.gz \
+Other release files: https://nodejs.org/dist/v12.20.2/ \
 Documentation: https://nodejs.org/docs/v12.20.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.21.0.md
+++ b/pages/en/blog/release/v12.21.0.md
@@ -26,21 +26,21 @@ Vulnerabilities fixed:
 * [[`922ada7713`](https://github.com/nodejs/node/commit/922ada7713)] - **(SEMVER-MINOR)** **http2**: add unknownProtocol timeout (Daniel Bevenius) [nodejs-private/node-private#246](https://github.com/nodejs-private/node-private/pull/246)
 * [[`1564752d55`](https://github.com/nodejs/node/commit/1564752d55)] - **src**: drop localhost6 as allowed host for inspector (Matteo Collina) [nodejs-private/node-private#244](https://github.com/nodejs-private/node-private/pull/244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.21.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.21.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.21.0/node-v12.21.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.21.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.21.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.21.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.21.0/node-v12.21.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.21.0/node-v12.21.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.21.0/ \
 Documentation: https://nodejs.org/docs/v12.21.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.0.md
+++ b/pages/en/blog/release/v12.22.0.md
@@ -70,21 +70,21 @@ Contributed by Trevor Norris [#35664](https://github.com/nodejs/node/pull/35664)
 * [[`8ddea3f16d`](https://github.com/nodejs/node/commit/8ddea3f16d)] - **(SEMVER-MINOR)** **v8**: implement v8.takeCoverage() (Joyee Cheung) [#33807](https://github.com/nodejs/node/pull/33807)
 * [[`eec7542781`](https://github.com/nodejs/node/commit/eec7542781)] - **(SEMVER-MINOR)** **worker**: add eventLoopUtilization() (Trevor Norris) [#35664](https://github.com/nodejs/node/pull/35664)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.0/node-v12.22.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.0/node-v12.22.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.0/node-v12.22.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.0/ \
 Documentation: https://nodejs.org/docs/v12.22.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.1.md
+++ b/pages/en/blog/release/v12.22.1.md
@@ -31,21 +31,21 @@ Vulnerabilities fixed:
 * [[`51a753c06f`](https://github.com/nodejs/node/commit/51a753c06f)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37939](https://github.com/nodejs/node/pull/37939)
 * [[`c85a519b48`](https://github.com/nodejs/node/commit/c85a519b48)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37939](https://github.com/nodejs/node/pull/37939)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.1/node-v12.22.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.1/node-v12.22.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.1/ \
 Documentation: https://nodejs.org/docs/v12.22.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.10.md
+++ b/pages/en/blog/release/v12.22.10.md
@@ -18,21 +18,21 @@ author: Ruy Adorno
 * \[[`33899b435d`](https://github.com/nodejs/node/commit/33899b435d)] - **deps**: upgrade npm to 6.14.16 (Ruy Adorno) [#41601](https://github.com/nodejs/node/pull/41601)
 * \[[`d9237c46ca`](https://github.com/nodejs/node/commit/d9237c46ca)] - **tools**: update tzdata to 2021a4 (Albert Wang) [#41443](https://github.com/nodejs/node/pull/41443)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.10/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.10/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.10/node-v12.22.10.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.10/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.10/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.10/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.10/node-v12.22.10.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.10/node-v12.22.10.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.10/ \
 Documentation: https://nodejs.org/docs/v12.22.10/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.11.md
+++ b/pages/en/blog/release/v12.22.11.md
@@ -25,21 +25,21 @@ run CI tests.
 * \[[`c372ec207d`](https://github.com/nodejs/node/commit/c372ec207d)] - **deps**: update archs files for OpenSSL-1.1.n (Richard Lau) [#42348](https://github.com/nodejs/node/pull/42348)
 * \[[`d574a1dccb`](https://github.com/nodejs/node/commit/d574a1dccb)] - **deps**: upgrade openssl sources to 1.1.1n (Richard Lau) [#42348](https://github.com/nodejs/node/pull/42348)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.11/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.11/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.11/node-v12.22.11.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.11/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.11/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.11/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.11/node-v12.22.11.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.11/node-v12.22.11.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.11/ \
 Documentation: https://nodejs.org/docs/v12.22.11/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.12.md
+++ b/pages/en/blog/release/v12.22.12.md
@@ -40,21 +40,21 @@ main branch.
 * \[[`171bb66ccc`](https://github.com/nodejs/node/commit/171bb66ccc)] - **node-api**: force env shutdown deferring behavior (Gabriel Schulhof) [#37303](https://github.com/nodejs/node/pull/37303)
 * \[[`e707514c80`](https://github.com/nodejs/node/commit/e707514c80)] - **src**: fix finalization crash (James M Snell) [#38250](https://github.com/nodejs/node/pull/38250)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.12/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.12/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.12/node-v12.22.12.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.12/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.12/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.12/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.12/node-v12.22.12.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.12/node-v12.22.12.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.12/ \
 Documentation: https://nodejs.org/docs/v12.22.12/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.2.md
+++ b/pages/en/blog/release/v12.22.2.md
@@ -27,21 +27,21 @@ Vulnerabilities fixed:
 * [[`923b3760f8`](https://github.com/nodejs/node/commit/923b3760f8)] - **deps**: upgrade npm to 6.14.13 (Ruy Adorno) [#38214](https://github.com/nodejs/node/pull/38214)
 * [[`a52790cba0`](https://github.com/nodejs/node/commit/a52790cba0)] - **win,msi**: set install directory permission (AkshayK) [nodejs-private/node-private#269](https://github.com/nodejs-private/node-private/pull/269)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.2/node-v12.22.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.2/node-v12.22.2.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.2/node-v12.22.2.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.2/ \
 Documentation: https://nodejs.org/docs/v12.22.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.3.md
+++ b/pages/en/blog/release/v12.22.3.md
@@ -19,21 +19,21 @@ installer.
 
 * [[`182f86a4d4`](https://github.com/nodejs/node/commit/182f86a4d4)] - **win,msi**: use localized "Authenticated Users" name (Richard Lau) [#39241](https://github.com/nodejs/node/pull/39241)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.3/node-v12.22.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.3/node-v12.22.3.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.3/node-v12.22.3.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.3/ \
 Documentation: https://nodejs.org/docs/v12.22.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.4.md
+++ b/pages/en/blog/release/v12.22.4.md
@@ -38,21 +38,21 @@ author: Richard Lau
 * [[`f552c45676`](https://github.com/nodejs/node/commit/f552c45676)] - **src**: move CHECK in AddIsolateFinishedCallback (Fedor Indutny) [#38010](https://github.com/nodejs/node/pull/38010)
 * [[`30ce0e66ae`](https://github.com/nodejs/node/commit/30ce0e66ae)] - **src**: update cares\_wrap OpenBSD defines (Anna Henningsen) [#38670](https://github.com/nodejs/node/pull/38670)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.4/node-v12.22.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.4/node-v12.22.4.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.4/node-v12.22.4.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.4/ \
 Documentation: https://nodejs.org/docs/v12.22.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.5.md
+++ b/pages/en/blog/release/v12.22.5.md
@@ -26,21 +26,21 @@ author: Bethany Nicolle Griggs
 * [[`2008c9722f`](https://github.com/nodejs/node/commit/2008c9722f)] - **http2**: update handling of rst\_stream with error code NGHTTP2\_CANCEL (Akshay K) [#39622](https://github.com/nodejs/node/pull/39622)
 * [[`1780bbc329`](https://github.com/nodejs/node/commit/1780bbc329)] - **tls**: validate "rejectUnauthorized: undefined" (Matteo Collina) [nodejs-private/node-private#276](https://github.com/nodejs-private/node-private/pull/276)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.5/node-v12.22.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.5/node-v12.22.5.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.5/node-v12.22.5.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.5/ \
 Documentation: https://nodejs.org/docs/v12.22.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.6.md
+++ b/pages/en/blog/release/v12.22.6.md
@@ -32,21 +32,21 @@ You can read more about it in:
 * [[`7a95637eb7`](https://github.com/nodejs/node/commit/7a95637eb7)] - **deps**: upgrade openssl sources to 1.1.1l (Richard Lau) [#39869](https://github.com/nodejs/node/pull/39869)
 * [[`840b0ffff6`](https://github.com/nodejs/node/commit/840b0ffff6)] - **deps**: upgrade npm to 6.14.15 (Darcy Clarke) [#39856](https://github.com/nodejs/node/pull/39856)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.6/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.6/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.6/node-v12.22.6.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.6/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.6/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.6/node-v12.22.6.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.6/node-v12.22.6.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.6/ \
 Documentation: https://nodejs.org/docs/v12.22.6/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.7.md
+++ b/pages/en/blog/release/v12.22.7.md
@@ -21,21 +21,21 @@ author: Danielle Adams
 * [[`d5d3a03246`](https://github.com/nodejs/node/commit/d5d3a03246)] - **http**: add regression test for smuggling content length (Matteo Collina) [nodejs-private/node-private#286](https://github.com/nodejs-private/node-private/pull/286)
 * [[`0858587f21`](https://github.com/nodejs/node/commit/0858587f21)] - **http**: add regression test for chunked smuggling (Matteo Collina) [nodejs-private/node-private#286](https://github.com/nodejs-private/node-private/pull/286)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.7/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.7/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.7/node-v12.22.7.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.7/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.7/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.7/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.7/node-v12.22.7.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.7/node-v12.22.7.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.7/ \
 Documentation: https://nodejs.org/docs/v12.22.7/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.8.md
+++ b/pages/en/blog/release/v12.22.8.md
@@ -36,21 +36,21 @@ Security Services 3.71 [#40281](https://github.com/nodejs/node/pull/40280).
 * \[[`e4339fe286`](https://github.com/nodejs/node/commit/e4339fe286)] - **tools**: add script to update c-ares (Richard Lau) [#40660](https://github.com/nodejs/node/pull/40660)
 * \[[`f50b9c1e8a`](https://github.com/nodejs/node/commit/f50b9c1e8a)] - **worker**: avoid potential deadlock on NearHeapLimit (Santiago Gimeno) [#38403](https://github.com/nodejs/node/pull/38403)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.8/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.8/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.8/node-v12.22.8.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.8/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.8/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.8/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.8/node-v12.22.8.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.8/node-v12.22.8.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.8/ \
 Documentation: https://nodejs.org/docs/v12.22.8/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.22.9.md
+++ b/pages/en/blog/release/v12.22.9.md
@@ -54,21 +54,21 @@ Thanks to Patrik Oldsberg (rugvip) for reporting this vulnerability.
 * \[[`8c2db2c86b`](https://github.com/nodejs/node/commit/8c2db2c86b)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen and Akshay Kumar) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 * \[[`e0fe6a635e`](https://github.com/nodejs/node/commit/e0fe6a635e)] - **tls**: drop support for URI alternative names (Tobias Nießen and Akshay Kumar) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.22.9/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.22.9/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.22.9/node-v12.22.9.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.22.9/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.9/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.9/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.9/node-v12.22.9.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.22.9/node-v12.22.9.tar.gz \
+Other release files: https://nodejs.org/dist/v12.22.9/ \
 Documentation: https://nodejs.org/docs/v12.22.9/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.3.0.md
+++ b/pages/en/blog/release/v12.3.0.md
@@ -156,21 +156,21 @@ author: Ruben Bridgewater
 * [[`e004d427ce`](https://github.com/nodejs/node/commit/e004d427ce)] - **worker**: use special message as MessagePort close command (Anna Henningsen) [#27705](https://github.com/nodejs/node/pull/27705)
 * [[`b7ed4d7187`](https://github.com/nodejs/node/commit/b7ed4d7187)] - **worker**: move `receiving_messages_` field to `MessagePort` (Anna Henningsen) [#27705](https://github.com/nodejs/node/pull/27705)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.3.0/node-v12.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.3.0/node-v12.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.3.0/node-v12.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.3.0/ \
 Documentation: https://nodejs.org/docs/v12.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.3.1.md
+++ b/pages/en/blog/release/v12.3.1.md
@@ -23,21 +23,21 @@ author: Ruben Bridgewater
 * [[`7438a557af`](https://github.com/nodejs/node/commit/7438a557af)] - **src**: remove util-inl.h include in node.h (Anna Henningsen) [#27804](https://github.com/nodejs/node/pull/27804)
 * [[`6f7005465a`](https://github.com/nodejs/node/commit/6f7005465a)] - **src, lib**: take control of prepareStackTrace (Gus Caplan) [#23926](https://github.com/nodejs/node/pull/23926)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.3.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.3.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.3.1/node-v12.3.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.3.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.3.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.3.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.3.1/node-v12.3.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.3.1/node-v12.3.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.3.1/ \
 Documentation: https://nodejs.org/docs/v12.3.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.4.0.md
+++ b/pages/en/blog/release/v12.4.0.md
@@ -141,21 +141,21 @@ author: Michaël Zasso
 * [[`728bc2f59a`](https://github.com/nodejs/node/commit/728bc2f59a)] - **tools**: update dependencies in tools/doc (Rich Trott) [#27927](https://github.com/nodejs/node/pull/27927)
 * [[`b54f3e0405`](https://github.com/nodejs/node/commit/b54f3e0405)] - **tools**: edit .eslintrc.js for minor maintainability improvements (Rich Trott) [#27789](https://github.com/nodejs/node/pull/27789)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.4.0/node-v12.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.4.0/node-v12.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.4.0/node-v12.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.4.0/ \
 Documentation: https://nodejs.org/docs/v12.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.5.0.md
+++ b/pages/en/blog/release/v12.5.0.md
@@ -231,21 +231,21 @@ author: Ruben Bridgewater
 * [[`79a8cd0dec`](https://github.com/nodejs/node/commit/79a8cd0dec)] - **worker**: add typechecking for postMessage transfer list (Anna Henningsen) [#28033](https://github.com/nodejs/node/pull/28033)
 * [[`d7641d833c`](https://github.com/nodejs/node/commit/d7641d833c)] - **worker**: use DataCloneError for unknown native objects (Anna Henningsen) [#28025](https://github.com/nodejs/node/pull/28025)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.5.0/node-v12.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.5.0/node-v12.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.5.0/node-v12.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.5.0/ \
 Documentation: https://nodejs.org/docs/v12.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.6.0.md
+++ b/pages/en/blog/release/v12.6.0.md
@@ -181,21 +181,21 @@ author: Michaël Zasso
 * [[`e6c7ebe90c`](https://github.com/nodejs/node/commit/e6c7ebe90c)] - **vm**: increase code coverage of source\_text\_module.js (kball) [#28363](https://github.com/nodejs/node/pull/28363)
 * [[`2053dd0c9c`](https://github.com/nodejs/node/commit/2053dd0c9c)] - **worker**: only unref port for stdin if we ref’ed it before (Anna Henningsen) [#28153](https://github.com/nodejs/node/pull/28153)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.6.0/node-v12.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.6.0/node-v12.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.6.0/node-v12.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.6.0/ \
 Documentation: https://nodejs.org/docs/v12.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.7.0.md
+++ b/pages/en/blog/release/v12.7.0.md
@@ -205,21 +205,21 @@ author: Michaël Zasso
 * [[`b8079f5c23`](https://github.com/nodejs/node/commit/b8079f5c23)] - **zlib**: remove usage of public util module (Karen He) [#28454](https://github.com/nodejs/node/pull/28454)
 * [[`03de306281`](https://github.com/nodejs/node/commit/03de306281)] - **zlib**: do not coalesce multiple `.flush()` calls (Anna Henningsen) [#28520](https://github.com/nodejs/node/pull/28520)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.7.0/node-v12.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.7.0/node-v12.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.7.0/node-v12.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.7.0/ \
 Documentation: https://nodejs.org/docs/v12.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.8.0.md
+++ b/pages/en/blog/release/v12.8.0.md
@@ -111,21 +111,21 @@ author: Ruben Bridgewater
 * [[`b282c8512b`](https://github.com/nodejs/node/commit/b282c8512b)] - **vm**: increase code coverage of source\_text\_module.js (kball) [#28350](https://github.com/nodejs/node/pull/28350)
 * [[`43acce1925`](https://github.com/nodejs/node/commit/43acce1925)] - **worker**: handle calling terminate when kHandler is null (elyalvarado) [#28370](https://github.com/nodejs/node/pull/28370)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.8.0/node-v12.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.8.0/node-v12.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.8.0/node-v12.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.8.0/ \
 Documentation: https://nodejs.org/docs/v12.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.8.1.md
+++ b/pages/en/blog/release/v12.8.1.md
@@ -43,21 +43,21 @@ Vulnerabilities fixed:
 * [[`530004ef32`](https://github.com/nodejs/node/commit/530004ef32)] - **http2**: only call into JS when necessary for session events (Anna Henningsen) [#29122](https://github.com/nodejs/node/pull/29122)
 * [[`58d8c9ef48`](https://github.com/nodejs/node/commit/58d8c9ef48)] - **http2**: improve JS-side debug logging (Anna Henningsen) [#29122](https://github.com/nodejs/node/pull/29122)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.8.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.8.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.8.1/node-v12.8.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.8.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.8.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.8.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.8.1/node-v12.8.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.8.1/node-v12.8.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.8.1/ \
 Documentation: https://nodejs.org/docs/v12.8.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.9.0.md
+++ b/pages/en/blog/release/v12.9.0.md
@@ -131,21 +131,21 @@ author: Michaël Zasso
 * [[`8426077898`](https://github.com/nodejs/node/commit/8426077898)] - **util**: assert: fix deepEqual comparing fake-boxed to real boxed primitive (Jordan Harband) [#29029](https://github.com/nodejs/node/pull/29029)
 * [[`d4e397a900`](https://github.com/nodejs/node/commit/d4e397a900)] - **worker**: fix crash when SharedArrayBuffer outlives creating thread (Anna Henningsen) [#29190](https://github.com/nodejs/node/pull/29190)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.9.0/node-v12.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.9.0/node-v12.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.9.0/node-v12.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v12.9.0/ \
 Documentation: https://nodejs.org/docs/v12.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v12.9.1.md
+++ b/pages/en/blog/release/v12.9.1.md
@@ -27,21 +27,21 @@ This release fixes two regressions in the **http** module:
 * [[`ff6330a6ac`](https://github.com/nodejs/node/commit/ff6330a6ac)] - **test**: fix 'timeout' typos (cjihrig) [#29234](https://github.com/nodejs/node/pull/29234)
 * [[`3c7a1a9090`](https://github.com/nodejs/node/commit/3c7a1a9090)] - **test, http**: add regression test for keepalive 'end' event (Matteo Collina) [#29263](https://github.com/nodejs/node/pull/29263)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v12.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v12.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v12.9.1/node-v12.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v12.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v12.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v12.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v12.9.1/node-v12.9.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v12.9.1/node-v12.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v12.9.1/ \
 Documentation: https://nodejs.org/docs/v12.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.0.0.md
+++ b/pages/en/blog/release/v13.0.0.md
@@ -209,21 +209,21 @@ author: Bethany Nicolle Griggs
 * [[`1e01f3f022`](https://github.com/nodejs/node/commit/1e01f3f022)] - **tools**: apply more stringent blank-line linting for markdown files (Rich Trott) [#29447](https://github.com/nodejs/node/pull/29447)
 * [[`f9caee986c`](https://github.com/nodejs/node/commit/f9caee986c)] - **vm**: add Synthetic modules (Gus Caplan) [#29864](https://github.com/nodejs/node/pull/29864)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.0.0/node-v13.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.0.0/node-v13.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.0.0/node-v13.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.0.0/ \
 Documentation: https://nodejs.org/docs/v13.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.0.1.md
+++ b/pages/en/blog/release/v13.0.1.md
@@ -51,21 +51,21 @@ author: Michaël Zasso
 * [[`c096f251e4`](https://github.com/nodejs/node/commit/c096f251e4)] - **test**: remove common.skipIfInspectorEnabled() (Rich Trott) [#29993](https://github.com/nodejs/node/pull/29993)
 * [[`b1b8663a23`](https://github.com/nodejs/node/commit/b1b8663a23)] - **test**: add cb error test for fs.close() (Matteo Rossi) [#29970](https://github.com/nodejs/node/pull/29970)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.0.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.0.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.0.1/node-v13.0.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.0.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.0.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.0.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.0.1/node-v13.0.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.0.1/node-v13.0.1.tar.gz \
+Other release files: https://nodejs.org/dist/v13.0.1/ \
 Documentation: https://nodejs.org/docs/v13.0.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.1.0.md
+++ b/pages/en/blog/release/v13.1.0.md
@@ -96,21 +96,21 @@ author: Michaël Zasso
 * [[`d549a34597`](https://github.com/nodejs/node/commit/d549a34597)] - **tools**: update ESLint to 6.6.0 (Colin Ihrig) [#30123](https://github.com/nodejs/node/pull/30123)
 * [[`a3757546e8`](https://github.com/nodejs/node/commit/a3757546e8)] - **tools**: doc: improve async workflow of generate.js (Theotime Poisseau) [#30106](https://github.com/nodejs/node/pull/30106)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.1.0/node-v13.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.1.0/node-v13.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.1.0/node-v13.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.1.0/ \
 Documentation: https://nodejs.org/docs/v13.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.10.0.md
+++ b/pages/en/blog/release/v13.10.0.md
@@ -112,21 +112,21 @@ author: Shelley Vohr
 * [[`f2389eba99`](https://github.com/nodejs/node/commit/f2389eba99)] - **worker**: emit runtime error on loop creation failure (Harshitha KP) [#31621](https://github.com/nodejs/node/pull/31621)
 * [[`f87ac90849`](https://github.com/nodejs/node/commit/f87ac90849)] - **worker**: unroll file extension regexp (Anna Henningsen) [#31779](https://github.com/nodejs/node/pull/31779)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.10.0/node-v13.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.10.0/node-v13.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.10.0/node-v13.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.10.0/ \
 Documentation: https://nodejs.org/docs/v13.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.10.1.md
+++ b/pages/en/blog/release/v13.10.1.md
@@ -34,21 +34,21 @@ a patch that ensures that individuals will once again be able to build Node.js f
 * [[`1539928ed9`](https://github.com/nodejs/node/commit/1539928ed9)] - **test**: add GC test for disabled AsyncLocalStorage (Andrey Pechkurov) [#31995](https://github.com/nodejs/node/pull/31995)
 * [[`be90817558`](https://github.com/nodejs/node/commit/be90817558)] - **test**: remove common.port from test-tls-securepair-client (Rich Trott) [#32024](https://github.com/nodejs/node/pull/32024)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.10.1/node-v13.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.10.1/node-v13.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.10.1/node-v13.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v13.10.1/ \
 Documentation: https://nodejs.org/docs/v13.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.11.0.md
+++ b/pages/en/blog/release/v13.11.0.md
@@ -127,21 +127,21 @@ author: Myles Borins
 * [[`eaf6723804`](https://github.com/nodejs/node/commit/eaf6723804)] - **vm**: refactor value validation with internal/validators.js (Denys Otrishko) [#31480](https://github.com/nodejs/node/pull/31480)
 * [[`dd83bd266d`](https://github.com/nodejs/node/commit/dd83bd266d)] - **(SEMVER-MINOR)** **wasi**: add returnOnExit option (Colin Ihrig) [#32101](https://github.com/nodejs/node/pull/32101)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.11.0/node-v13.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.11.0/node-v13.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.11.0/node-v13.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.11.0/ \
 Documentation: https://nodejs.org/docs/v13.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.12.0.md
+++ b/pages/en/blog/release/v13.12.0.md
@@ -136,21 +136,21 @@ impact on Node.js 13.x users with older versions of macOS.
 * [[`53fd0d80b1`](https://github.com/nodejs/node/commit/53fd0d80b1)] - **(SEMVER-MINOR)** **util**: use a global symbol for `util.promisify.custom` (ExE Boss) [#31672](https://github.com/nodejs/node/pull/31672)
 * [[`e83dcdef7e`](https://github.com/nodejs/node/commit/e83dcdef7e)] - **(SEMVER-MINOR)** **worker**: allow URL in Worker constructor (Antoine du HAMEL) [#31664](https://github.com/nodejs/node/pull/31664)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.12.0/node-v13.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.12.0/node-v13.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.12.0/node-v13.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.12.0/ \
 Documentation: https://nodejs.org/docs/v13.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.13.0.md
+++ b/pages/en/blog/release/v13.13.0.md
@@ -226,21 +226,21 @@ With this release, we welcome three new Node.js core collaborators:
 * [[`4acd7f4390`](https://github.com/nodejs/node/commit/4acd7f4390)] - **worker**: do not emit 'exit' events during process.exit() (Anna Henningsen) [#32546](https://github.com/nodejs/node/pull/32546)
 * [[`833d78afcf`](https://github.com/nodejs/node/commit/833d78afcf)] - **worker**: runtime error on pthread creation (Harshitha KP) [#32344](https://github.com/nodejs/node/pull/32344)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.13.0/node-v13.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.13.0/node-v13.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.13.0/node-v13.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.13.0/ \
 Documentation: https://nodejs.org/docs/v13.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.14.0.md
+++ b/pages/en/blog/release/v13.14.0.md
@@ -139,21 +139,21 @@ With this release, we welcome two new Node.js core collaborators:
 * [[`f14916ffc9`](https://github.com/nodejs/node/commit/f14916ffc9)] - **worker**: fix process.env var empty key access (Christopher Beeson) [#32921](https://github.com/nodejs/node/pull/32921)
 * [[`b80b08fe35`](https://github.com/nodejs/node/commit/b80b08fe35)] - **worker**: fix type check in receiveMessageOnPort (Anna Henningsen) [#32745](https://github.com/nodejs/node/pull/32745)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.14.0/node-v13.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.14.0/node-v13.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.14.0/node-v13.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.14.0/ \
 Documentation: https://nodejs.org/docs/v13.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.2.0.md
+++ b/pages/en/blog/release/v13.2.0.md
@@ -207,21 +207,21 @@ author: Myles Borins
 * [[`9b11bdb001`](https://github.com/nodejs/node/commit/9b11bdb001)] - **v8**: inspect unserializable objects (Anna Henningsen) [#30167](https://github.com/nodejs/node/pull/30167)
 * [[`2ec40c265a`](https://github.com/nodejs/node/commit/2ec40c265a)] - **(SEMVER-MINOR)** **worker**: allow specifying resource limits (Anna Henningsen) [#26628](https://github.com/nodejs/node/pull/26628)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.2.0/node-v13.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.2.0/node-v13.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.2.0/node-v13.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.2.0/ \
 Documentation: https://nodejs.org/docs/v13.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.3.0.md
+++ b/pages/en/blog/release/v13.3.0.md
@@ -206,21 +206,21 @@ author: Ruben Bridgewater
 * [[`18e9b56bf6`](https://github.com/nodejs/node/commit/18e9b56bf6)] - **util**: use let instead of var for util/inspect.js (Luciano) [#30399](https://github.com/nodejs/node/pull/30399)
 * [[`9ec53cf5c1`](https://github.com/nodejs/node/commit/9ec53cf5c1)] - **(SEMVER-MINOR)** **wasi**: introduce initial WASI support (cjihrig) [#30258](https://github.com/nodejs/node/pull/30258)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.3.0/node-v13.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.3.0/node-v13.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.3.0/node-v13.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.3.0/ \
 Documentation: https://nodejs.org/docs/v13.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.4.0.md
+++ b/pages/en/blog/release/v13.4.0.md
@@ -154,21 +154,21 @@ author: Myles Borins
 * [[`14269d15cf`](https://github.com/nodejs/node/commit/14269d15cf)] - **wasi**: use memory-tracking allocator (Anna Henningsen) [#30745](https://github.com/nodejs/node/pull/30745)
 * [[`71d43a5569`](https://github.com/nodejs/node/commit/71d43a5569)] - **(SEMVER-MINOR)** **worker**: add argv constructor option (legendecas) [#30559](https://github.com/nodejs/node/pull/30559)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.4.0/node-v13.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.4.0/node-v13.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.4.0/node-v13.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.4.0/ \
 Documentation: https://nodejs.org/docs/v13.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.5.0.md
+++ b/pages/en/blog/release/v13.5.0.md
@@ -96,21 +96,21 @@ author: Myles Borins
 * [[`2b0e2c280f`](https://github.com/nodejs/node/commit/2b0e2c280f)] - **v8**: use of TypedArray constructors from primordials (Sebastien Ahkrin) [#30740](https://github.com/nodejs/node/pull/30740)
 * [[`54d51dbe4c`](https://github.com/nodejs/node/commit/54d51dbe4c)] - **wasi**: require CLI flag to require() wasi module (Colin Ihrig) [#30963](https://github.com/nodejs/node/pull/30963)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.5.0/node-v13.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.5.0/node-v13.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.5.0/node-v13.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.5.0/ \
 Documentation: https://nodejs.org/docs/v13.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.6.0.md
+++ b/pages/en/blog/release/v13.6.0.md
@@ -206,21 +206,21 @@ author: Ruben Bridgewater
 * [[`10f7169d58`](https://github.com/nodejs/node/commit/10f7169d58)] - **zlib**: use for...of (Kamat, Trivikram) [#31051](https://github.com/nodejs/node/pull/31051)
 * [[`31bbae7c92`](https://github.com/nodejs/node/commit/31bbae7c92)] - **zlib**: allow writes after readable 'end' to finish (Anna Henningsen) [#31082](https://github.com/nodejs/node/pull/31082)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.6.0/node-v13.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.6.0/node-v13.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.6.0/node-v13.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.6.0/ \
 Documentation: https://nodejs.org/docs/v13.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.7.0.md
+++ b/pages/en/blog/release/v13.7.0.md
@@ -135,21 +135,21 @@ author: Shelley Vohr
 * [[`bdaac04c10`](https://github.com/nodejs/node/commit/bdaac04c10)] - **wasi**: improve use of primordials (cjihrig) [#31212](https://github.com/nodejs/node/pull/31212)
 * [[`66fe92353b`](https://github.com/nodejs/node/commit/66fe92353b)] - **win**: change to use Python in install tool (gengjiawen) [#31221](https://github.com/nodejs/node/pull/31221)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.7.0/node-v13.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.7.0/node-v13.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.7.0/node-v13.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.7.0/ \
 Documentation: https://nodejs.org/docs/v13.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.8.0.md
+++ b/pages/en/blog/release/v13.8.0.md
@@ -32,21 +32,21 @@ http option. Using the insecure HTTP parser should be avoided.
 * [[`25b6897e8a`](https://github.com/nodejs/node/commit/25b6897e8a)] - **http**: strip trailing OWS from header values (Sam Roberts) [nodejs-private/node-private#189](https://github.com/nodejs-private/node-private/pull/189)
 * [[`eea3a7429b`](https://github.com/nodejs/node/commit/eea3a7429b)] - **test**: using TE to smuggle reqs is not possible (Sam Roberts) [nodejs-private/node-private#199](https://github.com/nodejs-private/node-private/pull/199)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.8.0/node-v13.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.8.0/node-v13.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.8.0/node-v13.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.8.0/ \
 Documentation: https://nodejs.org/docs/v13.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v13.9.0.md
+++ b/pages/en/blog/release/v13.9.0.md
@@ -255,21 +255,21 @@ author: Shelley Vohr
 * [[`6fdef457c6`](https://github.com/nodejs/node/commit/6fdef457c6)] - **worker**: remove redundant closing of child port (aaccttrr) [#31555](https://github.com/nodejs/node/pull/31555)
 * [[`5656ec9f71`](https://github.com/nodejs/node/commit/5656ec9f71)] - **worker**: move JoinThread() back into exit callback (Anna Henningsen) [#31468](https://github.com/nodejs/node/pull/31468)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v13.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v13.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-aix-ppc64.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v13.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v13.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v13.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v13.9.0/node-v13.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-aix-ppc64.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v13.9.0/ \
 Documentation: https://nodejs.org/docs/v13.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.0.0.md
+++ b/pages/en/blog/release/v14.0.0.md
@@ -289,20 +289,20 @@ interact with `std::shared_ptr`. This is expected to be fixed in a later version
 * [[`7147df53e8`](https://github.com/nodejs/node/commit/7147df53e8)] - **worker**: fix type check in receiveMessageOnPort (Anna Henningsen) [#32745](https://github.com/nodejs/node/pull/32745)
 * [[`0c545f0f72`](https://github.com/nodejs/node/commit/0c545f0f72)] - **zlib**: emits 'close' event after readable 'end' (Sergey Zelenov) [#32050](https://github.com/nodejs/node/pull/32050)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.0.0/node-v14.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.0.0/node-v14.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.0.0/node-v14.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.0.0/ \
 Documentation: https://nodejs.org/docs/v14.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.1.0.md
+++ b/pages/en/blog/release/v14.1.0.md
@@ -117,20 +117,20 @@ author: Bethany Nicolle Griggs
 - [[`4143c747fc`](https://github.com/nodejs/node/commit/4143c747fc)] - **(SEMVER-MINOR)** **vm**: add importModuleDynamically option to compileFunction (Gus Caplan) [#32985](https://github.com/nodejs/node/pull/32985)
 - [[`c84d802449`](https://github.com/nodejs/node/commit/c84d802449)] - **worker**: fix process.env var empty key access (Christopher Beeson) [#32921](https://github.com/nodejs/node/pull/32921)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.1.0/node-v14.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.1.0/node-v14.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.1.0/node-v14.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.1.0/ \
 Documentation: https://nodejs.org/docs/v14.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.10.0.md
+++ b/pages/en/blog/release/v14.10.0.md
@@ -115,20 +115,20 @@ author: Richard Lau
 * [[`7ad629e4e4`](https://github.com/nodejs/node/commit/7ad629e4e4)] - **tools,doc**: remove "toc" anchor name (Rich Trott) [#34893](https://github.com/nodejs/node/pull/34893)
 * [[`94528f510e`](https://github.com/nodejs/node/commit/94528f510e)] - **zlib**: replace usage of internal stream state with public api (Denys Otrishko) [#34884](https://github.com/nodejs/node/pull/34884)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.10.0/node-v14.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.10.0/node-v14.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.10.0/node-v14.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.10.0/ \
 Documentation: https://nodejs.org/docs/v14.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.10.1.md
+++ b/pages/en/blog/release/v14.10.1.md
@@ -18,20 +18,20 @@ and a docs rendering regression that are being fixed in this release.
 * [[`3c92f93b44`](https://github.com/nodejs/node/commit/3c92f93b44)] - **doc**: restore color for visited links (Rich Trott) [#35108](https://github.com/nodejs/node/pull/35108)
 * [[`0f94c6b4e4`](https://github.com/nodejs/node/commit/0f94c6b4e4)] - ***Revert*** "**stream**: simpler and faster Readable async iterator" (Richard Lau)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.10.1/node-v14.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.10.1/node-v14.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.10.1/node-v14.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.10.1/ \
 Documentation: https://nodejs.org/docs/v14.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.11.0.md
+++ b/pages/en/blog/release/v14.11.0.md
@@ -22,20 +22,20 @@ Vulnerabilities fixed:
 * [[`dd828376a0`](https://github.com/nodejs/node/commit/dd828376a0)] - **deps**: update llhttp to 2.1.2 (Fedor Indutny) [nodejs-private/node-private#215](https://github.com/nodejs-private/node-private/pull/215)
 * [[`753f3b247a`](https://github.com/nodejs/node/commit/753f3b247a)] - **http**: add requestTimeout (Matteo Collina, Paolo Insogna, Robert Nagy) [nodejs-private/node-private#208](https://github.com/nodejs-private/node-private/pull/208)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.11.0/node-v14.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.11.0/node-v14.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.11.0/node-v14.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.11.0/ \
 Documentation: https://nodejs.org/docs/v14.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.12.0.md
+++ b/pages/en/blog/release/v14.12.0.md
@@ -90,20 +90,20 @@ author: Ruy Adorno
 * [[`25f93f3ec3`](https://github.com/nodejs/node/commit/25f93f3ec3)] - **test**: add more valid results to test-trace-atomics-wait (Anna Henningsen) [#35066](https://github.com/nodejs/node/pull/35066)
 * [[`0a97f44b50`](https://github.com/nodejs/node/commit/0a97f44b50)] - **tools**: update ESLint to 7.9.0 (Colin Ihrig) [#35170](https://github.com/nodejs/node/pull/35170)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.12.0/node-v14.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.12.0/node-v14.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.12.0/node-v14.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.12.0/ \
 Documentation: https://nodejs.org/docs/v14.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.13.0.md
+++ b/pages/en/blog/release/v14.13.0.md
@@ -59,20 +59,20 @@ author: Myles Borins
 * [[`c5d27e1e29`](https://github.com/nodejs/node/commit/c5d27e1e29)] - **tools,doc**: enforce alphabetical order for md refs (Antoine du Hamel) [#35244](https://github.com/nodejs/node/pull/35244)
 * [[`9d91842a9d`](https://github.com/nodejs/node/commit/9d91842a9d)] - **tools,doc**: upgrade dependencies (Antoine du Hamel) [#35244](https://github.com/nodejs/node/pull/35244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.13.0/node-v14.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.13.0/node-v14.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.13.0/node-v14.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.13.0/ \
 Documentation: https://nodejs.org/docs/v14.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.13.1.md
+++ b/pages/en/blog/release/v14.13.1.md
@@ -77,20 +77,20 @@ author: Bethany Nicolle Griggs
 * [[`4d29fb56f2`](https://github.com/nodejs/node/commit/4d29fb56f2)] - **tools**: add pythonenv to .gitignore (Michaël Zasso) [#35389](https://github.com/nodejs/node/pull/35389)
 * [[`6e9e5c3381`](https://github.com/nodejs/node/commit/6e9e5c3381)] - **tools,doc**: fix broken link in module.html (Rich Trott) [#35446](https://github.com/nodejs/node/pull/35446)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.13.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.13.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.13.1/node-v14.13.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.13.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.13.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.13.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.13.1/node-v14.13.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.13.1/node-v14.13.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.13.1/ \
 Documentation: https://nodejs.org/docs/v14.13.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.14.0.md
+++ b/pages/en/blog/release/v14.14.0.md
@@ -100,20 +100,20 @@ author: Myles Borins
 * [[`bd344108eb`](https://github.com/nodejs/node/commit/bd344108eb)] - ***Revert*** "**tools**: add missing uv\_setup\_argv() calls" (Beth Griggs) [#35641](https://github.com/nodejs/node/pull/35641)
 * [[`e8434d88fe`](https://github.com/nodejs/node/commit/e8434d88fe)] - **tools,test**: enable multiline-comment-style rule in tests (Rich Trott) [#35485](https://github.com/nodejs/node/pull/35485)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.14.0/node-v14.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.14.0/node-v14.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.14.0/node-v14.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.14.0/ \
 Documentation: https://nodejs.org/docs/v14.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.0.md
+++ b/pages/en/blog/release/v14.15.0.md
@@ -21,20 +21,20 @@ and will remain so until October 2021. After that time, it will move into
 * [[`90a5d59824`](https://github.com/nodejs/node/commit/90a5d59824)] - **doc**: fix Node.js 14.x changelogs (Richard Lau) [#35756](https://github.com/nodejs/node/pull/35756)
 * [[`7f788573b3`](https://github.com/nodejs/node/commit/7f788573b3)] - ***Revert*** "**test**: mark test-webcrypto-encrypt-decrypt-aes flaky" (Myles Borins) [#35666](https://github.com/nodejs/node/pull/35666)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.0/node-v14.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.0/node-v14.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.0/node-v14.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.0/ \
 Documentation: https://nodejs.org/docs/v14.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.1.md
+++ b/pages/en/blog/release/v14.15.1.md
@@ -20,20 +20,20 @@ Vulnerabilities fixed:
 
 * [[`1fd2c8142b`](https://github.com/nodejs/node/commit/1fd2c8142b)] - **deps**: cherry-pick 0d252eb from upstream c-ares (Michael Dawson) [nodejs-private/node-private#231](https://github.com/nodejs-private/node-private/pull/231)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.1/node-v14.15.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.1/node-v14.15.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.1/node-v14.15.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.1/ \
 Documentation: https://nodejs.org/docs/v14.15.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.2.md
+++ b/pages/en/blog/release/v14.15.2.md
@@ -205,20 +205,20 @@ author: Bethany Nicolle Griggs
 * [[`c4c8541621`](https://github.com/nodejs/node/commit/c4c8541621)] - **win,build,tools**: support VS prerelease (Baruch Odem) [#36033](https://github.com/nodejs/node/pull/36033)
 * [[`f59e225675`](https://github.com/nodejs/node/commit/f59e225675)] - **zlib**: test BrotliCompress throws invalid arg value (raisinten) [#35830](https://github.com/nodejs/node/pull/35830)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.2/node-v14.15.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.2/node-v14.15.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.2/node-v14.15.2.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.2/ \
 Documentation: https://nodejs.org/docs/v14.15.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.3.md
+++ b/pages/en/blog/release/v14.15.3.md
@@ -16,20 +16,20 @@ Node.js v14.15.2 included a commit that has caused reported breakages when cloni
 
 * [[`4264d9aa67`](https://github.com/nodejs/node/commit/4264d9aa67)] - ***Revert*** "**http**: lazy create IncomingMessage.headers" (Beth Griggs) [#36553](https://github.com/nodejs/node/pull/36553)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.3/node-v14.15.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.3/node-v14.15.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.3/node-v14.15.3.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.3/ \
 Documentation: https://nodejs.org/docs/v14.15.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.4.md
+++ b/pages/en/blog/release/v14.15.4.md
@@ -43,20 +43,20 @@ Vulnerabilities fixed:
 * [[`641f786bb1`](https://github.com/nodejs/node/commit/641f786bb1)] - **http**: unset `F_CHUNKED` on new `Transfer-Encoding` (Matteo Collina) [nodejs-private/node-private#228](https://github.com/nodejs-private/node-private/pull/228)
 * [[`4f8772f9b7`](https://github.com/nodejs/node/commit/4f8772f9b7)] - **src**: retain pointers to WriteWrap/ShutdownWrap (James M Snell) [nodejs-private/node-private#23](https://github.com/nodejs-private/node-private/pull/23)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.4/node-v14.15.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.4/node-v14.15.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.4/node-v14.15.4.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.4/ \
 Documentation: https://nodejs.org/docs/v14.15.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.15.5.md
+++ b/pages/en/blog/release/v14.15.5.md
@@ -28,20 +28,20 @@ author: Bethany Nicolle Griggs
 * [[`f206505e9d`](https://github.com/nodejs/node/commit/f206505e9d)] - **util**: fix instanceof checks with null prototypes during inspection (Ruben Bridgewater) [#36178](https://github.com/nodejs/node/pull/36178)
 * [[`2f7944b18b`](https://github.com/nodejs/node/commit/2f7944b18b)] - **util**: fix module prefixes during inspection (Ruben Bridgewater) [#36178](https://github.com/nodejs/node/pull/36178)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.15.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.15.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.15.5/node-v14.15.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.15.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.15.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.15.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.15.5/node-v14.15.5.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.15.5/node-v14.15.5.tar.gz \
+Other release files: https://nodejs.org/dist/v14.15.5/ \
 Documentation: https://nodejs.org/docs/v14.15.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.16.0.md
+++ b/pages/en/blog/release/v14.16.0.md
@@ -26,20 +26,20 @@ Vulnerabilities fixed:
 * [[`afea10b097`](https://github.com/nodejs/node/commit/afea10b097)] - **(SEMVER-MINOR)** **http2**: add unknownProtocol timeout (Daniel Bevenius) [nodejs-private/node-private#246](https://github.com/nodejs-private/node-private/pull/246)
 * [[`1ca3f5abcb`](https://github.com/nodejs/node/commit/1ca3f5abcb)] - **src**: drop localhost6 as allowed host for inspector (Matteo Collina) [nodejs-private/node-private#244](https://github.com/nodejs-private/node-private/pull/244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.16.0/node-v14.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.16.0/node-v14.16.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.16.0/node-v14.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.16.0/ \
 Documentation: https://nodejs.org/docs/v14.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.16.1.md
+++ b/pages/en/blog/release/v14.16.1.md
@@ -31,20 +31,20 @@ Vulnerabilities fixed:
 * [[`6bc8f58182`](https://github.com/nodejs/node/commit/6bc8f58182)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37938](https://github.com/nodejs/node/pull/37938)
 * [[`403a014ef6`](https://github.com/nodejs/node/commit/403a014ef6)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37938](https://github.com/nodejs/node/pull/37938)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.16.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.16.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.16.1/node-v14.16.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.16.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.16.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.16.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.16.1/node-v14.16.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.16.1/ \
 Documentation: https://nodejs.org/docs/v14.16.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.0.md
+++ b/pages/en/blog/release/v14.17.0.md
@@ -703,20 +703,20 @@ should be compatible.
 * [[`9460f2cd83`](https://github.com/nodejs/node/commit/9460f2cd83)] - **(SEMVER-MINOR)** **worker**: add eventLoopUtilization() (Trevor Norris) [#35664](https://github.com/nodejs/node/pull/35664)
 * [[`78ad8b4c44`](https://github.com/nodejs/node/commit/78ad8b4c44)] - **workers**: fix spawning from preload scripts (James M Snell) [#37481](https://github.com/nodejs/node/pull/37481)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.0/node-v14.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.0/node-v14.17.0.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.0/node-v14.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.0/ \
 Documentation: https://nodejs.org/docs/v14.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.1.md
+++ b/pages/en/blog/release/v14.17.1.md
@@ -268,20 +268,20 @@ author: Michaël Zasso
 * [[`740638de0f`](https://github.com/nodejs/node/commit/740638de0f)] - **zlib**: refactor to use primordial instead of \<string\>.startsWith (Rohan Chougule) [#36718](https://github.com/nodejs/node/pull/36718)
 * [[`32e10f388c`](https://github.com/nodejs/node/commit/32e10f388c)] - **zlib**: refactor to use more primordials (Antoine du Hamel) [#36347](https://github.com/nodejs/node/pull/36347)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.1/node-v14.17.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.1/node-v14.17.1.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.1/node-v14.17.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.1/ \
 Documentation: https://nodejs.org/docs/v14.17.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.2.md
+++ b/pages/en/blog/release/v14.17.2.md
@@ -22,20 +22,20 @@ Vulnerabilities fixed:
 * [[`a7496aba0a`](https://github.com/nodejs/node/commit/a7496aba0a)] - **deps**: uv: cherry-pick 99c29c9c2c9b (Ben Noordhuis) [nodejs-private/node-private#267](https://github.com/nodejs-private/node-private/pull/267)
 * [[`d0b449da1d`](https://github.com/nodejs/node/commit/d0b449da1d)] - **win,msi**: set install directory permission (AkshayK) [nodejs-private/node-private#269](https://github.com/nodejs-private/node-private/pull/269)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.2/node-v14.17.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.2/node-v14.17.2.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.2/node-v14.17.2.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.2/ \
 Documentation: https://nodejs.org/docs/v14.17.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.3.md
+++ b/pages/en/blog/release/v14.17.3.md
@@ -19,20 +19,20 @@ installer.
 
 * [[`0f00104a2c`](https://github.com/nodejs/node/commit/0f00104a2c)] - **win,msi**: use localized "Authenticated Users" name (Richard Lau) [#39241](https://github.com/nodejs/node/pull/39241)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.3/node-v14.17.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.3/node-v14.17.3.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.3/node-v14.17.3.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.3/ \
 Documentation: https://nodejs.org/docs/v14.17.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.4.md
+++ b/pages/en/blog/release/v14.17.4.md
@@ -157,20 +157,20 @@ This releases also fixes some regressions with internationalization introduced b
 * [[`dd00547ada`](https://github.com/nodejs/node/commit/dd00547ada)] - **vm**: use missing validator (Voltrex) [#38935](https://github.com/nodejs/node/pull/38935)
 * [[`2c28e00685`](https://github.com/nodejs/node/commit/2c28e00685)] - **worker**: do not look up context twice in PostMessage (Anna Henningsen) [#38784](https://github.com/nodejs/node/pull/38784)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.4/node-v14.17.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.4/node-v14.17.4.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.4/node-v14.17.4.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.4/ \
 Documentation: https://nodejs.org/docs/v14.17.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.5.md
+++ b/pages/en/blog/release/v14.17.5.md
@@ -26,20 +26,20 @@ author: Bethany Nicolle Griggs
 * [[`434872e838`](https://github.com/nodejs/node/commit/434872e838)] - **http2**: update handling of rst\_stream with error code NGHTTP2\_CANCEL (Akshay K) [#39622](https://github.com/nodejs/node/pull/39622)
 * [[`35b86110e4`](https://github.com/nodejs/node/commit/35b86110e4)] - **tls**: validate "rejectUnauthorized: undefined" (Matteo Collina) [nodejs-private/node-private#276](https://github.com/nodejs-private/node-private/pull/276)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.5/node-v14.17.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.5/node-v14.17.5.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.5/node-v14.17.5.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.5/ \
 Documentation: https://nodejs.org/docs/v14.17.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.17.6.md
+++ b/pages/en/blog/release/v14.17.6.md
@@ -32,20 +32,20 @@ You can read more about it in:
 * [[`71372625ae`](https://github.com/nodejs/node/commit/71372625ae)] - **deps**: upgrade openssl sources to 1.1.1l (Richard Lau) [#39868](https://github.com/nodejs/node/pull/39868)
 * [[`4276984803`](https://github.com/nodejs/node/commit/4276984803)] - **deps**: upgrade npm to 6.14.15 (Darcy Clarke) [#39856](https://github.com/nodejs/node/pull/39856)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.17.6/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.17.6/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.17.6/node-v14.17.6.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.17.6/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.17.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.17.6/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.17.6/node-v14.17.6.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.17.6/node-v14.17.6.tar.gz \
+Other release files: https://nodejs.org/dist/v14.17.6/ \
 Documentation: https://nodejs.org/docs/v14.17.6/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.18.0.md
+++ b/pages/en/blog/release/v14.18.0.md
@@ -496,20 +496,20 @@ author: Michaël Zasso
 * [[`f206af679c`](https://github.com/nodejs/node/commit/f206af679c)] - **typings**: add a few JSDoc typings for the net lib module (nerdthatnoonelikes) [#38953](https://github.com/nodejs/node/pull/38953)
 * [[`d458cd7e2b`](https://github.com/nodejs/node/commit/d458cd7e2b)] - **typings**: add JSDoc typings for timers (Voltrex) [#38834](https://github.com/nodejs/node/pull/38834)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.18.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.18.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.18.0/node-v14.18.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.18.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.18.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.18.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.18.0/node-v14.18.0.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.18.0/node-v14.18.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.18.0/ \
 Documentation: https://nodejs.org/docs/v14.18.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.18.1.md
+++ b/pages/en/blog/release/v14.18.1.md
@@ -21,20 +21,20 @@ author: Danielle Adams
 * [[`9b92ae2499`](https://github.com/nodejs/node/commit/9b92ae2499)] - **http**: add regression test for smuggling content length (Matteo Collina) [nodejs-private/node-private#285](https://github.com/nodejs-private/node-private/pull/285)
 * [[`f467539719`](https://github.com/nodejs/node/commit/f467539719)] - **http**: add regression test for chunked smuggling (Matteo Collina) [nodejs-private/node-private#285](https://github.com/nodejs-private/node-private/pull/285)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.18.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.18.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.18.1/node-v14.18.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.18.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.18.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.18.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.18.1/node-v14.18.1.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.18.1/node-v14.18.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.18.1/ \
 Documentation: https://nodejs.org/docs/v14.18.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.18.2.md
+++ b/pages/en/blog/release/v14.18.2.md
@@ -34,20 +34,20 @@ of allowable Python versions for building.
 * \[[`6b7b2bba41`](https://github.com/nodejs/node/commit/6b7b2bba41)] - **tools**: patch jinja2 for Python 3.10 compat (Michaël Zasso) [#40296](https://github.com/nodejs/node/pull/40296)
 * \[[`39583f77d8`](https://github.com/nodejs/node/commit/39583f77d8)] - **worker**: avoid potential deadlock on NearHeapLimit (Santiago Gimeno) [#38403](https://github.com/nodejs/node/pull/38403)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.18.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.18.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.18.2/node-v14.18.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.18.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.18.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.18.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.18.2/node-v14.18.2.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.18.2/node-v14.18.2.tar.gz \
+Other release files: https://nodejs.org/dist/v14.18.2/ \
 Documentation: https://nodejs.org/docs/v14.18.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.18.3.md
+++ b/pages/en/blog/release/v14.18.3.md
@@ -53,20 +53,20 @@ Thanks to Patrik Oldsberg (rugvip) for reporting this vulnerability.
 * \[[`83d8f880bb`](https://github.com/nodejs/node/commit/83d8f880bb)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen and Akshay Kumar) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 * \[[`461a0c674b`](https://github.com/nodejs/node/commit/461a0c674b)] - **tls**: drop support for URI alternative names (Tobias Nießen and Akshay Kumar) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.18.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.18.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.18.3/node-v14.18.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.18.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.18.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.18.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.18.3/node-v14.18.3.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.18.3/node-v14.18.3.tar.gz \
+Other release files: https://nodejs.org/dist/v14.18.3/ \
 Documentation: https://nodejs.org/docs/v14.18.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.19.0.md
+++ b/pages/en/blog/release/v14.19.0.md
@@ -69,20 +69,20 @@ Contributed by Richard Lau - [#40280](https://github.com/nodejs/node/pull/40280)
 * \[[`b050c65885`](https://github.com/nodejs/node/commit/b050c65885)] - **src**: add option to disable loading native addons (Dominic Elm) [#39977](https://github.com/nodejs/node/pull/39977)
 * \[[`c1695ac68a`](https://github.com/nodejs/node/commit/c1695ac68a)] - **tools**: update certdata.txt (Richard Lau) [#40280](https://github.com/nodejs/node/pull/40280)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.19.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.19.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.19.0/node-v14.19.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.19.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.19.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.19.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.19.0/node-v14.19.0.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.19.0/node-v14.19.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.19.0/ \
 Documentation: https://nodejs.org/docs/v14.19.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.19.1.md
+++ b/pages/en/blog/release/v14.19.1.md
@@ -21,20 +21,20 @@ Update to OpenSSL 1.1.1n, which addresses the following vulnerability:
 * \[[`3b1a0b24f0`](https://github.com/nodejs/node/commit/3b1a0b24f0)] - **deps**: update archs files for OpenSSL-1.1.1n (Richard Lau) [#42347](https://github.com/nodejs/node/pull/42347)
 * \[[`c83dd99e0b`](https://github.com/nodejs/node/commit/c83dd99e0b)] - **deps**: upgrade openssl sources to 1.1.1n (Richard Lau) [#42347](https://github.com/nodejs/node/pull/42347)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.19.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.19.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.19.1/node-v14.19.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.19.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.19.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.19.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.19.1/node-v14.19.1.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.19.1/node-v14.19.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.19.1/ \
 Documentation: https://nodejs.org/docs/v14.19.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.19.2.md
+++ b/pages/en/blog/release/v14.19.2.md
@@ -54,20 +54,20 @@ Contributed by Chengzhong Wu (@legendecas)
 * \[[`d4171e0eac`](https://github.com/nodejs/node/commit/d4171e0eac)] - **stream**: resume stream on drain (Robert Nagy) [#41848](https://github.com/nodejs/node/pull/41848)
 * \[[`de474c8b6f`](https://github.com/nodejs/node/commit/de474c8b6f)] - **worker**: do not send message if port is closing (Rich Trott) [#42357](https://github.com/nodejs/node/pull/42357)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.19.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.19.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.19.2/node-v14.19.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.19.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.19.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.19.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.19.2/node-v14.19.2.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.19.2/node-v14.19.2.tar.gz \
+Other release files: https://nodejs.org/dist/v14.19.2/ \
 Documentation: https://nodejs.org/docs/v14.19.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.19.3.md
+++ b/pages/en/blog/release/v14.19.3.md
@@ -19,20 +19,20 @@ author: Richard Lau
 * \[[`7f9a5ed4a8`](https://github.com/nodejs/node/commit/7f9a5ed4a8)] - **deps**: upgrade openssl sources to 1.1.1o (RafaelGSS) [#42956](https://github.com/nodejs/node/pull/42956)
 * \[[`61eba58cb6`](https://github.com/nodejs/node/commit/61eba58cb6)] - **doc**: add release key for Juan Arboleda (Juan José) [#42961](https://github.com/nodejs/node/pull/42961)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.19.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.19.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.19.3/node-v14.19.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.19.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.19.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.19.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.19.3/node-v14.19.3.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.19.3/node-v14.19.3.tar.gz \
+Other release files: https://nodejs.org/dist/v14.19.3/ \
 Documentation: https://nodejs.org/docs/v14.19.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.2.0.md
+++ b/pages/en/blog/release/v14.2.0.md
@@ -168,20 +168,20 @@ Contributed by rickyes - [#32964](https://github.com/nodejs/node/pull/32964).
 * [[`12426f59f5`](https://github.com/nodejs/node/commit/12426f59f5)] - **tools**: update remark-preset-lint-node@1.14.0 (Rich Trott) [#33072](https://github.com/nodejs/node/pull/33072)
 * [[`8c40ffc329`](https://github.com/nodejs/node/commit/8c40ffc329)] - **tools**: update broken types in type parser (Colin Ihrig) [#33068](https://github.com/nodejs/node/pull/33068)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.2.0/node-v14.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.2.0/node-v14.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.2.0/node-v14.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.2.0/ \
 Documentation: https://nodejs.org/docs/v14.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.20.0.md
+++ b/pages/en/blog/release/v14.20.0.md
@@ -23,20 +23,20 @@ author: Danielle Adams
 * \[[`48c5aa5cab`](https://github.com/nodejs/node/commit/48c5aa5cab)] - **src**: fix IPv4 validation in inspector\_socket (Tobias Nießen) [nodejs-private/node-private#320](https://github.com/nodejs-private/node-private/pull/320)
 * \[[`8e8aef836c`](https://github.com/nodejs/node/commit/8e8aef836c)] - **(SEMVER-MAJOR)** **src,deps,build,test**: add OpenSSL config appname (Daniel Bevenius) [#43124](https://github.com/nodejs/node/pull/43124)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.20.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.20.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.20.0/node-v14.20.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.20.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.20.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.20.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.20.0/node-v14.20.0.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.20.0/node-v14.20.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.20.0/ \
 Documentation: https://nodejs.org/docs/v14.20.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.20.1.md
+++ b/pages/en/blog/release/v14.20.1.md
@@ -24,20 +24,20 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`a1121b456c`](https://github.com/nodejs/node/commit/a1121b456c)] - **src**: fix IPv4 non routable validation (RafaelGSS) [nodejs-private/node-private#337](https://github.com/nodejs-private/node-private/pull/337)
 * \[[`de80707870`](https://github.com/nodejs/node/commit/de80707870)] - **src**: fix IS\_LTS and IS\_RELEASE flags (Richard Lau) [#43761](https://github.com/nodejs/node/pull/43761)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.20.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.20.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.20.1/node-v14.20.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.20.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.20.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.20.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.20.1/node-v14.20.1.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.20.1/node-v14.20.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.20.1/ \
 Documentation: https://nodejs.org/docs/v14.20.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.21.0.md
+++ b/pages/en/blog/release/v14.21.0.md
@@ -33,20 +33,20 @@ author: Danielle Adams
 * \[[`9487028043`](https://github.com/nodejs/node/commit/9487028043)] - **test**: fix intl tests on small-icu builds (Antoine du Hamel) [#41939](https://github.com/nodejs/node/pull/41939)
 * \[[`a1d52097f8`](https://github.com/nodejs/node/commit/a1d52097f8)] - **tools**: add more options to track flaky tests (Antoine du Hamel) [#43954](https://github.com/nodejs/node/pull/43954)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.21.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.21.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.21.0/node-v14.21.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.21.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.21.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.21.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.21.0/node-v14.21.0.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.21.0/node-v14.21.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.21.0/ \
 Documentation: https://nodejs.org/docs/v14.21.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.21.1.md
+++ b/pages/en/blog/release/v14.21.1.md
@@ -20,20 +20,20 @@ More detailed information on each of the vulnerabilities can be found in [Novemb
 
 * \[[`2b433af094`](https://github.com/nodejs/node/commit/2b433af094)] - **inspector**: harden IP address validation again (Tobias Nießen) [nodejs-private/node-private#354](https://github.com/nodejs-private/node-private/pull/354)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.21.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.21.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.21.1/node-v14.21.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.21.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.21.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.21.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.21.1/node-v14.21.1.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.21.1/node-v14.21.1.tar.gz \
+Other release files: https://nodejs.org/dist/v14.21.1/ \
 Documentation: https://nodejs.org/docs/v14.21.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.21.2.md
+++ b/pages/en/blog/release/v14.21.2.md
@@ -66,20 +66,20 @@ Savings Time (DST) for Fiji and Mexico. For more information, see
 * \[[`d6f1d7107b`](https://github.com/nodejs/node/commit/d6f1d7107b)] - **tools**: have test-asan use ubuntu-20.04 (Filip Skokan) [#45581](https://github.com/nodejs/node/pull/45581)
 * \[[`370a00f737`](https://github.com/nodejs/node/commit/370a00f737)] - **tools**: make license-builder.sh comply with shellcheck 0.8.0 (Rich Trott) [#41258](https://github.com/nodejs/node/pull/41258)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.21.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.21.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.21.2/node-v14.21.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.21.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.21.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.21.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.21.2/node-v14.21.2.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.21.2/node-v14.21.2.tar.gz \
+Other release files: https://nodejs.org/dist/v14.21.2/ \
 Documentation: https://nodejs.org/docs/v14.21.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.21.3.md
+++ b/pages/en/blog/release/v14.21.3.md
@@ -38,20 +38,20 @@ can get more details for the individual CVEs in
 * \[[`83975b7fb4`](https://github.com/nodejs/node/commit/83975b7fb4)] - **policy**: makeRequireFunction on mainModule.require (RafaelGSS) [nodejs-private/node-private#358](https://github.com/nodejs-private/node-private/pull/358)
 * \[[`a5f8798d7a`](https://github.com/nodejs/node/commit/a5f8798d7a)] - **test**: avoid left behind child processes (Richard Lau) [#46276](https://github.com/nodejs/node/pull/46276)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.21.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.21.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3.pkg<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.21.3/node-v14.21.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.21.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.21.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.21.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.21.3/node-v14.21.3.pkg \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.21.3/node-v14.21.3.tar.gz \
+Other release files: https://nodejs.org/dist/v14.21.3/ \
 Documentation: https://nodejs.org/docs/v14.21.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.3.0.md
+++ b/pages/en/blog/release/v14.3.0.md
@@ -141,20 +141,20 @@ It's now possible to use the await keyword outside of async functions, with the 
 * [[`b1a7fdac43`](https://github.com/nodejs/node/commit/b1a7fdac43)] - **worker**: call CancelTerminateExecution() before exiting Locker (Anna Henningsen) [#33347](https://github.com/nodejs/node/pull/33347)
 * [[`736ca65c2c`](https://github.com/nodejs/node/commit/736ca65c2c)] - **zlib**: reject windowBits=8 when mode=GZIP (Ben Noordhuis) [#33045](https://github.com/nodejs/node/pull/33045)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.3.0/node-v14.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.3.0/node-v14.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.3.0/node-v14.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.3.0/ \
 Documentation: https://nodejs.org/docs/v14.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.4.0.md
+++ b/pages/en/blog/release/v14.4.0.md
@@ -26,20 +26,20 @@ Vulnerabilities fixed:
 * [[`94571c1001`](https://github.com/nodejs/node/commit/94571c1001)] - **tls**: emit `session` after verifying certificate (Fedor Indutny) [nodejs-private/node-private#200](https://github.com/nodejs-private/node-private/pull/200)
 * [[`1658cf9ee6`](https://github.com/nodejs/node/commit/1658cf9ee6)] - **tools**: update certdata.txt (AshCripps) [#33682](https://github.com/nodejs/node/pull/33682)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.4.0/node-v14.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.4.0/node-v14.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.4.0/node-v14.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.4.0/ \
 Documentation: https://nodejs.org/docs/v14.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.5.0.md
+++ b/pages/en/blog/release/v14.5.0.md
@@ -369,20 +369,20 @@ Contributed by James Snell - [#33556](https://github.com/nodejs/node/pull/33556)
 * [[`64cae13799`](https://github.com/nodejs/node/commit/64cae13799)] - **worker**: use \_writev in internal communication (Anna Henningsen) [#33454](https://github.com/nodejs/node/pull/33454)
 * [[`7817b875a7`](https://github.com/nodejs/node/commit/7817b875a7)] - **worker**: fix race condition in node\_messaging.cc (Anna Henningsen) [#33429](https://github.com/nodejs/node/pull/33429)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.5.0/node-v14.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.5.0/node-v14.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.5.0/node-v14.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.5.0/ \
 Documentation: https://nodejs.org/docs/v14.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.6.0.md
+++ b/pages/en/blog/release/v14.6.0.md
@@ -170,20 +170,20 @@ author: Myles Borins
 * [[`9e04070d3c`](https://github.com/nodejs/node/commit/9e04070d3c)] - **(SEMVER-MINOR)** **worker**: add option to track unmanaged file descriptors (Anna Henningsen) [#34303](https://github.com/nodejs/node/pull/34303)
 * [[`105d5607a8`](https://github.com/nodejs/node/commit/105d5607a8)] - **zlib**: remove redundant variable in zlibBufferOnEnd (Andrey Pechkurov) [#34072](https://github.com/nodejs/node/pull/34072)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.6.0/node-v14.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.6.0/node-v14.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.6.0/node-v14.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.6.0/ \
 Documentation: https://nodejs.org/docs/v14.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.7.0.md
+++ b/pages/en/blog/release/v14.7.0.md
@@ -104,20 +104,20 @@ author: Myles Borins
 * [[`0aa3809b6b`](https://github.com/nodejs/node/commit/0aa3809b6b)] - **(SEMVER-MINOR)** **worker**: make MessagePort inherit from EventTarget (Anna Henningsen) [#34057](https://github.com/nodejs/node/pull/34057)
 * [[`252f37630a`](https://github.com/nodejs/node/commit/252f37630a)] - **zlib**: switch to lazy init for zlib streams (Andrey Pechkurov) [#34048](https://github.com/nodejs/node/pull/34048)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.7.0/node-v14.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.7.0/node-v14.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.7.0/node-v14.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.7.0/ \
 Documentation: https://nodejs.org/docs/v14.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.8.0.md
+++ b/pages/en/blog/release/v14.8.0.md
@@ -100,20 +100,20 @@ author: Shelley Vohr
 * [[`f46649bc5b`](https://github.com/nodejs/node/commit/f46649bc5b)] - **util**: print External address from inspect (unknown) [#34398](https://github.com/nodejs/node/pull/34398)
 * [[`2fa24c0ccc`](https://github.com/nodejs/node/commit/2fa24c0ccc)] - **wasi**: add \_\_wasi\_fd\_filestat\_set\_times() test (Colin Ihrig) [#34623](https://github.com/nodejs/node/pull/34623)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.8.0/node-v14.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.8.0/node-v14.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.8.0/node-v14.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.8.0/ \
 Documentation: https://nodejs.org/docs/v14.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v14.9.0.md
+++ b/pages/en/blog/release/v14.9.0.md
@@ -124,20 +124,20 @@ author: Bethany Nicolle Griggs
 * [[`03d601344a`](https://github.com/nodejs/node/commit/03d601344a)] - **worker**: do not crash when JSTransferable lists untransferable value (Anna Henningsen) [#34766](https://github.com/nodejs/node/pull/34766)
 * [[`b73943e476`](https://github.com/nodejs/node/commit/b73943e476)] - **workers**: add support for data: URLs (Antoine du HAMEL) [#34584](https://github.com/nodejs/node/pull/34584)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v14.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v14.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v14.9.0/node-v14.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v14.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v14.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v14.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v14.9.0/node-v14.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v14.9.0/node-v14.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v14.9.0/ \
 Documentation: https://nodejs.org/docs/v14.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.0.0.md
+++ b/pages/en/blog/release/v15.0.0.md
@@ -428,20 +428,20 @@ The V8 JavaScript engine has been updated to V8 8.6 (V8 8.4 is the latest availa
 * [[`076e4ed2d1`](https://github.com/nodejs/node/commit/076e4ed2d1)] - **tools**: update ESLint from 7.2.0 to 7.3.1 (Rich Trott) [#34000](https://github.com/nodejs/node/pull/34000)
 * [[`7afe3af200`](https://github.com/nodejs/node/commit/7afe3af200)] - **url**: fix file url reparse (Daijiro Wachi) [#35671](https://github.com/nodejs/node/pull/35671)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.0.0/node-v15.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.0.0/node-v15.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.0.0/node-v15.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.0.0/ \
 Documentation: https://nodejs.org/docs/v15.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.0.1.md
+++ b/pages/en/blog/release/v15.0.1.md
@@ -28,20 +28,20 @@ author: Bethany Nicolle Griggs
 * [[`6a7a61be7c`](https://github.com/nodejs/node/commit/6a7a61be7c)] - **src**: mark/pop OpenSSL errors in NewRootCertStore (Daniel Bevenius) [#35514](https://github.com/nodejs/node/pull/35514)
 * [[`d54edece99`](https://github.com/nodejs/node/commit/d54edece99)] - **test**: refactor test-crypto-pbkdf2 (Tobias Nießen) [#35693](https://github.com/nodejs/node/pull/35693)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.0.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.0.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.0.1/node-v15.0.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.0.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.0.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.0.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.0.1/node-v15.0.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.0.1/node-v15.0.1.tar.gz \
+Other release files: https://nodejs.org/dist/v15.0.1/ \
 Documentation: https://nodejs.org/docs/v15.0.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.1.0.md
+++ b/pages/en/blog/release/v15.1.0.md
@@ -252,20 +252,20 @@ Contributed by Joyee Cheung [#33010](https://github.com/nodejs/node/pull/33010).
 * [[`66da122d46`](https://github.com/nodejs/node/commit/66da122d46)] - **tools**: refloat 7 Node.js patches to cpplint.py (Rich Trott) [#35719](https://github.com/nodejs/node/pull/35719)
 * [[`042d4dd71c`](https://github.com/nodejs/node/commit/042d4dd71c)] - **tools**: bump cpplint to 1.5.0 (Rich Trott) [#35719](https://github.com/nodejs/node/pull/35719)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.1.0/node-v15.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.1.0/node-v15.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.1.0/node-v15.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.1.0/ \
 Documentation: https://nodejs.org/docs/v15.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.10.0.md
+++ b/pages/en/blog/release/v15.10.0.md
@@ -27,20 +27,20 @@ https://www.openssl.org/news/secadv/20210216.txt
 * [[`4184806dee`](https://github.com/nodejs/node/commit/4184806dee)] - **(SEMVER-MINOR)** **http2**: add unknownProtocol timeout (Daniel Bevenius) [nodejs-private/node-private#246](https://github.com/nodejs-private/node-private/pull/246)
 * [[`43ae9c46c3`](https://github.com/nodejs/node/commit/43ae9c46c3)] - **src**: drop localhost6 as allowed host for inspector (Matteo Collina) [nodejs-private/node-private#244](https://github.com/nodejs-private/node-private/pull/244)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.10.0/node-v15.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.10.0/node-v15.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.10.0/node-v15.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.10.0/ \
 Documentation: https://nodejs.org/docs/v15.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.11.0.md
+++ b/pages/en/blog/release/v15.11.0.md
@@ -99,20 +99,20 @@ author: Michaël Zasso
 * [[`31f4600b7a`](https://github.com/nodejs/node/commit/31f4600b7a)] - **worker**: fix interaction of terminate() with messaging port (Anna Henningsen) [#37319](https://github.com/nodejs/node/pull/37319)
 * [[`d93137b2a9`](https://github.com/nodejs/node/commit/d93137b2a9)] - **workers**: fix spawning from preload scripts (James M Snell) [#37481](https://github.com/nodejs/node/pull/37481)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.11.0/node-v15.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.11.0/node-v15.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.11.0/node-v15.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.11.0/ \
 Documentation: https://nodejs.org/docs/v15.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.12.0.md
+++ b/pages/en/blog/release/v15.12.0.md
@@ -129,20 +129,20 @@ author: Danielle Adams
 * [[`8024ffbba4`](https://github.com/nodejs/node/commit/8024ffbba4)] - **worker**: add ports property to MessageEvents (Anna Henningsen) [#37538](https://github.com/nodejs/node/pull/37538)
 * [[`f4fd3fb6a7`](https://github.com/nodejs/node/commit/f4fd3fb6a7)] - **worker**: allow BroadcastChannel in receiveMessageOnPort (Anna Henningsen) [#37535](https://github.com/nodejs/node/pull/37535)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.12.0/node-v15.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.12.0/node-v15.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.12.0/node-v15.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.12.0/ \
 Documentation: https://nodejs.org/docs/v15.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.13.0.md
+++ b/pages/en/blog/release/v15.13.0.md
@@ -108,20 +108,20 @@ author: Ruy Adorno
 * [[`3452618905`](https://github.com/nodejs/node/commit/3452618905)] - **tty**: validate file descriptor to avoid int32 overflow (Antoine du Hamel) [#37809](https://github.com/nodejs/node/pull/37809)
 * [[`d33f446abd`](https://github.com/nodejs/node/commit/d33f446abd)] - **util**: remove unreachable inspect code (Rich Trott) [#37941](https://github.com/nodejs/node/pull/37941)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.13.0/node-v15.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.13.0/node-v15.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.13.0/node-v15.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.13.0/ \
 Documentation: https://nodejs.org/docs/v15.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.14.0.md
+++ b/pages/en/blog/release/v15.14.0.md
@@ -77,20 +77,20 @@ Other Notable Changes:
 * [[`51e7a33d54`](https://github.com/nodejs/node/commit/51e7a33d54)] - **tools,doc**: add "legacy" badge in the TOC (Antoine du Hamel) [#37949](https://github.com/nodejs/node/pull/37949)
 * [[`570fbcef93`](https://github.com/nodejs/node/commit/570fbcef93)] - **url**: forbid pipe in URL host (Darshan Sen) [#37877](https://github.com/nodejs/node/pull/37877)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.14.0/node-v15.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.14.0/node-v15.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.14.0/ \
 Documentation: https://nodejs.org/docs/v15.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.2.0.md
+++ b/pages/en/blog/release/v15.2.0.md
@@ -86,20 +86,20 @@ author: Danielle Adams
 * [[`eea7e3b0d0`](https://github.com/nodejs/node/commit/eea7e3b0d0)] - **tools,lib**: tighten prefer-primordials rules for Error statics (Antoine du Hamel) [#36017](https://github.com/nodejs/node/pull/36017)
 * [[`7a2edea7ed`](https://github.com/nodejs/node/commit/7a2edea7ed)] - **win, build**: fix build time on Windows (Bartosz Sosnowski) [#35932](https://github.com/nodejs/node/pull/35932)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.2.0/node-v15.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.2.0/node-v15.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.2.0/node-v15.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.2.0/ \
 Documentation: https://nodejs.org/docs/v15.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.2.1.md
+++ b/pages/en/blog/release/v15.2.1.md
@@ -26,20 +26,20 @@ Vulnerabilities fixed:
 * [[`a2f652f7c5`](https://github.com/nodejs/node/commit/a2f652f7c5)] - **test**: move test-worker-eventlooputil to sequential (Rich Trott) [#35996](https://github.com/nodejs/node/pull/35996)
 * [[`b0b43b27d6`](https://github.com/nodejs/node/commit/b0b43b27d6)] - **test**: fix unreliable test-fs-write-file.js (Rich Trott) [#36102](https://github.com/nodejs/node/pull/36102)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.2.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.2.1/node-v15.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.2.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.2.1/node-v15.2.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.2.1/node-v15.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v15.2.1/ \
 Documentation: https://nodejs.org/docs/v15.2.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.3.0.md
+++ b/pages/en/blog/release/v15.3.0.md
@@ -120,20 +120,20 @@ author: Shelley Vohr
 * [[`f7b2fce1c1`](https://github.com/nodejs/node/commit/f7b2fce1c1)] - **vm**: refactor to use more primordials (Antoine du Hamel) [#36023](https://github.com/nodejs/node/pull/36023)
 * [[`4e3883ec2d`](https://github.com/nodejs/node/commit/4e3883ec2d)] - **win,build,tools**: support VS prerelease (Baruch Odem) [#36033](https://github.com/nodejs/node/pull/36033)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.3.0/node-v15.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.3.0/node-v15.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.3.0/node-v15.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.3.0/ \
 Documentation: https://nodejs.org/docs/v15.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.4.0.md
+++ b/pages/en/blog/release/v15.4.0.md
@@ -124,20 +124,20 @@ author: Danielle Adams
 * [[`802d44b1a9`](https://github.com/nodejs/node/commit/802d44b1a9)] - **(SEMVER-MINOR)** **worker**: add experimental BroadcastChannel (James M Snell) [#36271](https://github.com/nodejs/node/pull/36271)
 * [[`4b4caada9f`](https://github.com/nodejs/node/commit/4b4caada9f)] - **zlib**: refactor to use more primordials (Antoine du Hamel) [#36347](https://github.com/nodejs/node/pull/36347)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.4.0/node-v15.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.4.0/node-v15.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.4.0/node-v15.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.4.0/ \
 Documentation: https://nodejs.org/docs/v15.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.5.0.md
+++ b/pages/en/blog/release/v15.5.0.md
@@ -204,20 +204,20 @@ With this release, we welcome a new Node.js core collaborator:
 * [[`8ecf2f9976`](https://github.com/nodejs/node/commit/8ecf2f9976)] - **tools**: update doc tool dependencies (Michaël Zasso) [#36407](https://github.com/nodejs/node/pull/36407)
 * [[`040b39f076`](https://github.com/nodejs/node/commit/040b39f076)] - **tools**: enable no-unused-expressions lint rule (Michaël Zasso) [#36248](https://github.com/nodejs/node/pull/36248)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.5.0/node-v15.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.5.0/node-v15.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.5.0/node-v15.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.5.0/ \
 Documentation: https://nodejs.org/docs/v15.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.5.1.md
+++ b/pages/en/blog/release/v15.5.1.md
@@ -35,20 +35,20 @@ Vulnerabilities fixed:
 * [[`e0c9a2285c`](https://github.com/nodejs/node/commit/e0c9a2285c)] - **http**: unset `F_CHUNKED` on new `Transfer-Encoding` (Matteo Collina) [nodejs-private/node-private#228](https://github.com/nodejs-private/node-private/pull/228)
 * [[`9834ef85a0`](https://github.com/nodejs/node/commit/9834ef85a0)] - **src**: retain pointers to WriteWrap/ShutdownWrap (James M Snell) [nodejs-private/node-private#23](https://github.com/nodejs-private/node-private/pull/23)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.5.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.5.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.5.1/node-v15.5.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.5.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.5.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.5.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.5.1/node-v15.5.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.5.1/node-v15.5.1.tar.gz \
+Other release files: https://nodejs.org/dist/v15.5.1/ \
 Documentation: https://nodejs.org/docs/v15.5.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.6.0.md
+++ b/pages/en/blog/release/v15.6.0.md
@@ -195,20 +195,20 @@ author: Danielle Adams
 * [[`d5a9799e76`](https://github.com/nodejs/node/commit/d5a9799e76)] - **wasi**: refactor to avoid unsafe array iteration (Antoine du Hamel) [#36724](https://github.com/nodejs/node/pull/36724)
 * [[`b6f74b0b09`](https://github.com/nodejs/node/commit/b6f74b0b09)] - **zlib**: refactor to use primordial instead of \<string\>.startsWith (Rohan Chougule) [#36718](https://github.com/nodejs/node/pull/36718)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.6.0/node-v15.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.6.0/node-v15.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.6.0/node-v15.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.6.0/ \
 Documentation: https://nodejs.org/docs/v15.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.7.0.md
+++ b/pages/en/blog/release/v15.7.0.md
@@ -106,20 +106,20 @@ author: Ruy Adorno
 * [[`bf695ebdb1`](https://github.com/nodejs/node/commit/bf695ebdb1)] - **worker**: refactor to avoid unsafe array iteration (Antoine du Hamel) [#36735](https://github.com/nodejs/node/pull/36735)
 * [[`403b595ef5`](https://github.com/nodejs/node/commit/403b595ef5)] - **zlib**: refactor to avoid unsafe array iteration (Antoine du Hamel) [#36722](https://github.com/nodejs/node/pull/36722)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.7.0/node-v15.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.7.0/node-v15.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.7.0/node-v15.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.7.0/ \
 Documentation: https://nodejs.org/docs/v15.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.8.0.md
+++ b/pages/en/blog/release/v15.8.0.md
@@ -104,20 +104,20 @@ author: Michaël Zasso
 * [[`d2d6121f3e`](https://github.com/nodejs/node/commit/d2d6121f3e)] - **tools**: enable object-curly-newline in ESLint rules (Rich Trott) [#37040](https://github.com/nodejs/node/pull/37040)
 * [[`3187845980`](https://github.com/nodejs/node/commit/3187845980)] - **util**: add internal createDeferredPromise() (Colin Ihrig) [#37095](https://github.com/nodejs/node/pull/37095)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.8.0/node-v15.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.8.0/node-v15.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.8.0/node-v15.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.8.0/ \
 Documentation: https://nodejs.org/docs/v15.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v15.9.0.md
+++ b/pages/en/blog/release/v15.9.0.md
@@ -140,20 +140,20 @@ author: Danielle Adams
 * [[`66a14d3992`](https://github.com/nodejs/node/commit/66a14d3992)] - **vm**: add importModuleDynamically option to compileFunction (Gus Caplan) [#35431](https://github.com/nodejs/node/pull/35431)
 * [[`05a16e7259`](https://github.com/nodejs/node/commit/05a16e7259)] - **worker**: refactor to avoid unsafe array iteration (Antoine du Hamel) [#37346](https://github.com/nodejs/node/pull/37346)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v15.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v15.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v15.9.0/node-v15.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v15.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v15.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v15.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v15.9.0/node-v15.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v15.9.0/node-v15.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v15.9.0/ \
 Documentation: https://nodejs.org/docs/v15.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.0.0.md
+++ b/pages/en/blog/release/v16.0.0.md
@@ -360,21 +360,21 @@ Contributed by Michaël Zasso - [#37587](https://github.com/nodejs/node/pull/375
 * [[`26eed3e0ed`](https://github.com/nodejs/node/commit/26eed3e0ed)] - **vm**: add import assertion support (Gus Caplan) [#37176](https://github.com/nodejs/node/pull/37176)
 * [[`6986fa07eb`](https://github.com/nodejs/node/commit/6986fa07eb)] - **worker**: fix exit code for error thrown in handler (Nitzan Uziely) [#38012](https://github.com/nodejs/node/pull/38012)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.0.0/node-v16.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.0.0/node-v16.0.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.0.0/node-v16.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.0.0/ \
 Documentation: https://nodejs.org/docs/v16.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.1.0.md
+++ b/pages/en/blog/release/v16.1.0.md
@@ -124,21 +124,21 @@ author: Michaël Zasso
 * [[`ec5b06eae3`](https://github.com/nodejs/node/commit/ec5b06eae3)] - **util**: fix infinite recursion during inspection (Ruben Bridgewater) [#37079](https://github.com/nodejs/node/pull/37079)
 * [[`67bd0ec15c`](https://github.com/nodejs/node/commit/67bd0ec15c)] - **zlib**: fix brotli flush range (Khaidi Chu) [#38408](https://github.com/nodejs/node/pull/38408)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.1.0/node-v16.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.1.0/node-v16.1.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.1.0/node-v16.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.1.0/node-v16.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.1.0/ \
 Documentation: https://nodejs.org/docs/v16.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.10.0.md
+++ b/pages/en/blog/release/v16.10.0.md
@@ -119,21 +119,21 @@ author: Bethany Nicolle Griggs
 * [[`590ace418d`](https://github.com/nodejs/node/commit/590ace418d)] - **tools,doc**: fix misrendering of consecutive JS blocks (Rich Trott) [#40146](https://github.com/nodejs/node/pull/40146)
 * [[`5983568204`](https://github.com/nodejs/node/commit/5983568204)] - **worker**: avoid potential deadlock on NearHeapLimit (Santiago Gimeno) [#38403](https://github.com/nodejs/node/pull/38403)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.10.0/node-v16.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.10.0/node-v16.10.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.10.0/node-v16.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.10.0/ \
 Documentation: https://nodejs.org/docs/v16.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.11.0.md
+++ b/pages/en/blog/release/v16.11.0.md
@@ -123,21 +123,21 @@ author: Danielle Adams
 * [[`66d3101677`](https://github.com/nodejs/node/commit/66d3101677)] - **(SEMVER-MINOR)** **util**: improve ansi escape code regex (Colin Ihrig) [#40214](https://github.com/nodejs/node/pull/40214)
 * [[`f4164fa4c3`](https://github.com/nodejs/node/commit/f4164fa4c3)] - **(SEMVER-MINOR)** **util**: expose stripVTControlCharacters() (Colin Ihrig) [#40214](https://github.com/nodejs/node/pull/40214)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.11.0/node-v16.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.11.0/node-v16.11.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.11.0/node-v16.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.11.0/node-v16.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.11.0/ \
 Documentation: https://nodejs.org/docs/v16.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.11.1.md
+++ b/pages/en/blog/release/v16.11.1.md
@@ -21,21 +21,21 @@ author: Danielle Adams
 * [[`2d1eefad98`](https://github.com/nodejs/node/commit/2d1eefad98)] - **http**: add regression test for smuggling content length (Matteo Collina) [nodejs-private/node-private#284](https://github.com/nodejs-private/node-private/pull/284)
 * [[`45d419ab1c`](https://github.com/nodejs/node/commit/45d419ab1c)] - **http**: add regression test for chunked smuggling (Matteo Collina) [nodejs-private/node-private#284](https://github.com/nodejs-private/node-private/pull/284)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.11.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.11.1/node-v16.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.11.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.11.1/node-v16.11.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.11.1/node-v16.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.11.1/node-v16.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.11.1/ \
 Documentation: https://nodejs.org/docs/v16.11.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.12.0.md
+++ b/pages/en/blog/release/v16.12.0.md
@@ -90,21 +90,21 @@ Contributed by Jacob Smith, Geoffrey Booth, and Bradley Farias - https://github.
 * \[[`5f3f3a5128`](https://github.com/nodejs/node/commit/5f3f3a5128)] - **v8**: remove --harmony-top-level-await (Geoffrey Booth) [#40226](https://github.com/nodejs/node/pull/40226)
 * \[[`4116b6c907`](https://github.com/nodejs/node/commit/4116b6c907)] - **(SEMVER-MINOR)** **vm**: add support for import assertions in dynamic imports (Antoine du Hamel) [#40249](https://github.com/nodejs/node/pull/40249)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.12.0/node-v16.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.12.0/node-v16.12.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.12.0/node-v16.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.12.0/node-v16.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.12.0/ \
 Documentation: https://nodejs.org/docs/v16.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.13.0.md
+++ b/pages/en/blog/release/v16.13.0.md
@@ -15,21 +15,21 @@ with the codename 'Gallium'. The 16.x release line now moves into "Active LTS"
 and will remain so until October 2022. After that time, it will move into
 "Maintenance" until end of life in April 2024.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.13.0/node-v16.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.13.0/node-v16.13.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.13.0/node-v16.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.13.0/ \
 Documentation: https://nodejs.org/docs/v16.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.13.1.md
+++ b/pages/en/blog/release/v16.13.1.md
@@ -136,21 +136,21 @@ author: Bethany Nicolle Griggs
 * \[[`fbe0323ebf`](https://github.com/nodejs/node/commit/fbe0323ebf)] - **typings**: improve internal bindings typings (Mestery) [#40411](https://github.com/nodejs/node/pull/40411)
 * \[[`63ab0031c3`](https://github.com/nodejs/node/commit/63ab0031c3)] - **typings**: separate `internalBinding` typings (Mestery) [#40409](https://github.com/nodejs/node/pull/40409)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.13.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.13.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.13.1/node-v16.13.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.13.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.13.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.13.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.13.1/node-v16.13.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.13.1/node-v16.13.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.13.1/ \
 Documentation: https://nodejs.org/docs/v16.13.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.13.2.md
+++ b/pages/en/blog/release/v16.13.2.md
@@ -53,21 +53,21 @@ Thanks to Patrik Oldsberg (rugvip) for reporting this vulnerability.
 * \[[`965536fe3d`](https://github.com/nodejs/node/commit/965536fe3d)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 * \[[`a2cbfa95ff`](https://github.com/nodejs/node/commit/a2cbfa95ff)] - **tls**: drop support for URI alternative names (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.13.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.13.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.13.2/node-v16.13.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.13.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.13.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.13.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.13.2/node-v16.13.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.13.2/node-v16.13.2.tar.gz \
+Other release files: https://nodejs.org/dist/v16.13.2/ \
 Documentation: https://nodejs.org/docs/v16.13.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.14.0.md
+++ b/pages/en/blog/release/v16.14.0.md
@@ -460,21 +460,21 @@ Contributed by Antoine du Hamel and Geoffrey Booth [#40250](https://github.com/n
 * \[[`b15f5e48fa`](https://github.com/nodejs/node/commit/b15f5e48fa)] - **(SEMVER-MINOR)** **util**: always visualize cause property in errors during inspection (Ruben Bridgewater) [#41002](https://github.com/nodejs/node/pull/41002)
 * \[[`e29bd4699d`](https://github.com/nodejs/node/commit/e29bd4699d)] - **(SEMVER-MINOR)** **v8**: multi-tenant promise hook api (Stephen Belanger) [#39283](https://github.com/nodejs/node/pull/39283)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.14.0/node-v16.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.14.0/node-v16.14.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.14.0/node-v16.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.14.0/ \
 Documentation: https://nodejs.org/docs/v16.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.14.1.md
+++ b/pages/en/blog/release/v16.14.1.md
@@ -183,21 +183,21 @@ author: Danielle Adams
 * \[[`8218bab51d`](https://github.com/nodejs/node/commit/8218bab51d)] - **util**: remove unused fast path in internal debuglog (Rich Trott) [#41605](https://github.com/nodejs/node/pull/41605)
 * \[[`a4ad26d4dc`](https://github.com/nodejs/node/commit/a4ad26d4dc)] - **util**: check for null instead of flasy in loop (Rich Trott) [#41614](https://github.com/nodejs/node/pull/41614)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.14.1/node-v16.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.14.1/node-v16.14.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.1/node-v16.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.14.1/node-v16.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.14.1/ \
 Documentation: https://nodejs.org/docs/v16.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.14.2.md
+++ b/pages/en/blog/release/v16.14.2.md
@@ -21,21 +21,21 @@ Update to OpenSSL 1.1.1n, which addresses the following vulnerability:
 * \[[`7a6a870d58`](https://github.com/nodejs/node/commit/7a6a870d58)] - **deps**: upgrade openssl sources to OpenSSL\_1\_1\_1n (Hassaan Pasha) [#42352](https://github.com/nodejs/node/pull/42352)
 * \[[`c533b430f4`](https://github.com/nodejs/node/commit/c533b430f4)] - **test**: fix tests affected by OpenSSL update (Michael Dawson) [#42352](https://github.com/nodejs/node/pull/42352)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.14.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.14.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.14.2/node-v16.14.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.14.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.14.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.14.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.14.2/node-v16.14.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.14.2/node-v16.14.2.tar.gz \
+Other release files: https://nodejs.org/dist/v16.14.2/ \
 Documentation: https://nodejs.org/docs/v16.14.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.15.0.md
+++ b/pages/en/blog/release/v16.15.0.md
@@ -301,21 +301,21 @@ globals.
 * \[[`604621a275`](https://github.com/nodejs/node/commit/604621a275)] - **worker**: fix typo in debug statement (Antoine du Hamel) [#42011](https://github.com/nodejs/node/pull/42011)
 * \[[`237affc951`](https://github.com/nodejs/node/commit/237affc951)] - **(SEMVER-MINOR)** **worker**: graduate get/setEnvironmentData APIs (James M Snell) [#41272](https://github.com/nodejs/node/pull/41272)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.15.0/node-v16.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.15.0/node-v16.15.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.15.0/node-v16.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.15.0/ \
 Documentation: https://nodejs.org/docs/v16.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.15.1.md
+++ b/pages/en/blog/release/v16.15.1.md
@@ -35,21 +35,21 @@ author: Juan José Arboleda and Bethany Nicolle Griggs
 * \[[`feac215e4e`](https://github.com/nodejs/node/commit/feac215e4e)] - **tools**: disable trap handler for Windows cross-compiler (Michaël Zasso) [#40488](https://github.com/nodejs/node/pull/40488)
 * \[[`47cdddf59b`](https://github.com/nodejs/node/commit/47cdddf59b)] - **tools**: update V8 gypfiles for 9.6 (Michaël Zasso) [#40488](https://github.com/nodejs/node/pull/40488)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.15.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.15.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.15.1/node-v16.15.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.15.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.15.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.15.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.15.1/node-v16.15.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.15.1/node-v16.15.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.15.1/ \
 Documentation: https://nodejs.org/docs/v16.15.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.16.0.md
+++ b/pages/en/blog/release/v16.16.0.md
@@ -25,21 +25,21 @@ author: Danielle Adams
 * \[[`754c9bfde0`](https://github.com/nodejs/node/commit/754c9bfde0)] - **src**: fix IPv4 validation in inspector\_socket (Tobias Nießen) [nodejs-private/node-private#320](https://github.com/nodejs-private/node-private/pull/320)
 * \[[`447cf680b0`](https://github.com/nodejs/node/commit/447cf680b0)] - **(SEMVER-MAJOR)** **src,deps,build,test**: add OpenSSL config appname (Daniel Bevenius) [#43124](https://github.com/nodejs/node/pull/43124)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.16.0/node-v16.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.16.0/node-v16.16.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.16.0/node-v16.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.16.0/ \
 Documentation: https://nodejs.org/docs/v16.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.17.0.md
+++ b/pages/en/blog/release/v16.17.0.md
@@ -803,21 +803,21 @@ Contributed by Filip Skokan - [#42507](https://github.com/nodejs/node/pull/42507
 * \[[`b9ec3b4367`](https://github.com/nodejs/node/commit/b9ec3b4367)] - **tools,doc**: add guards against prototype pollution when creating proxies (Antoine du Hamel) [#43391](https://github.com/nodejs/node/pull/43391)
 * \[[`54e7d0d723`](https://github.com/nodejs/node/commit/54e7d0d723)] - **typings**: fix `os.cpus` invalid return type (Himself65) [#43006](https://github.com/nodejs/node/pull/43006)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.17.0/node-v16.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.17.0/node-v16.17.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.17.0/node-v16.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.17.0/ \
 Documentation: https://nodejs.org/docs/v16.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.17.1.md
+++ b/pages/en/blog/release/v16.17.1.md
@@ -27,21 +27,21 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`0713e21240`](https://github.com/nodejs/node/commit/0713e21240)] - **http**: disable chunked encoding when using OBS fold is used (Paolo Insogna) [nodejs-private/node-private#341](https://github.com/nodejs-private/node-private/pull/341)
 * \[[`77fe2f32e4`](https://github.com/nodejs/node/commit/77fe2f32e4)] - **src**: fix IPv4 non routable validation (RafaelGSS) [nodejs-private/node-private#337](https://github.com/nodejs-private/node-private/pull/337)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.17.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.17.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.17.1/node-v16.17.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.17.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.17.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.17.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.17.1/node-v16.17.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.17.1/node-v16.17.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.17.1/ \
 Documentation: https://nodejs.org/docs/v16.17.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.18.0.md
+++ b/pages/en/blog/release/v16.18.0.md
@@ -365,21 +365,21 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`0beedb7f1c`](https://github.com/nodejs/node/commit/0beedb7f1c)] - **v8**: add setHeapSnapshotNearHeapLimit (theanarkh) [#44420](https://github.com/nodejs/node/pull/44420)
 * \[[`8d259e6086`](https://github.com/nodejs/node/commit/8d259e6086)] - **win**: fix fs.realpath.native for long paths (StefanStojanovic) [#44536](https://github.com/nodejs/node/pull/44536)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.18.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.18.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.18.0/node-v16.18.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.18.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.18.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.18.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.18.0/node-v16.18.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.18.0/node-v16.18.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.18.0/node-v16.18.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.18.0/ \
 Documentation: https://nodejs.org/docs/v16.18.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.18.1.md
+++ b/pages/en/blog/release/v16.18.1.md
@@ -20,21 +20,21 @@ More detailed information on each of the vulnerabilities can be found in [Novemb
 
 * \[[`9ffddd7098`](https://github.com/nodejs/node/commit/9ffddd7098)] - **inspector**: harden IP address validation again (Tobias Nießen) [nodejs-private/node-private#354](https://github.com/nodejs-private/node-private/pull/354)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.18.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.18.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.18.1/node-v16.18.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.18.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.18.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.18.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.18.1/node-v16.18.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.18.1/node-v16.18.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.18.1/ \
 Documentation: https://nodejs.org/docs/v16.18.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.19.0.md
+++ b/pages/en/blog/release/v16.19.0.md
@@ -113,21 +113,21 @@ Experimental features:
 * \[[`254358c81e`](https://github.com/nodejs/node/commit/254358c81e)] - **tools**: refactor `avoid-prototype-pollution` lint rule (Antoine du Hamel) [#43476](https://github.com/nodejs/node/pull/43476)
 * \[[`8c73279ebb`](https://github.com/nodejs/node/commit/8c73279ebb)] - **(SEMVER-MINOR)** **util**: add default value option to parsearg (Manuel Spigolon) [#44631](https://github.com/nodejs/node/pull/44631)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.19.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.19.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.19.0/node-v16.19.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.19.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.19.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.19.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.19.0/node-v16.19.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.19.0/node-v16.19.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.19.0/node-v16.19.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.19.0/ \
 Documentation: https://nodejs.org/docs/v16.19.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.19.1.md
+++ b/pages/en/blog/release/v16.19.1.md
@@ -43,21 +43,21 @@ This security release includes OpenSSL security updates as outlined in the recen
 * \[[`b02d895137`](https://github.com/nodejs/node/commit/b02d895137)] - **policy**: makeRequireFunction on mainModule.require (RafaelGSS) [nodejs-private/node-private#358](https://github.com/nodejs-private/node-private/pull/358)
 * \[[`d7f83c420c`](https://github.com/nodejs/node/commit/d7f83c420c)] - **test**: avoid left behind child processes (Richard Lau) [#46276](https://github.com/nodejs/node/pull/46276)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.19.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.19.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.19.1/node-v16.19.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.19.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.19.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.19.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.19.1/node-v16.19.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.19.1/node-v16.19.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.19.1/ \
 Documentation: https://nodejs.org/docs/v16.19.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.2.0.md
+++ b/pages/en/blog/release/v16.2.0.md
@@ -104,21 +104,21 @@ author: Michaël Zasso
 * [[`fbf02e3198`](https://github.com/nodejs/node/commit/fbf02e3198)] - **(SEMVER-MINOR)** **util**: add util.types.isKeyObject and util.types.isCryptoKey (Filip Skokan) [#38619](https://github.com/nodejs/node/pull/38619)
 * [[`070ee4bb94`](https://github.com/nodejs/node/commit/070ee4bb94)] - ***Revert*** "**worker**: remove `ERR_CLOSED_MESSAGE_PORT`" (Juan José Arboleda) [#38510](https://github.com/nodejs/node/pull/38510)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.2.0/node-v16.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.2.0/node-v16.2.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.2.0/node-v16.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.2.0/node-v16.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.2.0/ \
 Documentation: https://nodejs.org/docs/v16.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.3.0.md
+++ b/pages/en/blog/release/v16.3.0.md
@@ -90,21 +90,21 @@ author: Danielle Adams
 * [[`a2da9e254c`](https://github.com/nodejs/node/commit/a2da9e254c)] - **worker**: use rwlock for sibling group (Anna Henningsen) [#38783](https://github.com/nodejs/node/pull/38783)
 * [[`18f3ba3674`](https://github.com/nodejs/node/commit/18f3ba3674)] - **worker**: leave TODO comments for using std::variant when possible (Anna Henningsen) [#38788](https://github.com/nodejs/node/pull/38788)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.3.0/node-v16.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.3.0/node-v16.3.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.3.0/node-v16.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.3.0/ \
 Documentation: https://nodejs.org/docs/v16.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.4.0.md
+++ b/pages/en/blog/release/v16.4.0.md
@@ -138,21 +138,21 @@ author: Danielle Adams
 * [[`f40725f2a1`](https://github.com/nodejs/node/commit/f40725f2a1)] - **vm**: use missing validator (Voltrex) [#38935](https://github.com/nodejs/node/pull/38935)
 * [[`f959cb3c68`](https://github.com/nodejs/node/commit/f959cb3c68)] - **worker**: do not look up context twice in PostMessage (Anna Henningsen) [#38784](https://github.com/nodejs/node/pull/38784)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.4.0/node-v16.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.4.0/node-v16.4.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.0/node-v16.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.4.0/node-v16.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.4.0/ \
 Documentation: https://nodejs.org/docs/v16.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.4.1.md
+++ b/pages/en/blog/release/v16.4.1.md
@@ -22,21 +22,21 @@ Vulnerabilities fixed:
 * [[`d33aead28b`](https://github.com/nodejs/node/commit/d33aead28b)] - **deps**: uv: cherry-pick 99c29c9c2c9b (Ben Noordhuis) [nodejs-private/node-private#267](https://github.com/nodejs-private/node-private/pull/267)
 * [[`2690907b81`](https://github.com/nodejs/node/commit/2690907b81)] - **win,msi**: set install directory permission (AkshayK) [nodejs-private/node-private#269](https://github.com/nodejs-private/node-private/pull/269)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.4.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.4.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.4.1/node-v16.4.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.4.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.4.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.4.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.4.1/node-v16.4.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.1/node-v16.4.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.4.1/node-v16.4.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.4.1/ \
 Documentation: https://nodejs.org/docs/v16.4.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.4.2.md
+++ b/pages/en/blog/release/v16.4.2.md
@@ -19,21 +19,21 @@ installer.
 
 * [[`76e709ec63`](https://github.com/nodejs/node/commit/76e709ec63)] - **win,msi**: use localized "Authenticated Users" name (Richard Lau) [#39241](https://github.com/nodejs/node/pull/39241)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.4.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.4.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.4.2/node-v16.4.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.4.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.4.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.4.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.4.2/node-v16.4.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.4.2/node-v16.4.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.4.2/node-v16.4.2.tar.gz \
+Other release files: https://nodejs.org/dist/v16.4.2/ \
 Documentation: https://nodejs.org/docs/v16.4.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.5.0.md
+++ b/pages/en/blog/release/v16.5.0.md
@@ -170,21 +170,21 @@ Contributed by James M Snell - [#39062](https://github.com/nodejs/node/pull/3906
 * [[`29673b8ac8`](https://github.com/nodejs/node/commit/29673b8ac8)] - **typings**: add JSDoc typings for timers (Voltrex) [#38834](https://github.com/nodejs/node/pull/38834)
 * [[`fe1c81f247`](https://github.com/nodejs/node/commit/fe1c81f247)] - **wasi**: use missing validator (Voltrex) [#39070](https://github.com/nodejs/node/pull/39070)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.5.0/node-v16.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.5.0/node-v16.5.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.5.0/node-v16.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.5.0/node-v16.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.5.0/ \
 Documentation: https://nodejs.org/docs/v16.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.6.0.md
+++ b/pages/en/blog/release/v16.6.0.md
@@ -152,21 +152,21 @@ Contributed by Michaël Zasso - [#39470](https://github.com/nodejs/node/pull/394
 * [[`e5d64473e8`](https://github.com/nodejs/node/commit/e5d64473e8)] - **tools**: use Node.js 16.x for GitHub workflow (Rich Trott) [#39362](https://github.com/nodejs/node/pull/39362)
 * [[`68fd6d5282`](https://github.com/nodejs/node/commit/68fd6d5282)] - **url**: prevent pathname setter from erasing path of path-only URLs (Darshan Sen) [#39060](https://github.com/nodejs/node/pull/39060)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.6.0/node-v16.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.6.0/node-v16.6.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.0/node-v16.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.6.0/node-v16.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.6.0/ \
 Documentation: https://nodejs.org/docs/v16.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.6.1.md
+++ b/pages/en/blog/release/v16.6.1.md
@@ -27,21 +27,21 @@ author: Michaël Zasso
 * [[`815fbec6f1`](https://github.com/nodejs/node/commit/815fbec6f1)] - **repl**: do not include legacy getter/setter methods in completion (Anna Henningsen) [#39576](https://github.com/nodejs/node/pull/39576)
 * [[`0405c8d3f0`](https://github.com/nodejs/node/commit/0405c8d3f0)] - **zlib**: avoid converting `Uint8Array` instances to `Buffer` (Antoine du Hamel) [#39492](https://github.com/nodejs/node/pull/39492)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.6.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.6.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.6.1/node-v16.6.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.6.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.6.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.6.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.6.1/node-v16.6.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.1/node-v16.6.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.6.1/node-v16.6.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.6.1/ \
 Documentation: https://nodejs.org/docs/v16.6.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.6.2.md
+++ b/pages/en/blog/release/v16.6.2.md
@@ -26,21 +26,21 @@ author: Bethany Nicolle Griggs
 * [[`a3c33d4ce7`](https://github.com/nodejs/node/commit/a3c33d4ce7)] - **http2**: update handling of rst\_stream with error code NGHTTP2\_CANCEL (Akshay K) [#39622](https://github.com/nodejs/node/pull/39622)
 * [[`6c7fff6f1d`](https://github.com/nodejs/node/commit/6c7fff6f1d)] - **tls**: validate "rejectUnauthorized: undefined" (Matteo Collina) [nodejs-private/node-private#276](https://github.com/nodejs-private/node-private/pull/276)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.6.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.6.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.6.2/node-v16.6.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.6.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.6.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.6.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.6.2/node-v16.6.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.6.2/node-v16.6.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.6.2/node-v16.6.2.tar.gz \
+Other release files: https://nodejs.org/dist/v16.6.2/ \
 Documentation: https://nodejs.org/docs/v16.6.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.7.0.md
+++ b/pages/en/blog/release/v16.7.0.md
@@ -134,21 +134,21 @@ author: Danielle Adams
 * [[`37dda19461`](https://github.com/nodejs/node/commit/37dda19461)] - **(SEMVER-MINOR)** **url,buffer**: implement URL.createObjectURL (James M Snell) [#39693](https://github.com/nodejs/node/pull/39693)
 * [[`dcab88ad38`](https://github.com/nodejs/node/commit/dcab88ad38)] - **worker**: add brand checks for detached properties/methods (James M Snell) [#39763](https://github.com/nodejs/node/pull/39763)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.7.0/node-v16.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.7.0/node-v16.7.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.7.0/node-v16.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.7.0/node-v16.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.7.0/ \
 Documentation: https://nodejs.org/docs/v16.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.8.0.md
+++ b/pages/en/blog/release/v16.8.0.md
@@ -50,21 +50,21 @@ author: Michaël Zasso
 * [[`c34e2534ab`](https://github.com/nodejs/node/commit/c34e2534ab)] - **tools**: update markdown lint dependencies (Rich Trott) [#39770](https://github.com/nodejs/node/pull/39770)
 * [[`66400374de`](https://github.com/nodejs/node/commit/66400374de)] - **(SEMVER-MINOR)** **util**: expose toUSVString (Robert Nagy) [#39814](https://github.com/nodejs/node/pull/39814)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.8.0/node-v16.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.8.0/node-v16.8.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.8.0/node-v16.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.8.0/node-v16.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.8.0/ \
 Documentation: https://nodejs.org/docs/v16.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.9.0.md
+++ b/pages/en/blog/release/v16.9.0.md
@@ -118,21 +118,21 @@ Contributed by Michaël Zasso - [#39947](https://github.com/nodejs/node/pull/399
 * [[`16271d2f50`](https://github.com/nodejs/node/commit/16271d2f50)] - **worker**: remove file extension check (Qingyu Deng) [#39788](https://github.com/nodejs/node/pull/39788)
 * [[`3b1ce93e03`](https://github.com/nodejs/node/commit/3b1ce93e03)] - **worker**: add brand checks for detached MessageEvent accessors (James M Snell) [#39773](https://github.com/nodejs/node/pull/39773)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.9.0/node-v16.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.9.0/node-v16.9.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.9.0/node-v16.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v16.9.0/ \
 Documentation: https://nodejs.org/docs/v16.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v16.9.1.md
+++ b/pages/en/blog/release/v16.9.1.md
@@ -16,21 +16,21 @@ This release fixes a [regression](https://github.com/nodejs/node/issues/40030) i
 
 * [[`04f1943109`](https://github.com/nodejs/node/commit/04f1943109)] - **deps**: V8: cherry-pick 9a607043cb31 (Jiawen Geng) [#40046](https://github.com/nodejs/node/pull/40046)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v16.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v16.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v16.9.1/node-v16.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v16.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v16.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v16.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v16.9.1/node-v16.9.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v16.9.1/node-v16.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v16.9.1/node-v16.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v16.9.1/ \
 Documentation: https://nodejs.org/docs/v16.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.0.0.md
+++ b/pages/en/blog/release/v17.0.0.md
@@ -224,21 +224,21 @@ Contributed by Antoine du Hamel - https://github.com/nodejs/node/pull/37947
 * [[`f581f6da94`](https://github.com/nodejs/node/commit/f581f6da94)] - **url**: fix performance regression (Brian White) [#39778](https://github.com/nodejs/node/pull/39778)
 * [[`02de40246f`](https://github.com/nodejs/node/commit/02de40246f)] - **v8**: remove --harmony-top-level-await (Geoffrey Booth) [#40226](https://github.com/nodejs/node/pull/40226)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.0.0/node-v17.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.0.0/node-v17.0.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.0.0/node-v17.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.0.0/node-v17.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.0.0/ \
 Documentation: https://nodejs.org/docs/v17.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.0.1.md
+++ b/pages/en/blog/release/v17.0.1.md
@@ -36,21 +36,21 @@ addons. These headers are now included. [#40526](https://github.com/nodejs/node/
 * [[`3f7c503b69`](https://github.com/nodejs/node/commit/3f7c503b69)] - **test**: adjust CLI flags test to ignore blank lines in doc (Rich Trott) [#40403](https://github.com/nodejs/node/pull/40403)
 * [[`7c42d9fcc6`](https://github.com/nodejs/node/commit/7c42d9fcc6)] - **test**: split test-crypto-dh.js (Joyee Cheung) [#40451](https://github.com/nodejs/node/pull/40451)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.0.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.0.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.0.1/node-v17.0.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.0.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.0.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.0.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.0.1/node-v17.0.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.0.1/node-v17.0.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.0.1/node-v17.0.1.tar.gz \
+Other release files: https://nodejs.org/dist/v17.0.1/ \
 Documentation: https://nodejs.org/docs/v17.0.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.1.0.md
+++ b/pages/en/blog/release/v17.1.0.md
@@ -135,21 +135,21 @@ author: Michaël Zasso
 * \[[`1e9f3cc522`](https://github.com/nodejs/node/commit/1e9f3cc522)] - **typings**: separate `internalBinding` typings (Mestery) [#40409](https://github.com/nodejs/node/pull/40409)
 * \[[`fbeb895ca6`](https://github.com/nodejs/node/commit/fbeb895ca6)] - **(SEMVER-MINOR)** **v8**: multi-tenant promise hook api (Stephen Belanger) [#39283](https://github.com/nodejs/node/pull/39283)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.1.0/node-v17.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.1.0/node-v17.1.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.1.0/node-v17.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.1.0/node-v17.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.1.0/ \
 Documentation: https://nodejs.org/docs/v17.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.2.0.md
+++ b/pages/en/blog/release/v17.2.0.md
@@ -129,21 +129,21 @@ author: Michaël Zasso
 * \[[`5b08e908ea`](https://github.com/nodejs/node/commit/5b08e908ea)] - **tools**: update babel-eslint-parser to 7.16.0 (Rich Trott) [#40720](https://github.com/nodejs/node/pull/40720)
 * \[[`30623c283a`](https://github.com/nodejs/node/commit/30623c283a)] - **tools**: improve update scripts (Rich Trott) [#40644](https://github.com/nodejs/node/pull/40644)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.2.0/node-v17.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.2.0/node-v17.2.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.2.0/node-v17.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.2.0/node-v17.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.2.0/ \
 Documentation: https://nodejs.org/docs/v17.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.3.0.md
+++ b/pages/en/blog/release/v17.3.0.md
@@ -155,21 +155,21 @@ Contributed by Richard Lau [#41177](https://github.com/nodejs/node/pull/41177).
 * \[[`91df200ad6`](https://github.com/nodejs/node/commit/91df200ad6)] - **(SEMVER-MINOR)** **util**: add numericSeparator to util.inspect (Ruben Bridgewater) [#41003](https://github.com/nodejs/node/pull/41003)
 * \[[`da87413257`](https://github.com/nodejs/node/commit/da87413257)] - **(SEMVER-MINOR)** **util**: always visualize cause property in errors during inspection (Ruben Bridgewater) [#41002](https://github.com/nodejs/node/pull/41002)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.3.0/node-v17.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.3.0/node-v17.3.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.3.0/node-v17.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.3.0/node-v17.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.3.0/ \
 Documentation: https://nodejs.org/docs/v17.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.3.1.md
+++ b/pages/en/blog/release/v17.3.1.md
@@ -53,21 +53,21 @@ Thanks to Patrik Oldsberg (rugvip) for reporting this vulnerability.
 * \[[`1f7fdff64a`](https://github.com/nodejs/node/commit/1f7fdff64a)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 * \[[`b11b4cc69d`](https://github.com/nodejs/node/commit/b11b4cc69d)] - **tls**: drop support for URI alternative names (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.3.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.3.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.3.1/node-v17.3.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.3.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.3.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.3.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.3.1/node-v17.3.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.3.1/node-v17.3.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.3.1/node-v17.3.1.tar.gz \
+Other release files: https://nodejs.org/dist/v17.3.1/ \
 Documentation: https://nodejs.org/docs/v17.3.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.4.0.md
+++ b/pages/en/blog/release/v17.4.0.md
@@ -188,21 +188,21 @@ author: Michaël Zasso
 * \[[`5ed8a1c017`](https://github.com/nodejs/node/commit/5ed8a1c017)] - **util**: do not reduce to a single line if not appropriate using inspect (Ruben Bridgewater) [#41083](https://github.com/nodejs/node/pull/41083)
 * \[[`ab5e94c832`](https://github.com/nodejs/node/commit/ab5e94c832)] - **util**: display a present-but-undefined error cause (Jordan Harband) [#41247](https://github.com/nodejs/node/pull/41247)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.4.0/node-v17.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.4.0/node-v17.4.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.4.0/node-v17.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.4.0/node-v17.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.4.0/ \
 Documentation: https://nodejs.org/docs/v17.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.5.0.md
+++ b/pages/en/blog/release/v17.5.0.md
@@ -229,21 +229,21 @@ flag that installs the `fetch`, `Request`, `Response` and `Headers` globals.
 * \[[`0e35d01a4a`](https://github.com/nodejs/node/commit/0e35d01a4a)] - **util**: check for null instead of flasy in loop (Rich Trott) [#41614](https://github.com/nodejs/node/pull/41614)
 * \[[`869cbb7b25`](https://github.com/nodejs/node/commit/869cbb7b25)] - **(SEMVER-MINOR)** **worker**: graduate get/setEnvironmentData APIs (James M Snell) [#41272](https://github.com/nodejs/node/pull/41272)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.5.0/node-v17.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.5.0/node-v17.5.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.5.0/node-v17.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.5.0/node-v17.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.5.0/ \
 Documentation: https://nodejs.org/docs/v17.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.6.0.md
+++ b/pages/en/blog/release/v17.6.0.md
@@ -139,21 +139,21 @@ author: Bryan English
 * \[[`cfafb45c2b`](https://github.com/nodejs/node/commit/cfafb45c2b)] - **tools,lib**: remove `global` and `Intl` from the list of globals (Antoine du Hamel) [#42014](https://github.com/nodejs/node/pull/42014)
 * \[[`ba35b6ccd1`](https://github.com/nodejs/node/commit/ba35b6ccd1)] - **worker**: fix typo in debug statement (Antoine du Hamel) [#42011](https://github.com/nodejs/node/pull/42011)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.6.0/node-v17.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.6.0/node-v17.6.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.6.0/node-v17.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.6.0/node-v17.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.6.0/ \
 Documentation: https://nodejs.org/docs/v17.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.7.0.md
+++ b/pages/en/blog/release/v17.7.0.md
@@ -108,21 +108,21 @@ author: Stewart X Addison
 * \[[`9aeda47d9c`](https://github.com/nodejs/node/commit/9aeda47d9c)] - **url**: fix url.parse() for @hostname (Rich Trott) [#42136](https://github.com/nodejs/node/pull/42136)
 * \[[`ecb5980e2f`](https://github.com/nodejs/node/commit/ecb5980e2f)] - **url, src**: modify one `special_back_slash` (Khaidi Chu) [#42112](https://github.com/nodejs/node/pull/42112)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.7.0/node-v17.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.7.0/node-v17.7.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.0/node-v17.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.7.0/node-v17.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.7.0/ \
 Documentation: https://nodejs.org/docs/v17.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.7.1.md
+++ b/pages/en/blog/release/v17.7.1.md
@@ -20,21 +20,21 @@ change that introduced the regression.
 
 * \[[`96a9e00fb3`](https://github.com/nodejs/node/commit/96a9e00fb3)] - **url**: revert fix url.parse() for `@hostname` (Antoine du Hamel) [#42280](https://github.com/nodejs/node/pull/42280)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.7.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.7.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.7.1/node-v17.7.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.7.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.7.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.7.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.7.1/node-v17.7.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.1/node-v17.7.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.7.1/node-v17.7.1.tar.gz \
+Other release files: https://nodejs.org/dist/v17.7.1/ \
 Documentation: https://nodejs.org/docs/v17.7.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.7.2.md
+++ b/pages/en/blog/release/v17.7.2.md
@@ -22,21 +22,21 @@ Update to OpenSSL 3.0.2, which addresses the following vulnerability:
 * \[[`c8b6d92af0`](https://github.com/nodejs/node/commit/c8b6d92af0)] - **test**: fix tests affected by OpenSSL update (Michael Dawson) [#42356](https://github.com/nodejs/node/pull/42356)
 * \[[`457e31ea09`](https://github.com/nodejs/node/commit/457e31ea09)] - **test**: renew certificates for specific test (Luigi Pinca) [#42342](https://github.com/nodejs/node/pull/42342)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.7.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.7.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.7.2/node-v17.7.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.7.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.7.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.7.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.7.2/node-v17.7.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.7.2/node-v17.7.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.7.2/node-v17.7.2.tar.gz \
+Other release files: https://nodejs.org/dist/v17.7.2/ \
 Documentation: https://nodejs.org/docs/v17.7.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.8.0.md
+++ b/pages/en/blog/release/v17.8.0.md
@@ -88,21 +88,21 @@ author: Bryan English
 * \[[`b89f4d5c17`](https://github.com/nodejs/node/commit/b89f4d5c17)] - **url**: trim leading and trailing C0 control chars (Rich Trott) [#42196](https://github.com/nodejs/node/pull/42196)
 * \[[`229fb40edc`](https://github.com/nodejs/node/commit/229fb40edc)] - **worker**: do not send message if port is closing (Rich Trott) [#42357](https://github.com/nodejs/node/pull/42357)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.8.0/node-v17.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.8.0/node-v17.8.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.8.0/node-v17.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.8.0/node-v17.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.8.0/ \
 Documentation: https://nodejs.org/docs/v17.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.9.0.md
+++ b/pages/en/blog/release/v17.9.0.md
@@ -112,21 +112,21 @@ author: Juan José Arboleda
 * \[[`3a1b0e5b87`](https://github.com/nodejs/node/commit/3a1b0e5b87)] - **tools**: bump cpplint to 1.6.0 (Rich Trott) [#42416](https://github.com/nodejs/node/pull/42416)
 * \[[`9344a06d9c`](https://github.com/nodejs/node/commit/9344a06d9c)] - **tools**: fix skip PR if CI is still running (Xuguang Mei) [#42377](https://github.com/nodejs/node/pull/42377)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.9.0/node-v17.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.9.0/node-v17.9.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.9.0/node-v17.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v17.9.0/ \
 Documentation: https://nodejs.org/docs/v17.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v17.9.1.md
+++ b/pages/en/blog/release/v17.9.1.md
@@ -28,21 +28,21 @@ See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-
 * \[[`871eace946`](https://github.com/nodejs/node/commit/871eace946)] - **deps**: update archs files for quictls/openssl-3.0.3 (RafaelGSS) [#43025](https://github.com/nodejs/node/pull/43025)
 * \[[`05fb807ab0`](https://github.com/nodejs/node/commit/05fb807ab0)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.3 (RafaelGSS) [#43025](https://github.com/nodejs/node/pull/43025)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v17.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v17.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v17.9.1/node-v17.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v17.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v17.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v17.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v17.9.1/node-v17.9.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v17.9.1/node-v17.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v17.9.1/node-v17.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v17.9.1/ \
 Documentation: https://nodejs.org/docs/v17.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.0.0.md
+++ b/pages/en/blog/release/v18.0.0.md
@@ -272,19 +272,19 @@ Contributed James Snell in <https://github.com/nodejs/node/pull/39062>, and Anto
 * \[[`0187bc5cdc`](https://github.com/nodejs/node/commit/0187bc5cdc)] - **v8**: make v8.writeHeapSnapshot() error codes consistent (Darshan Sen) [#42577](https://github.com/nodejs/node/pull/42577)
 * \[[`74b9baa426`](https://github.com/nodejs/node/commit/74b9baa426)] - **v8**: make writeHeapSnapshot throw if fopen fails (Antonio Román) [#41373](https://github.com/nodejs/node/pull/41373)
 
-Windows 64-bit Installer: https://nodejs.org/dist/v18.0.0/node-v18.0.0-x64.msi<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.0.0/node-v18.0.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.0.0/node-v18.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.0.0/<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v18.0.0/node-v18.0.0-x64.msi \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.0.0/node-v18.0.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.0.0/node-v18.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.0.0/ \
 Documentation: https://nodejs.org/docs/v18.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.1.0.md
+++ b/pages/en/blog/release/v18.1.0.md
@@ -108,21 +108,21 @@ author: Michaël Zasso
 * \[[`bf9240ae8c`](https://github.com/nodejs/node/commit/bf9240ae8c)] - **(SEMVER-MINOR)** **worker**: add hasRef() to MessagePort (Darshan Sen) [#42849](https://github.com/nodejs/node/pull/42849)
 * \[[`c3922afa1c`](https://github.com/nodejs/node/commit/c3922afa1c)] - **worker**: add hasRef() to the handle object (Darshan Sen) [#42756](https://github.com/nodejs/node/pull/42756)
 
-Windows 32-bit Installer: *Coming soon*<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.1.0/node-v18.1.0-x64.msi<br>
-Windows 32-bit Binary: *Coming soon*<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.1.0/node-v18.1.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.1.0/node-v18.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.1.0/<br>
+Windows 32-bit Installer: *Coming soon* \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.1.0/node-v18.1.0-x64.msi \
+Windows 32-bit Binary: *Coming soon* \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.1.0/node-v18.1.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.1.0/node-v18.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.1.0/node-v18.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.1.0/ \
 Documentation: https://nodejs.org/docs/v18.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.10.0.md
+++ b/pages/en/blog/release/v18.10.0.md
@@ -129,21 +129,21 @@ author: Rafael Gonzaga
 * \[[`9aa6a560e9`](https://github.com/nodejs/node/commit/9aa6a560e9)] - **v8**: add setHeapSnapshotNearHeapLimit (theanarkh) [#44420](https://github.com/nodejs/node/pull/44420)
 * \[[`360b74e94f`](https://github.com/nodejs/node/commit/360b74e94f)] - **win**: fix fs.realpath.native for long paths (StefanStojanovic) [#44536](https://github.com/nodejs/node/pull/44536)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.10.0/node-v18.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.10.0/node-v18.10.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.10.0/node-v18.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.10.0/node-v18.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.10.0/ \
 Documentation: https://nodejs.org/docs/v18.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.11.0.md
+++ b/pages/en/blog/release/v18.11.0.md
@@ -139,21 +139,21 @@ Contributed by Moshe Atlow in [#44366](https://github.com/nodejs/node/pull/44366
 * \[[`db5aeed702`](https://github.com/nodejs/node/commit/db5aeed702)] - **(SEMVER-MINOR)** **util**: add default value option to parsearg (Manuel Spigolon) [#44631](https://github.com/nodejs/node/pull/44631)
 * \[[`576ccdf125`](https://github.com/nodejs/node/commit/576ccdf125)] - **util**: increase robustness with primordials (Jordan Harband) [#41212](https://github.com/nodejs/node/pull/41212)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.11.0/node-v18.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.11.0/node-v18.11.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.11.0/node-v18.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.11.0/node-v18.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.11.0/ \
 Documentation: https://nodejs.org/docs/v18.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.12.0.md
+++ b/pages/en/blog/release/v18.12.0.md
@@ -15,21 +15,21 @@ with the codename 'Hydrogen'. The 18.x release line now moves into "Active LTS"
 and will remain so until October 2023. After that time, it will move into
 "Maintenance" until end of life in April 2025.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.12.0/node-v18.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.12.0/node-v18.12.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.12.0/node-v18.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.12.0/ \
 Documentation: https://nodejs.org/docs/v18.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.12.1.md
+++ b/pages/en/blog/release/v18.12.1.md
@@ -24,21 +24,21 @@ More detailed information on each of the vulnerabilities can be found in [Novemb
 * \[[`80218127c8`](https://github.com/nodejs/node/commit/80218127c8)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.7+quic [nodejs/node#45286](https://github.com/nodejs/node/pull/45286)
 * \[[`165342beac`](https://github.com/nodejs/node/commit/165342beac)] - **inspector**: harden IP address validation again (Tobias Nießen) [nodejs-private/node-private#354](https://github.com/nodejs-private/node-private/pull/354)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.12.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.12.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.12.1/node-v18.12.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.12.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.12.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.12.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.12.1/node-v18.12.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.12.1/node-v18.12.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.12.1/node-v18.12.1.tar.gz \
+Other release files: https://nodejs.org/dist/v18.12.1/ \
 Documentation: https://nodejs.org/docs/v18.12.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.13.0.md
+++ b/pages/en/blog/release/v18.13.0.md
@@ -471,21 +471,21 @@ Contributed by Colin Ihrig in [#45326](https://github.com/nodejs/node/pull/45326
 * \[[`09ea75823c`](https://github.com/nodejs/node/commit/09ea75823c)] - **watch**: add CLI flag to preserve output (Debadree Chatterjee) [#45717](https://github.com/nodejs/node/pull/45717)
 * \[[`24bfe543c5`](https://github.com/nodejs/node/commit/24bfe543c5)] - **watch**: watch for missing dependencies (Moshe Atlow) [#45348](https://github.com/nodejs/node/pull/45348)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.13.0/node-v18.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.13.0/node-v18.13.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.13.0/node-v18.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.13.0/ \
 Documentation: https://nodejs.org/docs/v18.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.14.0.md
+++ b/pages/en/blog/release/v18.14.0.md
@@ -290,21 +290,21 @@ breaking changes.
 * \[[`277d9da876`](https://github.com/nodejs/node/commit/277d9da876)] - **vm**: refactor to use validate function (Deokjin Kim) [#46176](https://github.com/nodejs/node/pull/46176)
 * \[[`96f1b2e731`](https://github.com/nodejs/node/commit/96f1b2e731)] - **vm**: refactor to use `validateStringArray` (Deokjin Kim) [#46020](https://github.com/nodejs/node/pull/46020)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.14.0/node-v18.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.14.0/node-v18.14.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.0/node-v18.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.14.0/node-v18.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.14.0/ \
 Documentation: https://nodejs.org/docs/v18.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.14.1.md
+++ b/pages/en/blog/release/v18.14.1.md
@@ -39,21 +39,21 @@ This security release includes OpenSSL security updates as outlined in the recen
 * \[[`0e3b796cc5`](https://github.com/nodejs/node/commit/0e3b796cc5)] - **lib**: makeRequireFunction patch when experimental policy (RafaelGSS) [nodejs-private/node-private#371](https://github.com/nodejs-private/node-private/pull/371)
 * \[[`7cccd5565f`](https://github.com/nodejs/node/commit/7cccd5565f)] - **policy**: makeRequireFunction on mainModule.require (RafaelGSS) [nodejs-private/node-private#371](https://github.com/nodejs-private/node-private/pull/371)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.14.1/node-v18.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.14.1/node-v18.14.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.1/node-v18.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.14.1/node-v18.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v18.14.1/ \
 Documentation: https://nodejs.org/docs/v18.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.14.2.md
+++ b/pages/en/blog/release/v18.14.2.md
@@ -20,21 +20,21 @@ author: Myles Borins
 * \[[`648041d568`](https://github.com/nodejs/node/commit/648041d568)] - **deps**: upgrade npm to 9.4.0 (npm team) [#46353](https://github.com/nodejs/node/pull/46353)
 * \[[`5e1f213f3c`](https://github.com/nodejs/node/commit/5e1f213f3c)] - **deps**: patch V8 to 10.2.154.26 (Michaël Zasso) [#46446](https://github.com/nodejs/node/pull/46446)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.14.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.14.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.14.2/node-v18.14.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.14.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.14.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.14.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.14.2/node-v18.14.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.14.2/node-v18.14.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.14.2/node-v18.14.2.tar.gz \
+Other release files: https://nodejs.org/dist/v18.14.2/ \
 Documentation: https://nodejs.org/docs/v18.14.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.15.0.md
+++ b/pages/en/blog/release/v18.15.0.md
@@ -114,21 +114,21 @@ author: Bethany Nicolle Griggs & Juan José Arboleda
 * \[[`02632b42cf`](https://github.com/nodejs/node/commit/02632b42cf)] - **(SEMVER-MINOR)** **v8**: support gc profile (theanarkh) [#46255](https://github.com/nodejs/node/pull/46255)
 * \[[`110ead9abb`](https://github.com/nodejs/node/commit/110ead9abb)] - **(SEMVER-MINOR)** **vm**: expose cachedDataRejected for vm.compileFunction (Anna Henningsen) [#46320](https://github.com/nodejs/node/pull/46320)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.15.0/node-v18.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.15.0/node-v18.15.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.15.0/node-v18.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.15.0/ \
 Documentation: https://nodejs.org/docs/v18.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.2.0.md
+++ b/pages/en/blog/release/v18.2.0.md
@@ -113,19 +113,19 @@ See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-
 * \[[`55ef6e81cb`](https://github.com/nodejs/node/commit/55ef6e81cb)] - **wasm**: add missing init reported by coverity (Michael Dawson) [#42897](https://github.com/nodejs/node/pull/42897)
 * \[[`5470578008`](https://github.com/nodejs/node/commit/5470578008)] - **worker**: fix stream racing with terminate (Keyhan Vakil) [#42874](https://github.com/nodejs/node/pull/42874)
 
-Windows 64-bit Installer: https://nodejs.org/dist/v18.2.0/node-v18.2.0-x64.msi<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.2.0/node-v18.2.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.2.0/node-v18.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.2.0/<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v18.2.0/node-v18.2.0-x64.msi \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.2.0/node-v18.2.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.2.0/node-v18.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.2.0/node-v18.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.2.0/ \
 Documentation: https://nodejs.org/docs/v18.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.3.0.md
+++ b/pages/en/blog/release/v18.3.0.md
@@ -100,21 +100,21 @@ author: Bryan English
 * \[[`d6cf409d78`](https://github.com/nodejs/node/commit/d6cf409d78)] - **(SEMVER-MINOR)** **util**: add parseArgs module (Benjamin Coe) [#42675](https://github.com/nodejs/node/pull/42675)
 * \[[`d91b489784`](https://github.com/nodejs/node/commit/d91b489784)] - **worker**: fix heap snapshot crash on exit (Chengzhong Wu) [#43123](https://github.com/nodejs/node/pull/43123)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.3.0/node-v18.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.3.0/node-v18.3.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.3.0/node-v18.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.3.0/node-v18.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.3.0/ \
 Documentation: https://nodejs.org/docs/v18.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.4.0.md
+++ b/pages/en/blog/release/v18.4.0.md
@@ -116,21 +116,21 @@ author: Danielle Adams
 * \[[`7fc432fa35`](https://github.com/nodejs/node/commit/7fc432fa35)] - **wasi**: use `kEmptyObject` (LiviaMedeiros) [#43159](https://github.com/nodejs/node/pull/43159)
 * \[[`44b65d0ca7`](https://github.com/nodejs/node/commit/44b65d0ca7)] - **worker**: use `kEmptyObject` (LiviaMedeiros) [#43159](https://github.com/nodejs/node/pull/43159)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.4.0/node-v18.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.4.0/node-v18.4.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.4.0/node-v18.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.4.0/node-v18.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.4.0/ \
 Documentation: https://nodejs.org/docs/v18.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.5.0.md
+++ b/pages/en/blog/release/v18.5.0.md
@@ -26,21 +26,21 @@ author: Rafael Gonzaga
 * \[[`3f0c3e142d`](https://github.com/nodejs/node/commit/3f0c3e142d)] - **(SEMVER-MAJOR)** **src,deps,build,test**: add OpenSSL config appname (Daniel Bevenius) [#43124](https://github.com/nodejs/node/pull/43124)
 * \[[`9578158ff8`](https://github.com/nodejs/node/commit/9578158ff8)] - **(SEMVER-MAJOR)** **src,doc,test**: add --openssl-shared-config option (Daniel Bevenius) [#43124](https://github.com/nodejs/node/pull/43124)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.5.0/node-v18.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.5.0/node-v18.5.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.5.0/node-v18.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.5.0/node-v18.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.5.0/ \
 Documentation: https://nodejs.org/docs/v18.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.6.0.md
+++ b/pages/en/blog/release/v18.6.0.md
@@ -210,21 +210,21 @@ Contributed by Jacob Smith, Geoffrey Booth, and Bradley Farias - <https://github
 * \[[`752380a959`](https://github.com/nodejs/node/commit/752380a959)] - **tools**: update main branch name (Feng Yu) [#43440](https://github.com/nodejs/node/pull/43440)
 * \[[`06c367ef8b`](https://github.com/nodejs/node/commit/06c367ef8b)] - **tools**: update lint-md-dependencies to rollup\@2.75.6 (Node.js GitHub Bot) [#43386](https://github.com/nodejs/node/pull/43386)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.6.0/node-v18.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.6.0/node-v18.6.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.6.0/node-v18.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.6.0/node-v18.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.6.0/ \
 Documentation: https://nodejs.org/docs/v18.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.7.0.md
+++ b/pages/en/blog/release/v18.7.0.md
@@ -151,21 +151,21 @@ author: Danielle Adams
 * \[[`f32aec8a6d`](https://github.com/nodejs/node/commit/f32aec8a6d)] - **util**: refactor to use validateObject (Kohei Ueno) [#43769](https://github.com/nodejs/node/pull/43769)
 * \[[`d7cfd0c5ba`](https://github.com/nodejs/node/commit/d7cfd0c5ba)] - **v8**: serialize BigInt64Array and BigUint64Array (Ben Noordhuis) [#43571](https://github.com/nodejs/node/pull/43571)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.7.0/node-v18.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.7.0/node-v18.7.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.7.0/node-v18.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.7.0/ \
 Documentation: https://nodejs.org/docs/v18.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.8.0.md
+++ b/pages/en/blog/release/v18.8.0.md
@@ -241,21 +241,21 @@ Contributed by Joyee Cheung in [#38905](https://github.com/nodejs/node/pull/3890
 * \[[`2cf3ce83d8`](https://github.com/nodejs/node/commit/2cf3ce83d8)] - **trace\_events**: add example (theanarkh) [#43253](https://github.com/nodejs/node/pull/43253)
 * \[[`2efce0fe5b`](https://github.com/nodejs/node/commit/2efce0fe5b)] - **typings**: add JSDoc for `internal/validators` (Yagiz Nizipli) [#44181](https://github.com/nodejs/node/pull/44181)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.8.0/node-v18.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.8.0/node-v18.8.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.8.0/node-v18.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.8.0/node-v18.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.8.0/ \
 Documentation: https://nodejs.org/docs/v18.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.9.0.md
+++ b/pages/en/blog/release/v18.9.0.md
@@ -119,21 +119,21 @@ author: Rafael Gonzaga
 * \[[`736a04aa13`](https://github.com/nodejs/node/commit/736a04aa13)] - **vm**: include vm context in the embedded snapshot (Joyee Cheung) [#44252](https://github.com/nodejs/node/pull/44252)
 * \[[`bce827e5d1`](https://github.com/nodejs/node/commit/bce827e5d1)] - **vm**: make ContextifyContext template context-independent (Joyee Cheung) [#44252](https://github.com/nodejs/node/pull/44252)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.9.0/node-v18.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.9.0/node-v18.9.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.9.0/node-v18.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.9.0/node-v18.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v18.9.0/ \
 Documentation: https://nodejs.org/docs/v18.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v18.9.1.md
+++ b/pages/en/blog/release/v18.9.1.md
@@ -39,21 +39,21 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`01bffcdd93`](https://github.com/nodejs/node/commit/01bffcdd93)] - **http**: disable chunked encoding when OBS fold is used (Paolo Insogna) [nodejs-private/node-private#341](https://github.com/nodejs-private/node-private/pull/341)
 * \[[`2c379d341d`](https://github.com/nodejs/node/commit/2c379d341d)] - **src**: fix IPv4 non routable validation (RafaelGSS) [nodejs-private/node-private#337](https://github.com/nodejs-private/node-private/pull/337)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v18.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v18.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v18.9.1/node-v18.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v18.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.9.1/node-v18.9.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.9.1/node-v18.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.9.1/node-v18.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v18.9.1/ \
 Documentation: https://nodejs.org/docs/v18.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.0.0.md
+++ b/pages/en/blog/release/v19.0.0.md
@@ -164,21 +164,21 @@ Contributed by Paolo Insogna in [#44967](https://github.com/nodejs/node/pull/449
 * \[[`87d0d7a069`](https://github.com/nodejs/node/commit/87d0d7a069)] - **url**: validate ipv4 part length (Yagiz Nizipli) [#42915](https://github.com/nodejs/node/pull/42915)
 * \[[`5b1bcf82f1`](https://github.com/nodejs/node/commit/5b1bcf82f1)] - **vm**: make ContextifyContext a BaseObject (Joyee Cheung) [#44796](https://github.com/nodejs/node/pull/44796)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.0.0/node-v19.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.0.0/node-v19.0.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.0.0/node-v19.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.0.0/ \
 Documentation: https://nodejs.org/docs/v19.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.0.1.md
+++ b/pages/en/blog/release/v19.0.1.md
@@ -24,21 +24,21 @@ More detailed information on each of the vulnerabilities can be found in [Novemb
 * \[[`85f4548d57`](https://github.com/nodejs/node/commit/85f4548d57)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.7+quic (RafaelGSS) [#45286](https://github.com/nodejs/node/pull/45286)
 * \[[`43403f56f7`](https://github.com/nodejs/node/commit/43403f56f7)] - **inspector**: harden IP address validation again (Tobias Nießen) [nodejs-private/node-private#354](https://github.com/nodejs-private/node-private/pull/354)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.0.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.0.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.0.1/node-v19.0.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.0.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.0.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.0.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.0.1/node-v19.0.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.0.1/node-v19.0.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.0.1/node-v19.0.1.tar.gz \
+Other release files: https://nodejs.org/dist/v19.0.1/ \
 Documentation: https://nodejs.org/docs/v19.0.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.1.0.md
+++ b/pages/en/blog/release/v19.1.0.md
@@ -259,21 +259,21 @@ Contributed by Yagiz Nizipli in [#45098](https://github.com/nodejs/node/pull/450
 * \[[`0deed8daeb`](https://github.com/nodejs/node/commit/0deed8daeb)] - **util**: improve textdecoder decode performance (Yagiz Nizipli) [#45294](https://github.com/nodejs/node/pull/45294)
 * \[[`d41f8ffc36`](https://github.com/nodejs/node/commit/d41f8ffc36)] - **(SEMVER-MINOR)** **util**: add MIME utilities (#21128) (Bradley Farias) [#21128](https://github.com/nodejs/node/pull/21128)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.1.0/node-v19.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.1.0/node-v19.1.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.1.0/node-v19.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.1.0/node-v19.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.1.0/ \
 Documentation: https://nodejs.org/docs/v19.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.2.0.md
+++ b/pages/en/blog/release/v19.2.0.md
@@ -144,21 +144,21 @@ Time zone data has been updated to 2022f. This includes changes to Daylight Savi
 * \[[`f86f90f839`](https://github.com/nodejs/node/commit/f86f90f839)] - **util**: improve text decoder performance (Yagiz Nizipli) [#45388](https://github.com/nodejs/node/pull/45388)
 * \[[`3263ceb21a`](https://github.com/nodejs/node/commit/3263ceb21a)] - **watch**: watch for missing dependencies (Moshe Atlow) [#45348](https://github.com/nodejs/node/pull/45348)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.2.0/node-v19.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.2.0/node-v19.2.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.2.0/node-v19.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.2.0/node-v19.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.2.0/ \
 Documentation: https://nodejs.org/docs/v19.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.3.0.md
+++ b/pages/en/blog/release/v19.3.0.md
@@ -197,21 +197,21 @@ breaking changes.
 * \[[`470384e7be`](https://github.com/nodejs/node/commit/470384e7be)] - **util**: use private symbols in JS land directly (Joyee Cheung) [#45379](https://github.com/nodejs/node/pull/45379)
 * \[[`cee6f382d8`](https://github.com/nodejs/node/commit/cee6f382d8)] - **watch**: add CLI flag to preserve output (Debadree Chatterjee) [#45717](https://github.com/nodejs/node/pull/45717)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.3.0/node-v19.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.3.0/node-v19.3.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.3.0/node-v19.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.3.0/node-v19.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.3.0/ \
 Documentation: https://nodejs.org/docs/v19.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.4.0.md
+++ b/pages/en/blog/release/v19.4.0.md
@@ -143,21 +143,21 @@ author: Rafael Gonzaga
 * \[[`389cc3e1d6`](https://github.com/nodejs/node/commit/389cc3e1d6)] - **vm**: refactor to use `validateStringArray` (Deokjin Kim) [#46020](https://github.com/nodejs/node/pull/46020)
 * \[[`7bd6a2c258`](https://github.com/nodejs/node/commit/7bd6a2c258)] - **wasi**: fast calls (snek) [#43697](https://github.com/nodejs/node/pull/43697)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.4.0/node-v19.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.4.0/node-v19.4.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.4.0/node-v19.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.4.0/node-v19.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.4.0/ \
 Documentation: https://nodejs.org/docs/v19.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.5.0.md
+++ b/pages/en/blog/release/v19.5.0.md
@@ -126,21 +126,21 @@ author: Rafael Gonzaga
 * \[[`4c1c20fae2`](https://github.com/nodejs/node/commit/4c1c20fae2)] - **trace\_events**: refactor to use `validateStringArray` (Deokjin Kim) [#46012](https://github.com/nodejs/node/pull/46012)
 * \[[`6c8a81d2dc`](https://github.com/nodejs/node/commit/6c8a81d2dc)] - **vm**: refactor to use validate function (Deokjin Kim) [#46176](https://github.com/nodejs/node/pull/46176)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.5.0/node-v19.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.5.0/node-v19.5.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.5.0/node-v19.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.5.0/node-v19.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.5.0/ \
 Documentation: https://nodejs.org/docs/v19.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.6.0.md
+++ b/pages/en/blog/release/v19.6.0.md
@@ -101,21 +101,21 @@ Added `--install-strategy=linked` option for installations similar to pnpm.
 * \[[`b4ac794923`](https://github.com/nodejs/node/commit/b4ac794923)] - **(SEMVER-MINOR)** **v8**: support gc profile (theanarkh) [#46255](https://github.com/nodejs/node/pull/46255)
 * \[[`34d70ce615`](https://github.com/nodejs/node/commit/34d70ce615)] - **(SEMVER-MINOR)** **vm**: expose cachedDataRejected for vm.compileFunction (Anna Henningsen) [#46320](https://github.com/nodejs/node/pull/46320)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.6.0/node-v19.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.6.0/node-v19.6.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.6.0/node-v19.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.6.0/node-v19.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.6.0/ \
 Documentation: https://nodejs.org/docs/v19.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.6.1.md
+++ b/pages/en/blog/release/v19.6.1.md
@@ -34,21 +34,21 @@ This security release includes OpenSSL security updates as outlined in the recen
 * \[[`2aae197670`](https://github.com/nodejs/node/commit/2aae197670)] - **lib**: makeRequireFunction patch when experimental policy (RafaelGSS) [nodejs-private/node-private#358](https://github.com/nodejs-private/node-private/pull/358)
 * \[[`6d17b693ec`](https://github.com/nodejs/node/commit/6d17b693ec)] - **policy**: makeRequireFunction on mainModule.require (RafaelGSS) [nodejs-private/node-private#358](https://github.com/nodejs-private/node-private/pull/358)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.6.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.6.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.6.1/node-v19.6.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.6.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.6.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.6.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.6.1/node-v19.6.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.6.1/node-v19.6.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.6.1/node-v19.6.1.tar.gz \
+Other release files: https://nodejs.org/dist/v19.6.1/ \
 Documentation: https://nodejs.org/docs/v19.6.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.7.0.md
+++ b/pages/en/blog/release/v19.7.0.md
@@ -143,21 +143,21 @@ author: Myles Borins
 * \[[`d6fbebda54`](https://github.com/nodejs/node/commit/d6fbebda54)] - **url**: remove unused `setURLConstructor` function (Yagiz Nizipli) [#46485](https://github.com/nodejs/node/pull/46485)
 * \[[`17b3ee33c2`](https://github.com/nodejs/node/commit/17b3ee33c2)] - **vm**: properly support symbols on globals (Nicolas DUBIEN) [#46458](https://github.com/nodejs/node/pull/46458)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v19.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v19.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0.pkg<br>
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-arm64.tar.gz<br>
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-x64.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-aix-ppc64.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v19.7.0/node-v19.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v19.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.7.0/node-v19.7.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.7.0/node-v19.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.7.0/node-v19.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.7.0/ \
 Documentation: https://nodejs.org/docs/v19.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.8.0.md
+++ b/pages/en/blog/release/v19.8.0.md
@@ -236,21 +236,21 @@ author: Michaël Zasso
 * \[[`60e5f45141`](https://github.com/nodejs/node/commit/60e5f45141)] - **(SEMVER-MINOR)** **wasi**: add support for version when creating WASI (Michael Dawson) [#46469](https://github.com/nodejs/node/pull/46469)
 * \[[`a646a22d0f`](https://github.com/nodejs/node/commit/a646a22d0f)] - **(SEMVER-MINOR)** **worker**: add support for worker name in inspector and trace\_events (Debadree Chatterjee) [#46832](https://github.com/nodejs/node/pull/46832)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0-x86.msi<br />
-Windows 64-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0-x64.msi<br />
-Windows 32-bit Binary: https://nodejs.org/dist/v19.8.0/win-x86/node.exe<br />
-Windows 64-bit Binary: https://nodejs.org/dist/v19.8.0/win-x64/node.exe<br />
-macOS 64-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0.pkg<br />
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-arm64.tar.gz<br />
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-x64.tar.gz<br />
-Linux 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-x64.tar.xz<br />
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-ppc64le.tar.xz<br />
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-s390x.tar.xz<br />
-AIX 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-aix-ppc64.tar.gz<br />
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-armv7l.tar.xz<br />
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-arm64.tar.xz<br />
-Source Code: https://nodejs.org/dist/v19.8.0/node-v19.8.0.tar.gz<br />
-Other release files: https://nodejs.org/dist/v19.8.0/<br />
+Windows 32-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.8.0/node-v19.8.0.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.8.0/node-v19.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.8.0/node-v19.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v19.8.0/ \
 Documentation: https://nodejs.org/docs/v19.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v19.8.1.md
+++ b/pages/en/blog/release/v19.8.1.md
@@ -17,21 +17,21 @@ Fixes: <https://github.com/nodejs/node/issues/47096>
 
 * \[[`f7c8aa4cf1`](https://github.com/nodejs/node/commit/f7c8aa4cf1)] - _**Revert**_ "**vm**: fix leak in vm.compileFunction when importModuleDynamically is used" (Michaël Zasso) [#47101](https://github.com/nodejs/node/pull/47101)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1-x86.msi<br />
-Windows 64-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1-x64.msi<br />
-Windows 32-bit Binary: https://nodejs.org/dist/v19.8.1/win-x86/node.exe<br />
-Windows 64-bit Binary: https://nodejs.org/dist/v19.8.1/win-x64/node.exe<br />
-macOS 64-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1.pkg<br />
-macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-arm64.tar.gz<br />
-macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-x64.tar.gz<br />
-Linux 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz<br />
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-ppc64le.tar.xz<br />
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-s390x.tar.xz<br />
-AIX 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-aix-ppc64.tar.gz<br />
-ARMv7 32-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-armv7l.tar.xz<br />
-ARMv8 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-arm64.tar.xz<br />
-Source Code: https://nodejs.org/dist/v19.8.1/node-v19.8.1.tar.gz<br />
-Other release files: https://nodejs.org/dist/v19.8.1/<br />
+Windows 32-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v19.8.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v19.8.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v19.8.1/node-v19.8.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v19.8.1/node-v19.8.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v19.8.1/node-v19.8.1.tar.gz \
+Other release files: https://nodejs.org/dist/v19.8.1/ \
 Documentation: https://nodejs.org/docs/v19.8.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.0.0.md
+++ b/pages/en/blog/release/v4.0.0.md
@@ -115,19 +115,19 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`7a8c3e08c3`](https://github.com/nodejs/node/commit/7a8c3e08c3)] - **timers**: Avoid linear scan in `_unrefActive`. (Julien Gilli) [#2540](https://github.com/nodejs/node/pull/2540)
 * [[`b630ebaf43`](https://github.com/nodejs/node/commit/b630ebaf43)] - **win,msi**: Upgrade from old upgrade code (João Reis) [#2439](https://github.com/nodejs/node/pull/2439)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0-x64.msi<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0-x64.msi \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.0.0/node-v4.0.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.0.0/ \
 Documentation: https://nodejs.org/docs/v4.0.0/api/
 
 Shasums (GPG signing hash: SHA1, file hash: SHA256):

--- a/pages/en/blog/release/v4.1.0.md
+++ b/pages/en/blog/release/v4.1.0.md
@@ -91,21 +91,21 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`ba47511976`](https://github.com/nodejs/node/commit/ba47511976)] - **tsc**: adjust TSC membership for IBM+StrongLoop (James M Snell) [#2858](https://github.com/nodejs/node/pull/2858)
 * [[`e035266805`](https://github.com/nodejs/node/commit/e035266805)] - **win,msi**: fix documentation shortcut url (Brian White) [#2781](https://github.com/nodejs/node/pull/2781)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.1.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv7.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.1.0/node-v4.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.1.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.0/node-v4.1.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-armv7.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.0/node-v4.1.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.1.0/node-v4.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.1.0/ \
 Documentation: https://nodejs.org/docs/v4.1.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.1.1.md
+++ b/pages/en/blog/release/v4.1.1.md
@@ -60,21 +60,21 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`3e09dcfc32`](https://github.com/nodejs/node/commit/3e09dcfc32)] - **test**: update cwd-enoent tests for AIX (Imran Iqbal) [#2909](https://github.com/nodejs/node/pull/2909)
 * [[`6ea8ec1c59`](https://github.com/nodejs/node/commit/6ea8ec1c59)] - **tools**: single, cross-platform tick processor (Matt Loring) [#2868](https://github.com/nodejs/node/pull/2868)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.1.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.1.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.1.1/node-v4.1.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.1.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.1.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.1.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.1/node-v4.1.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.1/node-v4.1.1-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.1.1/node-v4.1.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.1.1/ \
 Documentation: https://nodejs.org/docs/v4.1.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.1.2.md
+++ b/pages/en/blog/release/v4.1.2.md
@@ -78,21 +78,21 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`5ada45bf28`](https://github.com/nodejs/node/commit/5ada45bf28)] - **test**: replace deprecated util.debug() calls (Rich Trott) [#3082](https://github.com/nodejs/node/pull/3082)
 * [[`d8ab4e185d`](https://github.com/nodejs/node/commit/d8ab4e185d)] - **util**: optimize promise introspection (Ben Noordhuis) [#3130](https://github.com/nodejs/node/pull/3130)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.1.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.1.2/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.1.2/node-v4.1.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.1.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.1.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.1.2/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.1.2/node-v4.1.2.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.1.2/node-v4.1.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.1.2/ \
 Documentation: https://nodejs.org/docs/v4.1.2/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.0.md
+++ b/pages/en/blog/release/v4.2.0.md
@@ -106,21 +106,21 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * [[`8dfdee3733`](https://github.com/nodejs/node/commit/8dfdee3733)] - **util**: correctly inspect Map/Set Iterators (Evan Lucas) [#3119](https://github.com/nodejs/node/pull/3119)
 * [[`b5c51fdba0`](https://github.com/nodejs/node/commit/b5c51fdba0)] - **util**: fix check for Array constructor (Evan Lucas) [#3119](https://github.com/nodejs/node/pull/3119)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.0/node-v4.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.0/node-v4.2.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.0/node-v4.2.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.0/node-v4.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.0/ \
 Documentation: https://nodejs.org/docs/v4.2.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.1.md
+++ b/pages/en/blog/release/v4.2.1.md
@@ -31,21 +31,21 @@ layout: blog-post.hbs
 * [[`102cb7288c`](https://github.com/nodejs/node/commit/102cb7288c)] - **doc**: label v4.2.0 as LTS in changelog heading (Rod Vagg) [#3343](https://github.com/nodejs/node/pull/3343)
 * [[`c245a199a7`](https://github.com/nodejs/node/commit/c245a199a7)] - **lib**: fix undefined timeout regression (Ryan Graham) [#3331](https://github.com/nodejs/node/pull/3331
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.1/node-v4.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.1/node-v4.2.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.1/node-v4.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.1/ \
 Documentation: https://nodejs.org/docs/v4.2.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.2.md
+++ b/pages/en/blog/release/v4.2.2.md
@@ -99,21 +99,21 @@ This is an LTS maintenance release that addresses a number of issues:
 * [[`e69c869399`](https://github.com/nodejs/node/commit/e69c869399)] - **tls**: TLSSocket options default isServer false (Yuval Brik) [#2614](https://github.com/nodejs/node/pull/2614)
 * [[`0b32bbbf69`](https://github.com/nodejs/node/commit/0b32bbbf69)] - **v8**: pull fix for builtin code size on PPC (Michael Dawson) [#3474](https://github.com/nodejs/node/pull/3474)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.2/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/download/release/latest-v4.x/node-v4.2.2-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.2/node-v4.2.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.2/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.2/node-v4.2.2.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/download/release/latest-v4.x/node-v4.2.2-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.2/node-v4.2.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.2/ \
 Documentation: https://nodejs.org/docs/v4.2.2/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.3.md
+++ b/pages/en/blog/release/v4.2.3.md
@@ -33,21 +33,21 @@ author: Rod Vagg
 * [[`07233206e9`](https://github.com/nodejs/node/commit/07233206e9)] - **deps**: backport 6df9a1d from upstream v8 (Ben Noordhuis)
 * [[`1c8e6de78e`](https://github.com/nodejs/node/commit/1c8e6de78e)] - **http**: fix pipeline regression (Fedor Indutny)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.3/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.3/node-v4.2.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.3/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.3/node-v4.2.3.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.3/node-v4.2.3-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.3/node-v4.2.3.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.3/ \
 Documentation: https://nodejs.org/docs/v4.2.3/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.4.md
+++ b/pages/en/blog/release/v4.2.4.md
@@ -183,21 +183,21 @@ of fixes and documentation updates.
 * [[`47bb94a0c3`](https://github.com/nodejs/node/commit/47bb94a0c3)] - **zlib**: only apply drain listener if given callback (Craig Cavalier) [#3534](https://github.com/nodejs/node/pull/3534)
 * [[`4733a60158`](https://github.com/nodejs/node/commit/4733a60158)] - **zlib**: pass kind to recursive calls to flush (Myles Borins) [#3534](https://github.com/nodejs/node/pull/3534)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.4/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.4/node-v4.2.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.4/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.4/node-v4.2.4.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.4/node-v4.2.4.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.4/ \
 Documentation: https://nodejs.org/docs/v4.2.4/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.5.md
+++ b/pages/en/blog/release/v4.2.5.md
@@ -229,21 +229,21 @@ author: Myles Borins
 * [[`2d5380ea25`](https://github.com/nodejs/node/commit/2d5380ea25)] - **util**: fix constructor/instanceof checks (Brian White) [#3385](https://github.com/nodejs/node/pull/3385)
 * [[`1bf84b9d41`](https://github.com/nodejs/node/commit/1bf84b9d41)] - **util,src**: allow lookup of hidden values (cjihrig) [#3988](https://github.com/nodejs/node/pull/3988)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.5/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.5/node-v4.2.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.5/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.5/node-v4.2.5.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.5/node-v4.2.5-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.5/node-v4.2.5.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.5/ \
 Documentation: https://nodejs.org/docs/v4.2.5/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.2.6.md
+++ b/pages/en/blog/release/v4.2.6.md
@@ -24,21 +24,21 @@ author: Myles Borins
 * [[`1408f7abb1`](https://github.com/nodejs/node/commit/1408f7abb1)] - **module,src**: do not wrap modules with -1 lineOffset (cjihrig) [#4298](https://github.com/nodejs/node/pull/4298)
 * [[`1f8e1472cc`](https://github.com/nodejs/node/commit/1f8e1472cc)] - **test**: add test for debugging one line files (cjihrig) [#4298](https://github.com/nodejs/node/pull/4298)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.2.6/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.2.6/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.2.6/node-v4.2.6.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.2.6/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.2.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.2.6/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.2.6/node-v4.2.6.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.2.6/node-v4.2.6.tar.gz \
+Other release files: https://nodejs.org/dist/v4.2.6/ \
 Documentation: https://nodejs.org/docs/v4.2.6/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.3.0.md
+++ b/pages/en/blog/release/v4.3.0.md
@@ -28,21 +28,21 @@ This is an important security release. For full details see https://nodejs.org/e
 * [[`49ae2e0334`](https://github.com/nodejs/node/commit/49ae2e0334)] - **src**: avoid compiler warning in node_revert.cc (James M Snell)
 * [[`da3750f981`](https://github.com/nodejs/node/commit/da3750f981)] - **(SEMVER-MAJOR)** **src**: add --security-revert command line flag (James M Snell)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.3.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.3.0/node-v4.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.3.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.0/node-v4.3.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.0/node-v4.3.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.3.0/node-v4.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.3.0/ \
 Documentation: https://nodejs.org/docs/v4.3.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.3.1.md
+++ b/pages/en/blog/release/v4.3.1.md
@@ -91,21 +91,21 @@ author: Myles Borins
 * [[`c96800a432`](https://github.com/nodejs/node/commit/c96800a432)] - **tools**: fix license-builder.sh for ICU (Richard Lau) [#4762](https://github.com/nodejs/node/pull/4762)
 * [[`720b03dca7`](https://github.com/nodejs/node/commit/720b03dca7)] - **tools**: add license-builder.sh to construct LICENSE (Rod Vagg) [#4194](https://github.com/nodejs/node/pull/4194)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.3.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.3.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v4.3.1/node-v4.3.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.3.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.3.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.3.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.1/node-v4.3.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.1/node-v4.3.1-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v4.3.1/node-v4.3.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.3.1/ \
 Documentation: https://nodejs.org/docs/v4.3.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.3.2.md
+++ b/pages/en/blog/release/v4.3.2.md
@@ -19,22 +19,22 @@ author: Myles Borins
 
 * [[`c133797d09`](https://github.com/nodejs/node/commit/c133797d09)] - **deps**: upgrade openssl to 1.0.2g (Ben Noordhuis) [#5507](https://github.com/nodejs/node/pull/5507)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.3.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.3.2/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.3.2/node-v4.3.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.3.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.3.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.3.2/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.3.2/node-v4.3.2.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.3.2/node-v4.3.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.3.2/ \
 Documentation: https://nodejs.org/docs/v4.3.2/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.0.md
+++ b/pages/en/blog/release/v4.4.0.md
@@ -262,22 +262,22 @@ Notable semver patch changes include:
 * [[`01006392cf`](https://github.com/nodejs/node/commit/01006392cf)] - **tools,doc**: fix linting errors (Rich Trott) [#5161](https://github.com/nodejs/node/pull/5161)
 * [[`57a5f8731a`](https://github.com/nodejs/node/commit/57a5f8731a)] - **url**: change scoping of variables with let (Kári Tristan Helgason) [#4867](https://github.com/nodejs/node/pull/4867)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.0/node-v4.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.0/node-v4.4.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.0/node-v4.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.0/ \
 Documentation: https://nodejs.org/docs/v4.4.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.1.md
+++ b/pages/en/blog/release/v4.4.1.md
@@ -138,22 +138,22 @@ author: Myles Borins
 * [[`dff7091fce`](https://github.com/nodejs/node/commit/dff7091fce)] - **url**: group slashed protocols by protocol name (nettofarah) [#5380](https://github.com/nodejs/node/pull/5380)
 * [[`0e97a3ea51`](https://github.com/nodejs/node/commit/0e97a3ea51)] - **win,build**: support Visual C++ Build Tools 2015 (João Reis) [#5627](https://github.com/nodejs/node/pull/5627)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.1/node-v4.4.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.1/node-v4.4.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.1/node-v4.4.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.1/node-v4.4.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.1/ \
 Documentation: https://nodejs.org/docs/v4.4.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.2.md
+++ b/pages/en/blog/release/v4.4.2.md
@@ -66,22 +66,22 @@ This release includes a security update for npm. For more details you can read [
 * [[`f209effe8b`](https://github.com/nodejs/node/commit/f209effe8b)] - **test**: remove timer from test-http-1.0 (Santiago Gimeno) [#5129](https://github.com/nodejs/node/pull/5129)
 * [[`3a901b0e3e`](https://github.com/nodejs/node/commit/3a901b0e3e)] - **tools**: remove unused imports (Sakthipriyan Vairamani) [#5765](https://github.com/nodejs/node/pull/5765)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.2/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.2/node-v4.4.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.2/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.2/node-v4.4.2.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.2/node-v4.4.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.2/ \
 Documentation: https://nodejs.org/docs/v4.4.2/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.3.md
+++ b/pages/en/blog/release/v4.4.3.md
@@ -72,22 +72,22 @@ author: Myles Borins
 * [[`6f0bd64122`](https://github.com/nodejs/node/commit/6f0bd64122)] - **tools,doc**: fix incomplete json produced by doctool (firedfox) [#5966](https://github.com/nodejs/node/pull/5966)
 * [[`f7eb48302c`](https://github.com/nodejs/node/commit/f7eb48302c)] - **win,build**: build and test add-ons on test-ci (Bogdan Lobor) [#5886](https://github.com/nodejs/node/pull/5886)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.3/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.3/node-v4.4.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.3/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.3/node-v4.4.3.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.3/node-v4.4.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.3/node-v4.4.3.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.3/ \
 Documentation: https://nodejs.org/docs/v4.4.3/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.4.md
+++ b/pages/en/blog/release/v4.4.4.md
@@ -26,22 +26,22 @@ author: Myles Borins
 * [[`2dfeb01213`](https://github.com/nodejs/node/commit/2dfeb01213)] - **deps**: copy all openssl header files to include dir (Shigeki Ohtsu) [#6551](https://github.com/nodejs/node/pull/6551)
 * [[`72f9952516`](https://github.com/nodejs/node/commit/72f9952516)] - **deps**: upgrade openssl sources to 1.0.2h (Shigeki Ohtsu) [#6551](https://github.com/nodejs/node/pull/6551)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.4/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.4/node-v4.4.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.4/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.4/node-v4.4.4.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.4/node-v4.4.4.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.4/ \
 Documentation: https://nodejs.org/docs/v4.4.4/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.5.md
+++ b/pages/en/blog/release/v4.4.5.md
@@ -97,22 +97,22 @@ author: Myles Borins
 * [[`c893cd33d1`](https://github.com/nodejs/node/commit/c893cd33d1)] - **tools,doc**: parse types in braces everywhere (Alexander Makarenko) [#5329](https://github.com/nodejs/node/pull/5329)
 * [[`48684af55f`](https://github.com/nodejs/node/commit/48684af55f)] - **zlib**: fix use after null when calling .close (James Lal) [#5982](https://github.com/nodejs/node/pull/5982)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.5/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.5/node-v4.4.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.5/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.5/node-v4.4.5.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.5/node-v4.4.5.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.5/ \
 Documentation: https://nodejs.org/docs/v4.4.5/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.6.md
+++ b/pages/en/blog/release/v4.4.6.md
@@ -18,22 +18,22 @@ This release is specifically related to a Buffer overflow vulnerability discover
 
 * [[`134c3b3977`](https://github.com/nodejs/node/commit/134c3b3977)] - **deps**: backport 3a9bfec from v8 upstream (Ben Noordhuis) [nodejs/node-private#38](https://github.com/nodejs/node-private/pull/38)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.6/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.6/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.6/node-v4.4.6.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.6/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.6/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.6/node-v4.4.6.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.6/node-v4.4.6-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.6/node-v4.4.6.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.6/ \
 Documentation: https://nodejs.org/docs/v4.4.6/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.4.7.md
+++ b/pages/en/blog/release/v4.4.7.md
@@ -114,22 +114,22 @@ author: Myles Borins
 * [[`0f6146c6c0`](https://github.com/nodejs/node/commit/0f6146c6c0)] - **tools**: add tests for the doctool (Ian Kronquist) [#6031](https://github.com/nodejs/node/pull/6031)
 * [[`cc3645cff3`](https://github.com/nodejs/node/commit/cc3645cff3)] - **tools**: lint for alignment of variable assignments (Rich Trott) [#6869](https://github.com/nodejs/node/pull/6869)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.4.7/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.4.7/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.4.7/node-v4.4.7.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.4.7/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.4.7/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.4.7/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.4.7/node-v4.4.7.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.4.7/node-v4.4.7.tar.gz \
+Other release files: https://nodejs.org/dist/v4.4.7/ \
 Documentation: https://nodejs.org/docs/v4.4.7/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.5.0.md
+++ b/pages/en/blog/release/v4.5.0.md
@@ -301,22 +301,22 @@ Semver Patch:
 * [[`0bfedd13a9`](https://github.com/nodejs/node/commit/0bfedd13a9)] - **win,build**: add creation of zip and 7z package (Bartosz Sosnowski) [#5995](https://github.com/nodejs/node/pull/5995)
 * [[`7d66752f1f`](https://github.com/nodejs/node/commit/7d66752f1f)] - **zlib**: release callback and buffer after processing (Matt Lavin) [#6955](https://github.com/nodejs/node/pull/6955)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.5.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.5.0/node-v4.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.5.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.5.0/node-v4.5.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.5.0/node-v4.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.5.0/node-v4.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.5.0/ \
 Documentation: https://nodejs.org/docs/v4.5.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.6.0.md
+++ b/pages/en/blog/release/v4.6.0.md
@@ -46,22 +46,22 @@ Semver Patch:
 * [[`44e5776c0f`](https://github.com/nodejs/node/commit/44e5776c0f)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [nodejs/node#1389](https://github.com/nodejs/node/pull/1389)
 * [[`c7a601c090`](https://github.com/nodejs/node/commit/c7a601c090)] - **test**: remove openssl options of -no_\<prot> (Shigeki Ohtsu) [#8714](https://github.com/nodejs/node/pull/8714)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.6.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.6.0/node-v4.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.6.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v4.6.0/node-v4.6.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.6.0/node-v4.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.6.0/ \
 Documentation: https://nodejs.org/docs/v4.6.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v4.6.1.md
+++ b/pages/en/blog/release/v4.6.1.md
@@ -19,22 +19,22 @@ This is a security release. All Node.js users should consult the security releas
 * [[`f3c63e7ccf`](https://github.com/nodejs/node/commit/f3c63e7ccf)] - **deps**: avoid single-byte buffer overwrite (Daniel Stenberg) [#8849](https://github.com/nodejs/node/pull/8849)
 * [[`5a0daa6c2f`](https://github.com/nodejs/node/commit/5a0daa6c2f)] - **win,build**: try multiple timeservers when signing (Rod Vagg) [#9155](https://github.com/nodejs/node/pull/9155)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.6.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.6.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.6.1/node-v4.6.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.6.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.6.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.6.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.6.1/node-v4.6.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.1/node-v4.6.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.6.1/node-v4.6.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.6.1/ \
 Documentation: https://nodejs.org/docs/v4.6.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.6.2.md
+++ b/pages/en/blog/release/v4.6.2.md
@@ -239,23 +239,23 @@ author: Myles Borins
 * [[`e8be413d0d`](https://github.com/nodejs/node/commit/e8be413d0d)] - **win,msi**: add zh-CN translations for the installer (Minqi Pan) [#2569](https://github.com/nodejs/node/pull/2569)
 * [[`99f85b8340`](https://github.com/nodejs/node/commit/99f85b8340)] - **win,msi**: Added Italian translation (Matteo Collina) [#4647](https://github.com/nodejs/node/pull/4647)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.6.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.6.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x86.tar.xz<br><br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.6.2/node-v4.6.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.6.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.6.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.6.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.6.2/node-v4.6.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x86.tar.xz \ \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.6.2/node-v4.6.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.6.2/node-v4.6.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.6.2/ \
 Documentation: https://nodejs.org/docs/v4.6.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.7.0.md
+++ b/pages/en/blog/release/v4.7.0.md
@@ -137,23 +137,23 @@ Notable SEMVER-PATCH changes include:
 * [[`bdb6cf92c7`](https://github.com/nodejs/node/commit/bdb6cf92c7)] - **win,msi**: mark INSTALLDIR property as secure (João Reis) [#8795](https://github.com/nodejs/node/pull/8795)
 * [[`9a02414a29`](https://github.com/nodejs/node/commit/9a02414a29)] - **zlib**: fix raw inflate with custom dictionary (Tarjei Husøy)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.7.0/node-v4.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.7.0/node-v4.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.0/node-v4.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.7.0/node-v4.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.7.0/ \
 Documentation: https://nodejs.org/docs/v4.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.7.1.md
+++ b/pages/en/blog/release/v4.7.1.md
@@ -202,23 +202,23 @@ release, v4.7.2, with no changes.
 * [[`7b1b11a11c`](https://github.com/nodejs/node/commit/7b1b11a11c)] - **tools**: fix run-valgrind.py script (Ben Noordhuis) [#9520](https://github.com/nodejs/node/pull/9520)
 * [[`011ee0ba8b`](https://github.com/nodejs/node/commit/011ee0ba8b)] - **tools**: copy run-valgrind.py to tools/ (Ben Noordhuis) [#9520](https://github.com/nodejs/node/pull/9520)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.7.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.7.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.7.1/node-v4.7.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.7.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.7.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.7.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.7.1/node-v4.7.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.1/node-v4.7.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.7.1/node-v4.7.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.7.1/ \
 Documentation: https://nodejs.org/docs/v4.7.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.7.2.md
+++ b/pages/en/blog/release/v4.7.2.md
@@ -15,23 +15,23 @@ platforms for v4.7.1 after the release, the tarballs on the release server were
 overwritten and now have different shasums. In order to remove any ambiguity
 around the release we have opted to do a semver patch release with no changes.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.7.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.7.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.7.2/node-v4.7.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.7.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.7.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.7.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.7.2/node-v4.7.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.2/node-v4.7.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.7.2/node-v4.7.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.7.2/ \
 Documentation: https://nodejs.org/docs/v4.7.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.7.3.md
+++ b/pages/en/blog/release/v4.7.3.md
@@ -22,23 +22,23 @@ author: Myles Borins
 * [[`c80844769c`](https://github.com/nodejs/node/commit/c80844769c)] - **deps**: upgrade openssl sources to 1.0.2k (Shigeki Ohtsu) [#11021](https://github.com/nodejs/node/pull/11021)
 * [[`e3915a415b`](https://github.com/nodejs/node/commit/e3915a415b)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.7.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.7.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.7.3/node-v4.7.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.7.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.7.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.7.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.7.3/node-v4.7.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.7.3/node-v4.7.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.7.3/node-v4.7.3.tar.gz \
+Other release files: https://nodejs.org/dist/v4.7.3/ \
 Documentation: https://nodejs.org/docs/v4.7.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.0.md
+++ b/pages/en/blog/release/v4.8.0.md
@@ -147,23 +147,23 @@ author: Myles Borins
 * [[`9556ef3241`](https://github.com/nodejs/node/commit/9556ef3241)] - **vm**: add error message if we abort (Franziska Hinkelmann) [#8634](https://github.com/nodejs/node/pull/8634)
 * [[`fa11f4b1fc`](https://github.com/nodejs/node/commit/fa11f4b1fc)] - **win,msi**: add required UIRef for localized strings (Bill Ticehurst) [#8884](https://github.com/nodejs/node/pull/8884)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.0/node-v4.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.0/node-v4.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.0/node-v4.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.0/node-v4.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.0/ \
 Documentation: https://nodejs.org/docs/v4.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.1.md
+++ b/pages/en/blog/release/v4.8.1.md
@@ -167,23 +167,23 @@ author: Myles Borins
 * [[`ef63af6006`](https://github.com/nodejs/node/commit/ef63af6006)] - **tty**: avoid oob warning in TTYWrap::GetWindowSize() (Dmitry Tsvettsikh) [#11454](https://github.com/nodejs/node/pull/11454)
 * [[`2c84601062`](https://github.com/nodejs/node/commit/2c84601062)] - **util**: don't init Debug if it's not needed yet (Bryan English) [#8452](https://github.com/nodejs/node/pull/8452)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.1/node-v4.8.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.1/node-v4.8.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.1/node-v4.8.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.1/node-v4.8.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.1/ \
 Documentation: https://nodejs.org/docs/v4.8.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.2.md
+++ b/pages/en/blog/release/v4.8.2.md
@@ -21,23 +21,23 @@ author: Myles Borins
 * [[`253980ff38`](https://github.com/nodejs/node/commit/253980ff38)] - **deps**: fix CLEAR_HASH macro to be usable as a single statement (Sam Roberts) [#11616](https://github.com/nodejs/node/pull/11616)
 * [[`2e52a2699b`](https://github.com/nodejs/node/commit/2e52a2699b)] - **deps**: upgrade zlib to 1.2.11 (Sam Roberts) [#10980](https://github.com/nodejs/node/pull/10980)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.2/node-v4.8.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.2/node-v4.8.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.2/node-v4.8.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.2/node-v4.8.2.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.2/ \
 Documentation: https://nodejs.org/docs/v4.8.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.3.md
+++ b/pages/en/blog/release/v4.8.3.md
@@ -37,23 +37,23 @@ author: Myles Borins
 * [[`99749dccfe`](https://github.com/nodejs/node/commit/99749dccfe)] - **tls**: keep track of stream that is closed (jBarz) [#11776](https://github.com/nodejs/node/pull/11776)
 * [[`6d3aaa72a8`](https://github.com/nodejs/node/commit/6d3aaa72a8)] - **tls**: TLSSocket emits 'error' on handshake failure (Mariusz 'koder' Chwalba) [#8805](https://github.com/nodejs/node/pull/8805)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.3/node-v4.8.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.3/node-v4.8.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.3/node-v4.8.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.3/node-v4.8.3.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.3/ \
 Documentation: https://nodejs.org/docs/v4.8.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.4.md
+++ b/pages/en/blog/release/v4.8.4.md
@@ -22,23 +22,23 @@ author: Myles Borins
 * [[`d6969a717f`](https://github.com/nodejs/node/commit/d6969a717f)] - **http**: use Buffer.from to avoid Buffer(num) call (Сковорода Никита Андреевич) [nodejs/node-private#83](https://github.com/nodejs/node-private/pull/83)
 * [[`58a8f150e5`](https://github.com/nodejs/node/commit/58a8f150e5)] - **test**: verify hash seed uniqueness (Ali Ijaz Sheikh) [nodejs/node-private#84](https://github.com/nodejs/node-private/pull/84)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.4/node-v4.8.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.4/node-v4.8.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.4/node-v4.8.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.4/node-v4.8.4.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.4/ \
 Documentation: https://nodejs.org/docs/v4.8.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.5.md
+++ b/pages/en/blog/release/v4.8.5.md
@@ -17,23 +17,23 @@ author: Myles Borins
 
 * [[`f5defa2a7c`](https://github.com/nodejs/node/commit/733578bb2e)] - **zlib**: gracefully set windowBits from 8 to 9 (Myles Borins) [nodejs-private/node-private#95](https://github.com/nodejs-private/node-private/pull/95)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.5/node-v4.8.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.5/node-v4.8.5.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.5/node-v4.8.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.5/node-v4.8.5.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.5/ \
 Documentation: https://nodejs.org/docs/v4.8.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.6.md
+++ b/pages/en/blog/release/v4.8.6.md
@@ -68,23 +68,23 @@ author: Myles Borins
 * [[`a1f992975f`](https://github.com/nodejs/node/commit/a1f992975f)] - **zlib**: fix crash when initializing failed (Anna Henningsen) [#14666](https://github.com/nodejs/node/pull/14666)
 * [[`31bf595b94`](https://github.com/nodejs/node/commit/31bf595b94)] - **zlib**: fix node crashing on invalid options (Alexey Orlenko) [#13098](https://github.com/nodejs/node/pull/13098)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.6/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.6/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.6/node-v4.8.6.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.6/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.6/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.6/node-v4.8.6.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.6/node-v4.8.6-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.6/node-v4.8.6.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.6/ \
 Documentation: https://nodejs.org/docs/v4.8.6/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.8.7.md
+++ b/pages/en/blog/release/v4.8.7.md
@@ -23,23 +23,23 @@ author: Myles Borins
 * [[`b3afedfbe9`](https://github.com/nodejs/node/commit/b3afedfbe9)] - **deps**: upgrade openssl sources to 1.0.2n (Shigeki Ohtsu) [#17526](https://github.com/nodejs/node/pull/17526)
 * [[`f7eb162d0d`](https://github.com/nodejs/node/commit/f7eb162d0d)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.8.7/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.8.7/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.8.7/node-v4.8.7.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.8.7/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.8.7/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.8.7/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.8.7/node-v4.8.7.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.8.7/node-v4.8.7-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.8.7/node-v4.8.7.tar.gz \
+Other release files: https://nodejs.org/dist/v4.8.7/ \
 Documentation: https://nodejs.org/docs/v4.8.7/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.9.0.md
+++ b/pages/en/blog/release/v4.9.0.md
@@ -31,23 +31,23 @@ author: Myles Borins
 * [[`625986b699`](https://github.com/nodejs/node/commit/625986b699)] - **src**: drop CNNIC+StartCom certificate whitelisting (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 * [[`ebc46448a4`](https://github.com/nodejs/node/commit/ebc46448a4)] - **tools**: update certdata.txt (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.9.0/node-v4.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.9.0/node-v4.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.0/node-v4.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.9.0/node-v4.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v4.9.0/ \
 Documentation: https://nodejs.org/docs/v4.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v4.9.1.md
+++ b/pages/en/blog/release/v4.9.1.md
@@ -17,23 +17,23 @@ endian were built using GCC 4.9.X instead of GCC 4.8.X. This caused an ABI break
 environments. This has been fixed in our infrastructure and we are doing this release to ensure that
 the hosted binaries are adhering to our platform support contract.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v4.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v4.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v4.9.1/node-v4.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v4.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v4.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v4.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v4.9.1/node-v4.9.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-ppc64.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v4.9.1/node-v4.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v4.9.1/node-v4.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v4.9.1/ \
 Documentation: https://nodejs.org/docs/v4.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v5.0.0.md
+++ b/pages/en/blog/release/v5.0.0.md
@@ -178,21 +178,21 @@ The release notes below are annotated with the main breaking changes that warran
 * [[`6936468de2`](https://github.com/nodejs/node/commit/6936468de2)] - **vm**: remove Watchdog dependency on Environment (Ido Ben-Yair) [#3274](https://github.com/nodejs/node/pull/3274)
 * [[`80169b1f0a`](https://github.com/nodejs/node/commit/80169b1f0a)] - **(SEMVER-MAJOR)** **zlib**: decompression throw on truncated input (Yuval Brik) [#2595](https://github.com/nodejs/node/pull/2595)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.0.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.0.0/node-v5.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.0.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.0.0/node-v5.0.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.0.0/node-v5.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.0.0/ \
 Documentation: https://nodejs.org/docs/v5.0.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.1.0.md
+++ b/pages/en/blog/release/v5.1.0.md
@@ -169,21 +169,21 @@ author: Jeremiah Senkpiel
 * [[`33ffc62670`](https://github.com/nodejs/node/commit/33ffc62670)] - **zlib**: only apply drain listener if given callback (Craig Cavalier) [#3534](https://github.com/nodejs/node/pull/3534)
 * [[`d70deabf90`](https://github.com/nodejs/node/commit/d70deabf90)] - **zlib**: pass kind to recursive calls to flush (Myles Borins) [#3534](https://github.com/nodejs/node/pull/3534)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.1.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.1.0/node-v5.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.1.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.0/node-v5.1.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.1.0/node-v5.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.1.0/ \
 Documentation: https://nodejs.org/docs/v5.1.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.1.1.md
+++ b/pages/en/blog/release/v5.1.1.md
@@ -33,21 +33,21 @@ author: Rod Vagg
 * [[`533881f889`](https://github.com/nodejs/node/commit/533881f889)] - **deps**: upgrade openssl sources to 1.0.2e (Shigeki Ohtsu) [#4134](https://github.com/nodejs/node/pull/4134)
 * [[`12e70fafd3`](https://github.com/nodejs/node/commit/12e70fafd3)] - **http**: fix pipeline regression (Fedor Indutny)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.1.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.1.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.1.1/node-v5.1.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.1.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.1.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.1.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.1.1/node-v5.1.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.1.1/node-v5.1.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.1.1/ \
 Documentation: https://nodejs.org/docs/v5.1.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.10.0.md
+++ b/pages/en/blog/release/v5.10.0.md
@@ -89,22 +89,22 @@ written by [Forrest L Norvell](https://github.com/othiym23) from npm.
 * [[`77bed269ad`](https://github.com/nodejs/node/commit/77bed269ad)] - **win,build**: build and test add-ons on test-ci (Bogdan Lobor) [#5886](https://github.com/nodejs/node/pull/5886)
 * [[`afcd276ecc`](https://github.com/nodejs/node/commit/afcd276ecc)] - **zlib**: Fix handling of gzip magic bytes mid-file (Anna Henningsen) [#5863](https://github.com/nodejs/node/pull/5863)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.10.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.10.0/node-v5.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.10.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.10.0/node-v5.10.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.10.0/node-v5.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.10.0/ \
 Documentation: https://nodejs.org/docs/v5.10.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.10.1.md
+++ b/pages/en/blog/release/v5.10.1.md
@@ -49,22 +49,22 @@ author: Myles Borins
 * [[`50a062e691`](https://github.com/nodejs/node/commit/50a062e691)] - **tools**: remove obsolete lint config file (Rich Trott) [#5959](https://github.com/nodejs/node/pull/5959)
 * [[`7491fdcfe9`](https://github.com/nodejs/node/commit/7491fdcfe9)] - **tools**: remove disabling of already-disabled rule (Rich Trott) [#6013](https://github.com/nodejs/node/pull/6013)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.10.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.10.1/node-v5.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.10.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.10.1/node-v5.10.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.10.1/node-v5.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.10.1/ \
 Documentation: https://nodejs.org/docs/v5.10.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.11.0.md
+++ b/pages/en/blog/release/v5.11.0.md
@@ -130,22 +130,22 @@ author: Myles Borins
 * [[`2c23e14d5d`](https://github.com/nodejs/node/commit/2c23e14d5d)] - **(SEMVER-MINOR)** **zlib**: detect gzip files when using unzip* (Anna Henningsen) [#5884](https://github.com/nodejs/node/pull/5884)
 * [[`61167c3e23`](https://github.com/nodejs/node/commit/61167c3e23)] - **zlib**: fix gzip member head/buffer boundary issue (Anna Henningsen) [#5973](https://github.com/nodejs/node/pull/5973)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.11.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.11.0/node-v5.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.11.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.11.0/node-v5.11.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.11.0/node-v5.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.11.0/ \
 Documentation: https://nodejs.org/docs/v5.11.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.11.1.md
+++ b/pages/en/blog/release/v5.11.1.md
@@ -28,22 +28,22 @@ Please see our [blog post](https://nodejs.org/en/blog/vulnerability/openssl-may-
 * [[`c1ddefdd79`](https://github.com/nodejs/node/commit/c1ddefdd79)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [#1389](https://github.com/nodejs/node/pull/1389)
 * [[`bec5d50f1e`](https://github.com/nodejs/node/commit/bec5d50f1e)] - **test**: fix alpn tests for openssl1.0.2h (Shigeki Ohtsu) [#6552](https://github.com/nodejs/node/pull/6552)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.11.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.11.1/node-v5.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.11.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.11.1/node-v5.11.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.11.1/node-v5.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.11.1/ \
 Documentation: https://nodejs.org/docs/v5.11.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.12.0.md
+++ b/pages/en/blog/release/v5.12.0.md
@@ -26,22 +26,22 @@ This is a security release. All Node.js users should consult the security releas
 * [[`2ebeb82852`](https://github.com/nodejs/node/commit/2ebeb82852)] - **test**: fix test-net-* error code check for getaddrinfo(3) (Natanael Copa) [#5099](https://github.com/nodejs/node/pull/5099)
 * [[`03d36aea4f`](https://github.com/nodejs/node/commit/03d36aea4f)] - **(SEMVER-MINOR)** **test**: add buffer testcase for resetting kZeroFill (Сковорода Никита Андреевич) [#7169](https://github.com/nodejs/node/pull/7169)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.12.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.12.0/node-v5.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.12.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.12.0/node-v5.12.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.12.0/node-v5.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.12.0/ \
 Documentation: https://nodejs.org/docs/v5.12.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.2.0.md
+++ b/pages/en/blog/release/v5.2.0.md
@@ -134,21 +134,21 @@ author: Rod Vagg
 * [[`e68ea16c32`](https://github.com/nodejs/node/commit/e68ea16c32)] - **util**: add decorateErrorStack() (cjihrig) [#4013](https://github.com/nodejs/node/pull/4013)
 * [[`c584c3e08f`](https://github.com/nodejs/node/commit/c584c3e08f)] - **util,src**: allow lookup of hidden values (cjihrig) [#3988](https://github.com/nodejs/node/pull/3988)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.2.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.2.0/node-v5.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.2.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.2.0/node-v5.2.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.2.0/node-v5.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.2.0/ \
 Documentation: https://nodejs.org/docs/v5.2.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.3.0.md
+++ b/pages/en/blog/release/v5.3.0.md
@@ -82,21 +82,21 @@ author: Colin Ihrig
 * [[`d63cceeb10`](https://github.com/nodejs/node/commit/d63cceeb10)] - **tools**: add .editorconfig (ronkorving) [#2993](https://github.com/nodejs/node/pull/2993)
 * [[`4b267df93e`](https://github.com/nodejs/node/commit/4b267df93e)] - **udp**: remove a needless instanceof Buffer check (ronkorving) [#4301](https://github.com/nodejs/node/pull/4301)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.3.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.3.0/node-v5.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.3.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.3.0/node-v5.3.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.3.0/node-v5.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.3.0/ \
 Documentation: https://nodejs.org/docs/v5.3.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.4.0.md
+++ b/pages/en/blog/release/v5.4.0.md
@@ -129,21 +129,21 @@ author: Jeremiah Senkpiel
 * [[`14a947fc70`](https://github.com/nodejs/node/commit/14a947fc70)] - **tools**: run tick processor without forking (Matt Loring) [#4224](https://github.com/nodejs/node/pull/4224)
 * [[`8039ca06eb`](https://github.com/nodejs/node/commit/8039ca06eb)] - **util**: faster arrayToHash (Jackson Tian)  [#3964](https://github.com/nodejs/node/pull/3964)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.4.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.4.0/node-v5.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.4.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.0/node-v5.4.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.4.0/node-v5.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.4.0/ \
 Documentation: https://nodejs.org/docs/v5.4.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.4.1.md
+++ b/pages/en/blog/release/v5.4.1.md
@@ -52,21 +52,21 @@ author: Myles Borins
 * [[`6f9a96f497`](https://github.com/nodejs/node/commit/6f9a96f497)] - **test**: fix flaky unrefed timers test (Rich Trott) [#4599](https://github.com/nodejs/node/pull/4599)
 * [[`b70eec8f7b`](https://github.com/nodejs/node/commit/b70eec8f7b)] - **tls_legacy**: do not read on OpenSSL's stack (Fedor Indutny) [#4624](https://github.com/nodejs/node/pull/4624)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.4.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.4.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.4.1/node-v5.4.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.4.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.4.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.4.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.4.1/node-v5.4.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.4.1/node-v5.4.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.4.1/ \
 Documentation: https://nodejs.org/docs/v5.4.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.5.0.md
+++ b/pages/en/blog/release/v5.5.0.md
@@ -90,21 +90,21 @@ author: Evan Lucas
 * [[`aba3cc834e`](https://github.com/nodejs/node/commit/aba3cc834e)] - **tools**: fix license-builder.sh for ICU (Richard Lau) [#4762](https://github.com/nodejs/node/pull/4762)
 * [[`5f57005ec9`](https://github.com/nodejs/node/commit/5f57005ec9)] - **(SEMVER-MINOR)** **v8,src**: expose statistics about heap spaces (Ben Ripkens) [#4463](https://github.com/nodejs/node/pull/4463)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.5.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.5.0/node-v5.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.5.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.5.0/node-v5.5.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.5.0/node-v5.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.5.0/ \
 Documentation: https://nodejs.org/docs/v5.5.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.6.0.md
+++ b/pages/en/blog/release/v5.6.0.md
@@ -163,21 +163,21 @@ This is an important security release. For full details see https://nodejs.org/e
 * [[`386ad7e0b5`](https://github.com/nodejs/node/commit/386ad7e0b5)] - **tools**: fix setting path containing an ampersand (Brian White) [#4804](https://github.com/nodejs/node/pull/4804)
 * [[`e415eb27e5`](https://github.com/nodejs/node/commit/e415eb27e5)] - **url**: change scoping of variables with let (Kári Tristan Helgason) [#4867](https://github.com/nodejs/node/pull/4867)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.6.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x86.tar.gz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x86.tar.gz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x64.tar.gz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv6l.tar.gz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv7l.tar.gz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-arm64.tar.gz<br>
-Source Code: https://nodejs.org/dist/v5.6.0/node-v5.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.6.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.6.0/node-v5.6.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x86.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-x64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x86.tar.gz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-sunos-x64.tar.gz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv6l.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv7l.tar.gz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-arm64.tar.gz \
+Source Code: https://nodejs.org/dist/v5.6.0/node-v5.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.6.0/ \
 Documentation: https://nodejs.org/docs/v5.6.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.7.0.md
+++ b/pages/en/blog/release/v5.7.0.md
@@ -141,22 +141,22 @@ author: Rod Vagg
 * [[`6c8378b15b`](https://github.com/nodejs/node/commit/6c8378b15b)] - **vm**: fix `produceCachedData` (Jiho Choi) [#5343](https://github.com/nodejs/node/pull/5343)
 * [[`d1cacb814f`](https://github.com/nodejs/node/commit/d1cacb814f)] - **(SEMVER-MINOR)** **vm**: introduce `cachedData`/`produceCachedData` (Fedor Indutny) [#4777](https://github.com/nodejs/node/pull/4777)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.7.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.7.0/node-v5.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.7.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.7.0/node-v5.7.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.7.0/node-v5.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.7.0/ \
 Documentation: https://nodejs.org/docs/v5.7.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.7.1.md
+++ b/pages/en/blog/release/v5.7.1.md
@@ -100,22 +100,22 @@ author: Jeremiah Senkpiel
 * [[`9424fa5732`](https://github.com/nodejs/node/commit/9424fa5732)] - **url**: group slashed protocols by protocol name (nettofarah) [#5380](https://github.com/nodejs/node/pull/5380)
 * [[`dfe45f13e7`](https://github.com/nodejs/node/commit/dfe45f13e7)] - **url**: fix off-by-one error with parse() (Brian White) [#5394](https://github.com/nodejs/node/pull/5394)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.7.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.7.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.7.1/node-v5.7.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.7.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.7.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.7.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.7.1/node-v5.7.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.7.1/node-v5.7.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.7.1/ \
 Documentation: https://nodejs.org/docs/v5.7.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.8.0.md
+++ b/pages/en/blog/release/v5.8.0.md
@@ -53,22 +53,22 @@ author: Jeremiah Senkpiel
 * [[`971edde0cb`](https://github.com/nodejs/node/commit/971edde0cb)] - **util**: improve format() performance further (Brian White) [#5360](https://github.com/nodejs/node/pull/5360)
 * [[`c32d460747`](https://github.com/nodejs/node/commit/c32d460747)] - **util**: improve util.format performance (Evan Lucas) [#5360](https://github.com/nodejs/node/pull/5360)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.8.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.8.0/node-v5.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.8.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.8.0/node-v5.8.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.8.0/node-v5.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.8.0/ \
 Documentation: https://nodejs.org/docs/v5.8.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.9.0.md
+++ b/pages/en/blog/release/v5.9.0.md
@@ -83,22 +83,22 @@ https://github.com/nodejs/node/pull/5655
 * [[`0b545fb3f8`](https://github.com/nodejs/node/commit/0b545fb3f8)] - **win,build**: support Visual C++ Build Tools 2015 (João Reis) [#5627](https://github.com/nodejs/node/pull/5627)
 * [[`ef774ff9a8`](https://github.com/nodejs/node/commit/ef774ff9a8)] - **(SEMVER-MINOR)** **zlib**: add support for concatenated members (Kári Tristan Helgason) [#5120](https://github.com/nodejs/node/pull/5120)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.9.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.9.0/node-v5.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.9.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.9.0/node-v5.9.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.9.0/node-v5.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v5.9.0/ \
 Documentation: https://nodejs.org/docs/v5.9.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v5.9.1.md
+++ b/pages/en/blog/release/v5.9.1.md
@@ -62,22 +62,22 @@ author: Jeremiah Senkpiel
 * [[`d3654d80f3`](https://github.com/nodejs/node/commit/d3654d80f3)] - **timers**: improve setImmediate() performance (Brian White) [#4169](https://github.com/nodejs/node/pull/4169)
 * [[`b1a4870200`](https://github.com/nodejs/node/commit/b1a4870200)] - **tools**: remove unused imports (Sakthipriyan Vairamani) [#5765](https://github.com/nodejs/node/pull/5765)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v5.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v5.9.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v5.9.1/node-v5.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v5.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v5.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v5.9.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v5.9.1/node-v5.9.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v5.9.1/node-v5.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v5.9.1/ \
 Documentation: https://nodejs.org/docs/v5.9.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.0.0.md
+++ b/pages/en/blog/release/v6.0.0.md
@@ -306,22 +306,22 @@ Semver-minor and patch commits since v5.11.0
 * [[`e84c69310f`](https://github.com/nodejs/node/commit/e84c69310f)] - **tools**: enforce deepStrictEqual over deepEqual (Rich Trott) [#6213](https://github.com/nodejs/node/pull/6213)
 * [[`7940ecfa00`](https://github.com/nodejs/node/commit/7940ecfa00)] - **v8**: warn in Template::Set() on improper use (Ben Noordhuis) [#6277](https://github.com/nodejs/node/pull/6277)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.0.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.0.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.0.0/node-v6.0.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.0.0/node-v6.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.0.0/ \
 Documentation: https://nodejs.org/docs/v6.0.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.1.0.md
+++ b/pages/en/blog/release/v6.1.0.md
@@ -89,22 +89,22 @@ Please see our [blog post](https://nodejs.org/en/blog/vulnerability/openssl-may-
 * [[`91ab769940`](https://github.com/nodejs/node/commit/91ab769940)] - **(SEMVER-MINOR)** **util**: truncate inspect array and typed array (James M Snell) [#6334](https://github.com/nodejs/node/pull/6334)
 * [[`0bca959617`](https://github.com/nodejs/node/commit/0bca959617)] - **(SEMVER-MINOR)** **util**: fix inspecting of proxy objects (James M Snell) [#6465](https://github.com/nodejs/node/pull/6465)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.1.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.1.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.1.0/node-v6.1.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.1.0/node-v6.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.1.0/ \
 Documentation: https://nodejs.org/docs/v6.1.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.10.0.md
+++ b/pages/en/blog/release/v6.10.0.md
@@ -193,25 +193,25 @@ Notable SEMVER-PATCH changes include:
 * [[`9eaf2e9517`](https://github.com/nodejs/node/commit/9eaf2e9517)] - **watchdog**: add flag to mark handler as disabled (Bartosz Sosnowski) [#10248](https://github.com/nodejs/node/pull/10248)
 * [[`969dcab5aa`](https://github.com/nodejs/node/commit/969dcab5aa)] - **win,msi**: add required UIRef for localized strings (Bill Ticehurst) [#8884](https://github.com/nodejs/node/pull/8884)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.10.0/node-v6.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.10.0/node-v6.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.10.0/node-v6.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.10.0/ \
 Documentation: https://nodejs.org/docs/v6.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.10.1.md
+++ b/pages/en/blog/release/v6.10.1.md
@@ -329,25 +329,25 @@ author: Myles Borins
 * [[`fd1ffe4f5a`](https://github.com/nodejs/node/commit/fd1ffe4f5a)] - **v8**: fix --always-opt bug (Ben Noordhuis) [#9293](https://github.com/nodejs/node/pull/9293)
 * [[`a55af77fc5`](https://github.com/nodejs/node/commit/a55af77fc5)] - **vm**: refactor vm module (James M Snell) [#11392](https://github.com/nodejs/node/pull/11392)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.10.1/node-v6.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.10.1/node-v6.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.10.1/node-v6.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.10.1/ \
 Documentation: https://nodejs.org/docs/v6.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.10.2.md
+++ b/pages/en/blog/release/v6.10.2.md
@@ -28,25 +28,25 @@ author: Myles Borins
 * [[`52bdb8f246`](https://github.com/nodejs/node/commit/52bdb8f246)] - **deps**: backport 2cabc86 from upstream V8 (Michaël Zasso) [#12037](https://github.com/nodejs/node/pull/12037)
 * [[`64fc5a4541`](https://github.com/nodejs/node/commit/d60ceb8a02)] - **repl** Revert: "Revert "repl: disable Ctrl+C support..." (Myles Borins) [#12123](https://github.com/nodejs/node/pull/12123)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.10.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.10.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.10.2/node-v6.10.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.10.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.10.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.10.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.10.2/node-v6.10.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.10.2/node-v6.10.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.10.2/ \
 Documentation: https://nodejs.org/docs/v6.10.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.10.3.md
+++ b/pages/en/blog/release/v6.10.3.md
@@ -173,25 +173,25 @@ author: Myles Borins
 * [[`de63698066`](https://github.com/nodejs/node/commit/de63698066)] - **tools, test**: require const/let in test (Gibson Fahnestock) [#10685](https://github.com/nodejs/node/pull/10685)
 * [[`63449972d1`](https://github.com/nodejs/node/commit/63449972d1)] - **url**: use `hasIntl` instead of `try-catch` (Daijiro Wachi) [#11571](https://github.com/nodejs/node/pull/11571)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.10.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.10.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.10.3/node-v6.10.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.10.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.10.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.10.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.10.3/node-v6.10.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.10.3/node-v6.10.3.tar.gz \
+Other release files: https://nodejs.org/dist/v6.10.3/ \
 Documentation: https://nodejs.org/docs/v6.10.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.0.md
+++ b/pages/en/blog/release/v6.11.0.md
@@ -166,25 +166,25 @@ author: Myles Borins
 * [[`a0f9d5964e`](https://github.com/nodejs/node/commit/a0f9d5964e)] - **v8**: fix stack overflow in recursive method (Ben Noordhuis) [#12460](https://github.com/nodejs/node/pull/12460)
 * [[`2b3381aec6`](https://github.com/nodejs/node/commit/2b3381aec6)] - ***Revert*** "**v8**: drop v8::FunctionCallbackInfo\<T\>::NewTarget()" (Ben Noordhuis)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.0/node-v6.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.0/node-v6.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.0/node-v6.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.0/ \
 Documentation: https://nodejs.org/docs/v6.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.1.md
+++ b/pages/en/blog/release/v6.11.1.md
@@ -22,25 +22,25 @@ author: Myles Borins
 * [[`a92d4ca460`](https://github.com/nodejs/node/commit/a92d4ca460)] - **deps**: Debug code requires bigger buffer on s390 (Michael Dawson) [nodejs/node-private#93](https://github.com/nodejs/node-private/pull/93)
 * [[`6e247b8a4e`](https://github.com/nodejs/node/commit/6e247b8a4e)] - **test**: verify hash seed uniqueness (Ali Ijaz Sheikh) [nodejs/node-private#84](https://github.com/nodejs/node-private/pull/84)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.1/node-v6.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.1/node-v6.11.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.1/node-v6.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.1/ \
 Documentation: https://nodejs.org/docs/v6.11.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.2.md
+++ b/pages/en/blog/release/v6.11.2.md
@@ -248,25 +248,25 @@ author: Myles Borins
 * [[`6e60c838c9`](https://github.com/nodejs/node/commit/6e60c838c9)] - **vm**: fix displayErrors in runIn.. functions (Marcel Laverdet) [#13074](https://github.com/nodejs/node/pull/13074)
 * [[`55cbe24c60`](https://github.com/nodejs/node/commit/55cbe24c60)] - **zlib**: fix node crashing on invalid options (Alexey Orlenko) [#13098](https://github.com/nodejs/node/pull/13098)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.2/node-v6.11.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.2/node-v6.11.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.2/node-v6.11.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.2/ \
 Documentation: https://nodejs.org/docs/v6.11.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.3.md
+++ b/pages/en/blog/release/v6.11.3.md
@@ -177,25 +177,25 @@ This LTS release comes with 152 commits. This includes 75 which are test related
 * [[`bccd2f59b0`](https://github.com/nodejs/node/commit/bccd2f59b0)] - **v8**: handle proxy objects in MakeMirror(), v1 (Ben Noordhuis) [#14343](https://github.com/nodejs/node/pull/14343)
 * [[`e79c054f76`](https://github.com/nodejs/node/commit/e79c054f76)] - **zlib**: fix crash when initializing failed (Anna Henningsen) [#14666](https://github.com/nodejs/node/pull/14666)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.3/node-v6.11.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.3/node-v6.11.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.3/node-v6.11.3.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.3/ \
 Documentation: https://nodejs.org/docs/v6.11.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.4.md
+++ b/pages/en/blog/release/v6.11.4.md
@@ -107,25 +107,25 @@ author: Myles Borins
 * [[`f7b6d198b9`](https://github.com/nodejs/node/commit/f7b6d198b9)] - **tools**: eslint - use `error` and `off` (Refael Ackermann) [#14061](https://github.com/nodejs/node/pull/14061)
 * [[`f8b85e16cd`](https://github.com/nodejs/node/commit/f8b85e16cd)] - **tools**: replace assert-throw-arguments custom lint (Rich Trott) [#14547](https://github.com/nodejs/node/pull/14547)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.4/node-v6.11.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.4/node-v6.11.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.4/node-v6.11.4.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.4/ \
 Documentation: https://nodejs.org/docs/v6.11.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.11.5.md
+++ b/pages/en/blog/release/v6.11.5.md
@@ -17,25 +17,25 @@ author: Myles Borins
 
 * [[`dd764d9cb6`](https://github.com/nodejs/node/commit/b66e44c4d3)] - **zlib**: gracefully set windowBits from 8 to 9 (Myles Borins) [nodejs-private/node-private#95](https://github.com/nodejs-private/node-private/pull/95)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.11.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.11.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.11.5/node-v6.11.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.11.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.11.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.11.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.11.5/node-v6.11.5.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.11.5/node-v6.11.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.11.5/node-v6.11.5.tar.gz \
+Other release files: https://nodejs.org/dist/v6.11.5/ \
 Documentation: https://nodejs.org/docs/v6.11.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.12.0.md
+++ b/pages/en/blog/release/v6.12.0.md
@@ -164,25 +164,25 @@ author: Myles Borins
 * [[`88b9572d76`](https://github.com/nodejs/node/commit/88b9572d76)] - **tty**: require readline at top of file (Bryan English) [#15647](https://github.com/nodejs/node/pull/15647)
 * [[`27af0bb446`](https://github.com/nodejs/node/commit/27af0bb446)] - **url**: change variable name to be more descriptive (Yang-Kichang) [#15551](https://github.com/nodejs/node/pull/15551)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.12.0/node-v6.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.12.0/node-v6.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.0/node-v6.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.12.0/node-v6.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.12.0/ \
 Documentation: https://nodejs.org/docs/v6.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.12.1.md
+++ b/pages/en/blog/release/v6.12.1.md
@@ -283,25 +283,25 @@ author: Myles Borins
 * [[`5b5b5c0f15`](https://github.com/nodejs/node/commit/5b5b5c0f15)] - **tools**: use template literal in error message (Tim Chon) [#15846](https://github.com/nodejs/node/pull/15846)
 * [[`ae5930bbe4`](https://github.com/nodejs/node/commit/ae5930bbe4)] - **tty,doc**: add type-check to isatty (Bryan English) [#15567](https://github.com/nodejs/node/pull/15567)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.12.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.12.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.12.1/node-v6.12.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.12.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.12.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.12.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.12.1/node-v6.12.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.1/node-v6.12.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.12.1/node-v6.12.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.12.1/ \
 Documentation: https://nodejs.org/docs/v6.12.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.12.2.md
+++ b/pages/en/blog/release/v6.12.2.md
@@ -23,25 +23,25 @@ author: Myles Borins
 * [[`03651ad9d6`](https://github.com/nodejs/node/commit/03651ad9d6)] - **deps**: upgrade openssl sources to 1.0.2n (Shigeki Ohtsu) [#17526](https://github.com/nodejs/node/pull/17526)
 * [[`eb30387c6d`](https://github.com/nodejs/node/commit/eb30387c6d)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.12.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.12.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.12.2/node-v6.12.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.12.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.12.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.12.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.12.2/node-v6.12.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.2/node-v6.12.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.12.2/node-v6.12.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.12.2/ \
 Documentation: https://nodejs.org/docs/v6.12.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.12.3.md
+++ b/pages/en/blog/release/v6.12.3.md
@@ -131,25 +131,25 @@ author: Myles Borins
 * [[`dcf7646725`](https://github.com/nodejs/node/commit/dcf7646725)] - **tools**: fail tests if malformed status file (Rich Trott) [#16703](https://github.com/nodejs/node/pull/16703)
 * [[`d176073511`](https://github.com/nodejs/node/commit/d176073511)] - **tty**: refactor exports (cjihrig) [#16959](https://github.com/nodejs/node/pull/16959)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.12.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.12.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.12.3/node-v6.12.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.12.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.12.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.12.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.12.3/node-v6.12.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.12.3/node-v6.12.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.12.3/node-v6.12.3.tar.gz \
+Other release files: https://nodejs.org/dist/v6.12.3/ \
 Documentation: https://nodejs.org/docs/v6.12.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.13.0.md
+++ b/pages/en/blog/release/v6.13.0.md
@@ -160,25 +160,25 @@ author: Myles Borins
 * [[`60b10f0896`](https://github.com/nodejs/node/commit/60b10f0896)] - **url**: update IDNA handling (Timothy Gu) [#13362](https://github.com/nodejs/node/pull/13362)
 * [[`7af1ad0ec1`](https://github.com/nodejs/node/commit/7af1ad0ec1)] - **(SEMVER-MINOR)** **util**: add %i and %f formatting specifiers (Roman Reiss) [#10308](https://github.com/nodejs/node/pull/10308)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.13.0/node-v6.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.13.0/node-v6.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.0/node-v6.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.13.0/node-v6.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.13.0/ \
 Documentation: https://nodejs.org/docs/v6.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.13.1.md
+++ b/pages/en/blog/release/v6.13.1.md
@@ -39,25 +39,25 @@ author: Myles Borins
 * [[`16ef24bccf`](https://github.com/nodejs/node/commit/16ef24bccf)] - **test**: use smaller input file for test-zlib.js (Rich Trott) [#17988](https://github.com/nodejs/node/pull/17988)
 * [[`48790382f1`](https://github.com/nodejs/node/commit/48790382f1)] - **tools**: add number-isnan rule (Jon Moss) [#17556](https://github.com/nodejs/node/pull/17556)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.13.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.13.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.13.1/node-v6.13.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.13.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.13.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.13.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.13.1/node-v6.13.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.13.1/node-v6.13.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.13.1/node-v6.13.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.13.1/ \
 Documentation: https://nodejs.org/docs/v6.13.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.14.0.md
+++ b/pages/en/blog/release/v6.14.0.md
@@ -32,25 +32,25 @@ author: Myles Borins
 * [[`1dba2f4950`](https://github.com/nodejs/node/commit/1dba2f4950)] - **src**: drop CNNIC+StartCom certificate whitelisting (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 * [[`bdfeb1c739`](https://github.com/nodejs/node/commit/bdfeb1c739)] - **tools**: update certdata.txt (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.14.0/node-v6.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.14.0/node-v6.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.0/node-v6.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.14.0/node-v6.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.14.0/ \
 Documentation: https://nodejs.org/docs/v6.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.14.1.md
+++ b/pages/en/blog/release/v6.14.1.md
@@ -17,25 +17,25 @@ endian were built using GCC 4.9.X instead of GCC 4.8.X. This caused an ABI break
 environments. This has been fixed in our infrastructure and we are doing this release to ensure that
 the hosted binaries are adhering to our platform support contract.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.14.1/node-v6.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.14.1/node-v6.14.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.1/node-v6.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.14.1/node-v6.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.14.1/ \
 Documentation: https://nodejs.org/docs/v6.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.14.2.md
+++ b/pages/en/blog/release/v6.14.2.md
@@ -243,25 +243,25 @@ author: Myles Borins
 * [[`a91b1b928c`](https://github.com/nodejs/node/commit/a91b1b928c)] - **win, build**: fix intl-none option (Birunthan Mohanathas) [#18292](https://github.com/nodejs/node/pull/18292)
 * [[`6ff763bd66`](https://github.com/nodejs/node/commit/6ff763bd66)] - **win, build**: fix without-intl option (Bartosz Sosnowski) [#17614](https://github.com/nodejs/node/pull/17614)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.14.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.14.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.14.2/node-v6.14.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.14.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.14.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.14.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.14.2/node-v6.14.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.2/node-v6.14.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.14.2/node-v6.14.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.14.2/ \
 Documentation: https://nodejs.org/docs/v6.14.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.14.3.md
+++ b/pages/en/blog/release/v6.14.3.md
@@ -16,25 +16,25 @@ author: Evan Lucas
 
 * [[`7dbcfc6217`](https://github.com/nodejs/node/commit/7dbcfc6217)] - **src**: avoid hanging on Buffer#fill 0-length input (Сковорода Никита Андреевич) [nodejs-private/node-private#121](https://github.com/nodejs-private/node-private/pull/121)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.14.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.14.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.14.3/node-v6.14.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.14.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.14.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.14.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.14.3/node-v6.14.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.3/node-v6.14.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.14.3/node-v6.14.3.tar.gz \
+Other release files: https://nodejs.org/dist/v6.14.3/ \
 Documentation: https://nodejs.org/docs/v6.14.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.14.4.md
+++ b/pages/en/blog/release/v6.14.4.md
@@ -31,25 +31,25 @@ author: Rod Vagg
 * [[`58b9497ca8`](https://github.com/nodejs/node/commit/58b9497ca8)] - **test**: update certificates and private keys (Fedor Indutny) [#22184](https://github.com/nodejs/node/pull/22184)
 * [[`9863e11ea8`](https://github.com/nodejs/node/commit/9863e11ea8)] - **test**: update keys/Makefile to clean and build all (Daniel Bevenius) [#19975](https://github.com/nodejs/node/pull/19975)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.14.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.14.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.14.4/node-v6.14.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.14.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.14.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.14.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.14.4/node-v6.14.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.14.4/node-v6.14.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.14.4/node-v6.14.4.tar.gz \
+Other release files: https://nodejs.org/dist/v6.14.4/ \
 Documentation: https://nodejs.org/docs/v6.14.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.15.0.md
+++ b/pages/en/blog/release/v6.15.0.md
@@ -46,25 +46,25 @@ Fixes for the following CVEs are included in this release:
 * [[`a9791c9090`](https://github.com/nodejs/node/commit/a9791c9090)] - **src**: make debugger listen on 127.0.0.1 by default (Ben Noordhuis) [nodejs-private/node-private#148](https://github.com/nodejs-private/node-private/pull/148)
 * [[`9c268d0492`](https://github.com/nodejs/node/commit/9c268d0492)] - **url**: avoid hostname spoofing w/ javascript protocol (Matteo Collina) [nodejs-private/node-private#145](https://github.com/nodejs-private/node-private/pull/145)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.15.0/node-v6.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.15.0/node-v6.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.0/node-v6.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.15.0/node-v6.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.15.0/ \
 Documentation: https://nodejs.org/docs/v6.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.15.1.md
+++ b/pages/en/blog/release/v6.15.1.md
@@ -18,25 +18,25 @@ This is a patch release to address a bad backport of the fix for "Slowloris HTTP
 
 * [[`5d9005c359`](https://github.com/nodejs/node/commit/5d9005c359)] - **http**: fix backport of Slowloris headers (Matteo Collina) [#24796](https://github.com/nodejs/node/pull/24796)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.15.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.15.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.15.1/node-v6.15.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.15.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.15.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.15.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.15.1/node-v6.15.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.15.1/node-v6.15.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.15.1/ \
 Documentation: https://nodejs.org/docs/v6.15.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.16.0.md
+++ b/pages/en/blog/release/v6.16.0.md
@@ -26,25 +26,25 @@ a missing CLI flag to adjust the max header size of the http parser.
 * [[`c0c4de71f0`](https://github.com/nodejs/node/commit/c0c4de71f0)] - **(SEMVER-MINOR)** **http**: add maxHeaderSize property (cjihrig) [#24860](https://github.com/nodejs/node/pull/24860)
 * [[`8a3e0c0697`](https://github.com/nodejs/node/commit/8a3e0c0697)] - **http**: fix regression of binary upgrade response body (Matteo Collina) [#25036](https://github.com/nodejs/node/pull/25036)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.16.0/node-v6.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.16.0/node-v6.16.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.16.0/node-v6.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.16.0/ \
 Documentation: https://nodejs.org/docs/v6.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.17.0.md
+++ b/pages/en/blog/release/v6.17.0.md
@@ -37,25 +37,25 @@ Fixes for the following CVEs are included in this release:
 * [[`06a208d316`](https://github.com/nodejs/node/commit/06a208d316)] - **test**: refactor test-http-server-keep-alive-timeout (realwakka) [#13448](https://github.com/nodejs/node/pull/13448)
 * [[`1c7fbdc53b`](https://github.com/nodejs/node/commit/1c7fbdc53b)] - **test**: improve test-https-server-keep-alive-timeout (Rich Trott) [#13312](https://github.com/nodejs/node/pull/13312)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.17.0/node-v6.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.17.0/node-v6.17.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.17.0/node-v6.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.17.0/node-v6.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.17.0/ \
 Documentation: https://nodejs.org/docs/v6.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.17.1.md
+++ b/pages/en/blog/release/v6.17.1.md
@@ -25,25 +25,25 @@ Node 6 is due to go End-of-Life on 2019-04-30 - see [Release Schedule](https://g
 * [[`aedc7120ea`](https://github.com/nodejs/node/commit/aedc7120ea)] - **src**: fix bootstrap\_node on bsd (sylkat) [#22663](https://github.com/nodejs/node/pull/22663)
 * [[`b5d464955a`](https://github.com/nodejs/node/commit/b5d464955a)] - **test**: fix test-repl-envvars (Anna Henningsen) [#25226](https://github.com/nodejs/node/pull/25226)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.17.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.17.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.17.1/node-v6.17.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.17.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.17.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.17.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.17.1/node-v6.17.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.17.1/node-v6.17.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.17.1/ \
 Documentation: https://nodejs.org/docs/v6.17.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.2.0.md
+++ b/pages/en/blog/release/v6.2.0.md
@@ -151,22 +151,22 @@ running in big endian mode in addition to the existing 64-bit binaries for runni
 * [[`6d1527bb37`](https://github.com/nodejs/node/commit/6d1527bb37)] - **util**: fix invalid date output with util.inspect (Rumkin) [#6504](https://github.com/nodejs/node/pull/6504)
 * [[`1d6c17efd7`](https://github.com/nodejs/node/commit/1d6c17efd7)] - **util**: adhere to `noDeprecation` set at runtime (Anna Henningsen) [#6683](https://github.com/nodejs/node/pull/6683)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.2.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.2.0/node-v6.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.2.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.0/node-v6.2.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.0/node-v6.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.2.0/node-v6.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.2.0/ \
 Documentation: https://nodejs.org/docs/v6.2.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.2.1.md
+++ b/pages/en/blog/release/v6.2.1.md
@@ -156,22 +156,22 @@ author: Rod Vagg
 * [[`1e26b82ce4`](https://github.com/nodejs/node/commit/1e26b82ce4)] - **zlib**: release callback and buffer after processing (Matt Lavin) [#6955](https://github.com/nodejs/node/pull/6955)
 * [[`64415564de`](https://github.com/nodejs/node/commit/64415564de)] - **zlib**: remove `_closed` in source (Anna Henningsen) [#6574](https://github.com/nodejs/node/pull/6574)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.2.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.2.1/node-v6.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.2.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.1/node-v6.2.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.1/node-v6.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.2.1/node-v6.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.2.1/ \
 Documentation: https://nodejs.org/docs/v6.2.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.2.2.md
+++ b/pages/en/blog/release/v6.2.2.md
@@ -81,22 +81,22 @@ author: Evan Lucas
 * [[`9545c41cba`](https://github.com/nodejs/node/commit/9545c41cba)] - **tools**: fix license builder to work with icu-small (Myles Borins) [#7119](https://github.com/nodejs/node/pull/7119)
 * [[`6562c9fc75`](https://github.com/nodejs/node/commit/6562c9fc75)] - **tools,doc**: add example usage for REPLACEME tag (Anna Henningsen) [#6864](https://github.com/nodejs/node/pull/6864)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.2.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.2.2/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.2.2/node-v6.2.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.2.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.2.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.2.2/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.2.2/node-v6.2.2.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.2.2/node-v6.2.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.2.2/ \
 Documentation: https://nodejs.org/docs/v6.2.2/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.3.0.md
+++ b/pages/en/blog/release/v6.3.0.md
@@ -186,22 +186,22 @@ author: Jeremiah Senkpiel
 * [[`55b87c0238`](https://github.com/nodejs/node/commit/55b87c0238)] - **vm**: test for abort condition of current invocation (Anna Henningsen) [#7373](https://github.com/nodejs/node/pull/7373)
 * [[`d049919e7d`](https://github.com/nodejs/node/commit/d049919e7d)] - **(SEMVER-MINOR)** **vm**: add ability to break on sigint/ctrl+c (Anna Henningsen) [#6635](https://github.com/nodejs/node/pull/6635)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.3.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.3.0/node-v6.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.3.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.3.0/node-v6.3.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.0/node-v6.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.3.0/node-v6.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.3.0/ \
 Documentation: https://nodejs.org/docs/v6.3.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.3.1.md
+++ b/pages/en/blog/release/v6.3.1.md
@@ -106,22 +106,22 @@ author: Evan Lucas
 * [[`fa99dadda4`](https://github.com/nodejs/node/commit/fa99dadda4)] - **tools**: remove unnecessary imports and assignments (Sakthipriyan Vairamani) [#7483](https://github.com/nodejs/node/pull/7483)
 * [[`0858e620e9`](https://github.com/nodejs/node/commit/0858e620e9)] - **util**: inspect boxed symbols like other primitives (Anna Henningsen) [#7641](https://github.com/nodejs/node/pull/7641)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.3.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.3.1/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.3.1/node-v6.3.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.3.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.3.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.3.1/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.3.1/node-v6.3.1.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.3.1/node-v6.3.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.3.1/ \
 Documentation: https://nodejs.org/docs/v6.3.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.4.0.md
+++ b/pages/en/blog/release/v6.4.0.md
@@ -178,22 +178,22 @@ author: Colin Ihrig
 * [[`dbbcb9dbd9`](https://github.com/nodejs/node/commit/dbbcb9dbd9)] - **win,msi**: Added Italian translation (Matteo Collina) [#4647](https://github.com/nodejs/node/pull/4647)
 * [[`909254c901`](https://github.com/nodejs/node/commit/909254c901)] - **zlib**: remove unneeded property (Jan Schär) [#7987](https://github.com/nodejs/node/pull/7987)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.4.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.4.0/node-v6.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.4.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.4.0/node-v6.4.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.4.0/node-v6.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.4.0/node-v6.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.4.0/ \
 Documentation: https://nodejs.org/docs/v6.4.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.5.0.md
+++ b/pages/en/blog/release/v6.5.0.md
@@ -109,22 +109,22 @@ author: Evan Lucas
 * [[`44f781d06a`](https://github.com/nodejs/node/commit/44f781d06a)] - **v8**: warn in Template::Set() on improper use (Ben Noordhuis) [#6277](https://github.com/nodejs/node/pull/6277)
 * [[`a146e683dd`](https://github.com/nodejs/node/commit/a146e683dd)] - **win,msi**: add zh-CN translations for the installer (Minqi Pan) [#2569](https://github.com/nodejs/node/pull/2569)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.5.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.5.0/node-v6.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.5.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.5.0/node-v6.5.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.5.0/node-v6.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.5.0/ \
 Documentation: https://nodejs.org/docs/v6.5.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.6.0.md
+++ b/pages/en/blog/release/v6.6.0.md
@@ -134,22 +134,22 @@ author: Jeremiah Senkpiel
 * [[`14d356d0ab`](https://github.com/nodejs/node/commit/14d356d0ab)] - **win,build**: skip finding VS when not needed (João Reis) [#8412](https://github.com/nodejs/node/pull/8412)
 * [[`81d063e174`](https://github.com/nodejs/node/commit/81d063e174)] - **win,build**: fail on invalid option in vcbuild (João Reis) [#8412](https://github.com/nodejs/node/pull/8412)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.6.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.6.0/node-v6.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.6.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.6.0/node-v6.6.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.6.0/node-v6.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.6.0/ \
 Documentation: https://nodejs.org/docs/v6.6.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.7.0.md
+++ b/pages/en/blog/release/v6.7.0.md
@@ -50,22 +50,22 @@ Semver Patch:
 * [[`5902ba3989`](https://github.com/nodejs/node/commit/5902ba3989)] - **src**: Malloc/Calloc size 0 returns non-null pointer (Rich Trott) [#8572](https://github.com/nodejs/node/pull/8572)
 * [[`a14d832884`](https://github.com/nodejs/node/commit/a14d832884)] - **test**: remove openssl options of -no_\<prot> (Shigeki Ohtsu) [#8714](https://github.com/nodejs/node/pull/8714)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.7.0/win-x64/node.exe<br>
-Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0.pkg<br>
-Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.7.0/node-v6.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.7.0/win-x64/node.exe \
+Mac OS X 64-bit Installer: https://nodejs.org/dist/v6.7.0/node-v6.7.0.pkg \
+Mac OS X 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.7.0/node-v6.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.7.0/node-v6.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.7.0/ \
 Documentation: https://nodejs.org/docs/v6.7.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.8.0.md
+++ b/pages/en/blog/release/v6.8.0.md
@@ -11,7 +11,7 @@ author: Jeremiah Senkpiel
 ### Notable changes
 
 * **fs**:
-  * `SyncWriteStream` now inherits from `Stream.Writable`. (Anna Henningsen) [#8830](https://github.com/nodejs/node/pull/8830) <br>Practically, this means that when stdio is piped to a file, stdout and stderr will still be `Writable` streams.
+  * `SyncWriteStream` now inherits from `Stream.Writable`. (Anna Henningsen) [#8830](https://github.com/nodejs/node/pull/8830)  \Practically, this means that when stdio is piped to a file, stdout and stderr will still be `Writable` streams.
   * `fs.existsSync()` has been undeprecated. `fs.exists()` remains deprecated. (Dan Fabulich) [#8364](https://github.com/nodejs/node/pull/8364)
 * **http**: `http.request()` now accepts a `timeout` option. (Rene Weber) [#8101](https://github.com/nodejs/node/pull/8101)
 * **module**: The module loader now maintains its own realpath cache. (Anna Henningsen) [#8100](https://github.com/nodejs/node/pull/8100)
@@ -237,22 +237,22 @@ author: Jeremiah Senkpiel
 * [[`7403aaa13f`](https://github.com/nodejs/node/commit/7403aaa13f)] - **zlib**: tighten up dictionary tests (Tarjei Husøy) [#8512](https://github.com/nodejs/node/pull/8512)
 * [[`15474951a5`](https://github.com/nodejs/node/commit/15474951a5)] - **zlib**: fix raw inflate with custom dictionary (Tarjei Husøy) [#8512](https://github.com/nodejs/node/pull/8512)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.8.0/node-v6.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.8.0/node-v6.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.0/node-v6.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.8.0/node-v6.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.8.0/ \
 Documentation: https://nodejs.org/docs/v6.8.0/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.8.1.md
+++ b/pages/en/blog/release/v6.8.1.md
@@ -20,22 +20,22 @@ author: Evan Lucas
 * [[`8c4fab0a28`](https://github.com/nodejs/node/commit/8c4fab0a28)] - **stream**: fix `Writable` subclass instanceof checks (Anna Henningsen) [#9088](https://github.com/nodejs/node/pull/9088)
 * [[`7171bd6311`](https://github.com/nodejs/node/commit/7171bd6311)] - **timers**: fix regression with clearImmediate() (Brian White) [#9086](https://github.com/nodejs/node/pull/9086)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.8.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.8.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.8.1/node-v6.8.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.8.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.8.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.8.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.8.1/node-v6.8.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.8.1/node-v6.8.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.8.1/node-v6.8.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.8.1/ \
 Documentation: https://nodejs.org/docs/v6.8.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.9.0.md
+++ b/pages/en/blog/release/v6.9.0.md
@@ -64,22 +64,22 @@ It's time to start planning your migration from Node.js v4 LTS "Argon" to Node.j
 * [[`455272ad33`](https://github.com/nodejs/node/commit/455272ad33)] - **(SEMVER-MINOR)** **src**: add process.release.lts property (Rod Vagg) [#3212](https://github.com/nodejs/node/pull/3212)
 * [[`9ace073949`](https://github.com/nodejs/node/commit/9ace073949)] - **win,build**: try multiple timeservers when signing (Rod Vagg) [#9155](https://github.com/nodejs/node/pull/9155)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.0/node-v6.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.0/node-v6.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.0/node-v6.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.0/node-v6.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.0/ \
 Documentation: https://nodejs.org/docs/v6.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.9.1.md
+++ b/pages/en/blog/release/v6.9.1.md
@@ -21,22 +21,22 @@ author: Myles Borins
 * [[`c74d3a700a`](https://github.com/nodejs/node/commit/c74d3a700a)] - **tools**: make detached SHASUM .sig file for releases (Rod Vagg) [#9071](https://github.com/nodejs/node/pull/9071)
 * [[`955bbf876f`](https://github.com/nodejs/node/commit/955bbf876f)] - **tools**: explicitly set digest algo for SHASUM to 256 (Rod Vagg) [#9071](https://github.com/nodejs/node/pull/9071)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.1/node-v6.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.1/node-v6.9.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.1/node-v6.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.1/ \
 Documentation: https://nodejs.org/docs/v6.9.1/api/
 
 Shasums (GPG signing hash: SHA512, file hash: SHA256):

--- a/pages/en/blog/release/v6.9.2.md
+++ b/pages/en/blog/release/v6.9.2.md
@@ -167,25 +167,25 @@ author: Myles Borins
 * [[`52a04bbfe2`](https://github.com/nodejs/node/commit/52a04bbfe2)] - **util**: use template strings (Alejandro Oviedo Garcia) [#9120](https://github.com/nodejs/node/pull/9120)
 * [[`7dc875c08a`](https://github.com/nodejs/node/commit/7dc875c08a)] - **v8**: update make-v8.sh to use git (Jaideep Bajwa) [#9393](https://github.com/nodejs/node/pull/9393)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.2/node-v6.9.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.2/node-v6.9.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.2/node-v6.9.2.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.2/ \
 Documentation: https://nodejs.org/docs/v6.9.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.9.3.md
+++ b/pages/en/blog/release/v6.9.3.md
@@ -342,25 +342,25 @@ release, v6.9.4, with no changes.
 * [[`5401b04648`](https://github.com/nodejs/node/commit/5401b04648)] - **tools**: copy run-valgrind.py to tools/ (Ben Noordhuis) [#9520](https://github.com/nodejs/node/pull/9520)
 * [[`12fe071abf`](https://github.com/nodejs/node/commit/12fe071abf)] - **util**: move the case 'latin1' (Jackson Tian) [#9646](https://github.com/nodejs/node/pull/9646)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.3/node-v6.9.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.3/node-v6.9.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.3/node-v6.9.3.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.3/ \
 Documentation: https://nodejs.org/docs/v6.9.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.9.4.md
+++ b/pages/en/blog/release/v6.9.4.md
@@ -21,25 +21,25 @@ N/A
 
 N/A
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.4/node-v6.9.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.4/node-v6.9.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.4/node-v6.9.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.4/node-v6.9.4.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.4/ \
 Documentation: https://nodejs.org/docs/v6.9.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v6.9.5.md
+++ b/pages/en/blog/release/v6.9.5.md
@@ -22,25 +22,25 @@ author: Myles Borins
 * [[`3f2bef60b8`](https://github.com/nodejs/node/commit/3f2bef60b8)] - **deps**: upgrade openssl sources to 1.0.2k (Shigeki Ohtsu) [#11021](https://github.com/nodejs/node/pull/11021)
 * [[`c4678d2f9a`](https://github.com/nodejs/node/commit/c4678d2f9a)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v6.9.5/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v6.9.5/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v6.9.5/node-v6.9.5.tar.gz<br>
-Other release files: https://nodejs.org/dist/v6.9.5/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v6.9.5/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v6.9.5/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v6.9.5/node-v6.9.5.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v6.9.5/node-v6.9.5-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v6.9.5/node-v6.9.5.tar.gz \
+Other release files: https://nodejs.org/dist/v6.9.5/ \
 Documentation: https://nodejs.org/docs/v6.9.5/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.0.0.md
+++ b/pages/en/blog/release/v7.0.0.md
@@ -234,21 +234,21 @@ The release notes below are annotated with the main breaking changes. Note that 
 * [[`336b027411`](https://github.com/nodejs/node/commit/336b027411)] - **(SEMVER-MAJOR)** **url**: return valid file: urls fom url.format() (Rich Trott) [#7234](https://github.com/nodejs/node/pull/7234)
 * [[`197a465280`](https://github.com/nodejs/node/commit/197a465280)] - **(SEMVER-MAJOR)** **zlib**: move constants into zlib.constants (James M Snell) [#7203](https://github.com/nodejs/node/pull/7203)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-ppc64le.tar.xz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.0.0/node-v7.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.0.0/node-v7.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-ppc64le.tar.xz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.0.0/node-v7.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.0.0/node-v7.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.0.0/ \
 Documentation: https://nodejs.org/docs/v7.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.1.0.md
+++ b/pages/en/blog/release/v7.1.0.md
@@ -142,24 +142,24 @@ author: Evan Lucas
 * [[`4f0596fb03`](https://github.com/nodejs/node/commit/4f0596fb03)] - **util**: use template strings (Alejandro Oviedo Garcia) [#9120](https://github.com/nodejs/node/pull/9120)
 * [[`b083086ff2`](https://github.com/nodejs/node/commit/b083086ff2)] - **vm**: name anonymous functions (solebox) [#9388](https://github.com/nodejs/node/pull/9388)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.1.0/node-v7.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.1.0/node-v7.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.1.0/node-v7.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.1.0/node-v7.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.1.0/ \
 Documentation: https://nodejs.org/docs/v7.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.10.0.md
+++ b/pages/en/blog/release/v7.10.0.md
@@ -205,25 +205,25 @@ author: Evan Lucas
 * [[`e77f1e2177`](https://github.com/nodejs/node/commit/e77f1e2177)] - **v8**: fix stack overflow in recursive method (Ben Noordhuis) [#12460](https://github.com/nodejs/node/pull/12460)
 * [[`25b851bdd4`](https://github.com/nodejs/node/commit/25b851bdd4)] - **v8**: fix build errors with g++ 7 (Ben Noordhuis) [#12392](https://github.com/nodejs/node/pull/12392)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.10.0/node-v7.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.10.0/node-v7.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.10.0/node-v7.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.10.0/ \
 Documentation: https://nodejs.org/docs/v7.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.10.1.md
+++ b/pages/en/blog/release/v7.10.1.md
@@ -31,25 +31,25 @@ author: Evan Lucas
 * [[`8a82960e76`](https://github.com/nodejs/node/commit/8a82960e76)] - **deps**: cherry-pick 9478908a49 from cares upstream (David Drysdale) [nodejs/node-private#88](https://github.com/nodejs/node-private/pull/88)
 * [[`b5bf5e8086`](https://github.com/nodejs/node/commit/b5bf5e8086)] - **test**: verify hash seed uniqueness (Ali Ijaz Sheikh) [nodejs/node-private#84](https://github.com/nodejs/node-private/pull/84)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.10.1/node-v7.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.10.1/node-v7.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.10.1/node-v7.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.10.1/node-v7.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v7.10.1/ \
 Documentation: https://nodejs.org/docs/v7.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.2.0.md
+++ b/pages/en/blog/release/v7.2.0.md
@@ -127,24 +127,24 @@ _This is a security release impacting Windows 10 users._
 * [[`adcc5b15f7`](https://github.com/nodejs/node/commit/adcc5b15f7)] - **zlib**: fix linting recently-introduced lint error (Rich Trott) [#9524](https://github.com/nodejs/node/pull/9524)
 * [[`841a2c41d4`](https://github.com/nodejs/node/commit/841a2c41d4)] - **zlib**: name every function Ref: #8913 (solebox) [#9389](https://github.com/nodejs/node/pull/9389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.2.0/node-v7.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.2.0/node-v7.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.2.0/node-v7.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.2.0/ \
 Documentation: https://nodejs.org/docs/v7.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.2.1.md
+++ b/pages/en/blog/release/v7.2.1.md
@@ -214,24 +214,24 @@ author: Jeremiah Senkpiel
 * [[`561b1494bc`](https://github.com/nodejs/node/commit/561b1494bc)] - **tools**: allow test.py to use full paths of tests (Francis Gulotta) [#9694](https://github.com/nodejs/node/pull/9694)
 * [[`5ae549c3aa`](https://github.com/nodejs/node/commit/5ae549c3aa)] - **url**: fix -Warray-bounds warning (Santiago Gimeno) [#9751](https://github.com/nodejs/node/pull/9751)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.2.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.2.1/node-v7.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.2.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.2.1/node-v7.2.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.2.1/node-v7.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.2.1/node-v7.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v7.2.1/ \
 Documentation: https://nodejs.org/docs/v7.2.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.3.0.md
+++ b/pages/en/blog/release/v7.3.0.md
@@ -155,24 +155,24 @@ author: Colin Ihrig
 * [[`80cccce218`](https://github.com/nodejs/node/commit/80cccce218)] - **url, test**: including base argument in originFor (joyeecheung) [#10021](https://github.com/nodejs/node/pull/10021)
 * [[`7a0fe9f471`](https://github.com/nodejs/node/commit/7a0fe9f471)] - **win,msi**: add required UIRef for localized strings (Bill Ticehurst) [#8884](https://github.com/nodejs/node/pull/8884)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.3.0/node-v7.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.3.0/node-v7.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.3.0/node-v7.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.3.0/node-v7.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.3.0/ \
 Documentation: https://nodejs.org/docs/v7.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.4.0.md
+++ b/pages/en/blog/release/v7.4.0.md
@@ -163,24 +163,24 @@ author: Evan Lucas
 * [[`495213e545`](https://github.com/nodejs/node/commit/495213e545)] - **url**: mark ignored return value in node::url::Parse(...) (Christopher J. Brody) [#10141](https://github.com/nodejs/node/pull/10141)
 * [[`ba46374cb9`](https://github.com/nodejs/node/commit/ba46374cb9)] - **watchdog**: add flag to mark handler as disabled (Bartosz Sosnowski) [#10248](https://github.com/nodejs/node/pull/10248)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-sunos-x86.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.4.0/node-v7.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.4.0/node-v7.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-sunos-x86.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.4.0/node-v7.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.4.0/ \
 Documentation: https://nodejs.org/docs/v7.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.5.0.md
+++ b/pages/en/blog/release/v7.5.0.md
@@ -312,25 +312,25 @@ author: Evan Lucas
 * [[`d628f3a227`](https://github.com/nodejs/node/commit/d628f3a227)] - **util**: avoid out-of-bounds arguments index access (Teddy Katz) [#10569](https://github.com/nodejs/node/pull/10569)
 * [[`2641cd496d`](https://github.com/nodejs/node/commit/2641cd496d)] - **vm**: improve performance of vm.runIn*() (Rich Trott) [#10816](https://github.com/nodejs/node/pull/10816)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.5.0/node-v7.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.5.0/node-v7.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.5.0/node-v7.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.5.0/node-v7.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.5.0/ \
 Documentation: https://nodejs.org/docs/v7.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.6.0.md
+++ b/pages/en/blog/release/v7.6.0.md
@@ -143,25 +143,25 @@ author: Italo A. Casas
 * [[`322fc20333`](https://github.com/nodejs/node/commit/322fc20333)] - **(SEMVER-MINOR)** **url**: extend url.format to support WHATWG URL (James M Snell) [#10857](https://github.com/nodejs/node/pull/10857)
 * [[`cfadbc2661`](https://github.com/nodejs/node/commit/cfadbc2661)] - **util**: improve inspect for AsyncFunction (Michaël Zasso) [#11211](https://github.com/nodejs/node/pull/11211)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.6.0/node-v7.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.6.0/node-v7.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.6.0/node-v7.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.6.0/node-v7.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.6.0/ \
 Documentation: https://nodejs.org/docs/v7.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.7.0.md
+++ b/pages/en/blog/release/v7.7.0.md
@@ -188,25 +188,25 @@ Please refer to [this issue](https://github.com/nodejs/node/issues/11628) for mo
 * [[`3d133ebd3d`](https://github.com/nodejs/node/commit/3d133ebd3d)] - **util, debugger**: remove internalUtil.error (James M Snell) [#11448](https://github.com/nodejs/node/pull/11448)
 * [[`f55c628b2a`](https://github.com/nodejs/node/commit/f55c628b2a)] - **vm**: refactor vm module (James M Snell) [#11392](https://github.com/nodejs/node/pull/11392)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.7.0/node-v7.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.7.0/node-v7.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.0/node-v7.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.7.0/node-v7.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.7.0/ \
 Documentation: https://nodejs.org/docs/v7.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.7.1.md
+++ b/pages/en/blog/release/v7.7.1.md
@@ -23,25 +23,25 @@ Node.js 7.7.0 contains a bug that will prevent all native modules from building,
 * [[`3dc4a5f1f4`](https://github.com/nodejs/node/commit/3dc4a5f1f4)] - **tracing**: fix -Wunused-private-field warning (Santiago Gimeno) [#10416](https://github.com/nodejs/node/pull/10416)
 * [[`8a918bf411`](https://github.com/nodejs/node/commit/8a918bf411)] - **tracing**: fix -Wreorder warning (Santiago Gimeno) [#10416](https://github.com/nodejs/node/pull/10416)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.7.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.7.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.7.1/node-v7.7.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.7.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.7.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.7.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.7.1/node-v7.7.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.1/node-v7.7.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.7.1/node-v7.7.1.tar.gz \
+Other release files: https://nodejs.org/dist/v7.7.1/ \
 Documentation: https://nodejs.org/docs/v7.7.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.7.2.md
+++ b/pages/en/blog/release/v7.7.2.md
@@ -64,25 +64,25 @@ author: Evan Lucas
 * [[`24e6fcce8b`](https://github.com/nodejs/node/commit/24e6fcce8b)] - **url**: use `hasIntl` instead of `try-catch` (Daijiro Wachi) [#11571](https://github.com/nodejs/node/pull/11571)
 * [[`7b84363636`](https://github.com/nodejs/node/commit/7b84363636)] - **util**: fix inspecting symbol key in string (Ali BARIN) [#11672](https://github.com/nodejs/node/pull/11672)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.7.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.7.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.7.2/node-v7.7.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.7.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.7.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.7.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.7.2/node-v7.7.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.2/node-v7.7.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.7.2/node-v7.7.2.tar.gz \
+Other release files: https://nodejs.org/dist/v7.7.2/ \
 Documentation: https://nodejs.org/docs/v7.7.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.7.3.md
+++ b/pages/en/blog/release/v7.7.3.md
@@ -44,25 +44,25 @@ author: Italo A. Casas
 * [[`5e7baa5a72`](https://github.com/nodejs/node/commit/5e7baa5a72)] - **tools**: add links to the stability index reference (Michael Cox) [#11664](https://github.com/nodejs/node/pull/11664)
 * [[`c5874d1bd4`](https://github.com/nodejs/node/commit/c5874d1bd4)] - **url**: remove invalid file protocol check (Brian White) [#11691](https://github.com/nodejs/node/pull/11691)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.7.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.7.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.7.3/node-v7.7.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.7.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.7.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.7.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.7.3/node-v7.7.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.3/node-v7.7.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.7.3/node-v7.7.3.tar.gz \
+Other release files: https://nodejs.org/dist/v7.7.3/ \
 Documentation: https://nodejs.org/docs/v7.7.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.7.4.md
+++ b/pages/en/blog/release/v7.7.4.md
@@ -65,25 +65,25 @@ Thank you to @italoacasas for preparing the majority of this release.
 * [[`540830116b`](https://github.com/nodejs/node/commit/540830116b)] - **tls**: keep track of stream that is closed (jBarz) [#11776](https://github.com/nodejs/node/pull/11776)
 * [[`9a59913039`](https://github.com/nodejs/node/commit/9a59913039)] - **util**: avoid using forEach (James M Snell) [#11582](https://github.com/nodejs/node/pull/11582)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.7.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.7.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.7.4/node-v7.7.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.7.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.7.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.7.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.7.4/node-v7.7.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.7.4/node-v7.7.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.7.4/node-v7.7.4.tar.gz \
+Other release files: https://nodejs.org/dist/v7.7.4/ \
 Documentation: https://nodejs.org/docs/v7.7.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.8.0.md
+++ b/pages/en/blog/release/v7.8.0.md
@@ -89,25 +89,25 @@ author: Myles Borins
 * [[`f6755182e5`](https://github.com/nodejs/node/commit/f6755182e5)] - **url**: show input in parse error message (Joyee Cheung) [#11934](https://github.com/nodejs/node/pull/11934)
 * [[`c51d925c84`](https://github.com/nodejs/node/commit/c51d925c84)] - **url**: restrict setting protocol to "file" (Daijiro Wachi) [#11887](https://github.com/nodejs/node/pull/11887)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.8.0/node-v7.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.8.0/node-v7.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.8.0/node-v7.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.8.0/node-v7.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.8.0/ \
 Documentation: https://nodejs.org/docs/v7.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v7.9.0.md
+++ b/pages/en/blog/release/v7.9.0.md
@@ -68,25 +68,25 @@ author: Italo A. Casas
 * [[`1ee38eb874`](https://github.com/nodejs/node/commit/1ee38eb874)] - **(SEMVER-MINOR)** **util**: add %i and %f formatting specifiers (Roman Reiss) [#10308](https://github.com/nodejs/node/pull/10308)
 * [[`5ac719d0d2`](https://github.com/nodejs/node/commit/5ac719d0d2)] - **doc**: add deprecations page to docs toc (Michaël Zasso) [#12268](https://github.com/nodejs/node/pull/12268)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v7.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v7.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v7.9.0/node-v7.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v7.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v7.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v7.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v7.9.0/node-v7.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v7.9.0/node-v7.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v7.9.0/ \
 Documentation: https://nodejs.org/docs/v7.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.0.0.md
+++ b/pages/en/blog/release/v8.0.0.md
@@ -1215,25 +1215,25 @@ we've dropped the "v" and call it Node.js 8.
 * [[`1c93e8c94b`](https://github.com/nodejs/node/commit/1c93e8c94b)] - **win**: make buildable on VS2017 (Refael Ackermann) [#11852](https://github.com/nodejs/node/pull/11852)
 * [[`ea01cd7adb`](https://github.com/nodejs/node/commit/ea01cd7adb)] - **zlib**: remove unused declaration (Anna Henningsen) [#12432](https://github.com/nodejs/node/pull/12432)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.0.0/node-v8.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.0.0/node-v8.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.0.0/node-v8.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.0.0/ \
 Documentation: https://nodejs.org/docs/v8.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.1.0.md
+++ b/pages/en/blog/release/v8.1.0.md
@@ -156,25 +156,25 @@ author: James M Snell, Rod Vagg
 * [[`cc3174a937`](https://github.com/nodejs/node/commit/cc3174a937)] - **(SEMVER-MINOR)** **zlib**: expose amount of data read for engines (Alexander O'Mara) [#13088](https://github.com/nodejs/node/pull/13088)
 * [[`bb77d6c1cc`](https://github.com/nodejs/node/commit/bb77d6c1cc)] - **(SEMVER-MINOR)** **zlib**: option for engine in convenience methods (Alexander O'Mara) [#13089](https://github.com/nodejs/node/pull/13089)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.1.0/node-v8.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.1.0/node-v8.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.0/node-v8.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.1.0/node-v8.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.1.0/ \
 Documentation: https://nodejs.org/docs/v8.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.1.1.md
+++ b/pages/en/blog/release/v8.1.1.md
@@ -86,25 +86,25 @@ author: Anna Henningsen
 * [[`a0f8faa3a4`](https://github.com/nodejs/node/commit/a0f8faa3a4)] - **v8**: fix debug builds on Windows (Bartosz Sosnowski) [#13634](https://github.com/nodejs/node/pull/13634)
 * [[`38a1cfb5e6`](https://github.com/nodejs/node/commit/38a1cfb5e6)] - **v8**: add a js class for Serializer/Dserializer (Rajaram Gaunker) [#13541](https://github.com/nodejs/node/pull/13541)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.1.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.1.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.1.1/node-v8.1.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.1.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.1.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.1.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.1.1/node-v8.1.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.1/node-v8.1.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.1.1/node-v8.1.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.1.1/ \
 Documentation: https://nodejs.org/docs/v8.1.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.1.2.md
+++ b/pages/en/blog/release/v8.1.2.md
@@ -12,25 +12,25 @@ author: Rod Vagg
 
 Fix broken `process.release` properties in 8.1.1 causing failure to compile native add-ons on platforms other than Windows. This is a fix in the Node.js build process so there are no additional code commits included on top of 8.1.1.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.1.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.1.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.1.2/node-v8.1.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.1.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.1.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.1.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.1.2/node-v8.1.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.2/node-v8.1.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.1.2/node-v8.1.2.tar.gz \
+Other release files: https://nodejs.org/dist/v8.1.2/ \
 Documentation: https://nodejs.org/docs/v8.1.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.1.3.md
+++ b/pages/en/blog/release/v8.1.3.md
@@ -84,25 +84,25 @@ author: Anna Henningsen & Rod Vagg
 * [[`c046a21321`](https://github.com/nodejs/node/commit/c046a21321)] - **util**: ignore invalid format specifiers (Michaël Zasso) [#13674](https://github.com/nodejs/node/pull/13674)
 * [[`c68e472b76`](https://github.com/nodejs/node/commit/c68e472b76)] - **v8**: fix RegExp nits in v8_prof_polyfill.js (Vse Mozhet Byt) [#13709](https://github.com/nodejs/node/pull/13709)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.1.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.1.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.1.3/node-v8.1.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.1.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.1.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.1.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.1.3/node-v8.1.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.3/node-v8.1.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.1.3/node-v8.1.3.tar.gz \
+Other release files: https://nodejs.org/dist/v8.1.3/ \
 Documentation: https://nodejs.org/docs/v8.1.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.1.4.md
+++ b/pages/en/blog/release/v8.1.4.md
@@ -21,25 +21,25 @@ author: Evan Lucas
 * [[`d70fac47af`](https://github.com/nodejs/node/commit/d70fac47af)] - **deps**: cherry-pick 9478908a49 from cares upstream (David Drysdale) [nodejs/node-private#88](https://github.com/nodejs/node-private/pull/88)
 * [[`803d689873`](https://github.com/nodejs/node/commit/803d689873)] - **test**: verify hash seed uniqueness (Ali Ijaz Sheikh) [nodejs/node-private#84](https://github.com/nodejs/node-private/pull/84)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.1.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.1.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.1.4/node-v8.1.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.1.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.1.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.1.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.1.4/node-v8.1.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.1.4/node-v8.1.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.1.4/node-v8.1.4.tar.gz \
+Other release files: https://nodejs.org/dist/v8.1.4/ \
 Documentation: https://nodejs.org/docs/v8.1.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.10.0.md
+++ b/pages/en/blog/release/v8.10.0.md
@@ -330,24 +330,24 @@ and ICU, a bugfix in npm, and support for building with OpenSSL 1.1.0.
 * [[`2a2c881df3`](https://github.com/nodejs/node/commit/2a2c881df3)] - **(SEMVER-MINOR)** **v8**: make building addons with VS2013 work again (Ben Noordhuis) [#16413](https://github.com/nodejs/node/pull/16413)
 * [[`6df169c409`](https://github.com/nodejs/node/commit/6df169c409)] - **win, build**: fix without-intl option (Bartosz Sosnowski) [#17614](https://github.com/nodejs/node/pull/17614)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.10.0/node-v8.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.10.0/node-v8.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.10.0/node-v8.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.10.0/ \
 Documentation: https://nodejs.org/docs/v8.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.11.0.md
+++ b/pages/en/blog/release/v8.11.0.md
@@ -32,24 +32,24 @@ author: Myles Borins
 * [[`6ee4228c1d`](https://github.com/nodejs/node/commit/6ee4228c1d)] - **src**: drop CNNIC+StartCom certificate whitelisting (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 * [[`633e23a618`](https://github.com/nodejs/node/commit/633e23a618)] - **tools**: update certdata.txt (Ben Noordhuis) [#19322](https://github.com/nodejs/node/pull/19322)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.11.0/node-v8.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.11.0/node-v8.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.11.0/node-v8.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.11.0/ \
 Documentation: https://nodejs.org/docs/v8.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.11.1.md
+++ b/pages/en/blog/release/v8.11.1.md
@@ -22,24 +22,24 @@ and it is possible that Node.js version 8.X may be built on the 4.9.X compiler a
 time as the stated [minimum compiler requirement](https://github.com/nodejs/node/blob/v8.x/BUILDING.md)
 for Node.js version 8.X is 4.9.4.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.11.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.11.1/node-v8.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.11.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.11.1/node-v8.11.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.1/node-v8.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.11.1/node-v8.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.11.1/ \
 Documentation: https://nodejs.org/docs/v8.11.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.11.2.md
+++ b/pages/en/blog/release/v8.11.2.md
@@ -238,24 +238,24 @@ author: Myles Borins
 * [[`8ac69c457b`](https://github.com/nodejs/node/commit/8ac69c457b)] - **v8**: add missing ',' in OpenBSD's 'sources' section. (Aaron Bieber) [#18448](https://github.com/nodejs/node/pull/18448)
 * [[`c61754fad9`](https://github.com/nodejs/node/commit/c61754fad9)] - **win, build**: fix intl-none option (Birunthan Mohanathas) [#18292](https://github.com/nodejs/node/pull/18292)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.11.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.11.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.11.2/node-v8.11.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.11.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.11.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.11.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.11.2/node-v8.11.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.11.2/node-v8.11.2.tar.gz \
+Other release files: https://nodejs.org/dist/v8.11.2/ \
 Documentation: https://nodejs.org/docs/v8.11.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.11.3.md
+++ b/pages/en/blog/release/v8.11.3.md
@@ -25,24 +25,24 @@ author: Evan Lucas
 * [[`bc91220ca2`](https://github.com/nodejs/node/commit/bc91220ca2)] - **test**: add tls write error regression test (Shigeki Ohtsu) [nodejs-private/node-private#131](https://github.com/nodejs-private/node-private/pull/131)
 * [[`acd11b01c4`](https://github.com/nodejs/node/commit/acd11b01c4)] - **test**: add regression test for nghttp2 CVE-2018-1000168 (James M Snell) [nodejs-private/node-private#125](https://github.com/nodejs-private/node-private/pull/125)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.11.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.11.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.11.3/node-v8.11.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.11.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.11.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.11.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.11.3/node-v8.11.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.11.3/node-v8.11.3.tar.gz \
+Other release files: https://nodejs.org/dist/v8.11.3/ \
 Documentation: https://nodejs.org/docs/v8.11.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.11.4.md
+++ b/pages/en/blog/release/v8.11.4.md
@@ -30,24 +30,24 @@ author: Rod Vagg
 * [[`0c047c4d9a`](https://github.com/nodejs/node/commit/0c047c4d9a)] - **test**: update certificates and private keys (Fedor Indutny) [#22184](https://github.com/nodejs/node/pull/22184)
 * [[`7c6d0f604b`](https://github.com/nodejs/node/commit/7c6d0f604b)] - **test**: update keys/Makefile to clean and build all (Daniel Bevenius) [#19975](https://github.com/nodejs/node/pull/19975)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.11.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.11.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.11.4/node-v8.11.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.11.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.11.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.11.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.11.4/node-v8.11.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.11.4/node-v8.11.4.tar.gz \
+Other release files: https://nodejs.org/dist/v8.11.4/ \
 Documentation: https://nodejs.org/docs/v8.11.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.12.0.md
+++ b/pages/en/blog/release/v8.12.0.md
@@ -326,24 +326,24 @@ author: Myles Borins
 * [[`ec1828c2b6`](https://github.com/nodejs/node/commit/ec1828c2b6)] - **(SEMVER-MAJOR)** **v8**: add new to the throw statement (Ruben Bridgewater) [#13857](https://github.com/nodejs/node/pull/13857)
 * [[`8a5c100793`](https://github.com/nodejs/node/commit/8a5c100793)] - **win, tools**: add nasm to boxstarter script (Bartosz Sosnowski) [#19950](https://github.com/nodejs/node/pull/19950)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.12.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.12.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.12.0/node-v8.12.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.12.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.12.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.12.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.12.0/node-v8.12.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.12.0/node-v8.12.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.12.0/ \
 Documentation: https://nodejs.org/docs/v8.12.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.13.0.md
+++ b/pages/en/blog/release/v8.13.0.md
@@ -151,24 +151,24 @@ author: Myles Borins
 * [[`f2158f30fb`](https://github.com/nodejs/node/commit/f2158f30fb)] - **test**: improve assertion in test-inspector.js (Rich Trott) [#22849](https://github.com/nodejs/node/pull/22849)
 * [[`f5985c734c`](https://github.com/nodejs/node/commit/f5985c734c)] - **tls,http2**: handle writes after SSL destroy more gracefully (Anna Henningsen) [#18987](https://github.com/nodejs/node/pull/18987)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.13.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.13.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.13.0/node-v8.13.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.13.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.13.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.13.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.13.0/node-v8.13.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.13.0/node-v8.13.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.13.0/node-v8.13.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.13.0/ \
 Documentation: https://nodejs.org/docs/v8.13.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.14.0.md
+++ b/pages/en/blog/release/v8.14.0.md
@@ -42,24 +42,24 @@ Fixes for the following CVEs are included in this release:
 * [[`7f362a11ee`](https://github.com/nodejs/node/commit/7f362a11ee)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [nodejs/node#1389](https://github.com/nodejs/node/pull/1389)
 * [[`53a6e4eb20`](https://github.com/nodejs/node/commit/53a6e4eb20)] - **url**: avoid hostname spoofing w/ javascript protocol (Matteo Collina) [nodejs-private/node-private#145](https://github.com/nodejs-private/node-private/pull/145)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.14.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.14.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.14.0/node-v8.14.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.14.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.14.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.14.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.14.0/node-v8.14.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.0/node-v8.14.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.14.0/node-v8.14.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.14.0/ \
 Documentation: https://nodejs.org/docs/v8.14.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.14.1.md
+++ b/pages/en/blog/release/v8.14.1.md
@@ -105,24 +105,24 @@ author: Myles Borins
 * [[`2a8a28c436`](https://github.com/nodejs/node/commit/2a8a28c436)] - **tools**: make Travis commit linting more robust (Rich Trott) [#23397](https://github.com/nodejs/node/pull/23397)
 * [[`c15d236545`](https://github.com/nodejs/node/commit/c15d236545)] - **tools**: apply linting to first commit in PRs (Rich Trott) [#22452](https://github.com/nodejs/node/pull/22452)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.14.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.14.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.14.1/node-v8.14.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.14.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.14.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.14.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.14.1/node-v8.14.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.14.1/node-v8.14.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.14.1/ \
 Documentation: https://nodejs.org/docs/v8.14.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.15.0.md
+++ b/pages/en/blog/release/v8.15.0.md
@@ -28,24 +28,24 @@ a missing CLI flag to adjust the max header size of the http parser.
 * [[`e1fbc26c6a`](https://github.com/nodejs/node/commit/e1fbc26c6a)] - **test**: move test-benchmark-path to sequential (Rich Trott) [#21393](https://github.com/nodejs/node/pull/21393)
 * [[`aef71c05a2`](https://github.com/nodejs/node/commit/aef71c05a2)] - **test**: mark test-http2-settings-flood as flaky on Windows (Rich Trott) [#25048](https://github.com/nodejs/node/pull/25048)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.15.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.15.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.15.0/node-v8.15.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.15.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.15.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.15.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.15.0/node-v8.15.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.15.0/node-v8.15.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.15.0/ \
 Documentation: https://nodejs.org/docs/v8.15.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.15.1.md
+++ b/pages/en/blog/release/v8.15.1.md
@@ -30,24 +30,24 @@ Fixes for the following CVEs are included in this release:
 * [[`76d52c508a`](https://github.com/nodejs/node/commit/76d52c508a)] - **http**: prevent slowloris with keepalive connections (Matteo Collina) [nodejs-private/node-private#162](https://github.com/nodejs-private/node-private/pull/162)
 * [[`6969fad7d6`](https://github.com/nodejs/node/commit/6969fad7d6)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.15.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.15.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.15.1/node-v8.15.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.15.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.15.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.15.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.15.1/node-v8.15.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.15.1/node-v8.15.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.15.1/node-v8.15.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.15.1/ \
 Documentation: https://nodejs.org/docs/v8.15.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.16.0.md
+++ b/pages/en/blog/release/v8.16.0.md
@@ -50,24 +50,24 @@ author: Myles Borins
 * [[`91620b8bd6`](https://github.com/nodejs/node/commit/91620b8bd6)] - **tls**: fix legacy SecurePair session resumption (Ben Noordhuis) [#26452](https://github.com/nodejs/node/pull/26452)
 * [[`1a9582b7a6`](https://github.com/nodejs/node/commit/1a9582b7a6)] - **tools**: allow input for TTY tests (Anna Henningsen) [#23053](https://github.com/nodejs/node/pull/23053)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.16.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.16.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.16.0/node-v8.16.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.16.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.16.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.16.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.16.0/node-v8.16.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.16.0/node-v8.16.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.16.0/ \
 Documentation: https://nodejs.org/docs/v8.16.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.16.1.md
+++ b/pages/en/blog/release/v8.16.1.md
@@ -49,24 +49,24 @@ Vulnerabilities fixed:
 * [[`b095e35f1f`](https://github.com/nodejs/node/commit/b095e35f1f)] - **http2**: improve http2 code a bit (James M Snell) [#23984](https://github.com/nodejs/node/pull/23984)
 * [[`cc282239c1`](https://github.com/nodejs/node/commit/cc282239c1)] - **test**: apply test-http2-max-session-memory-leak from v12.x (Anna Henningsen) [#29122](https://github.com/nodejs/node/pull/29122)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.16.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.16.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.16.1/node-v8.16.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.16.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.16.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.16.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.16.1/node-v8.16.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.1/node-v8.16.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.16.1/node-v8.16.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.16.1/ \
 Documentation: https://nodejs.org/docs/v8.16.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.16.2.md
+++ b/pages/en/blog/release/v8.16.2.md
@@ -39,24 +39,24 @@ author: Bethany Nicolle Griggs
 * [[`4fbadf6a9e`](https://github.com/nodejs/node/commit/4fbadf6a9e)] - **tools**: update certdata.txt (Sam Roberts) [#27374](https://github.com/nodejs/node/pull/27374)
 * [[`529b2ad25f`](https://github.com/nodejs/node/commit/529b2ad25f)] - **tools**: update certdata.txt (Sam Roberts) [#25113](https://github.com/nodejs/node/pull/25113)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.16.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.16.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.16.2/node-v8.16.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.16.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.16.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.16.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.16.2/node-v8.16.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.16.2/node-v8.16.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.16.2/node-v8.16.2.tar.gz \
+Other release files: https://nodejs.org/dist/v8.16.2/ \
 Documentation: https://nodejs.org/docs/v8.16.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.17.0.md
+++ b/pages/en/blog/release/v8.17.0.md
@@ -17,24 +17,24 @@ author: Myles Borins
 * [[`208b813e49`](https://github.com/nodejs/node/commit/208b813e49)] - **build,win**: add test-ci-native and test-ci-js (João Reis) [#30724](https://github.com/nodejs/node/pull/30724)
 * [[`369a23a670`](https://github.com/nodejs/node/commit/369a23a670)] - **deps**: update npm to 6.13.4 (Audrey Eschright) [#30904](https://github.com/nodejs/node/pull/30904)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.17.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.17.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.17.0/node-v8.17.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.17.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.17.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.17.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.17.0/node-v8.17.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.17.0/node-v8.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.17.0/node-v8.17.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.17.0/ \
 Documentation: https://nodejs.org/docs/v8.17.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.2.0.md
+++ b/pages/en/blog/release/v8.2.0.md
@@ -297,25 +297,25 @@ Big thanks to @addaleax who prepared the vast majority of this release.
 * [[`a675c3d3b7`](https://github.com/nodejs/node/commit/a675c3d3b7)] - **util**: remove redundant declaration (Vse Mozhet Byt) [#14199](https://github.com/nodejs/node/pull/14199)
 * [[`8cba959a93`](https://github.com/nodejs/node/commit/8cba959a93)] - **util**: add callbackify (Refael Ackermann) [#13750](https://github.com/nodejs/node/pull/13750)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.2.0/node-v8.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.2.0/node-v8.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.0/node-v8.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.2.0/node-v8.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.2.0/ \
 Documentation: https://nodejs.org/docs/v8.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.2.1.md
+++ b/pages/en/blog/release/v8.2.1.md
@@ -20,25 +20,25 @@ author: Jeremiah Senkpiel
 * [[`302c19b006`](https://github.com/nodejs/node/commit/302c19b006)] - **process**: triggerAsyncId can be undefined (Matteo Collina) [#14387](https://github.com/nodejs/node/pull/14387)
 * [[`6fce1a314e`](https://github.com/nodejs/node/commit/6fce1a314e)] - **zlib**: check if the stream is destroyed before push (Matteo Collina) [#14330](https://github.com/nodejs/node/pull/14330)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.2.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.2.1/node-v8.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.2.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.2.1/node-v8.2.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.2.1/node-v8.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.2.1/ \
 Documentation: https://nodejs.org/docs/v8.2.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.3.0.md
+++ b/pages/en/blog/release/v8.3.0.md
@@ -204,25 +204,25 @@ https://medium.com/the-node-js-collection/get-ready-a-new-v8-is-coming-node-js-p
 * [[`a8132943c5`](https://github.com/nodejs/node/commit/a8132943c5)] - **zlib**: fix crash when initializing failed (Anna Henningsen) [#14666](https://github.com/nodejs/node/pull/14666)
 * [[`e529914e70`](https://github.com/nodejs/node/commit/e529914e70)] - **zlib**: fix interaction of flushing and needDrain (Anna Henningsen) [#14527](https://github.com/nodejs/node/pull/14527)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.3.0/node-v8.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.3.0/node-v8.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.3.0/node-v8.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.3.0/node-v8.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.3.0/ \
 Documentation: https://nodejs.org/docs/v8.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.4.0.md
+++ b/pages/en/blog/release/v8.4.0.md
@@ -134,25 +134,25 @@ author: Anna Henningsen
 * [[`116841056a`](https://github.com/nodejs/node/commit/116841056a)] - **util**: improve util.inspect performance (Ruben Bridgewater) [#14492](https://github.com/nodejs/node/pull/14492)
 * [[`7203924fea`](https://github.com/nodejs/node/commit/7203924fea)] - **(SEMVER-MINOR)** **util**: implement %o and %O as formatting specifiers (Greg Alexander) [#14558](https://github.com/nodejs/node/pull/14558)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.4.0/node-v8.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.4.0/node-v8.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.4.0/node-v8.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.4.0/ \
 Documentation: https://nodejs.org/docs/v8.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.5.0.md
+++ b/pages/en/blog/release/v8.5.0.md
@@ -287,25 +287,25 @@ author: Myles Borins
 * [[`de10c0f515`](https://github.com/nodejs/node/commit/de10c0f515)] - **util**: fix inspect array w. negative maxArrayLength (Ruben Bridgewater) [#14880](https://github.com/nodejs/node/pull/14880)
 * [[`c3c6cb1c13`](https://github.com/nodejs/node/commit/c3c6cb1c13)] - **util**: use proper circular reference checking (Anna Henningsen) [#14790](https://github.com/nodejs/node/pull/14790)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.5.0/node-v8.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.5.0/node-v8.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.5.0/node-v8.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.5.0/node-v8.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.5.0/ \
 Documentation: https://nodejs.org/docs/v8.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.6.0.md
+++ b/pages/en/blog/release/v8.6.0.md
@@ -168,24 +168,24 @@ author: James M Snell
 * [[`7d95dc385c`](https://github.com/nodejs/node/commit/7d95dc385c)] - **vm**: support parsing a script in a specific context (Timothy Gu) [#14888](https://github.com/nodejs/node/pull/14888)
 james@ubuntu:~/node/main$
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x64.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.6.0/node-v8.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.6.0/node-v8.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-sunos-x64.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.6.0/node-v8.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.6.0/node-v8.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.6.0/ \
 Documentation: https://nodejs.org/docs/v8.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.7.0.md
+++ b/pages/en/blog/release/v8.7.0.md
@@ -244,25 +244,25 @@ author: Myles Borins
 * [[`58c68c2fcb`](https://github.com/nodejs/node/commit/58c68c2fcb)] - **util**: use faster -0 check (Brian White) [#15726](https://github.com/nodejs/node/pull/15726)
 * [[`d2e1545406`](https://github.com/nodejs/node/commit/d2e1545406)] - **(SEMVER-MINOR)** **util**: deprecate obj.inspect for custom inspection (Rich Trott) [#15631](https://github.com/nodejs/node/pull/15631)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.7.0/node-v8.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.7.0/node-v8.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.7.0/node-v8.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.7.0/ \
 Documentation: https://nodejs.org/docs/v8.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.8.0.md
+++ b/pages/en/blog/release/v8.8.0.md
@@ -314,25 +314,25 @@ author: Myles Borins
 * [[`f5e56aac0c`](https://github.com/nodejs/node/commit/f5e56aac0c)] - **url**: fix port overflow checking (Rimas Misevičius) [#15794](https://github.com/nodejs/node/pull/15794)
 * [[`c2b1435b55`](https://github.com/nodejs/node/commit/e82e2745af)] - **zlib**: gracefully set windowBits from 8 to 9 (Myles Borins) [nodejs-private/node-private#95](https://github.com/nodejs-private/node-private/pull/95)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.8.0/node-v8.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.8.0/node-v8.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.0/node-v8.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.8.0/node-v8.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.8.0/ \
 Documentation: https://nodejs.org/docs/v8.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.8.1.md
+++ b/pages/en/blog/release/v8.8.1.md
@@ -29,25 +29,25 @@ author: Colin Ihrig
 * [[`10894c3835`](https://github.com/nodejs/node/commit/10894c3835)] - **test**: allow for different nsswitch.conf settings (Daniel Bevenius) [#16378](https://github.com/nodejs/node/pull/16378)
 * [[`2a53165aa0`](https://github.com/nodejs/node/commit/2a53165aa0)] - **test**: add missing assertion (cjihrig) [#15519](https://github.com/nodejs/node/pull/15519)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.8.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.8.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.8.1/node-v8.8.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.8.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.8.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.8.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.8.1/node-v8.8.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.8.1/node-v8.8.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.8.1/ \
 Documentation: https://nodejs.org/docs/v8.8.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.9.0.md
+++ b/pages/en/blog/release/v8.9.0.md
@@ -138,25 +138,25 @@ an in-depth look at the significant changes in the Node 8.x release line.
 * [[`55ba1d4115`](https://github.com/nodejs/node/commit/55ba1d4115)] - **util**: expand test coverage for util.deprecate (Ashish Kaila) [#16305](https://github.com/nodejs/node/pull/16305)
 * [[`8fd75fb9b5`](https://github.com/nodejs/node/commit/8fd75fb9b5)] - **(SEMVER-MINOR)** **util**: graduate TextEncoder/TextDecoder, tests (James M Snell) [#15743](https://github.com/nodejs/node/pull/15743)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.9.0/node-v8.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.9.0/node-v8.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.9.0/node-v8.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v8.9.0/ \
 Documentation: https://nodejs.org/docs/v8.9.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.9.1.md
+++ b/pages/en/blog/release/v8.9.1.md
@@ -31,25 +31,25 @@ author: Gibson Fahnestock
 * [[`bf26b96fd6`](https://github.com/nodejs/node/commit/bf26b96fd6)] - **src**: add 'dynamic' process.release.lts property (Rod Vagg) [#16656](https://github.com/nodejs/node/pull/16656)
 * [[`dfac6cc0bb`](https://github.com/nodejs/node/commit/dfac6cc0bb)] - **test**: update process-release for Node 8 Carbon (Jeremiah Senkpiel) [#16656](https://github.com/nodejs/node/pull/16656)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.9.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.9.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.9.1/node-v8.9.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.9.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.9.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.9.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.9.1/node-v8.9.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.9.1/node-v8.9.1.tar.gz \
+Other release files: https://nodejs.org/dist/v8.9.1/ \
 Documentation: https://nodejs.org/docs/v8.9.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.9.2.md
+++ b/pages/en/blog/release/v8.9.2.md
@@ -126,24 +126,24 @@ author: Gibson Fahnestock
 * [[`40fa970914`](https://github.com/nodejs/node/commit/40fa970914)] - **tools**: replace string concetation with templates (Patrick Heneise) [#16801](https://github.com/nodejs/node/pull/16801)
 * [[`0d4f62c85f`](https://github.com/nodejs/node/commit/0d4f62c85f)] - **tools,build**: allow build without `remark-cli` (Refael Ackermann) [#16893](https://github.com/nodejs/node/pull/16893)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.9.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.9.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.9.2/node-v8.9.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.9.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.9.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.9.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.9.2/node-v8.9.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.2/node-v8.9.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.9.2/node-v8.9.2.tar.gz \
+Other release files: https://nodejs.org/dist/v8.9.2/ \
 Documentation: https://nodejs.org/docs/v8.9.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.9.3.md
+++ b/pages/en/blog/release/v8.9.3.md
@@ -37,24 +37,24 @@ author: Myles Borins
 * [[`26b43c87ee`](https://github.com/nodejs/node/commit/26b43c87ee)] - **src**: add method to compute storage in WriteWrap (Anna Henningsen) [#16727](https://github.com/nodejs/node/pull/16727)
 * [[`99d775ca07`](https://github.com/nodejs/node/commit/99d775ca07)] - **test**: fix flaky test-http2-create-client-connect (David Benjamin) [#16130](https://github.com/nodejs/node/pull/16130)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.9.3/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.9.3/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.9.3/node-v8.9.3.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.9.3/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.9.3/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.9.3/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.9.3/node-v8.9.3.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.9.3/node-v8.9.3.tar.gz \
+Other release files: https://nodejs.org/dist/v8.9.3/ \
 Documentation: https://nodejs.org/docs/v8.9.3/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v8.9.4.md
+++ b/pages/en/blog/release/v8.9.4.md
@@ -304,24 +304,24 @@ author: Gibson Fahnestock
 * [[`3236944761`](https://github.com/nodejs/node/commit/3236944761)] - **util**: fix negative 0 check in inspect (Gus Caplan) [#17507](https://github.com/nodejs/node/pull/17507)
 * [[`943258e093`](https://github.com/nodejs/node/commit/943258e093)] - **util**: remove check for global.process (Gus Caplan) [#17435](https://github.com/nodejs/node/pull/17435)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v8.9.4/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v8.9.4/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v8.9.4/node-v8.9.4.tar.gz<br>
-Other release files: https://nodejs.org/dist/v8.9.4/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v8.9.4/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v8.9.4/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v8.9.4/node-v8.9.4.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v8.9.4/node-v8.9.4.tar.gz \
+Other release files: https://nodejs.org/dist/v8.9.4/ \
 Documentation: https://nodejs.org/docs/v8.9.4/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.0.0.md
+++ b/pages/en/blog/release/v9.0.0.md
@@ -312,25 +312,25 @@ author: James M Snell
 * [[`2421984727`](https://github.com/nodejs/node/commit/2421984727)] - **zlib**: check cleanup return values (Anna Henningsen) [#14673](https://github.com/nodejs/node/pull/14673)
 * [[`add4b0ab8c`](https://github.com/nodejs/node/commit/add4b0ab8c)] - **zlib**: improve performance (Brian White) [#13322](https://github.com/nodejs/node/pull/13322)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.0.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.0.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.0.0/node-v9.0.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.0.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.0.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.0.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.0.0/node-v9.0.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.0.0/node-v9.0.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.0.0/node-v9.0.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.0.0/ \
 Documentation: https://nodejs.org/docs/v9.0.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.1.0.md
+++ b/pages/en/blog/release/v9.1.0.md
@@ -118,25 +118,25 @@ author: Colin Ihrig
 * [[`326a048a5c`](https://github.com/nodejs/node/commit/326a048a5c)] - **tools**: add fixer for no-let-in-for-declaration (Weijia Wang) [#16642](https://github.com/nodejs/node/pull/16642)
 * [[`d6a0ffe367`](https://github.com/nodejs/node/commit/d6a0ffe367)] - **zlib**: warn before crash on invalid internals usage (Anna Henningsen) [#16657](https://github.com/nodejs/node/pull/16657)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.1.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.1.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.1.0/node-v9.1.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.1.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.1.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.1.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.1.0/node-v9.1.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.1.0/node-v9.1.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.1.0/node-v9.1.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.1.0/ \
 Documentation: https://nodejs.org/docs/v9.1.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.10.0.md
+++ b/pages/en/blog/release/v9.10.0.md
@@ -117,24 +117,24 @@ author: Myles Borins
 * [[`89e7a5faad`](https://github.com/nodejs/node/commit/89e7a5faad)] - **tools**: fix nits in tools/doc/preprocess.js (Vse Mozhet Byt) [#19473](https://github.com/nodejs/node/pull/19473)
 * [[`0414a8c7ed`](https://github.com/nodejs/node/commit/0414a8c7ed)] - **tools**: fix logic nit in tools/doc/generate.js (Vse Mozhet Byt) [#19475](https://github.com/nodejs/node/pull/19475)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.10.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.10.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.10.0/node-v9.10.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.10.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.10.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.10.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.10.0/node-v9.10.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.0/node-v9.10.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.10.0/node-v9.10.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.10.0/ \
 Documentation: https://nodejs.org/docs/v9.10.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.10.1.md
+++ b/pages/en/blog/release/v9.10.1.md
@@ -22,24 +22,24 @@ and it is possible that Node.js version 9.X may be built on the 4.9.X compiler a
 time as the stated [minimum compiler requirement](https://github.com/nodejs/node/blob/v8.x/BUILDING.md)
 for Node.js version 9.X is 4.9.4.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.10.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.10.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.10.1/node-v9.10.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.10.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.10.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.10.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.10.1/node-v9.10.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.10.1/node-v9.10.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.10.1/node-v9.10.1.tar.gz \
+Other release files: https://nodejs.org/dist/v9.10.1/ \
 Documentation: https://nodejs.org/docs/v9.10.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.11.0.md
+++ b/pages/en/blog/release/v9.11.0.md
@@ -105,24 +105,24 @@ author: Myles Borins
 * [[`fdc51a1331`](https://github.com/nodejs/node/commit/fdc51a1331)] - **url**: remove redundant function (Sergey Golovin) [#19076](https://github.com/nodejs/node/pull/19076)
 * [[`99e3c77808`](https://github.com/nodejs/node/commit/99e3c77808)] - **url**: refactor "escapeParam" function to make it common (Sergey Golovin) [#19076](https://github.com/nodejs/node/pull/19076)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.11.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.11.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.11.0/node-v9.11.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.11.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.11.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.11.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.11.0/node-v9.11.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.0/node-v9.11.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.11.0/node-v9.11.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.11.0/ \
 Documentation: https://nodejs.org/docs/v9.11.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.11.1.md
+++ b/pages/en/blog/release/v9.11.1.md
@@ -15,24 +15,24 @@ No additional commits.
 An infrastructure issue caused a non-functioning msi installer for x64 to be promoted.
 The patch release is to ensure that all binaries and installers work as expected.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.11.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.11.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.11.1/node-v9.11.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.11.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.11.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.11.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.11.1/node-v9.11.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.11.1/node-v9.11.1.tar.gz \
+Other release files: https://nodejs.org/dist/v9.11.1/ \
 Documentation: https://nodejs.org/docs/v9.11.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.11.2.md
+++ b/pages/en/blog/release/v9.11.2.md
@@ -28,24 +28,24 @@ author: Evan Lucas
 * [[`0ab90acaf3`](https://github.com/nodejs/node/commit/0ab90acaf3)] - **test**: add regression test for nghttp2 CVE-2018-1000168 (James M Snell) [nodejs-private/node-private#124](https://github.com/nodejs-private/node-private/pull/124)
 * [[`84f23d2f12`](https://github.com/nodejs/node/commit/84f23d2f12)] - **tls**: fix SSL write error handling (Anna Henningsen) [nodejs-private/node-private#130](https://github.com/nodejs-private/node-private/pull/130)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.11.2/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.11.2/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.11.2/node-v9.11.2.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.11.2/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.11.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.11.2/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.11.2/node-v9.11.2.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.11.2/node-v9.11.2.tar.gz \
+Other release files: https://nodejs.org/dist/v9.11.2/ \
 Documentation: https://nodejs.org/docs/v9.11.2/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.2.0.md
+++ b/pages/en/blog/release/v9.2.0.md
@@ -153,25 +153,25 @@ author: Evan Lucas
 * [[`625999b840`](https://github.com/nodejs/node/commit/625999b840)] - **tools**: don't lint files that have not changed (Joyee Cheung) [#16581](https://github.com/nodejs/node/pull/16581)
 * [[`942a9ed6a8`](https://github.com/nodejs/node/commit/942a9ed6a8)] - **tools,build**: allow build without `remark-cli` (Refael Ackermann) [#16893](https://github.com/nodejs/node/pull/16893)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.2.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.2.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc64le.tar.xz<br>
-Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc64.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.2.0/node-v9.2.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.2.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.2.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.2.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.2.0/node-v9.2.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc64le.tar.xz \
+Linux PPC BE 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-ppc64.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.0/node-v9.2.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.2.0/node-v9.2.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.2.0/ \
 Documentation: https://nodejs.org/docs/v9.2.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.2.1.md
+++ b/pages/en/blog/release/v9.2.1.md
@@ -31,24 +31,24 @@ author: Evan Lucas
 * [[`6a76097fad`](https://github.com/nodejs/node/commit/6a76097fad)] - **http2**: major update to internals (James M Snell) [#17105](https://github.com/nodejs/node/pull/17105)
 * [[`e14c0babe0`](https://github.com/nodejs/node/commit/e14c0babe0)] - **openssl**: fix keypress requirement in apps on win32 (Shigeki Ohtsu) [iojs/io.js#1389](https://github.com/iojs/io.js/pull/1389)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.2.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.2.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.2.1/node-v9.2.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.2.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.2.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.2.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.2.1/node-v9.2.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.2.1/node-v9.2.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.2.1/node-v9.2.1.tar.gz \
+Other release files: https://nodejs.org/dist/v9.2.1/ \
 Documentation: https://nodejs.org/docs/v9.2.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.3.0.md
+++ b/pages/en/blog/release/v9.3.0.md
@@ -415,24 +415,24 @@ author: Myles Borins
 * [[`45ca714005`](https://github.com/nodejs/node/commit/45ca714005)] - **zlib**: fix assert fail for bad write in object mode (Kevin Locke) [#16960](https://github.com/nodejs/node/pull/16960)
 * [[`fa01fe6819`](https://github.com/nodejs/node/commit/fa01fe6819)] - **zlib**: fix decompression of empty data streams (Anna Henningsen) [#17042](https://github.com/nodejs/node/pull/17042)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.3.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.3.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.3.0/node-v9.3.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.3.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.3.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.3.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.3.0/node-v9.3.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.3.0/node-v9.3.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.3.0/node-v9.3.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.3.0/ \
 Documentation: https://nodejs.org/docs/v9.3.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.4.0.md
+++ b/pages/en/blog/release/v9.4.0.md
@@ -280,24 +280,24 @@ author: Myles Borins
 * [[`7bf4102db9`](https://github.com/nodejs/node/commit/7bf4102db9)] - **win, build**: fix without-intl option (Bartosz Sosnowski) [#17614](https://github.com/nodejs/node/pull/17614)
 * [[`584e74d8cc`](https://github.com/nodejs/node/commit/584e74d8cc)] - **(SEMVER-MINOR)** **zlib**: add ArrayBuffer support (Jem Bezooyen) [#16042](https://github.com/nodejs/node/pull/16042)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.4.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.4.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.4.0/node-v9.4.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.4.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.4.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.4.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.4.0/node-v9.4.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.4.0/node-v9.4.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.4.0/node-v9.4.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.4.0/ \
 Documentation: https://nodejs.org/docs/v9.4.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.5.0.md
+++ b/pages/en/blog/release/v9.5.0.md
@@ -188,24 +188,24 @@ author: Evan Lucas
 * [[`d349fcae11`](https://github.com/nodejs/node/commit/d349fcae11)] - **tools**: update ESLint to 4.15.0 (Michaël Zasso) [#17820](https://github.com/nodejs/node/pull/17820)
 * [[`4bc4d004b1`](https://github.com/nodejs/node/commit/4bc4d004b1)] - **tools**: move eslint from tools to tools/node_modules (Michaël Zasso) [#17820](https://github.com/nodejs/node/pull/17820)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.5.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.5.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.5.0/node-v9.5.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.5.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.5.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.5.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.5.0/node-v9.5.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.5.0/node-v9.5.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.5.0/node-v9.5.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.5.0/ \
 Documentation: https://nodejs.org/docs/v9.5.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.6.0.md
+++ b/pages/en/blog/release/v9.6.0.md
@@ -245,24 +245,24 @@ author: Myles Borins
 * [[`1cbd76a100`](https://github.com/nodejs/node/commit/1cbd76a100)] - **vm**: add modules (Gus Caplan) [#17560](https://github.com/nodejs/node/pull/17560)
 * [[`c34e2f4fc5`](https://github.com/nodejs/node/commit/c34e2f4fc5)] - **win, build**: fix intl-none option (Birunthan Mohanathas) [#18292](https://github.com/nodejs/node/pull/18292)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.6.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.6.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.6.0/node-v9.6.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.6.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.6.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.6.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.6.0/node-v9.6.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.0/node-v9.6.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.6.0/node-v9.6.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.6.0/ \
 Documentation: https://nodejs.org/docs/v9.6.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.6.1.md
+++ b/pages/en/blog/release/v9.6.1.md
@@ -19,24 +19,24 @@ This is a special release to fix potentially Semver-Major regression that was re
 
 * [[`761caec379`](https://github.com/nodejs/node/commit/761caec379)] - **events**: preset `usingDomains` to false (Myles Borins) [#18944](https://github.com/nodejs/node/pull/18944)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.6.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.6.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.6.1/node-v9.6.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.6.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.6.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.6.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.6.1/node-v9.6.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.6.1/node-v9.6.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.6.1/node-v9.6.1.tar.gz \
+Other release files: https://nodejs.org/dist/v9.6.1/ \
 Documentation: https://nodejs.org/docs/v9.6.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.7.0.md
+++ b/pages/en/blog/release/v9.7.0.md
@@ -94,24 +94,24 @@ author: Rod Vagg
 * [[`28fa906ec1`](https://github.com/nodejs/node/commit/28fa906ec1)] - **(SEMVER-MINOR)** **util**: implement util.getSystemErrorName() (Joyee Cheung) [#18186](https://github.com/nodejs/node/pull/18186)
 * [[`38797b5804`](https://github.com/nodejs/node/commit/38797b5804)] - **vm**: consolidate validation (Timothy O. Peters) [#18816](https://github.com/nodejs/node/pull/18816)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.7.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.7.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.7.0/node-v9.7.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.7.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.7.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.7.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.7.0/node-v9.7.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.0/node-v9.7.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.7.0/node-v9.7.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.7.0/ \
 Documentation: https://nodejs.org/docs/v9.7.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.7.1.md
+++ b/pages/en/blog/release/v9.7.1.md
@@ -12,24 +12,24 @@ No additional commits are included in this release.
 
 A new version was published due to a bad `node-v9.7.0.pkg` (macOS installer) file that was published to nodejs.org in the previous release.
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.7.1/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.7.1/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.7.1/node-v9.7.1.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.7.1/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.7.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.7.1/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.7.1/node-v9.7.1.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.7.1/node-v9.7.1.tar.gz \
+Other release files: https://nodejs.org/dist/v9.7.1/ \
 Documentation: https://nodejs.org/docs/v9.7.1/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.8.0.md
+++ b/pages/en/blog/release/v9.8.0.md
@@ -98,24 +98,24 @@ author: Myles Borins
 * [[`3d4cda3a7d`](https://github.com/nodejs/node/commit/3d4cda3a7d)] - **(SEMVER-MINOR)** **trace_events**: add file pattern cli option (Andreas Madsen) [#18480](https://github.com/nodejs/node/pull/18480)
 * [[`3e8e1524ac`](https://github.com/nodejs/node/commit/3e8e1524ac)] - **util**: use blue on non-windows systems for number (Gus Caplan) [#18925](https://github.com/nodejs/node/pull/18925)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.8.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.8.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.8.0/node-v9.8.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.8.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.8.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.8.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.8.0/node-v9.8.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.8.0/node-v9.8.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.8.0/node-v9.8.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.8.0/ \
 Documentation: https://nodejs.org/docs/v9.8.0/api/
 
 ### SHASUMS

--- a/pages/en/blog/release/v9.9.0.md
+++ b/pages/en/blog/release/v9.9.0.md
@@ -163,24 +163,24 @@ author: Myles Borins
 * [[`ce3a5af69f`](https://github.com/nodejs/node/commit/ce3a5af69f)] - **(SEMVER-MINOR)** **util**: rename util.inspect argument (Ruben Bridgewater) [#17576](https://github.com/nodejs/node/pull/17576)
 * [[`fd4c05ab56`](https://github.com/nodejs/node/commit/fd4c05ab56)] - **(SEMVER-MINOR)** **util**: fix custom inspect description (Ruben Bridgewater) [#17576](https://github.com/nodejs/node/pull/17576)
 
-Windows 32-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0-x86.msi<br>
-Windows 64-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0-x64.msi<br>
-Windows 32-bit Binary: https://nodejs.org/dist/v9.9.0/win-x86/node.exe<br>
-Windows 64-bit Binary: https://nodejs.org/dist/v9.9.0/win-x64/node.exe<br>
-macOS 64-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0.pkg<br>
-macOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-darwin-x64.tar.gz<br>
-Linux 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x86.tar.xz<br>
-Linux 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x64.tar.xz<br>
-Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-ppc64le.tar.xz<br>
-Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-s390x.tar.xz<br>
-AIX 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-aix-ppc64.tar.gz<br>
-SmartOS 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x86.tar.xz<br>
-SmartOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x64.tar.xz<br>
-ARMv6 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv6l.tar.xz<br>
-ARMv7 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv7l.tar.xz<br>
-ARMv8 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-arm64.tar.xz<br>
-Source Code: https://nodejs.org/dist/v9.9.0/node-v9.9.0.tar.gz<br>
-Other release files: https://nodejs.org/dist/v9.9.0/<br>
+Windows 32-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v9.9.0/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v9.9.0/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v9.9.0/node-v9.9.0.pkg \
+macOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-darwin-x64.tar.gz \
+Linux 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x86.tar.xz \
+Linux 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-aix-ppc64.tar.gz \
+SmartOS 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x86.tar.xz \
+SmartOS 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-sunos-x64.tar.xz \
+ARMv6 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv6l.tar.xz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v9.9.0/node-v9.9.0.tar.gz \
+Other release files: https://nodejs.org/dist/v9.9.0/ \
 Documentation: https://nodejs.org/docs/v9.9.0/api/
 
 ### SHASUMS

--- a/scripts/release-post/template.hbs
+++ b/scripts/release-post/template.hbs
@@ -9,9 +9,9 @@ author: {{author}}
 {{changelog}}
 
 {{#files}}
-{{.}}<br />
+{{.}} \
 {{/files}}
-Other release files: https://nodejs.org/dist/v{{version}}/<br />
+Other release files: https://nodejs.org/dist/v{{version}}/ \
 Documentation: https://nodejs.org/docs/v{{version}}/api/
 
 ### SHASUMS


### PR DESCRIPTION
This PR introduces the [GitHub Flavoured Markdown Plugin](https://mdxjs.com/guides/gfm/) (Remark) and updates the Release Blog Post script to follow the [Hard Line convention](https://spec.commonmark.org/0.30/#hard-line-breaks) from CommonMark.

It also updates all existing blog posts to follow that convention.

---

**Reasoning behind:**

When we switched to MDXJS as the Parser for Markdown, it meant that we also adopted the standard CommonMark specification for Markdown. Whilst most of the Markdown files got fixed, and whilst `<br />` tags are technically not invalid CommonMark syntax, they're not part of the specification.

Thus, we needed to update the blog posts to follow the specification.

Closes #5146