### PR TITLE
ci: only run linting on Ubuntu

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,13 +9,8 @@ env:
 
 jobs:
   lint:
-    name: Lint on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Lint
+    runs-on: ubuntu-latest
 
     steps:
       - name: Git Checkout


### PR DESCRIPTION
The linting tools like ESLint are well tested for cross-platform issues, so it doesn't really need to be run in a matrix build.