### PR TITLE
chore: fix storybook local development mode

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -10,5 +10,4 @@ not dead
 
 [development]
 
-defaults and supports es6-module
-maintained node versions
+defaults


### PR DESCRIPTION
Fixes `storybook` local development mode.

![image](https://user-images.githubusercontent.com/68445491/234886698-42207a54-3022-4aee-8e36-b8babbd9bd86.png)
