### PR TITLE
blog: add windows arm64 for v19.9.0 and later

### DIFF
--- a/pages/en/blog/release/v19.9.0.md
+++ b/pages/en/blog/release/v19.9.0.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-04-11T00:31:42.343Z
+date: 2023-04-12T12:49:06.779Z
 category: release
 title: Node v19.9.0 (Current)
 layout: blog-post.hbs
@@ -184,8 +184,10 @@ events:
 
 Windows 32-bit Installer: https://nodejs.org/dist/v19.9.0/node-v19.9.0-x86.msi \
 Windows 64-bit Installer: https://nodejs.org/dist/v19.9.0/node-v19.9.0-x64.msi \
+Windows ARM 64-bit Installer: https://nodejs.org/dist/v19.9.0/node-v19.9.0-arm64.msi \
 Windows 32-bit Binary: https://nodejs.org/dist/v19.9.0/win-x86/node.exe \
 Windows 64-bit Binary: https://nodejs.org/dist/v19.9.0/win-x64/node.exe \
+Windows ARM 64-bit Binary: https://nodejs.org/dist/v19.9.0/win-arm64/node.exe \
 macOS 64-bit Installer: https://nodejs.org/dist/v19.9.0/node-v19.9.0.pkg \
 macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v19.9.0/node-v19.9.0-darwin-arm64.tar.gz \
 macOS Intel 64-bit Binary: https://nodejs.org/dist/v19.9.0/node-v19.9.0-darwin-x64.tar.gz \

--- a/scripts/release-post/downloadsTable.mjs
+++ b/scripts/release-post/downloadsTable.mjs
@@ -12,12 +12,20 @@ const allDownloads = [
     templateUrl: 'https://nodejs.org/dist/v%version%/node-v%version%-x64.msi',
   },
   {
+    title: 'Windows ARM 64-bit Installer',
+    templateUrl: 'https://nodejs.org/dist/v%version%/node-v%version%-arm64.msi',
+  },
+  {
     title: 'Windows 32-bit Binary',
     templateUrl: 'https://nodejs.org/dist/v%version%/win-x86/node.exe',
   },
   {
     title: 'Windows 64-bit Binary',
     templateUrl: 'https://nodejs.org/dist/v%version%/win-x64/node.exe',
+  },
+  {
+    title: 'Windows ARM 64-bit Binary',
+    templateUrl: 'https://nodejs.org/dist/v%version%/win-arm64/node.exe',
   },
   {
     title: 'macOS 64-bit Installer',
@@ -190,6 +198,14 @@ const resolveDownloads = version => {
   if (semVer.satisfies(version, '< 16.0.0')) {
     downloads = downloads.filter(
       ver => ver.title !== 'macOS Apple Silicon 64-bit Binary'
+    );
+  }
+
+  if (semVer.satisfies(version, '< 19.9.0')) {
+    downloads = downloads.filter(
+      ver =>
+        ver.title !== 'Windows ARM 64-bit Installer' &&
+        ver.title !== 'Windows ARM 64-bit Binary'
     );
   }
 


### PR DESCRIPTION
Since Node.js supports Windows ARM64 as a tier 2 platform starting with v19.9.0 onward, this PR adds it to the `downloadsTable.js` logic. The updated `19.9.0.md` was generated by running an updated script and I also tested with a version lower than 19.9.0. 

cc @RafaelGSS

Refs: https://github.com/nodejs/node/pull/47233