### PR TITLE
fix: use proper datetime to fix server-side/client-siode mismatch

### DIFF
--- a/layouts/BlogIndexLayout.tsx
+++ b/layouts/BlogIndexLayout.tsx
@@ -4,7 +4,6 @@ import BaseLayout from './BaseLayout';
 import Pagination from '../components/Pagination';
 import LocalizedLink from '../components/LocalizedLink';
 import { useBlogData } from '../hooks/useBlogData';
-import { getTimeComponent } from '../util/getTimeComponent';
 import type { FC, PropsWithChildren } from 'react';
 import type { BlogPost } from '../types';
 
@@ -40,7 +39,14 @@ const BlogIndexLayout: FC<PropsWithChildren> = ({ children }) => {
         <ul className="blog-index">
           {posts.map((post: BlogPost) => (
             <li key={post.slug}>
-              {getTimeComponent(post.date.toString(), '%d %b')}
+              <time dateTime={post.date}>
+                {new Date(post.date).toLocaleString('en-GB', {
+                  timeZone: 'UTC',
+                  month: 'short',
+                  day: '2-digit',
+                })}
+              </time>
+
               <LocalizedLink href={post.slug}>{post.title}</LocalizedLink>
             </li>
           ))}

--- a/layouts/BlogPostLayout.tsx
+++ b/layouts/BlogPostLayout.tsx
@@ -1,7 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 import BaseLayout from './BaseLayout';
 import { useLayoutContext } from '../hooks/useLayoutContext';
-import { getTimeComponent } from '../util/getTimeComponent';
 import type { FC, PropsWithChildren } from 'react';
 import type { LegacyBlogFrontMatter } from '../types';
 
@@ -21,7 +20,15 @@ const BlogPostLayout: FC<PropsWithChildren> = ({ children }) => {
                 id="layouts.blogPost.author.byLine"
                 values={{ author: author || null }}
               />
-              {getTimeComponent(date)}
+
+              <time dateTime={date}>
+                {new Date(date).toLocaleString('en-GB', {
+                  timeZone: 'UTC',
+                  month: 'short',
+                  day: '2-digit',
+                  year: 'numeric',
+                })}
+              </time>
             </span>
           </div>
 

--- a/layouts/CategoryIndexLayout.tsx
+++ b/layouts/CategoryIndexLayout.tsx
@@ -3,7 +3,6 @@ import BaseLayout from './BaseLayout';
 import LocalizedLink from '../components/LocalizedLink';
 import { useLayoutContext } from '../hooks/useLayoutContext';
 import { useBlogData } from '../hooks/useBlogData';
-import { getTimeComponent } from '../util/getTimeComponent';
 import type { FC, PropsWithChildren } from 'react';
 import type { BlogPost } from '../types';
 
@@ -24,7 +23,14 @@ const CategoryIndexLayout: FC<PropsWithChildren> = ({ children }) => {
         <ul className="blog-index">
           {posts.map((post: BlogPost) => (
             <li key={post.slug}>
-              {getTimeComponent(post.date.toString(), '%d %b %y')}
+              <time dateTime={post.date}>
+                {new Date(post.date).toLocaleString('en-GB', {
+                  timeZone: 'UTC',
+                  month: 'short',
+                  day: '2-digit',
+                })}
+              </time>
+
               <LocalizedLink href={post.slug}>{post.title}</LocalizedLink>
             </li>
           ))}

--- a/next-data/generateBlogPostsData.mjs
+++ b/next-data/generateBlogPostsData.mjs
@@ -35,7 +35,7 @@ const getFrontMatter = (filename, source) => {
   } = graymatter(source).data;
 
   // we add the year to the pagination set
-  blogMetadata.pagination.add(new Date(date).getFullYear());
+  blogMetadata.pagination.add(new Date(date).getUTCFullYear());
 
   // we add the category to the categories set
   blogMetadata.categories.add(category);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "remark-gfm": "^3.0.1",
         "semver": "^7.5.3",
         "sharp": "^0.32.1",
-        "strftime": "^0.10.2",
         "turbo": "^1.10.7",
         "typescript": "^5.1.6"
       },
@@ -26770,14 +26769,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/strftime": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.2.tgz",
-      "integrity": "sha512-Y6IZaTVM80chcMe7j65Gl/0nmlNdtt+KWPle5YeCAjmsBfw+id2qdaJ5MDrxUq+OmHKab+jHe7mUjU/aNMSZZg==",
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "remark-gfm": "^3.0.1",
     "semver": "^7.5.3",
     "sharp": "^0.32.1",
-    "strftime": "^0.10.2",
     "turbo": "^1.10.7",
     "typescript": "^5.1.6"
   },

--- a/theme.tsx
+++ b/theme.tsx
@@ -28,5 +28,5 @@ export default memo(
   // that comes from `getStaticProps`. This means that the `props` should never change.
   // At least the `props.content` should never. We should not calculate based on `children`
   // As this component should never have a dynamic children
-  (prev, next) => JSON.stringify(prev.content) === JSON.stringify(next.content)
+  (prev, next) => JSON.stringify(prev) === JSON.stringify(next)
 );

--- a/util/formatTime.ts
+++ b/util/formatTime.ts
@@ -1,4 +1,0 @@
-import strftime from 'strftime';
-
-export const formatTime = (date: string, format: string) =>
-  strftime(format || '%F', new Date(date));

--- a/util/getTimeComponent.tsx
+++ b/util/getTimeComponent.tsx
@@ -1,7 +1,0 @@
-import { formatTime } from './formatTime';
-
-export const getTimeComponent = (date: string, humanFormat = '%F') => (
-  <time dateTime={formatTime(date, '%FT%T%z')}>
-    {formatTime(date, humanFormat)}
-  </time>
-);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes two issues on the Node.js Website related to rendering.

- The first issue is caused due to server-side/client-side Date rendering mismatch since the formatting function used is timezone-based. We updated the rendering of the `time` HTML elements by using JavaScript's built-in `toLocaleString` function. We've forced a `UTC` timezone and use `en-GB` locale information.
- The second issue is caused when the MDX-generated contents are identical, and the comparison of the `theme.tsx` memoization asserts both props as being the same as the comparison only used the MDX content as a comparison, excluding other props such as frontmatter. This should fix Next.js, not "moving" to another page. (The issue is that a re-rendering would not occur).
- This PR also removes the `strftime` package and utilities that are not used anymore.

Fixes #5478 