### PR TITLE
chore: add remote turbo cache and simplified gh actions cache (#5326)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -38,27 +38,23 @@ jobs:
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v3
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
+      - name: GitHub Actions Cache
+        uses: actions/cache@v3
         with:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build Next.js
         run: npx turbo build
         env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache/turbo') }}
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -44,8 +44,10 @@ jobs:
           path: |
             .next/cache
             node_modules/.cache
+          key: build-${{ hashFiles('**/package-lock.json') }}-
           restore-keys: |
-            ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
+            build-${{ hashFiles('**/package-lock.json') }}-
+          enableCrossOsArchive: true
 
       - name: Build Next.js
         run: npx turbo build
@@ -61,7 +63,8 @@ jobs:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          enableCrossOsArchive: true
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -38,13 +38,12 @@ jobs:
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v3
 
-      - name: GitHub Actions Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
 
@@ -55,6 +54,14 @@ jobs:
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           NODE_OPTIONS: '--max_old_space_size=4096'
           NEXT_BASE_PATH: /nodejs.org
+
+      - name: Save Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            .next/cache
+            node_modules/.cache
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
 
       - name: Export Next.js static files
         run: npx turbo export

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,12 +24,11 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: GitHub Actions Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           restore-keys: |
             ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
 
@@ -38,6 +37,13 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+      - name: Save Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            node_modules/.cache
+          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -63,12 +69,11 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: GitHub Actions Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           restore-keys: |
             ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
 
@@ -77,6 +82,13 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+      - name: Save Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            node_modules/.cache
+          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
 
   build:
     name: Build on ${{ matrix.os }}
@@ -102,13 +114,12 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: GitHub Actions Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
 
@@ -118,3 +129,11 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Save Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            .next/cache
+            node_modules/.cache
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,8 +29,10 @@ jobs:
         with:
           path: |
             node_modules/.cache
+          key: tests-${{ hashFiles('**/package-lock.json') }}-
           restore-keys: |
-            ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
+            tests-${{ hashFiles('**/package-lock.json') }}-
+          enableCrossOsArchive: true
 
       - name: Run Linting
         run: npx turbo lint
@@ -43,7 +45,8 @@ jobs:
         with:
           path: |
             node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          enableCrossOsArchive: true
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -74,8 +77,10 @@ jobs:
         with:
           path: |
             node_modules/.cache
+          key: tests-${{ hashFiles('**/package-lock.json') }}-
           restore-keys: |
-            ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
+            tests-${{ hashFiles('**/package-lock.json') }}-
+          enableCrossOsArchive: true
 
       - name: Run Unit Tests
         run: npx turbo test:ci
@@ -88,7 +93,8 @@ jobs:
         with:
           path: |
             node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          enableCrossOsArchive: true
 
   build:
     name: Build on ${{ matrix.os }}
@@ -120,8 +126,10 @@ jobs:
           path: |
             .next/cache
             node_modules/.cache
+          key: build-${{ hashFiles('**/package-lock.json') }}-
           restore-keys: |
-            ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
+            build-${{ hashFiles('**/package-lock.json') }}-
+          enableCrossOsArchive: true
 
       - name: Build Next.js
         run: npx turbo build
@@ -136,4 +144,5 @@ jobs:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          enableCrossOsArchive: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,22 +24,20 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
-
-      - name: Run Linting
-        run: npx turbo lint
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
+      - name: GitHub Actions Cache
+        uses: actions/cache@v3
         with:
           path: |
             node_modules/.cache
           key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          restore-keys: |
+            ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Run Linting
+        run: npx turbo lint
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -65,22 +63,20 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules/.cache
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
-
-      - name: Run Unit Tests
-        run: npx turbo test:ci
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
+      - name: GitHub Actions Cache
+        uses: actions/cache@v3
         with:
           path: |
             node_modules/.cache
           key: ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          restore-keys: |
+            ${{ runner.os }}-tests-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Run Unit Tests
+        run: npx turbo test:ci
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
   build:
     name: Build on ${{ matrix.os }}
@@ -106,23 +102,19 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Restore Cache
-        uses: actions/cache/restore@v3
+      - name: GitHub Actions Cache
+        uses: actions/cache@v3
         with:
           path: |
             .next/cache
             node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build Next.js
         run: npx turbo build
         env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           NODE_OPTIONS: '--max_old_space_size=4096'
-
-      - name: Save Cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            .next/cache
-            node_modules/.cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache/turbo') }}


### PR DESCRIPTION
This PR enables Turbo as the cache provider, as it does the better calculation of the Cache Hash, and it's quicker than GitHub Actions Cache.

This should also make the Turbo cache more precise.