### PR TITLE
chore: added dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
           - "remark-gfm"
           - "@mdx-js/*"
       react:
-        pattersn:
+        patterns:
           - "react"
           - "react-dom"
           - "@types/react"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,40 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: meta
+    groups:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+          - "@types/testing-library*"
+      next-js:
+        patterns:
+          - "next"
+          - "turbo"
+          - "next-mdx-remote"
+          - "next-sitemap"
+          - "next-themes"
+          - "@vercel/*"
+      remark-mdx:
+        patterns:
+          - "@vcarl/remark-headings"
+          - "remark-gfm"
+          - "@mdx-js/*"
+      react:
+        pattersn:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,29 +14,29 @@ updates:
     groups:
       storybook:
         patterns:
-          - "storybook"
-          - "@storybook/*"
+          - 'storybook'
+          - '@storybook/*'
       testing-library:
         patterns:
-          - "@testing-library/*"
-          - "@types/testing-library*"
+          - '@testing-library/*'
+          - '@types/testing-library*'
       next-js:
         patterns:
-          - "next"
-          - "turbo"
-          - "next-mdx-remote"
-          - "next-sitemap"
-          - "next-themes"
-          - "@vercel/*"
+          - 'next'
+          - 'turbo'
+          - 'next-mdx-remote'
+          - 'next-sitemap'
+          - 'next-themes'
+          - '@vercel/*'
       remark-mdx:
         patterns:
-          - "@vcarl/remark-headings"
-          - "remark-gfm"
-          - "@mdx-js/*"
+          - '@vcarl/remark-headings'
+          - 'remark-gfm'
+          - '@mdx-js/*'
       react:
         patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR enables `dependabot` with the grouping of dependencies. (https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)