### PR TITLE
Fix header layout on small screen size

### DIFF
--- a/styles/page-modules/_header.scss
+++ b/styles/page-modules/_header.scss
@@ -175,7 +175,7 @@ header {
   header {
     .switchers {
       justify-content: center;
-      margin-bottom: 16px;
+      margin: 10px 0 16px;
       position: unset;
     }
 

--- a/styles/page-modules/_header.scss
+++ b/styles/page-modules/_header.scss
@@ -135,7 +135,7 @@ header {
 @media screen and (min-width: 481px) {
   header {
     ul {
-      height: 42px;
+      min-height: 42px;
 
       li {
         margin-top: 4px;


### PR DESCRIPTION
Before 
<img width="691" alt="image" src="https://user-images.githubusercontent.com/5843270/228014353-a1680327-d1c1-48f5-a70f-a6dd7a5fdfc1.png">

After
<img width="637" alt="image" src="https://user-images.githubusercontent.com/5843270/228014017-9f56b575-eb8a-4483-895c-2fef0a10aacd.png">


Closes #5096