### PR TITLE
docs(zh-cn): dont-block-the-event-loop.md mailformed link

### DIFF
--- a/pages/zh-cn/docs/guides/dont-block-the-event-loop.md
+++ b/pages/zh-cn/docs/guides/dont-block-the-event-loop.md
@@ -295,7 +295,7 @@ asyncAvg(n, function(avg){
 1. 你可以通过开发 [C++ 插件](https://nodejs.org/api/addons.html) 的方式使用内置的 Node.js 工作池。稍早之前的 Node.js 版本，通过使用 [NAN](https://github.com/nodejs/nan) 的方式编译你的 C++ 插件，在新版的 Node.js 上使用 [N-API](https://nodejs.org/api/n-api.html)。 [node-webworker-threads](https://www.npmjs.com/package/webworker-threads) 提供了一个仅用 JavaScript 就可以访问 Node.js 的工作池的方式。
 2. 您可以创建和管理自己专用于计算的工作线程池，而不是使用 Node.js 自带的负责的 I/O 的工作线程池。最直接的方法就是使用 [Child Process](https://nodejs.org/api/child_process.html) 或者是 [cluster](https://nodejs.org/api/cluster.html)。
 
-你 *不应该*直接为每个请求都创建一个[子进程](https://nodejs.org/api/child_process.html)。 因为客户端请求的频率可能远远高于你的服务器能创建和管理子进程的频率，这种情况你的服务器就变成了一个[炸弹](https://en.wikipedia.org/wiki/Fork_bomb)。
+你 *不应该*直接为每个请求都创建一个[子进程](https://nodejs.org/api/child_process.html)。 因为客户端请求的频率可能远远高于你的服务器能创建和管理子进程的频率，这种情况你的服务器就变成了一个[Fork 炸弹](https://en.wikipedia.org/wiki/Fork_bomb)。
 
 ##### 转移到工作线程池的缺陷
 这种方法的缺点是它增大了 *通信开销* 。 因为 Node. js 仅允许事件循环线程去查访问应用程序的“命名空间”（保存着 JavaScript 状态）。 在工作线程中是无法操作事件循环线程的命名空间中的 JavaScript 对象的。 因此，您必须序列化和反序列化任何要在线程间共享的对象。 然后，工作线程可以对属于自己的这些对象的副本进行操作，并将修改后的对象（或“补丁”） 返回到事件循环线程。

--- a/pages/zh-cn/docs/guides/dont-block-the-event-loop.md
+++ b/pages/zh-cn/docs/guides/dont-block-the-event-loop.md
@@ -295,7 +295,7 @@ asyncAvg(n, function(avg){
 1. 你可以通过开发 [C++ 插件](https://nodejs.org/api/addons.html) 的方式使用内置的 Node.js 工作池。稍早之前的 Node.js 版本，通过使用 [NAN](https://github.com/nodejs/nan) 的方式编译你的 C++ 插件，在新版的 Node.js 上使用 [N-API](https://nodejs.org/api/n-api.html)。 [node-webworker-threads](https://www.npmjs.com/package/webworker-threads) 提供了一个仅用 JavaScript 就可以访问 Node.js 的工作池的方式。
 2. 您可以创建和管理自己专用于计算的工作线程池，而不是使用 Node.js 自带的负责的 I/O 的工作线程池。最直接的方法就是使用 [Child Process](https://nodejs.org/api/child_process.html) 或者是 [cluster](https://nodejs.org/api/cluster.html)。
 
-你 *不应该*直接为每个请求都创建一个[子进程](https://nodejs.org/api/child_process.html)[。 因为客户端请求的频率可能远远高于你的服务器能创建和管理子进程的频率，这种情况你的服务器就变成了一个<](https://en.wikipedia.org/wiki/Fork_bomb)a href="https://en.wikipedia.org/wiki/Fork_bomb">Fork 炸弹</a>。
+你 *不应该*直接为每个请求都创建一个[子进程](https://nodejs.org/api/child_process.html)。 因为客户端请求的频率可能远远高于你的服务器能创建和管理子进程的频率，这种情况你的服务器就变成了一个[炸弹](https://en.wikipedia.org/wiki/Fork_bomb)。
 
 ##### 转移到工作线程池的缺陷
 这种方法的缺点是它增大了 *通信开销* 。 因为 Node. js 仅允许事件循环线程去查访问应用程序的“命名空间”（保存着 JavaScript 状态）。 在工作线程中是无法操作事件循环线程的命名空间中的 JavaScript 对象的。 因此，您必须序列化和反序列化任何要在线程间共享的对象。 然后，工作线程可以对属于自己的这些对象的副本进行操作，并将修改后的对象（或“补丁”） 返回到事件循环线程。


### PR DESCRIPTION
Fixes #5230
Should probably go through Crowdin, but it looks like these links got mangled. Not sure if it was with their editor or on the export