### PR TITLE
fix: update banner endDate to valid ISO string

### DIFF
--- a/site.json
+++ b/site.json
@@ -34,7 +34,7 @@
   "websiteBanners": {
     "index": {
       "startDate": "2023-06-13T14:30:00.000Z",
-      "endDate": "2023-06-20:00:00.000Z",
+      "endDate": "2023-06-20T00:00:00.000Z",
       "text": "New security releases to be made available June 20th, 2023",
       "link": "https://nodejs.org/en/blog/vulnerability/june-2023-security-releases/"
     }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Make the banner `endDate` a valid ISO date string. I'm unable to test this locally, but it looks like an invalid date would cause the banner to not display:
https://github.com/nodejs/nodejs.org/blob/7a4e29c8090caa8980f51a5676731ea43888f729/components/Home/Banner.tsx#L12-L15
https://github.com/nodejs/nodejs.org/blob/7a4e29c8090caa8980f51a5676731ea43888f729/util/dateIsBetween.ts#L2-L8

On my machine, Firefox 113 returns an invalid date for
```javascript
new Date("2023-06-20:00:00.000Z")
```

whereas the same input for Edge 114 returns a valid date
```console
Tue Jun 20 2023 01:00:00 GMT+0100 (British Summer Time) {}
```

## Related Issues

Refs: https://github.com/nodejs/nodejs.org/issues/5435

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [ ] I've covered new added functionality with unit tests if necessary.
