### PR TITLE
docs: fixed the order of sections in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ We also offer other commands that offer you assistance during your local develop
 - `npx turbo storybook:build` builds Storybook as a static web application for publishing
 - `npx turbo test` runs jest (unit-tests) locally
 
+## Vocabulary
+
+- A **Contributor** is any individual who creates an issue/PR, comments on an issue/PR
+  or contributes in some other way.
+- A **Collaborator** is a contributor with write access to the repository. See [here](#becoming-a-collaborator) on how to become a collaborator.
+
 ## Creating Components
 
 The Node.js Website uses **React.js** as a Frontend Library for the development of the Website. React allows us to create user interfaces with a modern take on Web Development.
@@ -252,12 +258,6 @@ In the case that an objection is raised in a pull request by another collaborato
 ### When merging
 
 - [`squash`][] pull requests made up of multiple commits
-
-## Vocabulary
-
-- A **Contributor** is any individual who creates an issue/PR, comments on an issue/PR
-  or contributes in some other way.
-- A **Collaborator** is a contributor with write access to the repository. See [here](#becoming-a-collaborator) on how to become a collaborator.
 
 ## Becoming a collaborator
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Just moved the Vocabulary section to the top of Getting started section to align with the table of contents:

![image](https://github.com/nodejs/nodejs.org/assets/114554280/e5b3638b-b466-443f-b490-0a677e177884)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Ref: #5393
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [ ] I've covered new added functionality with unit tests if necessary.
