### PR TITLE
chore: updated eslint rules and packages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -26,3 +26,6 @@ pages/**/*.md
 
 # We shouldn't lint statically generated Storybook files
 storybook-static
+
+# This file naturally might break conventional rules
+global.d.ts

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,12 +31,16 @@
     },
     {
       "files": ["**/*.{ts,tsx}"],
+      "extends": ["plugin:@typescript-eslint/recommended"],
       "parser": "@typescript-eslint/parser",
       "plugins": ["@typescript-eslint"],
       "globals": { "globalThis": false },
       "rules": {
-        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-        "@typescript-eslint/consistent-type-imports": "error"
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/no-empty-function": "off"
+      },
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
       }
     },
     {

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,9 +1,7 @@
 declare global {
   // @TODO: Update this to use the correct type
-  // eslint-disable-next-line no-unused-vars
   var __nextra_pageContext__: Record<string, any>;
 
-  // eslint-disable-next-line no-unused-vars
   interface Window {
     startLegacyApp: Function;
   }


### PR DESCRIPTION
This PR updates the ESLint rules to follow the recommended TypeScript Plugin rules and fixes ESLint error complaints. It also updates packages from `package-lock`.

This PR is a no-brainer and going to be merged as soon as build passes.