### PR TITLE
chore: adjust working group mentions

### DIFF
--- a/pages/en/get-involved/contribute.md
+++ b/pages/en/get-involved/contribute.md
@@ -41,7 +41,7 @@ By becoming a collaborator, contributors can have even more impact on the projec
 * comments on issues and pull requests
 * contributions to the Node.js website
 * assistance provided to end users and novice contributors
-* participation in Working Groups
+* participation in working groups
 * other participation in the wider Node.js community
 
 If individuals making valuable contributions do not believe they have been considered for commit access, they may [log an issue](https://github.com/nodejs/TSC/issues) or [contact a TSC member](https://github.com/nodejs/node#tsc-technical-steering-committee) directly.

--- a/pages/en/get-involved/index.md
+++ b/pages/en/get-involved/index.md
@@ -11,8 +11,8 @@ layout: contribute.hbs
 * For real-time chat about Node.js development use one of the platforms below
   * For IRC, go to `irc.libera.chat` in the `#node.js` channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [a web client](https://kiwiirc.com/nextclient/)
   * For Slack, there are two options:
-    * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community. Some Working Groups have discussion channels there.
-    * The [OpenJSF Slack](https://slack-invite.openjsf.org/) is a Foundation run Slack with several Node.js channels (channels prefixed by `#nodejs-` are related to the project). Some Working Groups have discussion channels there.
+    * The [OpenJSF Slack](https://slack-invite.openjsf.org/) is a Foundation run Slack with several Node.js channels (channels prefixed by `#nodejs-` are related to the project).
+    * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community.
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
 * The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
 


### PR DESCRIPTION
Use "working group" rather than "Working Group".

Remove unnecessary mention of working group channels regarding Slack.

Put OpenJS Slack first in Slack list. (Not related to working groups, but since I was editing that text anyway....)