### PR TITLE
chore: remove retired CommComm mention

### DIFF
--- a/pages/en/about/governance.md
+++ b/pages/en/about/governance.md
@@ -22,17 +22,14 @@ For the current list of Collaborators, see the project's [README.md][].
 
 A guide for Collaborators is maintained at [collaborator-guide.md][].
 
-## Top Level Committees
+## Technical Steering Committee
 
-The project is governed jointly by the [Technical Steering Committee (TSC)][]
-which is responsible for high-level guidance of the project, and the
-[Community Committee (CommComm)][] which is responsible for guiding and
-extending the Node.js community.
+The project is governed by the [Technical Steering Committee (TSC)][]
+which is responsible for high-level guidance of the project.
 
 [collaborator-guide.md]: https://github.com/nodejs/node/blob/main/doc/contributing/collaborator-guide.md
-[Community Committee (CommComm)]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: https://github.com/nodejs/node/blob/main/README.md#current-project-team-members
-[Technical Steering Committee (TSC)]: https://github.com/nodejs/TSC/blob/master/TSC-Charter.md
+[Technical Steering Committee (TSC)]: https://github.com/nodejs/TSC/blob/main/TSC-Charter.md
 [TSC]: https://github.com/nodejs/TSC
 [nodejs/node]: https://github.com/nodejs/node


### PR DESCRIPTION
CommComm is retired. Remove it from the governance page.

While editing that text, I also updated the link to the TSC charter.