### PR TITLE
blog: adjust sec release for HRS

### DIFF
--- a/pages/en/blog/vulnerability/june-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/june-2023-security-releases.md
@@ -148,7 +148,7 @@ Thank you, to Marc Schönefeld for reporting this vulnerability and thank you [T
 
 ## HTTP Request Smuggling via Empty headers separated by CR (Medium) (CVE-2023-30589)
 
-The llhttp parser in the http module in Node v20.2.0 does not strictly use the CRLF sequence to delimit HTTP requests.
+The llhttp parser in the http module in Node.js does not strictly use the CRLF sequence to delimit HTTP requests.
 This can lead to HTTP Request Smuggling (HRS).
 
 The CR character (without LF) is sufficient to delimit HTTP header fields in the llhttp parser.


### PR DESCRIPTION
This vuln doesn't affect only Node.js 20. Removing the mention of v20.2.0 to avoid confusion.

cc: @nodejs/security-triage 