### PR TITLE
chore: no-unused-vars ignores pattern starting with _

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
       "plugins": ["@typescript-eslint"],
       "globals": { "globalThis": false },
       "rules": {
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "@typescript-eslint/consistent-type-imports": "error"
       }
     },


### PR DESCRIPTION
See https://eslint.org/docs/latest/rules/no-unused-vars#argsignorepattern

Declaring function signature type, e.g. (name: string) => void, upsets ESLint. This commit will add rule to ignore pattern starting with _, so you can declare it (_name: string) => void.
