### PR TITLE
fix: typo "vector attacks"

### DIFF
--- a/pages/en/docs/guides/security/index.md
+++ b/pages/en/docs/guides/security/index.md
@@ -211,7 +211,7 @@ or a range. However, when pinning a dependency to an exact version, its
 transitive dependencies are not themselves pinned.
 This still leaves the application vulnerable to unwanted/unexpected updates.
 
-Possible vector attacks:
+Possible attack vectors:
 
 * Typosquatting attacks
 * Lockfile poisoning


### PR DESCRIPTION
I’m not sure about the change in the last line, I didn’t touch it when creating this PR in the browser. Could it be about a different newline or something?