### PR TITLE
fix: Windows-rendering of content

### DIFF
--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -41,16 +41,17 @@ const getAllPaths = async () => {
     (locale = '') =>
     (files = []) =>
       sourcePages.map(filename => {
-        let path = filename.replace(nextConstants.MD_EXTENSION_REGEX, '');
+        // remove the index.md(x) suffix from a pathname
+        let pathname = filename.replace(nextConstants.MD_EXTENSION_REGEX, '');
         // remove trailing slash for correct Windows pathing of the index files
-        if (path.length > 1 && path.endsWith(sep)) {
-          path = path.substring(0, path.length - 1);
+        if (pathname.length > 1 && pathname.endsWith(sep)) {
+          pathname = pathname.substring(0, pathname.length - 1);
         }
         return {
-          pathname: normalize(path),
+          pathname: normalize(pathname),
           filename: filename,
           localised: files.includes(filename),
-          routeWithLocale: `${locale}/${path}`,
+          routeWithLocale: `${locale}/${pathname}`,
         };
       });
 

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -46,6 +46,7 @@ const getAllPaths = async () => {
         if (path.length > 1 && path.endsWith(sep)) {
           path = path.substring(0, path.length - 1);
         }
+
         return {
           pathname: normalize(path),
           filename: filename,

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import { join } from 'node:path';
+import { join, normalize, sep } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { VFile } from 'vfile';
 import remarkGfm from 'remark-gfm';
@@ -41,10 +41,13 @@ const getAllPaths = async () => {
     (locale = '') =>
     (files = []) =>
       sourcePages.map(filename => {
-        const path = filename.replace(nextConstants.MD_EXTENSION_REGEX, '');
-
+        let path = filename.replace(nextConstants.MD_EXTENSION_REGEX, '');
+        // remove trailing slash for correct Windows pathing of the index files
+        if (path.length > 1 && path.endsWith(sep)) {
+          path = path.substring(0, path.length - 1);
+        }
         return {
-          pathname: path,
+          pathname: normalize(path),
           filename: filename,
           localised: files.includes(filename),
           routeWithLocale: `${locale}/${path}`,
@@ -99,7 +102,7 @@ export const getMarkdownFile = (
   // which prevents any malicious attempts to access non-allowed pages
   // or other files that do not belong to the `sourcePages`
   if (routes && routes.length) {
-    const route = routes.find(route => route.pathname === pathname);
+    const route = routes.find(route => route.pathname === normalize(pathname));
 
     if (route && route.filename) {
       // this determines if we should be using the fallback rendering to the default locale


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I'd hadn't clicked around the site locally on my Windows machine in a bit, instead only rendering the homepage. The homepage was rendering fine, but every other page was 404ing content due to Windows pathing. I fixed this in two cases, indexes and deeper paths.

![image](https://github.com/nodejs/nodejs.org/assets/298435/e5a7f0b8-4b8d-472c-bbb9-4391d14faa52)

## Validation

All of these pages should continue to render for you locally.

- http://localhost:3000/en
- http://localhost:3000/en/about/
- http://localhost:3000/en/about/governance

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [x] I've covered new added functionality with unit tests if necessary.
