### PR TITLE
fix: Uncomfortable border radius of download links

### DIFF
--- a/styles/page-modules/_download.scss
+++ b/styles/page-modules/_download.scss
@@ -31,8 +31,8 @@
     display: flex;
     list-style: none;
     margin: 0;
-    text-align: center;
     overflow: hidden;
+    text-align: center;
   }
 
   li {
@@ -43,11 +43,11 @@
 
   a {
     background: $light-green;
+    border-radius: 0 !important;
     color: $active-green;
     display: block;
     padding-top: 1em;
     width: 100%;
-    border-radius: 0 !important;
   }
 
   .download-logo {
@@ -76,10 +76,10 @@
   }
 
   .download-version-toggle {
-    display: flex;
-    flex-wrap: nowrap;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
+    display: flex;
+    flex-wrap: nowrap;
 
     a {
       border-radius: 0;
@@ -109,9 +109,9 @@
   }
 
   .download-platform {
-    border-top: 2px solid $node-green;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
+    border-top: 2px solid $node-green;
   }
 }
 

--- a/styles/page-modules/_download.scss
+++ b/styles/page-modules/_download.scss
@@ -32,6 +32,7 @@
     list-style: none;
     margin: 0;
     text-align: center;
+    overflow: hidden;
   }
 
   li {
@@ -46,6 +47,7 @@
     display: block;
     padding-top: 1em;
     width: 100%;
+    border-radius: 0 !important;
   }
 
   .download-logo {
@@ -76,6 +78,8 @@
   .download-version-toggle {
     display: flex;
     flex-wrap: nowrap;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
 
     a {
       border-radius: 0;
@@ -106,6 +110,8 @@
 
   .download-platform {
     border-top: 2px solid $node-green;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
   }
 }
 


### PR DESCRIPTION
The `border-radius` of download links look uncomfortable, so I just fixed it.

Before:

![image](https://user-images.githubusercontent.com/50199130/235559525-c8420ed1-c19e-4dd6-9c83-fdac88e1b29b.png)

After:

![无标题](https://user-images.githubusercontent.com/52018749/235587407-8c5f33c4-1503-4577-bce6-b16c23aead37.png)
