### PR TITLE
chore(crowdin): add mdx to the config file (#5208

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,7 +4,7 @@ pull_request_labels:
   - i18n
   - crowdin
 files:
-  - source: /pages/en/**/*.md
+  - source: /pages/en/**/*.(md|mdx)
     translation: /pages/%two_letters_code%/**/%original_file_name%
     content_segmentation: 0
     ignore:


### PR DESCRIPTION
This PR fixes the Crowdin configuration that is not including MDX files.

As this is a critical fix, I'm merging straight away as described on our CONTRIBUTION guidelines.