### PR TITLE
chore(slashes): disable trailing slashes

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   siteUrl: 'https://nodejs.org',
   generateRobotsTxt: true,
-  trailingSlash: true,
+  trailingSlash: false,
   generateIndexSitemap: false,
   robotsTxtOptions: {
     policies: [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,7 +19,7 @@ const withNextra = nextra({
 });
 
 export default withNextra({
-  trailingSlash: true,
+  trailingSlash: false,
   images: { unoptimized: true },
   outputFileTracing: false,
   basePath: process.env.NEXT_BASE_PATH || '',


### PR DESCRIPTION
This PR disables trailing slashes, which makes GitHub Pages default 404 to work, and reduces the amount of files/folders.

cc @targos @richardlau