### PR TITLE
chore: gnu tar for unzipping cache files on windows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,6 +59,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      - name: "Use GNU tar instead BSD tar"
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+
       - name: Git Checkout
         uses: actions/checkout@v3
         with:
@@ -115,6 +120,16 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      - name: "Use GNU tar instead BSD tar"
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+
+      - name: "Use GNU tar instead BSD tar"
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"    
+
       - name: Git Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,6 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
-          enableCrossOsArchive: true
 
       - name: Install NPM packages
         run: npm ci
@@ -49,7 +48,6 @@ jobs:
             .next/cache
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}
-          enableCrossOsArchive: true
 
   unit-tests:
     name: Tests on ${{ matrix.os }}
@@ -85,7 +83,6 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
-          enableCrossOsArchive: true
 
       - name: Install NPM packages
         run: npm ci
@@ -112,7 +109,6 @@ jobs:
             .next/cache
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}
-          enableCrossOsArchive: true
 
   build:
     name: Build on ${{ matrix.os }}
@@ -148,7 +144,6 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
-          enableCrossOsArchive: true
 
       - name: Install NPM packages
         run: npm ci
@@ -169,4 +164,3 @@ jobs:
             .next/cache
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}
-          enableCrossOsArchive: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}
           enableCrossOsArchive: true
 
   unit-tests:
@@ -111,7 +111,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}
           enableCrossOsArchive: true
 
   build:
@@ -168,5 +168,5 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}
           enableCrossOsArchive: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,20 +19,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install NPM packages
-        run: npm ci
 
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
           path: |
+            ~/.npm
+            .next/cache
             node_modules/.cache
-          key: tests-${{ hashFiles('**/package-lock.json') }}-
-          restore-keys: |
-            tests-${{ hashFiles('**/package-lock.json') }}-
+          key: cache-${{ hashFiles('package-lock.json') }}-
+          restore-keys: cache-
           enableCrossOsArchive: true
+
+      - name: Install NPM packages
+        run: npm ci
 
       - name: Run Linting
         run: npx turbo lint
@@ -45,8 +45,10 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
+            ~/.npm
+            .next/cache
             node_modules/.cache
-          key: tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           enableCrossOsArchive: true
 
   unit-tests:
@@ -73,20 +75,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install NPM packages
-        run: npm ci
 
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
           path: |
+            ~/.npm
+            .next/cache
             node_modules/.cache
-          key: tests-${{ hashFiles('**/package-lock.json') }}-
-          restore-keys: |
-            tests-${{ hashFiles('**/package-lock.json') }}-
+          key: cache-${{ hashFiles('package-lock.json') }}-
+          restore-keys: cache-
           enableCrossOsArchive: true
+
+      - name: Install NPM packages
+        run: npm ci
 
       - name: Run Unit Tests
         run: npx turbo test:unit -- --coverage
@@ -106,8 +108,10 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
+            ~/.npm
+            .next/cache
             node_modules/.cache
-          key: tests-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           enableCrossOsArchive: true
 
   build:
@@ -125,11 +129,6 @@ jobs:
         shell: cmd
         run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
 
-      - name: "Use GNU tar instead BSD tar"
-        if: matrix.os == 'windows-latest'
-        shell: cmd
-        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"    
-
       - name: Git Checkout
         uses: actions/checkout@v3
         with:
@@ -139,21 +138,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install NPM packages
-        run: npm ci
 
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
           path: |
+            ~/.npm
             .next/cache
             node_modules/.cache
-          key: build-${{ hashFiles('**/package-lock.json') }}-
-          restore-keys: |
-            build-${{ hashFiles('**/package-lock.json') }}-
+          key: cache-${{ hashFiles('package-lock.json') }}-
+          restore-keys: cache-
           enableCrossOsArchive: true
+
+      - name: Install NPM packages
+        run: npm ci
 
       - name: Build Next.js
         run: npx turbo build
@@ -167,7 +165,8 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
+            ~/.npm
             .next/cache
             node_modules/.cache
-          key: build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
+          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('node_modules/.cache') }}
           enableCrossOsArchive: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Restore Cache
         uses: actions/cache/restore@v3
@@ -73,6 +74,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Restore Cache
         uses: actions/cache/restore@v3
@@ -134,6 +136,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Restore Cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,12 +15,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
@@ -30,6 +24,12 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install NPM packages
         run: npm ci
@@ -70,12 +70,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
@@ -85,6 +79,12 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install NPM packages
         run: npm ci
@@ -132,12 +132,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
       - name: Restore Cache
         uses: actions/cache/restore@v3
         with:
@@ -147,6 +141,12 @@ jobs:
             node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: cache-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install NPM packages
         run: npm ci


### PR DESCRIPTION
This PR simply adopts `GNU` tar for Windows runs as the default tar unzip strategy is super slow.