### PR TITLE
chore: set up testing-library jest extend

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -6,6 +6,7 @@ const createJestConfig = nextJest({
 
 /** @type {import('jest').Config} */
 const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
Some components tests from `nodejs.dev` use `@testing-library/jest-dom` custom matchers (eg: [SectionTitle.test.tsx#L16](https://github.com/nodejs/nodejs.dev/blob/main/src/components/CommonComponents/SectionTitle/__tests__/SectionTitle.test.tsx#L16)), but it's not installed here.