### PR TITLE
chore(config): removed experimental option (#5276

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,5 +23,4 @@ export default withNextra({
   images: { unoptimized: true },
   outputFileTracing: false,
   basePath: process.env.NEXT_BASE_PATH || '',
-  experimental: { webpackBuildWorker: true },
 });


### PR DESCRIPTION
Well, with Next.js 13.3.0 this config option is breaking the `major/website-redesign` branch. Pretty much this option being enabled "bite my tongue" and it might make sense to wait for this to become a stable option, as it might randomly break during Next.js updates.

I'm merging this ASAP as builds are breaking on `major/website-redesign`