### PR TITLE
chore: use turbo as cache provider

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,14 +15,14 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-
 jobs:
   build:
     name: Build for GitHub Pages
     runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     steps:
       - name: Git Checkout

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,13 +39,10 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Build Next.js
-        run: npx turbo build
+        run: npx turbo build --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
-          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
-          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
-          TURBO_REMOTE_ONLY: true
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,6 +15,11 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+  TURBO_REMOTE_ONLY: true
+
 jobs:
   build:
     name: Build for GitHub Pages
@@ -38,27 +43,11 @@ jobs:
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v3
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Build Next.js
         run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache/turbo') }}
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -43,9 +43,9 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
-          NODE_OPTIONS: '--max_old_space_size=4096'
-          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,7 +18,6 @@ concurrency:
 env:
   TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-  TURBO_REMOTE_ONLY: true
 
 jobs:
   build:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,10 +39,13 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Build Next.js
-        run: npx turbo build --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
+        run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -43,8 +43,8 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
           TURBO_REMOTE_ONLY: true
 
       - name: Export Next.js static files

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,10 +20,6 @@ jobs:
     name: Build for GitHub Pages
     runs-on: ubuntu-latest
 
-    env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -47,6 +43,9 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
+          NODE_OPTIONS: '--max_old_space_size=4096'
+          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,11 @@ jobs:
         run: npm ci
 
       - name: Run Linting
-        run: npx turbo lint --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
+        run: npx turbo lint
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -52,7 +56,11 @@ jobs:
         run: npm ci
 
       - name: Run Unit Tests
-        run: npx turbo test:ci --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
+        run: npx turbo test:ci
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true
 
   build:
     name: Build on ${{ matrix.os }}
@@ -79,6 +87,9 @@ jobs:
         run: npm ci
 
       - name: Build Next.js
-        run: npx turbo build --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
+        run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,6 @@ on:
 env:
   TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-  TURBO_REMOTE_ONLY: true
 
 jobs:
   lint:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
 
-    env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
@@ -30,14 +26,14 @@ jobs:
 
       - name: Run Linting
         run: npx turbo lint
+        env:
+          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_REMOTE_ONLY: true
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
-    env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     strategy:
       fail-fast: false
@@ -61,14 +57,14 @@ jobs:
 
       - name: Run Unit Tests
         run: npx turbo test:ci
+        env:
+          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_REMOTE_ONLY: true
 
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
-    env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     strategy:
       fail-fast: false
@@ -94,3 +90,6 @@ jobs:
         run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
+          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_REMOTE_ONLY: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+  TURBO_REMOTE_ONLY: true
+
 jobs:
   lint:
     name: Lint
@@ -24,22 +29,8 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Run Linting
         run: npx turbo lint
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -65,22 +56,8 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Run Unit Tests
         run: npx turbo test:ci
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
 
   build:
     name: Build on ${{ matrix.os }}
@@ -106,23 +83,7 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Build Next.js
         run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache/turbo') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Run Linting
         run: npx turbo lint
         env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
           TURBO_REMOTE_ONLY: true
 
   unit-tests:
@@ -58,8 +58,8 @@ jobs:
       - name: Run Unit Tests
         run: npx turbo test:ci
         env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
           TURBO_REMOTE_ONLY: true
 
   build:
@@ -90,6 +90,6 @@ jobs:
         run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
+          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
           TURBO_REMOTE_ONLY: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Run Linting
         run: npx turbo lint
         env:
-          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_ONLY: true
 
   unit-tests:
@@ -58,8 +58,8 @@ jobs:
       - name: Run Unit Tests
         run: npx turbo test:ci
         env:
-          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_ONLY: true
 
   build:
@@ -90,6 +90,6 @@ jobs:
         run: npx turbo build
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-          TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_ONLY: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     steps:
       - name: Git Checkout
@@ -34,6 +34,10 @@ jobs:
   unit-tests:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     strategy:
       fail-fast: false
@@ -61,6 +65,10 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: ${{ secrets.VERCEL_TEAM_ID }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,11 +25,7 @@ jobs:
         run: npm ci
 
       - name: Run Linting
-        run: npx turbo lint
-        env:
-          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
-          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
-          TURBO_REMOTE_ONLY: true
+        run: npx turbo lint --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -56,11 +52,7 @@ jobs:
         run: npm ci
 
       - name: Run Unit Tests
-        run: npx turbo test:ci
-        env:
-          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
-          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
-          TURBO_REMOTE_ONLY: true
+        run: npx turbo test:ci --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
 
   build:
     name: Build on ${{ matrix.os }}
@@ -87,9 +79,6 @@ jobs:
         run: npm ci
 
       - name: Build Next.js
-        run: npx turbo build
+        run: npx turbo build --token=${{ secrets.TURBO_TOKEN }} --team=${{ secrets.TURBO_TEAM }} --remote-only
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-          TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
-          TURBO_TEAM: '${{ secrets.TURBO_TEAM }}'
-          TURBO_REMOTE_ONLY: true


### PR DESCRIPTION
This PR enables Turbo as the cache provider, as it does the better calculation of the Cache Hash, and it's quicker than GitHub Actions Cache.

This should also make the Turbo cache more precise.