### PR TITLE
chore: introduce vercel deployments 🎉 

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -66,11 +66,13 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy to Vercel (Preview)
+
+on:
+  push:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy to Vercel (Preview)
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    environment:
+      name: vercel-preview
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - id: deploy
+        name: Deploy Project Artifacts to Vercel
+        run: echo "::set-output name=url::$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       name: vercel-preview
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ steps.deploy.outputs.deploy_url }}
 
     steps:
       - name: Git Checkout
@@ -40,4 +40,4 @@ jobs:
 
       - id: deploy
         name: Deploy Project Artifacts to Vercel
-        run: echo "::set-output name=url::$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
+        run: echo "deploy_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy to Vercel (Production)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy to Vercel (Production)
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    environment:
+      name: vercel-production
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - id: deploy
+        name: Deploy Project Artifacts to Vercel
+        run: echo "::set-output name=url::$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -17,7 +17,7 @@ jobs:
 
     environment:
       name: vercel-production
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ steps.deploy.outputs.deploy_url }}
 
     steps:
       - name: Git Checkout
@@ -40,4 +40,4 @@ jobs:
 
       - id: deploy
         name: Deploy Project Artifacts to Vercel
-        run: echo "::set-output name=url::$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
+        run: echo "deploy_url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage
 
 # Storybook
 storybook-static
+
+# Vercel Deployment
+.vercel


### PR DESCRIPTION
This PR introduces the GitHub Actions for Vercel Deployments (Prod and Branch Previews).

This is a foundational step for migrating our infrastructure from our DigitalOcean Droplets for the Node.js Website into our recently acquired **Vercel** infrastructure.

**Note:** The "Production" branch deployments are just for Experimentation and are not replacing the https://nodejs.org Production Deployments nor changing any logic. They get deployed to a completely random Vercel URI.