### PR TITLE
feat: better separation of mdx content and headings support

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,11 +32,6 @@ const nextConfig = {
     // We disable the support for legacy browsers which should reduce the polyiffing
     // and the overall bundle size for the Node.js Website client runtime
     legacyBrowsers: false,
-    // This feature reduces the Next.js memory consumption by compartimentalising
-    // the Webpack builds into smaller threads that are responsible for building
-    // smaller pieces of the website instead of all pages at onces
-    // this increases slightly build time in favor of less memory usage
-    webpackBuildWorker: true,
     // Some of our static pages from `getStaticProps` have a lot of data
     // since we pass the fully-compiled MDX page from `MDXRemote` through
     // a page's static props.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,8 @@ const nextConfig = {
   // We intentionally disable Next.js's built-in i18n support
   // as we dom have our own i18n and internationalisation engine
   i18n: null,
+  // We want to always enforce that SWC minifies the sources even during Development mode
+  // so that bundles are minified on-the-go. SWF minifying is fast, and has almost no penalties
   swcMinify: true,
   // We don't use trailing slashes on URLs from the Node.js Website
   trailingSlash: false,
@@ -39,9 +41,6 @@ const nextConfig = {
     // since we pass the fully-compiled MDX page from `MDXRemote` through
     // a page's static props.
     largePageDataBytes: 128 * 100000,
-    // This allows us to use SuperJson which supports custom data types for the JSON schema
-    // @see https://github.com/blitz-js/superjson
-    swcPlugins: [['next-superjson-plugin', {}]],
     // We disable the bundling and tracing of some files on the Serverless & Edge Runtimes
     // as otherwise they would explode the bundle size (server) and the tracing time
     outputFileTracingExcludes: {

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -159,7 +159,11 @@ export const getStaticProps = async (source = '', filename = '') => {
 
     // After the MDX gets processed with the remarkPlugins, some extra `data` that might come along
     // the `frontmatter` comes from `serialize` built-in support to `remark-frontmatter`
-    const { headings, matter: frontmatter } = sourceAsVirtualFile.data;
+    const { headings, matter: rawFrontmatter } = sourceAsVirtualFile.data;
+
+    // This serialises the Frontmatter into a JSON object that is compatible with the
+    // `getStaticProps` supported data type for props. (No prop value can be an object or not a primitive)
+    const frontmatter = JSON.parse(JSON.stringify(rawFrontmatter));
 
     // this defines the basic props that should be passed back to the `DynamicPage` component
     // We only want the `compiledSource` as we use `MDXProvider` for custom components along the journey

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdx-js/react": "^2.3.0",
         "@nodevu/core": "^0.1.0",
         "@types/node": "^18.16.19",
+        "@vcarl/remark-headings": "^0.1.0",
         "@vercel/analytics": "^1.0.1",
         "classnames": "^2.3.2",
         "cross-env": "^7.0.3",
@@ -8488,6 +8489,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vcarl/remark-headings": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vcarl/remark-headings/-/remark-headings-0.1.0.tgz",
+      "integrity": "sha512-ffQxJUcapJ9Bk+fiGN49YJ9RaYMibrSTSezB1Fcrtu+0YSZxA3bsaLlIv1u/4sjPIeW/BKrs4xtMT3l3P9Ba5Q==",
+      "dependencies": {
+        "mdast-util-to-string": "^3.1.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
+    "node_modules/@vcarl/remark-headings/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@vercel/analytics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mdx-js/react": "^2.3.0",
         "@nodevu/core": "^0.1.0",
         "@types/node": "^18.16.19",
         "@vcarl/remark-headings": "^0.1.0",
@@ -22,18 +21,15 @@
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.8.0",
         "husky": "^8.0.3",
-        "next": "^13.4.7",
+        "next": "^13.4.8",
         "next-mdx-remote": "^4.4.1",
         "next-sitemap": "^4.1.8",
         "next-superjson-plugin": "^0.5.8",
         "next-themes": "^0.2.1",
         "prismjs": "^1.29.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
         "react-icons": "^4.10.1",
         "react-intl": "^6.4.4",
         "remark-gfm": "^3.0.1",
-        "sass": "^1.63.6",
         "semver": "^7.5.3",
         "sharp": "^0.32.1",
         "strftime": "^0.10.2",
@@ -84,6 +80,13 @@
       },
       "engines": {
         "node": "v18"
+      },
+      "peerDependencies": {
+        "@mdx-js/react": "^2.3.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.63.6",
+        "vfile": "^5.3.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -139,35 +142,35 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
+      "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
+      "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
         "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helpers": "^7.22.6",
+        "@babel/parser": "^7.22.6",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.6",
         "@babel/types": "^7.22.5",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -217,16 +220,16 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
-      "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
+      "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.5",
+        "@babel/compat-data": "^7.22.6",
         "@babel/helper-validator-option": "^7.22.5",
-        "browserslist": "^4.21.3",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -236,9 +239,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.5.tgz",
-      "integrity": "sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.6.tgz",
+      "integrity": "sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -248,8 +251,8 @@
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-replace-supers": "^7.22.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "semver": "^6.3.0"
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -259,14 +262,14 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.5.tgz",
-      "integrity": "sha512-1VpEFOIbMRaXyDeUwUfmTIxExLwQ+zkW+Bh5zXpApA3oQedBx9v/updixWxnx/bZpKw7u8VxWjb/qWpIcmPq8A==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.6.tgz",
+      "integrity": "sha512-nBookhLKxAWo/TUCmhnaEJyLz2dekjQvv5SRpE9epWQBcpedWLKt8aZdsuT9XV5ovzR3fENLjRXVT0GsSlGGhA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "regexpu-core": "^5.3.1",
-        "semver": "^6.3.0"
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
+        "regexpu-core": "^5.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -450,9 +453,9 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-      "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -504,13 +507,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
-      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
+      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.6",
         "@babel/types": "^7.22.5"
       },
       "engines": {
@@ -603,9 +606,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+      "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1295,19 +1298,19 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.5.tgz",
-      "integrity": "sha512-2edQhLfibpWpsVBx2n/GKOz6JdGQvLruZQfGr9l1qes2KQaWswjBzhQF7UDUZMNaMMQeYnQzxwOMPsbYF7wqPQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
+      "integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-replace-supers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1719,9 +1722,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.5.tgz",
-      "integrity": "sha512-AconbMKOMkyG+xCng2JogMCDcqW8wedQAqpVIL4cOSescZ7+iW8utC6YDZLMCSUIReEA733gzRSaOSXMAt/4WQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
+      "integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1896,17 +1899,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.5.tgz",
-      "integrity": "sha512-bg4Wxd1FWeFx3daHFTWk1pkSWK/AyQuiyAoeZAOkAOUBjnZPH6KT7eMxouV47tQ6hl6ax2zyAWBdWZXbrvXlaw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.6.tgz",
+      "integrity": "sha512-+AGkst7Kqq3QUflKGkhWWMRb9vaKamoreNmYc+sjsIpOp+TsyU0exhp3RlwjQa/HdlKkPt3AMDwfg8Hpt9Vwqg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "babel-plugin-polyfill-corejs2": "^0.4.3",
         "babel-plugin-polyfill-corejs3": "^0.8.1",
-        "babel-plugin-polyfill-regenerator": "^0.5.0",
-        "semver": "^6.3.0"
+        "babel-plugin-polyfill-regenerator": "^0.5.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2073,13 +2076,13 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.5.tgz",
-      "integrity": "sha512-fj06hw89dpiZzGZtxn+QybifF07nNiZjZ7sazs2aVDcysAZVGjW7+7iFYxg6GLNM47R/thYfLdrXc+2f11Vi9A==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.6.tgz",
+      "integrity": "sha512-IHr0AXHGk8oh8HYSs45Mxuv6iySUBwDTIzJSnXN7PURqHdxJVQlCoXmKJgyvSS9bcNf9NVRVE35z+LkCvGmi6w==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.5",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -2110,7 +2113,7 @@
         "@babel/plugin-transform-block-scoping": "^7.22.5",
         "@babel/plugin-transform-class-properties": "^7.22.5",
         "@babel/plugin-transform-class-static-block": "^7.22.5",
-        "@babel/plugin-transform-classes": "^7.22.5",
+        "@babel/plugin-transform-classes": "^7.22.6",
         "@babel/plugin-transform-computed-properties": "^7.22.5",
         "@babel/plugin-transform-destructuring": "^7.22.5",
         "@babel/plugin-transform-dotall-regex": "^7.22.5",
@@ -2135,7 +2138,7 @@
         "@babel/plugin-transform-object-rest-spread": "^7.22.5",
         "@babel/plugin-transform-object-super": "^7.22.5",
         "@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-        "@babel/plugin-transform-optional-chaining": "^7.22.5",
+        "@babel/plugin-transform-optional-chaining": "^7.22.6",
         "@babel/plugin-transform-parameters": "^7.22.5",
         "@babel/plugin-transform-private-methods": "^7.22.5",
         "@babel/plugin-transform-private-property-in-object": "^7.22.5",
@@ -2153,11 +2156,11 @@
         "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
         "@babel/preset-modules": "^0.1.5",
         "@babel/types": "^7.22.5",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "babel-plugin-polyfill-corejs2": "^0.4.3",
         "babel-plugin-polyfill-corejs3": "^0.8.1",
         "babel-plugin-polyfill-regenerator": "^0.5.0",
-        "core-js-compat": "^3.30.2",
-        "semver": "^6.3.0"
+        "core-js-compat": "^3.31.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2383,9 +2386,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -2409,9 +2412,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-      "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.6.tgz",
+      "integrity": "sha512-53CijMvKlLIDlOTrdWiHileRddlIiwUIyCKqYa7lYnnPldXCG5dUSN38uT0cA6i7rHWNKJLH0VU/Kxdr1GzB3w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
@@ -2419,8 +2422,8 @@
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.6",
         "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2471,9 +2474,9 @@
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ=="
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
-      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz",
+      "integrity": "sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==",
       "dev": true,
       "funding": [
         {
@@ -2506,9 +2509,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.1.tgz",
-      "integrity": "sha512-pUjtFbaKbiFNjJo8pprrIaXLvQvWIlwPiFnRI4sEnc4F0NIGTOsw8kaJSR3CmZAKEvV8QYckovgAnWQC0bgLLQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz",
+      "integrity": "sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==",
       "dev": true,
       "funding": [
         {
@@ -2524,7 +2527,7 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^2.2.0",
+        "@csstools/css-parser-algorithms": "^2.3.0",
         "@csstools/css-tokenizer": "^2.1.1"
       }
     },
@@ -2552,6 +2555,21 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
@@ -3569,6 +3587,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/core/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
@@ -3970,6 +3994,12 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/@jest/expect/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/@jest/expect/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4122,6 +4152,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
+    },
+    "node_modules/@jest/fake-timers/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/@jest/globals": {
       "version": "29.5.0",
@@ -4519,10 +4555,14 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.4.tgz",
-      "integrity": "sha512-KE/SxsDqNs3rrWwFHcRh15ZLVFrI0YoZtgAdIyIq9k5hUNmiWRXXThPomIxHuL20sLdgzbDFyvkUMna14bvtrw==",
-      "dev": true
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
@@ -4620,14 +4660,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.7.tgz",
-      "integrity": "sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw=="
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.8.tgz",
+      "integrity": "sha512-twuSf1klb3k9wXI7IZhbZGtFCWvGD4wXTY2rmvzIgVhXhs7ISThrbNyutBx3jWIL8Y/Hk9+woytFz5QsgtcRKQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.7.tgz",
-      "integrity": "sha512-ANEPltxzXbyyG7CvqxdY4PmeM5+RyWdAJGufTHnU+LA/i3J6IDV2r8Z4onKwskwKEhwqzz5lMaSYGGXLyHX+mg==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.8.tgz",
+      "integrity": "sha512-cmfVHpxWjjcETFt2WHnoFU6EmY69QcPJRlRNAooQlNe53Ke90vg1Ci/dkPffryJZaxxiRziP9bQrV8lDVCn3Fw==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -4654,9 +4694,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz",
-      "integrity": "sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.8.tgz",
+      "integrity": "sha512-MSFplVM4dTWOuKAUv0XR9gY7AWtMSBu9os9f+kp+s5rWhM1I2CdR3obFttd6366nS/W/VZxbPM5oEIdlIa46zA==",
       "cpu": [
         "arm64"
       ],
@@ -4669,9 +4709,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.7.tgz",
-      "integrity": "sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.8.tgz",
+      "integrity": "sha512-Reox+UXgonon9P0WNDE6w85DGtyBqGitl/ryznOvn6TvfxEaZIpTgeu3ZrJLU9dHSMhiK7YAM793mE/Zii2/Qw==",
       "cpu": [
         "x64"
       ],
@@ -4684,9 +4724,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.7.tgz",
-      "integrity": "sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.8.tgz",
+      "integrity": "sha512-kdyzYvAYtqQVgzIKNN7e1rLU8aZv86FDSRqPlOkKZlvqudvTO0iohuTPmnEEDlECeBM6qRPShNffotDcU/R2KA==",
       "cpu": [
         "arm64"
       ],
@@ -4699,9 +4739,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.7.tgz",
-      "integrity": "sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.8.tgz",
+      "integrity": "sha512-oWxx4yRkUGcR81XwbI+T0zhZ3bDF6V1aVLpG+C7hSG50ULpV8gC39UxVO22/bv93ZlcfMY4zl8xkz9Klct6dpQ==",
       "cpu": [
         "arm64"
       ],
@@ -4714,9 +4754,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.7.tgz",
-      "integrity": "sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.8.tgz",
+      "integrity": "sha512-anhtvuO6eE9YRhYnaEGTfbpH3L5gT/9qPFcNoi6xS432r/4DAtpJY8kNktqkTVevVIC/pVumqO8tV59PR3zbNg==",
       "cpu": [
         "x64"
       ],
@@ -4729,9 +4769,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.7.tgz",
-      "integrity": "sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.8.tgz",
+      "integrity": "sha512-aR+J4wWfNgH1DwCCBNjan7Iumx0lLtn+2/rEYuhIrYLY4vnxqSVGz9u3fXcgUwo6Q9LT8NFkaqK1vPprdq+BXg==",
       "cpu": [
         "x64"
       ],
@@ -4744,9 +4784,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.7.tgz",
-      "integrity": "sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.8.tgz",
+      "integrity": "sha512-OWBKIrJwQBTqrat0xhxEB/jcsjJR3+diD9nc/Y8F1mRdQzsn4bPsomgJyuqPVZs6Lz3K18qdIkvywmfSq75SsQ==",
       "cpu": [
         "arm64"
       ],
@@ -4759,9 +4799,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.7.tgz",
-      "integrity": "sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.8.tgz",
+      "integrity": "sha512-agiPWGjUndXGTOn4ChbKipQXRA6/UPkywAWIkx7BhgGv48TiJfHTK6MGfBoL9tS6B4mtW39++uy0wFPnfD0JWg==",
       "cpu": [
         "ia32"
       ],
@@ -4774,9 +4814,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.7.tgz",
-      "integrity": "sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.8.tgz",
+      "integrity": "sha512-UIRKoByVKbuR6SnFG4JM8EMFlJrfEGuUQ1ihxzEleWcNwRMMiVaCj1KyqfTOW8VTQhJ0u8P1Ngg6q1RwnIBTtw==",
       "cpu": [
         "x64"
       ],
@@ -4786,6 +4826,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/semver-v6": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+      "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5035,15 +5084,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -5096,19 +5136,19 @@
       }
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.0.24.tgz",
-      "integrity": "sha512-sIPY6uH8I26KBWUb5fMYBB9xCKB02oSM8gIHzqPZ0DnW8zl+p6+dX3tAdX+XQvb9YOLJihxZ1GF1tOxFduc3Pw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.0.25.tgz",
+      "integrity": "sha512-UgqNz7Sqr8v2KyIZlQKcysULIExCLRwmHc+O+QJqeKhz/MD89hFTsH612XaIJMwBqfcdKvxLBL6euaUbziUzlQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/components": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/components": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
@@ -5136,20 +5176,20 @@
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-7.0.24.tgz",
-      "integrity": "sha512-x05Ng4wyBRkrupgSkBHKZSGPyUbvIDGiBseA/AjA/BNAMUMWy3t8ll9f7tlKzyDPaUeBSv8peP21r/Ry26Eqhw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-7.0.25.tgz",
+      "integrity": "sha512-bldiCQWDz9e+xseWdjcRW0/1CR2cA3H5dHk7L8KoEJiVzBAARNcLJgNOnCIxuwAlNJqlRCCxo9PfVRfBtyU75g==",
       "dev": true,
       "dependencies": {
-        "@storybook/blocks": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/components": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/blocks": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/components": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "lodash": "^4.17.21",
         "ts-dedent": "^2.0.0"
       },
@@ -5171,21 +5211,21 @@
       }
     },
     "node_modules/@storybook/addon-interactions": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.0.24.tgz",
-      "integrity": "sha512-N0BWt13T8lA+L0pAcC3xwhVMWQhrwHaXFqC6aJ1OxJb9pkA85S6Pk7VJRATDpmu9C3JO0OU3EOBB2YVVwcmD0A==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.0.25.tgz",
+      "integrity": "sha512-PETXdOPBjOEMY8pSuVFERuutT1tj5mWDVPE9//xv8khiDnBei1rbpHVQTVm+4gezQHTiDbwXaAldcJy2/W8q+g==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/components": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/components": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "7.0.24",
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/instrumenter": "7.0.25",
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "jest-mock": "^27.0.6",
         "polished": "^4.2.2",
         "ts-dedent": "^2.2.0"
@@ -5208,14 +5248,14 @@
       }
     },
     "node_modules/@storybook/addons": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.0.24.tgz",
-      "integrity": "sha512-e15hORnOD0ugvOVOTyZyLJhbDTWa4G1OHVUlboazy8O4TSvAXNBdLV1wOdY5RGoGD6Z5A4iR/gZXM0qc6Fh9xg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.0.25.tgz",
+      "integrity": "sha512-Dry/LOKHh7mLVcrKScWBaDq5rmw2DCOZ+Z6/PfhfuMua/GQ6YV1+Ykofew6ROBsq9FlgZCHDsRVVMZrV9Bvldg==",
       "dev": true,
       "dependencies": {
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/types": "7.0.24"
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/types": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -5227,13 +5267,13 @@
       }
     },
     "node_modules/@storybook/api": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.24.tgz",
-      "integrity": "sha512-rjWZgBbt43Ma5Vg2RwK9FtiF9ZkLRT+vOfDFtRL1PQkOIUlYlm33dOdPTh+HrW5QMO9cj/cchqmzU2AtgEZCyw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.25.tgz",
+      "integrity": "sha512-EgNUz49ObMTkQvCgxLqHf8wAFwv8B4y23RKXgl7q/HYA+jSWc5SZiNLleNxme7GqCo0qh+wjeU0luPv/A426WA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/manager-api": "7.0.24"
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/manager-api": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -5253,22 +5293,22 @@
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.0.24.tgz",
-      "integrity": "sha512-76pe4QC3WZBVxBt/RomGubW5xzbh4uF7LVn1Vonfujf4GaHgIDzu7KtLIjgM3NmDJCsp3PNfbgA1EKzWrPQz2A==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.0.25.tgz",
+      "integrity": "sha512-R0On6JMPPqtLI7yXzKWC3wFbbW2MmHZBlY4bMNH/PYoyY2u7mSCM+49Qwsulja8I/bG8mAraueVWTNbyEunQyg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/components": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/components": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/csf": "^0.1.0",
-        "@storybook/docs-tools": "7.0.24",
+        "@storybook/docs-tools": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/lodash": "^4.14.167",
         "color-convert": "^2.0.1",
         "dequal": "^2.0.2",
@@ -5291,15 +5331,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.0.24.tgz",
-      "integrity": "sha512-qSehfB1yS1ch/XSUdqNaTXitboNry4aKASte+kFhM5wSJcAgGBeB5akz8pc+JiRPWozqyceYkIdTG/KcRDeojg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.0.25.tgz",
+      "integrity": "sha512-ziVXhQHc4GH8iGQHZT1CLk2xLSetr4i8maiwfP6FNLe1/lL1AqtrW+mWsGyhdSfUS6OaMnm/nd62orNftapA4w==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/manager": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/manager": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
         "@types/ejs": "^3.1.1",
         "@types/find-cache-dir": "^3.2.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
@@ -5319,31 +5359,31 @@
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-7.0.24.tgz",
-      "integrity": "sha512-gA4otfsq9yTRT2IdYKkyqUdy+60a09CRDUtM1JB8a1eLmyL4az02qZv/l6D9Ccj/w5JNcJndtJX+3thOowOWOQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-7.0.25.tgz",
+      "integrity": "sha512-ZqqItMYGFIG/b1CumoWKMivZiGN9oNYhK8qUJ8uvefitxiFyeLKEujB7D8RYKqChPVgjtoaQzf+ANLqQ1YFOvg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.10",
-        "@storybook/addons": "7.0.24",
-        "@storybook/api": "7.0.24",
-        "@storybook/channel-postmessage": "7.0.24",
-        "@storybook/channel-websocket": "7.0.24",
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-api": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/components": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/core-events": "7.0.24",
-        "@storybook/core-webpack": "7.0.24",
+        "@storybook/addons": "7.0.25",
+        "@storybook/api": "7.0.25",
+        "@storybook/channel-postmessage": "7.0.25",
+        "@storybook/channel-websocket": "7.0.25",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-api": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/components": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/core-events": "7.0.25",
+        "@storybook/core-webpack": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/preview": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/router": "7.0.24",
-        "@storybook/store": "7.0.24",
-        "@storybook/theming": "7.0.24",
+        "@storybook/manager-api": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/preview": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/router": "7.0.25",
+        "@storybook/store": "7.0.25",
+        "@storybook/theming": "7.0.25",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.4",
         "babel-loader": "^9.0.0",
@@ -5389,14 +5429,14 @@
       "dev": true
     },
     "node_modules/@storybook/channel-postmessage": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.24.tgz",
-      "integrity": "sha512-QLtLXjEeTEwBN/7pB888mBaykmRU9Jy2BitvZuLJWyHHygTYm3vYZOaGR37DT+q/6Ob5GaZ0tURZmCSNDe8IIA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.25.tgz",
+      "integrity": "sha512-h4AHsgaGNcTJD8gzHAOAA6L9oxg4fVOw0LVO1L6Jd0CJ0jDV1jc3UPqh+i3bkTOB/4xjaT5xSr1h+eCUAA+N+w==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/global": "^5.0.0",
         "qs": "^6.10.0",
         "telejson": "^7.0.3"
@@ -5407,13 +5447,13 @@
       }
     },
     "node_modules/@storybook/channel-websocket": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-7.0.24.tgz",
-      "integrity": "sha512-GKSlWx5FgMQM0TKRCSGNTxLh0YU7xmg7m6FH8b/mvhH0Uido487qcJap2Ma/WOLe8aRiZo9jJpfcbUsKBWhuMg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-7.0.25.tgz",
+      "integrity": "sha512-7xAknhCPFpz2UF7LHN1/88pZyaNs9s+Q7u6o8U/arCG0QqepVmrtbHgoMqbsto93BzRl1qRSlC9iBr0b24AthA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
         "@storybook/global": "^5.0.0",
         "telejson": "^7.0.3"
       },
@@ -5423,9 +5463,9 @@
       }
     },
     "node_modules/@storybook/channels": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.24.tgz",
-      "integrity": "sha512-NZVLwMhtzy6cZrNRjshFvMAD9mQTmJDNwhohodSkM/YFCDVFhmxQk9tgizVGh9MwY3CYGJ1SI96RUejGosb49Q==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.25.tgz",
+      "integrity": "sha512-FLuXysj0uHBQNHpfiggtyaV0EFCMVWgEQjJLeBysqB/+sBCtpjrD7kUKrgJFF+N/IEhJq/dlWt7jOpxT2bffQA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5433,21 +5473,21 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.0.24.tgz",
-      "integrity": "sha512-TmHPJrcqUMAGpPKqw0PHI82m+Tyh6J8LgWjyZENpOGJlQH6SJ5caA/ho9R3pqVuMRRcnGgWt0xq1YJtDlYBN9g==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.0.25.tgz",
+      "integrity": "sha512-AewMs4xoBfRVtDIqbFIPgM+5rbHR899f5z6kuXmD9wOyX46ye+6e6NKoD47k0o5rPMRu4cZWx+tgLQCwGOGQBg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.2",
         "@babel/preset-env": "^7.20.2",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/core-server": "7.0.24",
-        "@storybook/csf-tools": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/telemetry": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/codemod": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/core-server": "7.0.25",
+        "@storybook/csf-tools": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/telemetry": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/semver": "^7.3.4",
         "chalk": "^4.1.0",
         "commander": "^6.2.1",
@@ -5496,13 +5536,13 @@
       }
     },
     "node_modules/@storybook/client-api": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-7.0.24.tgz",
-      "integrity": "sha512-D9brib29aET1peRq6Nu7iBFgE+9W7ia3KCua5/AS980RFnXgGPE9x07knTbaAOuiHxHFrmQpdFF9BvVms1GS4A==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-7.0.25.tgz",
+      "integrity": "sha512-vNIK0SGnmtvhKPl9VlGMntg2BiEsLWwpllczgj/rsiYIha3FIongRcdpKw2HWyBP8SX/561UZ/Cv/eru89medQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/preview-api": "7.0.24"
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/preview-api": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -5510,9 +5550,9 @@
       }
     },
     "node_modules/@storybook/client-logger": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.24.tgz",
-      "integrity": "sha512-4zRTb+QQ1hWaRqad/UufZNRfi2d/cf5a40My72Ct97VwjhJFE6aQ3K+hl1Xt6hh8dncDL2JK3cgziw6ElqjT0w==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.25.tgz",
+      "integrity": "sha512-jPUH38qA+FFiEkeA6vzo2Uq2tbgJolII2nKcKw6K6KMSv+/lJNElQ4extEvXHjmPe7TqPIZVDlh8QMh5DlZO5Q==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -5523,18 +5563,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.0.24.tgz",
-      "integrity": "sha512-PukV4GRPIISuVxpMMlTilwlGXdZ7E+JZWHNVb1tTwntmxMNcby8UxyWSHjbOpA2fxXGeUCjgCpcfTymJ+hxoYw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.0.25.tgz",
+      "integrity": "sha512-z/suUfSENphxZqWEJCA3Yz+/MFUcD3mXEm5+5cXR+phWUdIa+TJOdF07CC0YNIFtyqlxZ1fvNuZ5T5bUx0dmlw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.21.0",
         "@babel/preset-env": "~7.21.0",
         "@babel/types": "~7.21.2",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/csf-tools": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/types": "7.0.25",
         "cross-spawn": "^7.0.3",
         "globby": "^11.0.2",
         "jscodeshift": "^0.14.0",
@@ -5756,16 +5796,16 @@
       }
     },
     "node_modules/@storybook/components": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.0.24.tgz",
-      "integrity": "sha512-Pu7zGurCyWyiuFl2Pb5gybHA0f4blmHuVqccbMqnUw4Ew80BRu8AqfhNqN2hNdxFCx0mmy0baRGVftx76rNZ0w==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.0.25.tgz",
+      "integrity": "sha512-eY6R8P7HRisamVed/HwsgLerhDvL3UKdg9KsgBMoGLc7//lC2Zf9qYnDSMWutCdXJh0Te+gJS/i4Jv63YP3mDQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "memoizerific": "^1.11.3",
         "use-resize-observer": "^9.1.0",
         "util-deprecate": "^1.0.2"
@@ -5780,13 +5820,13 @@
       }
     },
     "node_modules/@storybook/core-client": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.0.24.tgz",
-      "integrity": "sha512-uToMHbi5EnOk+8Z941j0hrRE1h9u/QWqCmqS2FBIWrBOeREwy0AAib1/hqihzhO7OzekY5mtLTANiCpIpLHAHQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.0.25.tgz",
+      "integrity": "sha512-7KZg9DmCxLXLNwFZtalLLvN8kkGrSwf8ASFF1KXK5AM9oi0+ZOMZekCAuUzLM6g/vc/wMNYtQYnmMDlxD4xXSQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/preview-api": "7.0.24"
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/preview-api": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -5794,13 +5834,13 @@
       }
     },
     "node_modules/@storybook/core-common": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.24.tgz",
-      "integrity": "sha512-FHjL2dpwDHnicLTePkiZMfO5eFxJxpTP2xmGWFQnWFTyEgh+ipcWnLVoYYXiKcc6EzKED0yebk8rAIalbzpICg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.0.25.tgz",
+      "integrity": "sha512-ohnYWhsDgOC23CMFeRlR4OM/Y5l7qq0wQiM3KtCYqFUnRwNkHZJ+rj7s6wkKKGUDy4pebvApeW7HFm/sLWaJgw==",
       "dev": true,
       "dependencies": {
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/node": "^16.0.0",
         "@types/node-fetch": "^2.6.4",
         "@types/pretty-hrtime": "^1.0.0",
@@ -5892,9 +5932,9 @@
       }
     },
     "node_modules/@storybook/core-events": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.24.tgz",
-      "integrity": "sha512-xkf/rihCkhqMeh5EA8lVp90/mzbb2gcg6I3oeFWw2hognVcTnPXg6llhWdU4Spqd0cals7GEFmQugIILCmH8GA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.25.tgz",
+      "integrity": "sha512-abM0M+H19eZu0dRK+/2PB0W9b7xXFhiPddXpFCjIfJQFGPIwGBWVAFot1bKR5Mu4IB9OftkJYMRtYEEBrNep3A==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5902,25 +5942,25 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.0.24.tgz",
-      "integrity": "sha512-FJgdbtLgppFMd/RedF728I+v45TRG7s5/3RJfwgRgbq4ZEhKFzZN66MwWFeq3i5Q8ETHVwAxyVvC/JrRqAJxoA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.0.25.tgz",
+      "integrity": "sha512-fMXXmalaIhoqNvFll00M0b0jzdtSXzEACWx1Ssbo9TOgj8DHr/RAItzZ9U+pq0mHV2OQHwliAlWiMBZ3VBEQ+A==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.88",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/builder-manager": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.0.24",
+        "@storybook/csf-tools": "7.0.25",
         "@storybook/docs-mdx": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/telemetry": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/manager": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/telemetry": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/detect-port": "^1.3.0",
         "@types/node": "^16.0.0",
         "@types/node-fetch": "^2.5.7",
@@ -5961,14 +6001,14 @@
       "dev": true
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-7.0.24.tgz",
-      "integrity": "sha512-sM0hX55uNFXfQdRMthFdY6luWmi9MG+dIj6bNPiVY2SxNenxj62P/0/R/1Ime27X/vzFbi12pqUijzPNUwiwQw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-7.0.25.tgz",
+      "integrity": "sha512-fVLNcUexaXZKXuEDQVLlAb204zD4Knn8tnGx09x6p5I7f7eJhzvqRGvBmWKl9EAsHbm1nUdwzhulrOgePmhM8g==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/node": "^16.0.0",
         "ts-dedent": "^2.0.0"
       },
@@ -5993,9 +6033,9 @@
       }
     },
     "node_modules/@storybook/csf-tools": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.24.tgz",
-      "integrity": "sha512-RBNiXY3ht6XpcIyVgxBo7mK2t32tJuC93OO/HgcoRFClcdA8HUnlva297XpJpMqCgrcF8fPqRo+ZcLeC7vjzvw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.0.25.tgz",
+      "integrity": "sha512-ybxHmnQDEoqZZnc1DtsFuRmQG6va3eSo/eZeH6ixzTmuA5QWVx1UE7lA97c1wgbipa17+Jo1hJaMkoMPeKc7ew==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "~7.21.1",
@@ -6003,7 +6043,7 @@
         "@babel/traverse": "~7.21.2",
         "@babel/types": "~7.21.2",
         "@storybook/csf": "^0.1.0",
-        "@storybook/types": "7.0.24",
+        "@storybook/types": "7.0.25",
         "fs-extra": "^11.1.0",
         "recast": "^0.23.1",
         "ts-dedent": "^2.0.0"
@@ -6082,15 +6122,15 @@
       "dev": true
     },
     "node_modules/@storybook/docs-tools": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.0.24.tgz",
-      "integrity": "sha512-vmDHmHB1B5CWsYQ7CEtfz4vdf36VK/EZdNQUox9kdN935Dks7KSuGcDdXiRlWc78e94/A9+1mJQpyfwtn3E8fQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.0.25.tgz",
+      "integrity": "sha512-8JCQ+pFSbXNOdiCcQsfEW1A9u1CuwI/bgP0/xbw5Odl7H4ZQHwdJKOSH3qP5fBnSGIU9j2Leiaka8Kn49e7DOg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.10",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/doctrine": "^0.0.3",
         "doctrine": "^3.0.0",
         "lodash": "^4.17.21"
@@ -6107,16 +6147,16 @@
       "dev": true
     },
     "node_modules/@storybook/instrumenter": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-7.0.24.tgz",
-      "integrity": "sha512-XQ4Whq0rqW9eFMTtRpLxcl6bCf+KO3UZYcm+H63EDn9TstDyopmqv1fDg2tmJOpqLo143F8qLVC89rI7M/lO6w==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-7.0.25.tgz",
+      "integrity": "sha512-47O2P7pYT80HGkI+9/6QztFz+O5kCcbdR/v2l0nbWQIxDDX+4flPZXmcN0bw2Rrw0rYm7YB/0RIHy5Xy+c5YNg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "7.0.24"
+        "@storybook/preview-api": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -6124,9 +6164,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.0.24.tgz",
-      "integrity": "sha512-LsQd2cFJViwoPJ7K0A/XBWrBBhJv7F0J6+aa7qHszNmIZHVbMXyZfiX7JS3RHVs4I2kLuNpSk4X+iDG0QAafEQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.0.25.tgz",
+      "integrity": "sha512-K5yJImNXcBGGUIeRJ/ccpIV1rpT7B164h4tzTtwO73uI6VR58ZPMjkyt/YAfJ81kxQFkJXYkdy2+L5flftZ4SA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6134,19 +6174,19 @@
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.24.tgz",
-      "integrity": "sha512-cBpgDWq8reFgyrv4fBZlZJQyWYb9cDW0LDe476rWn/29uXNvYMNsHRwveLNgSA8Oy1NdyQCgf4ZgcYvY3wpvMA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.25.tgz",
+      "integrity": "sha512-ZuimeFd9jUlYip1TLa+Q+CoU7xfHk7ZrCeuPSWG3QGodgt0L1gSwRbQnoS8ZN895Y3i0WQX32nnRWwwSWGrjgA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/router": "7.0.24",
-        "@storybook/theming": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/router": "7.0.25",
+        "@storybook/theming": "7.0.25",
+        "@storybook/types": "7.0.25",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "memoizerific": "^1.11.3",
@@ -6165,9 +6205,9 @@
       }
     },
     "node_modules/@storybook/nextjs": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-7.0.24.tgz",
-      "integrity": "sha512-SQqqeSyshs58Gluc+EZrjaSWAspOZ0YRRmZK3+cepomFsm22m1phInoFi1Zcvsf5CirjIjWUbYzxgYO6OUyhKw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-7.0.25.tgz",
+      "integrity": "sha512-3t2zGWRaOW4NYv242T1Rvev/8oXSpXDMqdEVlcYA9ZdvZIu88r9SmBXZ79bI8K0iKARN1IrMLjWwQvn9HGW3qA==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -6182,13 +6222,13 @@
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.21.0",
         "@babel/runtime": "^7.21.0",
-        "@storybook/addon-actions": "7.0.24",
-        "@storybook/builder-webpack5": "7.0.24",
-        "@storybook/core-common": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/preset-react-webpack": "7.0.24",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/react": "7.0.24",
+        "@storybook/addon-actions": "7.0.25",
+        "@storybook/builder-webpack5": "7.0.25",
+        "@storybook/core-common": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/preset-react-webpack": "7.0.25",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/react": "7.0.25",
         "@types/node": "^16.0.0",
         "css-loader": "^6.7.3",
         "find-up": "^5.0.0",
@@ -6248,9 +6288,9 @@
       "dev": true
     },
     "node_modules/@storybook/node-logger": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.24.tgz",
-      "integrity": "sha512-gjcYnreYBBtZVF6p/cHMas4FEafPddjsLMrAfB+0lLGoRdUwWVto46BZTHQ9seY5gPW0JQydAdDGHko8/kEOXA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.0.25.tgz",
+      "integrity": "sha512-ZzglyuEuYgged6xHhupQ3a4N2icvQq+4GL5UXNlMWgSMwthO7yeJERJHavvjjFIukQIF8d5plTy27/LCueIX3g==",
       "dev": true,
       "dependencies": {
         "@types/npmlog": "^4.1.2",
@@ -6264,18 +6304,18 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-7.0.24.tgz",
-      "integrity": "sha512-9BI243TMv5f+CjzGVB3CFA82E2kWYhQTaRoeNKxxk7NvgiascFMATkgBjIwtGYVXL9umk8mytzulOq/oXPnscQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-7.0.25.tgz",
+      "integrity": "sha512-bfbn4buFTA/sG/plHJhy6g3FsPt/UVzxSWBDWeQBMJypYIbCn9Ql7qkHuaHmn358RGdu94nSpqwqBs1vReDxKw==",
       "dev": true,
       "dependencies": {
         "@babel/preset-flow": "^7.18.6",
         "@babel/preset-react": "^7.18.6",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.5",
-        "@storybook/core-webpack": "7.0.24",
-        "@storybook/docs-tools": "7.0.24",
-        "@storybook/node-logger": "7.0.24",
-        "@storybook/react": "7.0.24",
+        "@storybook/core-webpack": "7.0.25",
+        "@storybook/docs-tools": "7.0.25",
+        "@storybook/node-logger": "7.0.25",
+        "@storybook/react": "7.0.25",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.4",
@@ -6314,9 +6354,9 @@
       "dev": true
     },
     "node_modules/@storybook/preview": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.24.tgz",
-      "integrity": "sha512-rej4Wz8Qy4gVuyvg4cpQGkR4wJc3b+0Uv6EYylbmpdj2585cOhFtRBykagDVZteVU4xaLMT7YHIZRnoLmJKIgw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.0.25.tgz",
+      "integrity": "sha512-p6lYYq1YqfvALsE9Kbb/1GBDDuJ2diZNDrCZloIU77q7/dR8+HaERSVTzXCS1NLpatUVQ5SHfd3JjajUUO2HKg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6324,18 +6364,18 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.24.tgz",
-      "integrity": "sha512-psycU07tuB5nyJvfAJiDN/9e8cjOdJ+5lrCSYC3vPzH86LxADDIN0/8xFb1CaQWcXZsADEFJGpHKWbRhjym5ew==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.25.tgz",
+      "integrity": "sha512-/KiCKMOFGSc9LaQxuNDEeWqqn/GRROCWeg4wyhm4bsxhd/DsQfTmLaB/rW0+GZpMMZoOfSITkSYETNCPzNhO9g==",
       "dev": true,
       "dependencies": {
-        "@storybook/channel-postmessage": "7.0.24",
-        "@storybook/channels": "7.0.24",
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-events": "7.0.24",
+        "@storybook/channel-postmessage": "7.0.25",
+        "@storybook/channels": "7.0.25",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-events": "7.0.25",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/types": "7.0.24",
+        "@storybook/types": "7.0.25",
         "@types/qs": "^6.9.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
@@ -6351,18 +6391,18 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.0.24.tgz",
-      "integrity": "sha512-JAgSs8ANysBl3+cOAjFSVG3bA2V/wP6jyu7oK0jSATRQhHRjRS/tHFMA82j0j98G2sr3JXQUxNt55Qq3k2mUcg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.0.25.tgz",
+      "integrity": "sha512-yH4KfD1am19Ui7Kqw0hWe5mbFgrsXaCDqbe29dXbXUpHHfIpptHSyYoJ1dJH+GZP2VXkYMi+aqKlqvQpG9Dmrg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-client": "7.0.24",
-        "@storybook/docs-tools": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-client": "7.0.25",
+        "@storybook/docs-tools": "7.0.25",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "7.0.24",
-        "@storybook/react-dom-shim": "7.0.24",
-        "@storybook/types": "7.0.24",
+        "@storybook/preview-api": "7.0.25",
+        "@storybook/react-dom-shim": "7.0.25",
+        "@storybook/types": "7.0.25",
         "@types/escodegen": "^0.0.6",
         "@types/estree": "^0.0.51",
         "@types/node": "^16.0.0",
@@ -6415,9 +6455,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.0.24.tgz",
-      "integrity": "sha512-YOP1C3dWTLYP5mPb7hNuDRIhADzz+ppfb+S22JNJ3kqm+tsyE/YtAbRf80k6QIG1LzukMpGoEnjjOPOsWsyvFQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.0.25.tgz",
+      "integrity": "sha512-kSwGNqchGVOGP77zFdghN+td6aDgo4VRButnqao6hHnDAGtppMky8AET3jkEgeT8wU01R9TOk5QmEs5JaDHTfA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6435,12 +6475,12 @@
       "dev": true
     },
     "node_modules/@storybook/router": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.24.tgz",
-      "integrity": "sha512-SRCV+srCZUbko/V0phVN8jY8ilrxQWWAY/gegwNlIYaNqLJSyYqIj739VDmX+deXl6rOEpFLZreClVXWiDU9+w==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.25.tgz",
+      "integrity": "sha512-RcTe407o9m2KvDv+vKG3Qd2zdkswGSa6rIGKvvF/N1wEjB9pyu+HBW5PjAwlXWwPeWpfaz2du/KmXk+dxEFfug==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
         "memoizerific": "^1.11.3",
         "qs": "^6.10.0"
       },
@@ -6454,13 +6494,13 @@
       }
     },
     "node_modules/@storybook/store": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/store/-/store-7.0.24.tgz",
-      "integrity": "sha512-T6BOXpiIAiGpQcfe0Hyu3d+8Gd0sUaVTSDXJLadfr7tqC6qmMpOuyApFu1qRfgJqh4aykUb75ESCvYWoEjwm+A==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/store/-/store-7.0.25.tgz",
+      "integrity": "sha512-TRjA26Z0d2ZE9D1l8cDPhOl1vvyBeddBdQ4rjXUw4qMM2PrebkNyYNGF9S+bzhRZlE8mvz5jSEAUYQXCm/9Org==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/preview-api": "7.0.24"
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/preview-api": "7.0.25"
       },
       "funding": {
         "type": "opencollective",
@@ -6468,13 +6508,13 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.0.24.tgz",
-      "integrity": "sha512-mLGwm3yeWlM9Srrcecrpce4m8uyazIMkHIYcBC0cD2L/JzIRzeRS3Na8QlLKz4/+Hxawm7K/pE/DBrVjvBbm8A==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.0.25.tgz",
+      "integrity": "sha512-fL1saVz/HaQzFcgp1RccfefKTHr1A1yKRwXg1b68YUO+/7IbbAH/2GrefCLYkXYaHH0uqdVKy9rXuV2sU8rwyQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.0.24",
-        "@storybook/core-common": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
+        "@storybook/core-common": "7.0.25",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -7362,6 +7402,12 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/@storybook/test-runner/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/@storybook/test-runner/node_modules/resolve.exports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -7407,13 +7453,13 @@
       }
     },
     "node_modules/@storybook/theming": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.24.tgz",
-      "integrity": "sha512-CMeCCfqffJ/D5rBl1HpAM/e5Vw0h7ucT+CLzP0ALtLrguz9ZzOiIZYgMj17KpfvWqje7HT+DwEtNkSrnJ01FNQ==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.25.tgz",
+      "integrity": "sha512-OaLtP4jjN6NGvdZpfQq3FO2IE/uZDxcXJdEXCf8azzAyhwvFU5kMA8huCE1KvOGJfAR5lPfDMQDKMXTlkV7frg==",
       "dev": true,
       "dependencies": {
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-        "@storybook/client-logger": "7.0.24",
+        "@storybook/client-logger": "7.0.25",
         "@storybook/global": "^5.0.0",
         "memoizerific": "^1.11.3"
       },
@@ -7427,12 +7473,12 @@
       }
     },
     "node_modules/@storybook/types": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.24.tgz",
-      "integrity": "sha512-SZh/XBHP1TT5bmEk0W52nT0v6fUnYwmZVls3da5noutdgOAiwL7TANtl41XrNjG+UDr8x0OE3PVVJi+LhwUaNA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.25.tgz",
+      "integrity": "sha512-18Mn8IRbgsR+QXRa25wbNRJiKapKvODVx6rbBIH9Kim30gbTCgukYKJQlus27IODMMzMr86LiXKgnGpFv6NQ5w==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.0.24",
+        "@storybook/channels": "7.0.25",
         "@types/babel__core": "^7.0.0",
         "@types/express": "^4.7.0",
         "file-system-cache": "2.3.0"
@@ -8046,6 +8092,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
@@ -8304,17 +8356,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.1.tgz",
-      "integrity": "sha512-KSWsVvsJsLJv3c4e73y/Bzt7OpqMCADUO846bHcuWYSYM19bldbAeDv7dYyV0jwkbMfJ2XdlzwjhXtuD7OY6bw==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
+      "integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.60.1",
-        "@typescript-eslint/type-utils": "5.60.1",
-        "@typescript-eslint/utils": "5.60.1",
+        "@typescript-eslint/scope-manager": "5.61.0",
+        "@typescript-eslint/type-utils": "5.61.0",
+        "@typescript-eslint/utils": "5.61.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
@@ -8338,14 +8390,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.1.tgz",
-      "integrity": "sha512-pHWlc3alg2oSMGwsU/Is8hbm3XFbcrb6P5wIxcQW9NsYBfnrubl/GhVVD/Jm/t8HXhA2WncoIRfBtnCgRGV96Q==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
+      "integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.60.1",
-        "@typescript-eslint/types": "5.60.1",
-        "@typescript-eslint/typescript-estree": "5.60.1",
+        "@typescript-eslint/scope-manager": "5.61.0",
+        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/typescript-estree": "5.61.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -8365,13 +8417,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.1.tgz",
-      "integrity": "sha512-Dn/LnN7fEoRD+KspEOV0xDMynEmR3iSHdgNsarlXNLGGtcUok8L4N71dxUgt3YvlO8si7E+BJ5Fe3wb5yUw7DQ==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
+      "integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.60.1",
-        "@typescript-eslint/visitor-keys": "5.60.1"
+        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/visitor-keys": "5.61.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -8382,13 +8434,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.1.tgz",
-      "integrity": "sha512-vN6UztYqIu05nu7JqwQGzQKUJctzs3/Hg7E2Yx8rz9J+4LgtIDFWjjl1gm3pycH0P3mHAcEUBd23LVgfrsTR8A==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
+      "integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.60.1",
-        "@typescript-eslint/utils": "5.60.1",
+        "@typescript-eslint/typescript-estree": "5.61.0",
+        "@typescript-eslint/utils": "5.61.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -8409,9 +8461,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.1.tgz",
-      "integrity": "sha512-zDcDx5fccU8BA0IDZc71bAtYIcG9PowaOwaD8rjYbqwK7dpe/UMQl3inJ4UtUK42nOCT41jTSCwg76E62JpMcg==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
+      "integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -8422,13 +8474,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.1.tgz",
-      "integrity": "sha512-hkX70J9+2M2ZT6fhti5Q2FoU9zb+GeZK2SLP1WZlvUDqdMbEKhexZODD1WodNRyO8eS+4nScvT0dts8IdaBzfw==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
+      "integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.60.1",
-        "@typescript-eslint/visitor-keys": "5.60.1",
+        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/visitor-keys": "5.61.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -8449,17 +8501,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.1.tgz",
-      "integrity": "sha512-tiJ7FFdFQOWssFa3gqb94Ilexyw0JVxj6vBzaSpfN/8IhoKkDuSAenUKvsSHw2A/TMpJb26izIszTXaqygkvpQ==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
+      "integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.60.1",
-        "@typescript-eslint/types": "5.60.1",
-        "@typescript-eslint/typescript-estree": "5.60.1",
+        "@typescript-eslint/scope-manager": "5.61.0",
+        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/typescript-estree": "5.61.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -8475,12 +8527,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.1.tgz",
-      "integrity": "sha512-xEYIxKcultP6E/RMKqube11pGjXH1DCo60mQoWhVYyKfLkwbIVVjYxmOenNMxILx0TjCujPTjjnTIVzm09TXIw==",
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
+      "integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.60.1",
+        "@typescript-eslint/types": "5.61.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -8498,18 +8550,6 @@
       "dependencies": {
         "mdast-util-to-string": "^3.1.0",
         "unist-util-visit": "^4.0.0"
-      }
-    },
-    "node_modules/@vcarl/remark-headings/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@vercel/analytics": {
@@ -10170,9 +10210,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001509",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
-      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12051,9 +12091,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.447",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
-      "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==",
+      "version": "1.4.449",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
+      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -12476,12 +12516,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.7.tgz",
-      "integrity": "sha512-+IRAyD0+J1MZaTi9RQMPUfr6Q+GCZ1wOkK6XM52Vokh7VI4R6YFGOFzdkEFHl4ZyIX4FKa5vcwUP2WscSFNjNQ==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.8.tgz",
+      "integrity": "sha512-2hE0b6lHuhtHBX8VgEXi8v4G8PVrPUBMOSLCTq8qtcQ2qQOX7+uBOLK2kU4FD2qDZzyXNlhmuH+WLT5ptY4XLA==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.4.7",
+        "@next/eslint-plugin-next": "13.4.8",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -13155,14 +13195,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/estree-util-to-js/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/estree-util-visit": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.2.1.tgz",
@@ -13830,9 +13862,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.210.2",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.210.2.tgz",
-      "integrity": "sha512-kQiVau1WnXMCxJziuOF9wk4EoE/sPTU5H7dWOJN+7lsh+tmUh6LXz1dcLE44D+ouVIg8RRnfRZQymZqzKfh5fA==",
+      "version": "0.211.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.211.0.tgz",
+      "integrity": "sha512-Ftqkqisn4MA8u+1I7KGYz35y/RtLsRETsK4qrH6KkDUjxnC4mgq3CcXbckHpGyfTErqMyVhJnlJ56feEn9Cn7A==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -13984,21 +14016,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "optional": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "optional": true
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -14491,12 +14508,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -14820,11 +14831,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -15098,7 +15104,8 @@
     "node_modules/immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -16658,6 +16665,12 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-circus/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/jest-circus/node_modules/resolve.exports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -17069,6 +17082,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-config/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/jest-diff": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
@@ -17109,6 +17128,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/jest-docblock": {
       "version": "28.1.1",
@@ -17234,6 +17259,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
+    },
+    "node_modules/jest-each/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/jest-environment-jsdom": {
       "version": "29.5.0",
@@ -17594,6 +17625,12 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-leak-detector/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/jest-matcher-utils": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
@@ -17634,6 +17671,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/jest-message-util": {
       "version": "29.5.0",
@@ -17706,6 +17749,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/jest-mock": {
       "version": "27.5.1",
@@ -18367,6 +18416,12 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/jest-runner/node_modules/resolve.exports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -18629,6 +18684,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-snapshot/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/jest-util": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
@@ -18752,6 +18813,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-validate/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/jest-watch-typeahead": {
       "version": "2.2.2",
@@ -20026,6 +20093,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-gfm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
@@ -20124,18 +20201,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-gfm-table/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-gfm-table/node_modules/micromark": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
@@ -20212,18 +20277,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -20338,18 +20391,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-expression/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -20506,18 +20547,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-mdx-jsx/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-mdx-jsx/node_modules/micromark": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
@@ -20606,18 +20635,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-mdx/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-mdx/node_modules/micromark": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
@@ -20697,18 +20714,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -20812,23 +20817,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string": {
+    "node_modules/mdast-util-to-string": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
       "dependencies": {
         "@types/mdast": "^3.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -21944,11 +21939,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.7.tgz",
-      "integrity": "sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.8.tgz",
+      "integrity": "sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==",
       "dependencies": {
-        "@next/env": "13.4.7",
+        "@next/env": "13.4.8",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -21964,15 +21959,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.7",
-        "@next/swc-darwin-x64": "13.4.7",
-        "@next/swc-linux-arm64-gnu": "13.4.7",
-        "@next/swc-linux-arm64-musl": "13.4.7",
-        "@next/swc-linux-x64-gnu": "13.4.7",
-        "@next/swc-linux-x64-musl": "13.4.7",
-        "@next/swc-win32-arm64-msvc": "13.4.7",
-        "@next/swc-win32-ia32-msvc": "13.4.7",
-        "@next/swc-win32-x64-msvc": "13.4.7"
+        "@next/swc-darwin-arm64": "13.4.8",
+        "@next/swc-darwin-x64": "13.4.8",
+        "@next/swc-linux-arm64-gnu": "13.4.8",
+        "@next/swc-linux-arm64-musl": "13.4.8",
+        "@next/swc-linux-x64-gnu": "13.4.8",
+        "@next/swc-linux-x64-musl": "13.4.8",
+        "@next/swc-win32-arm64-msvc": "13.4.8",
+        "@next/swc-win32-ia32-msvc": "13.4.8",
+        "@next/swc-win32-x64-msvc": "13.4.8"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -22221,15 +22216,16 @@
       }
     },
     "node_modules/node-polyfill-webpack-plugin/node_modules/readable-stream": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.1.tgz",
-      "integrity": "sha512-llAHX9QC25bz5RPIoTeJxPaA/hgryaldValRhVZ2fK9bzbmFiscpz8fw6iBTvJfAk1w4FC1KXQme/nO7fbKyKg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -22334,9 +22330,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
-      "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.6.tgz",
+      "integrity": "sha512-vSZ4miHQ4FojLjmz2+ux4B0/XA16jfwt/LBzIUftDpRd8tujHFkXjMyLwjS08fIZCzesj2z7gJukOKJwqebJAQ==",
       "dev": true
     },
     "node_modules/nyc": {
@@ -23689,12 +23685,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/property-information": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
@@ -24046,6 +24036,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -24106,6 +24097,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -24179,10 +24171,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -25000,19 +24991,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-lint-no-inline-padding/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-lint-no-literal-urls": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/remark-lint-no-literal-urls/-/remark-lint-no-literal-urls-3.1.2.tgz",
@@ -25026,19 +25004,6 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-lint-no-literal-urls/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -25412,18 +25377,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse/node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26064,6 +26017,7 @@
       "version": "1.63.6",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
       "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -26135,6 +26089,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -26568,6 +26523,14 @@
       "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
       "dev": true
     },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -26756,12 +26719,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.0.24.tgz",
-      "integrity": "sha512-ilQDM4+KaNO8s5jU4EnS68JWb9KaLR0+xTNa/BEXQa18SnSt/qZYORXtqispwkyuL/9xwaMVwtS+st7JOucNWA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.0.25.tgz",
+      "integrity": "sha512-DYuzERkvmUCJFT+6RQyLMCcs6lTuezUygtCEXew+JDU+CSAUpXSSp+w/nJEHT53lQ86mjIk2YcMtDsq0RGzYhw==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "7.0.24"
+        "@storybook/cli": "7.0.25"
       },
       "bin": {
         "sb": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,9 @@
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.8.0",
         "husky": "^8.0.3",
-        "next": "^13.4.8",
+        "next": "13.4.7",
         "next-mdx-remote": "^4.4.1",
         "next-sitemap": "^4.1.8",
-        "next-superjson-plugin": "^0.5.8",
         "next-themes": "^0.2.1",
         "prismjs": "^1.29.0",
         "react-icons": "^4.10.1",
@@ -33,7 +32,6 @@
         "semver": "^7.5.3",
         "sharp": "^0.32.1",
         "strftime": "^0.10.2",
-        "superjson": "^1.12.4",
         "turbo": "^1.10.7",
         "typescript": "^5.1.6"
       },
@@ -4660,9 +4658,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.8.tgz",
-      "integrity": "sha512-twuSf1klb3k9wXI7IZhbZGtFCWvGD4wXTY2rmvzIgVhXhs7ISThrbNyutBx3jWIL8Y/Hk9+woytFz5QsgtcRKQ=="
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.7.tgz",
+      "integrity": "sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.8",
@@ -4694,9 +4692,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.8.tgz",
-      "integrity": "sha512-MSFplVM4dTWOuKAUv0XR9gY7AWtMSBu9os9f+kp+s5rWhM1I2CdR3obFttd6366nS/W/VZxbPM5oEIdlIa46zA==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz",
+      "integrity": "sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==",
       "cpu": [
         "arm64"
       ],
@@ -4709,9 +4707,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.8.tgz",
-      "integrity": "sha512-Reox+UXgonon9P0WNDE6w85DGtyBqGitl/ryznOvn6TvfxEaZIpTgeu3ZrJLU9dHSMhiK7YAM793mE/Zii2/Qw==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.7.tgz",
+      "integrity": "sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==",
       "cpu": [
         "x64"
       ],
@@ -4724,9 +4722,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.8.tgz",
-      "integrity": "sha512-kdyzYvAYtqQVgzIKNN7e1rLU8aZv86FDSRqPlOkKZlvqudvTO0iohuTPmnEEDlECeBM6qRPShNffotDcU/R2KA==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.7.tgz",
+      "integrity": "sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==",
       "cpu": [
         "arm64"
       ],
@@ -4739,9 +4737,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.8.tgz",
-      "integrity": "sha512-oWxx4yRkUGcR81XwbI+T0zhZ3bDF6V1aVLpG+C7hSG50ULpV8gC39UxVO22/bv93ZlcfMY4zl8xkz9Klct6dpQ==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.7.tgz",
+      "integrity": "sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==",
       "cpu": [
         "arm64"
       ],
@@ -4754,9 +4752,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.8.tgz",
-      "integrity": "sha512-anhtvuO6eE9YRhYnaEGTfbpH3L5gT/9qPFcNoi6xS432r/4DAtpJY8kNktqkTVevVIC/pVumqO8tV59PR3zbNg==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.7.tgz",
+      "integrity": "sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==",
       "cpu": [
         "x64"
       ],
@@ -4769,9 +4767,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.8.tgz",
-      "integrity": "sha512-aR+J4wWfNgH1DwCCBNjan7Iumx0lLtn+2/rEYuhIrYLY4vnxqSVGz9u3fXcgUwo6Q9LT8NFkaqK1vPprdq+BXg==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.7.tgz",
+      "integrity": "sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==",
       "cpu": [
         "x64"
       ],
@@ -4784,9 +4782,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.8.tgz",
-      "integrity": "sha512-OWBKIrJwQBTqrat0xhxEB/jcsjJR3+diD9nc/Y8F1mRdQzsn4bPsomgJyuqPVZs6Lz3K18qdIkvywmfSq75SsQ==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.7.tgz",
+      "integrity": "sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==",
       "cpu": [
         "arm64"
       ],
@@ -4799,9 +4797,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.8.tgz",
-      "integrity": "sha512-agiPWGjUndXGTOn4ChbKipQXRA6/UPkywAWIkx7BhgGv48TiJfHTK6MGfBoL9tS6B4mtW39++uy0wFPnfD0JWg==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.7.tgz",
+      "integrity": "sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==",
       "cpu": [
         "ia32"
       ],
@@ -4814,9 +4812,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.8.tgz",
-      "integrity": "sha512-UIRKoByVKbuR6SnFG4JM8EMFlJrfEGuUQ1ihxzEleWcNwRMMiVaCj1KyqfTOW8VTQhJ0u8P1Ngg6q1RwnIBTtw==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.7.tgz",
+      "integrity": "sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==",
       "cpu": [
         "x64"
       ],
@@ -10949,20 +10947,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "node_modules/copy-anything": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
-      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
-      "dependencies": {
-        "is-what": "^4.1.8"
-      },
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.31.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.0.tgz",
@@ -14831,6 +14815,11 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -15905,17 +15894,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-what": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
-      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-windows": {
@@ -21939,11 +21917,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.8.tgz",
-      "integrity": "sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==",
+      "version": "13.4.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.7.tgz",
+      "integrity": "sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==",
       "dependencies": {
-        "@next/env": "13.4.8",
+        "@next/env": "13.4.7",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -21959,15 +21937,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.8",
-        "@next/swc-darwin-x64": "13.4.8",
-        "@next/swc-linux-arm64-gnu": "13.4.8",
-        "@next/swc-linux-arm64-musl": "13.4.8",
-        "@next/swc-linux-x64-gnu": "13.4.8",
-        "@next/swc-linux-x64-musl": "13.4.8",
-        "@next/swc-win32-arm64-msvc": "13.4.8",
-        "@next/swc-win32-ia32-msvc": "13.4.8",
-        "@next/swc-win32-x64-msvc": "13.4.8"
+        "@next/swc-darwin-arm64": "13.4.7",
+        "@next/swc-darwin-x64": "13.4.7",
+        "@next/swc-linux-arm64-gnu": "13.4.7",
+        "@next/swc-linux-arm64-musl": "13.4.7",
+        "@next/swc-linux-x64-gnu": "13.4.7",
+        "@next/swc-linux-x64-musl": "13.4.7",
+        "@next/swc-win32-arm64-msvc": "13.4.7",
+        "@next/swc-win32-ia32-msvc": "13.4.7",
+        "@next/swc-win32-x64-msvc": "13.4.7"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -22031,18 +22009,6 @@
       },
       "peerDependencies": {
         "next": "*"
-      }
-    },
-    "node_modules/next-superjson-plugin": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/next-superjson-plugin/-/next-superjson-plugin-0.5.8.tgz",
-      "integrity": "sha512-a6znMUzHWRAaxmQNHkgANJORdI0gjSC0JvsxRRKba6vb4BJRs/i2KpwEg/s91JYDhHsnZS+tkeb3MDCJWXJY4w==",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "peerDependencies": {
-        "next": "^13",
-        "superjson": "^1"
       }
     },
     "node_modules/next-themes": {
@@ -23593,12 +23559,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
-    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -23684,6 +23644,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/property-information": {
       "version": "6.2.0",
@@ -24171,9 +24137,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -27293,17 +27260,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/superjson": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.4.tgz",
-      "integrity": "sha512-vkpPQAxdCg9SLfPv5GPC5fnGrui/WryktoN9O5+Zif/14QIMjw+RITf/5LbBh+9QpBFb3KNvJth+puz2H8o6GQ==",
-      "dependencies": {
-        "copy-anything": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@mdx-js/react": "^2.3.0",
     "@nodevu/core": "^0.1.0",
     "@types/node": "^18.16.19",
     "@vcarl/remark-headings": "^0.1.0",
@@ -51,24 +50,26 @@
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.8.0",
     "husky": "^8.0.3",
-    "next": "^13.4.7",
+    "next": "^13.4.8",
     "next-mdx-remote": "^4.4.1",
     "next-sitemap": "^4.1.8",
-    "next-superjson-plugin": "^0.5.8",
     "next-themes": "^0.2.1",
     "prismjs": "^1.29.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",
     "react-intl": "^6.4.4",
     "remark-gfm": "^3.0.1",
-    "sass": "^1.63.6",
     "semver": "^7.5.3",
     "sharp": "^0.32.1",
     "strftime": "^0.10.2",
-    "superjson": "^1.12.4",
     "turbo": "^1.10.7",
     "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "@mdx-js/react": "^2.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sass": "^1.63.6",
+    "vfile": "^5.3.7"
   },
   "devDependencies": {
     "@storybook/addon-controls": "^7.0.24",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.8.0",
     "husky": "^8.0.3",
-    "next": "^13.4.8",
+    "next": "13.4.7",
     "next-mdx-remote": "^4.4.1",
     "next-sitemap": "^4.1.8",
     "next-themes": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@mdx-js/react": "^2.3.0",
     "@nodevu/core": "^0.1.0",
     "@types/node": "^18.16.19",
+    "@vcarl/remark-headings": "^0.1.0",
     "@vercel/analytics": "^1.0.1",
     "classnames": "^2.3.2",
     "cross-env": "^7.0.3",

--- a/pages/[...path].tsx
+++ b/pages/[...path].tsx
@@ -2,10 +2,9 @@ import Theme from '../theme';
 import * as nextDynamic from '../next.dynamic.mjs';
 import * as nextConstants from '../next.constants.mjs';
 import type { GetStaticPaths, GetStaticProps } from 'next';
-import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
+import type { DynamicStaticProps } from '../types';
 
-type StaticParams = { path: string[] };
-type StaticProps = { content: MDXRemoteSerializeResult };
+type DynamicStaticPaths = { path: string[] };
 
 // This is a small utility that allows us to quickly separate locale from the remaning pathname
 const getLocaleAndPathname = ([locale, ...path]: string[] = []) => [
@@ -35,8 +34,8 @@ const mapPathnameToRoute = (pathname: string) => ({
 // This method receives the props from `getStaticProps` and renders/builds the Markdown
 // content on demand by loading the file on the server-side and serializing the Markdown/MDX content
 export const getStaticProps: GetStaticProps<
-  StaticProps,
-  StaticParams
+  DynamicStaticProps,
+  DynamicStaticPaths
 > = async ({ params = { path: [] } }) => {
   const [locale, pathname] = getLocaleAndPathname(params.path);
 
@@ -65,7 +64,7 @@ export const getStaticProps: GetStaticProps<
 
 // This method is used to retrieve all native statically supported pages (SCR) that
 // we want to provide during build-time + allow fallback for dynamic pages during (ISR)
-export const getStaticPaths: GetStaticPaths<StaticParams> = async () => {
+export const getStaticPaths: GetStaticPaths<DynamicStaticPaths> = async () => {
   const paths = [];
 
   // Retrieves all the dynamic generated paths

--- a/providers/mdxProvider.tsx
+++ b/providers/mdxProvider.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 import { MDXProvider as BaseMDXProvider } from '@mdx-js/react';
+import { MDXRemote } from 'next-mdx-remote';
 import HighlightJS from 'highlight.js/lib/core';
 import HighlightJavaScript from 'highlight.js/lib/languages/javascript';
 import AnchoredHeading from '../components/AnchoredHeading';
 import NodeApiVersionLinks from '../components/Docs/NodeApiVersionLinks';
-import type { FC, PropsWithChildren } from 'react';
+import type { FC } from 'react';
 import type { MDXComponents } from 'mdx/types';
 
 const mdxComponents: MDXComponents = {
@@ -22,7 +23,7 @@ const mdxComponents: MDXComponents = {
 // @TODO: Once we migrate to `nodejs.dev` components, get rid of Highlight.js
 HighlightJS.registerLanguage('javascript', HighlightJavaScript);
 
-export const MDXProvider: FC<PropsWithChildren> = ({ children }) => {
+export const MDXProvider: FC<{ content: string }> = ({ content }) => {
   // Re-highlights the pages on route change
   useEffect(() => HighlightJS.highlightAll(), []);
 
@@ -30,7 +31,7 @@ export const MDXProvider: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <BaseMDXProvider components={mdxComponents} disableParentContext>
-      {children}
+      <MDXRemote compiledSource={content} frontmatter={null} scope={null} />
     </BaseMDXProvider>
   );
 };

--- a/theme.tsx
+++ b/theme.tsx
@@ -1,20 +1,22 @@
 import { memo } from 'react';
-import { MDXRemote } from 'next-mdx-remote';
+
 import { LayoutProvider } from './providers/layoutProvider';
 import { MDXProvider } from './providers/mdxProvider';
 import HtmlHead from './components/HtmlHead';
 import type { FC, PropsWithChildren } from 'react';
-import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
+import type { DynamicStaticProps } from './types';
 
-type ThemeProps = PropsWithChildren<{
-  content?: MDXRemoteSerializeResult;
-}>;
+type ThemeProps = PropsWithChildren<DynamicStaticProps>;
 
-const Theme: FC<ThemeProps> = ({ content, children }) => (
+// This is the Dynamic Page Theme Component that supports Dynamic MDX Page Rendering
+// With the dynamic MDXProvider Component.
+// @TODO: When migrating to the new Layout approach, each Layout should manually invoke the MDXProvider
+// @TODO: And use the MDX Content, Frontmatter, Headings and Children as seemed fit.
+const Theme: FC<ThemeProps> = ({ content, frontmatter = {}, children }) => (
   <>
-    <HtmlHead frontMatter={content?.frontmatter || {}} />
-    <LayoutProvider frontMatter={content?.frontmatter || {}}>
-      <MDXProvider>{content && <MDXRemote {...content} />}</MDXProvider>
+    <HtmlHead frontMatter={frontmatter} />
+    <LayoutProvider frontMatter={frontmatter}>
+      {content && <MDXProvider content={content} />}
 
       {children}
     </LayoutProvider>

--- a/theme.tsx
+++ b/theme.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-
 import { LayoutProvider } from './providers/layoutProvider';
 import { MDXProvider } from './providers/mdxProvider';
 import HtmlHead from './components/HtmlHead';

--- a/types/dynamic.ts
+++ b/types/dynamic.ts
@@ -1,0 +1,8 @@
+import type { Heading } from '@vcarl/remark-headings';
+import type { LegacyFrontMatter } from './frontmatter';
+
+export interface DynamicStaticProps {
+  content?: string;
+  frontmatter?: LegacyFrontMatter;
+  headings?: Heading[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,3 +10,4 @@ export * from './navigation';
 export * from './prevNextLink';
 export * from './releases';
 export * from './middlewares';
+export * from './dynamic';


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR introduces a better separation of the `MDXRemote` props on the `next.dynamic.mjs` generation; It introduces support to the `VFile` metadata through the `unified` pipeline, which can be used for the Remark Plugins that mutate the `VFile` meta, such as `remark-frontmatter`, `remark-headings`.

And ultimately does a better separation of the `theme.tsx` with the `mdxProvider` content.

Lastly, it adds support to Headings for the TOC generation through `remark-headings`
