### PR TITLE
fix: other downloads incorrect for 'current'

### DIFF
--- a/components/Home/HomeDownloadButton.tsx
+++ b/components/Home/HomeDownloadButton.tsx
@@ -15,7 +15,7 @@ const HomeDownloadButton = (props: HomeDownloadButtonProps) => {
   } = useNextraContext();
 
   const nodeDownloadLink = `https://nodejs.org/dist/${props.node}/`;
-  const nodeApiLink = `/latest-${props.nodeMajor}/docs/api/`;
+  const nodeApiLink = `https://nodejs.org/dist/latest-${props.nodeMajor}/docs/api/`;
   const nodeAllDownloadsLink = `/download${props.isLts ? '/' : '/current'}`;
   const nodeDownloadTitle =
     `${labels.download} ${props.nodeNumeric}` +

--- a/components/Home/HomeDownloadButton.tsx
+++ b/components/Home/HomeDownloadButton.tsx
@@ -15,8 +15,8 @@ const HomeDownloadButton = (props: HomeDownloadButtonProps) => {
   } = useNextraContext();
 
   const nodeDownloadLink = `https://nodejs.org/dist/${props.node}/`;
-  const nodeApiLink = `https://nodejs.org/dist/latest-${props.nodeMajor}/docs/api/`;
-
+  const nodeApiLink = `/latest-${props.nodeMajor}/docs/api/`;
+  const nodeAllDownloadsLink = `/download${props.isLts ? '/' : '/current'}`;
   const nodeDownloadTitle =
     `${labels.download} ${props.nodeNumeric}` +
     ` ${labels[props.isLts ? 'lts' : 'current']}`;
@@ -35,7 +35,7 @@ const HomeDownloadButton = (props: HomeDownloadButtonProps) => {
 
       <ul className="list-divider-pipe home-secondary-links">
         <li>
-          <LocalizedLink href="/download/">
+          <LocalizedLink href={nodeAllDownloadsLink}>
             {labels['other-downloads']}
           </LocalizedLink>
         </li>


### PR DESCRIPTION
Fixes https://github.com/nodejs/nodejs.org/issues/5272

I hit this bug when I was looking for the Windows/Arm64 builds on the web site - the link underneath the current release for "other downloads" takes you to the LTS ones without this.

