### PR TITLE
docs: extended security guide to include OpenSSF tooling

### DIFF
--- a/pages/en/docs/guides/security/index.md
+++ b/pages/en/docs/guides/security/index.md
@@ -412,7 +412,7 @@ functionality isn't securely stable. Although, feedback is highly appreciated.
 
 ## OpenSSF Tools
 
-The [OpenSSF][] is leading several initiatives that can be very useful, especially if you plan to publish an Npm package. These initiatives include:
+The [OpenSSF][] is leading several initiatives that can be very useful, especially if you plan to publish an npm package. These initiatives include:
 
 - [OpenSSF Scorecard][] Scorecard evaluates open source projects using a series of automated security risk checks. You can use it to proactively assess vulnerabilities and dependencies in your code base and make informed decisions about accepting vulnerabilities.
 - [OpenSSF Best Practices Badge Program][] Projects can voluntarily self-certify by describing how they comply with each best practice. This will generate a badge that can be added to the project.

--- a/pages/en/docs/guides/security/index.md
+++ b/pages/en/docs/guides/security/index.md
@@ -410,6 +410,13 @@ The use of experimental features in production isn't recommended.
 Experimental features can suffer breaking changes if needed, and their
 functionality isn't securely stable. Although, feedback is highly appreciated.
 
+## OpenSSF Tools
+
+The [OpenSSF][] is leading several initiatives that can be very useful, especially if you plan to publish an Npm package. These initiatives include:
+
+- [OpenSSF Scorecard][] Scorecard evaluates open source projects using a series of automated security risk checks. You can use it to proactively assess vulnerabilities and dependencies in your code base and make informed decisions about accepting vulnerabilities.
+- [OpenSSF Best Practices Badge Program][] Projects can voluntarily self-certify by describing how they comply with each best practice. This will generate a badge that can be added to the project.
+
 [threat model]: https://github.com/nodejs/node/blob/main/SECURITY.md#the-nodejs-threat-model
 [security guidance issue]: https://github.com/nodejs/security-wg/issues/488
 [nodejs guideline]: https://github.com/goldbergyoni/nodebestpractices
@@ -438,3 +445,6 @@ functionality isn't securely stable. Although, feedback is highly appreciated.
 [policy mechanism with integrity checking]: https://nodejs.org/api/permissions.html#integrity-checks
 [experimental-features]: #experimental-features-in-production
 [`Socket`]: https://socket.dev/
+[OpenSSF]: https://openssf.org/
+[OpenSSF Scorecard]: https://securityscorecards.dev/
+[OpenSSF Best Practices Badge Program]: https://bestpractices.coreinfrastructure.org/en


### PR DESCRIPTION
Hi all!

I am not very sure about how to manage the translations with the latests changes, but I am happy to update the spanish version for this change as well in this PR or in a separate one.

Regarding the pure content changes, let's see if there are at least 2 more members of the @nodejs/security that can review it before we merge it. 😉

We discuss to include this references in https://github.com/nodejs/security-wg/issues/932 