### PR TITLE
chore: lock nextjs to 13.2.0 (#5301

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "handlebars": "^4.7.7",
         "highlight.js": "^11.7.0",
         "isomorphic-dompurify": "^1.1.0",
-        "next": "^13.2.4",
+        "next": "^13.2.0",
         "next-sitemap": "^4.0.6",
         "nextra": "^2.2.20",
         "node-version-data": "^1.1.0",
@@ -3872,7 +3872,8 @@
     "node_modules/@next/env": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
-      "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ=="
+      "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ==",
+      "peer": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.3.0",
@@ -3883,10 +3884,40 @@
         "glob": "7.1.7"
       }
     },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.0.tgz",
+      "integrity": "sha512-VMetUwBWtDBGzNiOkhiWTP+99ZYW5NVRpIGlUsldEtY8IQIqleaUgW9iamsO0kDSjhWNdCQCB+xu5HcCvmDTww==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.0.tgz",
+      "integrity": "sha512-fAiP54Om3fSj5aKntxEvW5fWzyMUzLzjFrHuUt5jBnTRWM4QikhLy547OZDoxycyk4GoQVHmNMSA3hILsrV/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
-      "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.0.tgz",
+      "integrity": "sha512-F4zbvPnq3zCTqyyM6WN8ledazzJx3OrxIdc2ewnqnfk6tjBZ/aq1M27GhEfylGjZG1KvbtJCxUqi7dR/6R94bA==",
       "cpu": [
         "arm64"
       ],
@@ -3899,9 +3930,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
-      "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.0.tgz",
+      "integrity": "sha512-Y9+fB7TLAAnkCZQXWjwJg5bi1pT5NuNkI+HoKYp26U1J0SxW5vZWFGc31WFmmHIz3wA0zlaQfRa4mF7cpZL5yw==",
       "cpu": [
         "x64"
       ],
@@ -3913,10 +3944,40 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.0.tgz",
+      "integrity": "sha512-b9bCLlfznbV6e6Vg9wKYZJs7Uz8z/Py9105MYq95a3JlHiI3e/fvBpm1c7fe5QlvWJlqyNav6Clyu1W+lDk+IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.0.tgz",
+      "integrity": "sha512-jY/2JjDVVyktzRtMclAIVLgOxk5Ut9NKu8kKMCPdKMf9/ila37UpRfIh2fOXtRhv8AK7Lq/iSI/v2vjopZxZgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
-      "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.0.tgz",
+      "integrity": "sha512-EKjWU3/lSBhOwPQRQLbySUnATnXygCjGd8ag3rP6d7kTIhfuPO4pY+DYW+wHOt5qB1ULNRmW0sXZ/ZKnQrVszw==",
       "cpu": [
         "arm64"
       ],
@@ -3929,9 +3990,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
-      "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.0.tgz",
+      "integrity": "sha512-T5R9r23Docwo6PYZRzndeFB5WUN3+smMbyk25K50MAngCiSydr82/YfAetcp7Ov7Shp4a8xXP9DHDIsBas6wbQ==",
       "cpu": [
         "arm64"
       ],
@@ -3944,9 +4005,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
-      "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.0.tgz",
+      "integrity": "sha512-FeXTc2KFvUSnTJmkpNMKoBHmNA1Ujr3QdfcKnVm/gXWqK+rfuEhAiRNOo+6mPcQ0noEge1j8Ai+W1LTbdDwPZQ==",
       "cpu": [
         "x64"
       ],
@@ -3959,9 +4020,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
-      "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.0.tgz",
+      "integrity": "sha512-7Y0XMUzWDWI94pxC0xWGMWrgTFKHu/myc+GTNVEwvLtI9WA0brKqZrL1tCQW/+t6J+5XqS7w+AHbViaF+muu1A==",
       "cpu": [
         "x64"
       ],
@@ -3974,9 +4035,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
-      "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.0.tgz",
+      "integrity": "sha512-NM5h2gEMe8EtvOeRU3vRM83tq1xo6Qvhuz0xJem/176SAMxbqzAz4LLP3l9VyUI3SIzGyiztvF/1c0jqeq7UEA==",
       "cpu": [
         "arm64"
       ],
@@ -3989,9 +4050,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
-      "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.0.tgz",
+      "integrity": "sha512-G7YEJZX9wkcUaBOvXQSCF9Wb2sqP8hhsmFXF6po7M3llw4b+2ut2DXLf+UMdthOdUK0u+Ijhy5F7SbW9HOn2ig==",
       "cpu": [
         "ia32"
       ],
@@ -4004,9 +4065,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
-      "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.0.tgz",
+      "integrity": "sha512-QTAjSuPevnZnlHfC4600+4NvxRuPar6tWdYbPum9vnk3OIH1xu9YLK+2ArPGFd0bB2K8AoY2SIMbs1dhK0GjQQ==",
       "cpu": [
         "x64"
       ],
@@ -8292,17 +8353,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
       "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -18362,13 +18412,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
-      "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.0.tgz",
+      "integrity": "sha512-vhByvKHedsaMwNTwXKzK4IMmNp7XI7vN4etcGUoIpLrIuDfoYA3bS0ImS4X9F6lKzopG5aVp7a1CjuzF2NGkvA==",
       "dependencies": {
-        "@next/env": "13.3.0",
+        "@next/env": "13.2.0",
         "@swc/helpers": "0.4.14",
-        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1"
@@ -18380,18 +18429,22 @@
         "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.3.0",
-        "@next/swc-darwin-x64": "13.3.0",
-        "@next/swc-linux-arm64-gnu": "13.3.0",
-        "@next/swc-linux-arm64-musl": "13.3.0",
-        "@next/swc-linux-x64-gnu": "13.3.0",
-        "@next/swc-linux-x64-musl": "13.3.0",
-        "@next/swc-win32-arm64-msvc": "13.3.0",
-        "@next/swc-win32-ia32-msvc": "13.3.0",
-        "@next/swc-win32-x64-msvc": "13.3.0"
+        "@next/swc-android-arm-eabi": "13.2.0",
+        "@next/swc-android-arm64": "13.2.0",
+        "@next/swc-darwin-arm64": "13.2.0",
+        "@next/swc-darwin-x64": "13.2.0",
+        "@next/swc-freebsd-x64": "13.2.0",
+        "@next/swc-linux-arm-gnueabihf": "13.2.0",
+        "@next/swc-linux-arm64-gnu": "13.2.0",
+        "@next/swc-linux-arm64-musl": "13.2.0",
+        "@next/swc-linux-x64-gnu": "13.2.0",
+        "@next/swc-linux-x64-musl": "13.2.0",
+        "@next/swc-win32-arm64-msvc": "13.2.0",
+        "@next/swc-win32-ia32-msvc": "13.2.0",
+        "@next/swc-win32-x64-msvc": "13.2.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/api": "^1.4.0",
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^18.2.0",
@@ -18456,6 +18509,11 @@
         "@next/env": "*",
         "next": "*"
       }
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.0.tgz",
+      "integrity": "sha512-yv9oaRVa+AxFa27uQOVecS931NrE+GcQSqcL2HaRxL8NunStLtPiyNm/VixvdzfiWLabMz4dXvbXfwCNaECzcw=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",
@@ -22850,14 +22908,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/strftime": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "handlebars": "^4.7.7",
     "highlight.js": "^11.7.0",
     "isomorphic-dompurify": "^1.1.0",
-    "next": "^13.2.4",
+    "next": "13.2.0",
     "next-sitemap": "^4.0.6",
     "nextra": "^2.2.20",
     "node-version-data": "^1.1.0",


### PR DESCRIPTION
This PR locks Next.js to 13.2.0 as any version higher than 13.2.0 introduces an issue with Vercel Deployments not being able to use Cache.

This seems to be a https://github.com/shuding/nextra bug and it is reported here: https://github.com/shuding/nextra/issues/1564