### PR TITLE
chore: reduce requirement from 2 approvals to 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ We recommend a read on our [Collaborator Guide](COLLABORATOR_GUIDE.md#accepting-
     - Fast-tracking is only allowed for small bug fixes, small feature changes, localisation changes, or other sort of non-critical/highly-impacting changes that are not covered by the previous rule that allows PRs to be merged immediately.
     - Fast-tracking cannot be used for updates on the COLLABORATOR_GUIDE, CONTRIBUTING guide, CODEOWNERS, GitHub Actions or any security-impacting file or document that changes the governing policies of this repository.
 - There must be no objections after a 48 hour period (Or 72 hours if the PR was authored on the weekend).
-- At least two approvals are required if the target branch is `main`
+- At least one approval is required for any PR to be merged.
 - Tests must be included in Pull Requests for new features or bug fixes. If any test(s) are failing, you are responsible for fixing them.
 
 Each contribution is accepted only if there is no objection to it by a collaborator. During the review, collaborators may request that a specific contributor who is an expert in a particular area give an "LGTM" before the PR can be merged.


### PR DESCRIPTION
Hey @nodejs/website I'm proposing we change the minimum amount of approvals for having a PR getting merged from 2 to 1.

This is due to not so many people being active on the Website Team. And often I cannot get reviews for PRs for long periods of time.