### PR TITLE
chore: use defined urls for distribution and api docs

### DIFF
--- a/components/Api/JsonLink/index.tsx
+++ b/components/Api/JsonLink/index.tsx
@@ -1,7 +1,9 @@
 import { FormattedMessage } from 'react-intl';
 import { FaRobot } from 'react-icons/fa';
-import styles from './index.module.scss';
+import { DOCS_URL } from '../../../next.constants.mjs';
 import type { FC } from 'react';
+
+import styles from './index.module.scss';
 
 type JsonLinkProps = {
   fileName: string;
@@ -10,9 +12,7 @@ type JsonLinkProps = {
 
 const JsonLink: FC<JsonLinkProps> = ({ fileName, version }) => (
   <div className={styles.json}>
-    <a
-      href={`https://nodejs.org/docs/latest-${version}.x/api/${fileName}.json`}
-    >
+    <a href={`${DOCS_URL}latest-${version}.x/api/${fileName}.json`}>
       <FormattedMessage id="components.api.jsonLink.title" tagName="span" />
       <FaRobot className={styles.FaRobotIcon} />
     </a>

--- a/components/Docs/NodeApiVersionLinks.tsx
+++ b/components/Docs/NodeApiVersionLinks.tsx
@@ -1,62 +1,64 @@
+import { DOCS_URL } from '../../next.constants.mjs';
+
 // Note.: This is a temporary Component used only until the transition to `nodejs/nodejs.dev` content is done
 const NodeApiVersionLinks = () => (
   <ul>
     <li>
-      <a href="https://nodejs.org/docs/latest-v20.x/api/">Node.js 20.x</a>
+      <a href={`${DOCS_URL}latest-v20.x/api/`}>Node.js 20.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v19.x/api/">Node.js 19.x</a>
+      <a href={`${DOCS_URL}latest-v19.x/api/`}>Node.js 19.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v18.x/api/">Node.js 18.x</a>
+      <a href={`${DOCS_URL}latest-v18.x/api/`}>Node.js 18.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v17.x/api/">Node.js 17.x</a>
+      <a href={`${DOCS_URL}latest-v17.x/api/`}>Node.js 17.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v16.x/api/">Node.js 16.x</a>
+      <a href={`${DOCS_URL}latest-v16.x/api/`}>Node.js 16.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v15.x/api/">Node.js 15.x</a>
+      <a href={`${DOCS_URL}latest-v15.x/api/`}>Node.js 15.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v14.x/api/">Node.js 14.x</a>
+      <a href={`${DOCS_URL}latest-v14.x/api/`}>Node.js 14.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v13.x/api/">Node.js 13.x</a>
+      <a href={`${DOCS_URL}latest-v13.x/api/`}>Node.js 13.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v12.x/api/">Node.js 12.x</a>
+      <a href={`${DOCS_URL}latest-v12.x/api/`}>Node.js 12.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v11.x/api/">Node.js 11.x</a>
+      <a href={`${DOCS_URL}latest-v11.x/api/`}>Node.js 11.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v10.x/api/">Node.js 10.x</a>
+      <a href={`${DOCS_URL}latest-v10.x/api/`}>Node.js 10.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v9.x/api/">Node.js 9.x</a>
+      <a href={`${DOCS_URL}latest-v9.x/api/`}>Node.js 9.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v8.x/api/">Node.js 8.x</a>
+      <a href={`${DOCS_URL}latest-v8.x/api/`}>Node.js 8.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v7.x/api/">Node.js 7.x</a>
+      <a href={`${DOCS_URL}latest-v7.x/api/`}>Node.js 7.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v6.x/api/">Node.js 6.x</a>
+      <a href={`${DOCS_URL}latest-v6.x/api/`}>Node.js 6.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v5.x/api/">Node.js 5.x</a>
+      <a href={`${DOCS_URL}latest-v5.x/api/`}>Node.js 5.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v4.x/api/">Node.js 4.x</a>
+      <a href={`${DOCS_URL}latest-v4.x/api/`}>Node.js 4.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v0.12.x/api/">Node.js 0.12.x</a>
+      <a href={`${DOCS_URL}latest-v0.12.x/api/`}>Node.js 0.12.x</a>
     </li>
     <li>
-      <a href="https://nodejs.org/docs/latest-v0.10.x/api/">Node.js 0.10.x</a>
+      <a href={`${DOCS_URL}latest-v0.10.x/api/`}>Node.js 0.10.x</a>
     </li>
   </ul>
 );

--- a/components/Downloads/PrimaryDownloadMatrix.tsx
+++ b/components/Downloads/PrimaryDownloadMatrix.tsx
@@ -3,6 +3,7 @@ import semVer from 'semver';
 import LocalizedLink from '../LocalizedLink';
 import { useDetectOS } from '../../hooks/useDetectOS';
 import { useLayoutContext } from '../../hooks/useLayoutContext';
+import { DIST_URL } from '../../next.constants.mjs';
 import type { LegacyDownloadsFrontMatter, NodeRelease } from '../../types';
 import type { FC } from 'react';
 
@@ -58,7 +59,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
         <ul className="no-padding download-platform">
           <li>
             <a
-              href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-x${bitness}.msi`}
+              href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-x${bitness}.msi`}
               data-version={versionWithPrefix}
             >
               <svg
@@ -78,7 +79,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
           </li>
           <li>
             <a
-              href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}.pkg`}
+              href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}.pkg`}
             >
               <svg
                 className="download-logo"
@@ -97,7 +98,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
           </li>
           <li>
             <a
-              href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}.tar.gz`}
+              href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}.tar.gz`}
             >
               <svg
                 className="download-logo"
@@ -123,14 +124,14 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.WindowsInstaller} (.msi)</th>
             <td colSpan={hasWindowsArm64 ? 1 : 2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-x86.msi`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-x86.msi`}
               >
                 32-bit
               </a>
             </td>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-x64.msi`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-x64.msi`}
               >
                 64-bit
               </a>
@@ -138,7 +139,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             {hasWindowsArm64 && (
               <td colSpan={1}>
                 <a
-                  href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-arm64.msi`}
+                  href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-arm64.msi`}
                 >
                   ARM64
                 </a>
@@ -150,14 +151,14 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.WindowsBinary} (.zip)</th>
             <td colSpan={hasWindowsArm64 ? 1 : 2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-win-x86.zip`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-win-x86.zip`}
               >
                 32-bit
               </a>
             </td>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-win-x64.zip`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-win-x64.zip`}
               >
                 64-bit
               </a>
@@ -165,7 +166,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             {hasWindowsArm64 && (
               <td colSpan={1}>
                 <a
-                  href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-win-arm64.zip`}
+                  href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-win-arm64.zip`}
                 >
                   ARM64
                 </a>
@@ -177,7 +178,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.MacOSInstaller} (.pkg)</th>
             <td colSpan={4}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}.pkg`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}.pkg`}
               >
                 64-bit / ARM64
               </a>
@@ -187,14 +188,14 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.MacOSBinary} (.tar.gz)</th>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-darwin-x64.tar.gz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-darwin-x64.tar.gz`}
               >
                 64-bit
               </a>
             </td>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-darwin-arm64.tar.gz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-darwin-arm64.tar.gz`}
               >
                 ARM64
               </a>
@@ -205,7 +206,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.LinuxBinaries} (x64)</th>
             <td colSpan={4}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-linux-x64.tar.xz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-linux-x64.tar.xz`}
               >
                 64-bit
               </a>
@@ -215,14 +216,14 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.LinuxBinaries} (ARM)</th>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-linux-armv7l.tar.xz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-linux-armv7l.tar.xz`}
               >
                 ARMv7
               </a>
             </td>
             <td colSpan={2}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-linux-arm64.tar.xz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-linux-arm64.tar.xz`}
               >
                 ARMv8
               </a>
@@ -233,7 +234,7 @@ const PrimaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{downloads.SourceCode}</th>
             <td colSpan={4}>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}.tar.gz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}.tar.gz`}
               >
                 node-{versionWithPrefix}.tar.gz
               </a>

--- a/components/Downloads/SecondaryDownloadMatrix.tsx
+++ b/components/Downloads/SecondaryDownloadMatrix.tsx
@@ -1,6 +1,7 @@
 import DownloadList from './DownloadList';
 import { useLayoutContext } from '../../hooks/useLayoutContext';
 import { WithNodeRelease } from '../../providers/withNodeRelease';
+import { DIST_URL } from '../../next.constants.mjs';
 import type { LegacyDownloadsFrontMatter, NodeRelease } from '../../types';
 import type { FC } from 'react';
 
@@ -32,7 +33,7 @@ const SecondaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{additional.LinuxPowerSystems}</th>
             <td>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-linux-ppc64le.tar.xz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-linux-ppc64le.tar.xz`}
               >
                 64-bit
               </a>
@@ -43,7 +44,7 @@ const SecondaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{additional.LinuxSystemZ}</th>
             <td>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-linux-s390x.tar.xz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-linux-s390x.tar.xz`}
               >
                 64-bit
               </a>
@@ -53,7 +54,7 @@ const SecondaryDownloadMatrix: FC<NodeRelease> = ({
             <th>{additional.AIXPowerSystems}</th>
             <td>
               <a
-                href={`https://nodejs.org/dist/${versionWithPrefix}/node-${versionWithPrefix}-aix-ppc64.tar.gz`}
+                href={`${DIST_URL}${versionWithPrefix}/node-${versionWithPrefix}-aix-ppc64.tar.gz`}
               >
                 64-bit
               </a>

--- a/components/Home/HomeDownloadButton.tsx
+++ b/components/Home/HomeDownloadButton.tsx
@@ -3,6 +3,7 @@ import { useDetectOS } from '../../hooks/useDetectOS';
 import { useLayoutContext } from '../../hooks/useLayoutContext';
 import { downloadUrlByOS } from '../../util/downloadUrlByOS';
 import { getNodejsChangelog } from '../../util/getNodeJsChangelog';
+import { DIST_URL } from '../../next.constants.mjs';
 import type { FC } from 'react';
 import type { NodeRelease } from '../../types';
 
@@ -19,7 +20,7 @@ const HomeDownloadButton: FC<NodeRelease> = ({
   const { os, bitness } = useDetectOS();
 
   const nodeDownloadLink = downloadUrlByOS(versionWithPrefix, os, bitness);
-  const nodeApiLink = `https://nodejs.org/dist/latest-v${major}.x/docs/api/`;
+  const nodeApiLink = `${DIST_URL}latest-v${major}.x/docs/api/`;
   const nodeAllDownloadsLink = `/download${isLts ? '/' : '/current'}`;
 
   const nodeDownloadTitle = `${labels?.download} ${version} ${labels?.[

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -27,14 +27,30 @@ export const ENABLE_STATIC_EXPORT =
 /**
  * This is used for any place that requires the full canonical URL path for the Node.js Website (and its deployment), such as for example, the Node.js RSS Feed.
  *
- * This variable can either come from the Vercel Deployment as `NEXT_PUBLIC_VERCEL_URL` or from the `NEXT_BASE_URL` environment variable that is manually defined
+ * This variable can either come from the Vercel Deployment as `NEXT_PUBLIC_VERCEL_URL` or from the `NEXT_PUBLIC_BASE_URL` Environment Variable that is manually defined
  * by us if necessary. Otherwise it will fallback to the default Node.js Website URL.
  *
  * @see https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#framework-environment-variables
  */
 export const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-  : process.env.NEXT_BASE_URL || 'https://nodejs.org';
+  : process.env.NEXT_PUBLIC_BASE_URL || 'https://nodejs.org';
+
+/**
+ * This is used for any place that requires the Node.js distribution URL (which by default is nodejs.org/dist)
+ *
+ * Note that this is a manual Environment Variable defined by us if necessary.
+ */
+export const DIST_URL =
+  process.env.NEXT_PUBLIC_DIST_URL || 'https://nodejs.org/dist/';
+
+/**
+ * This is used for any place that requires the Node.js API Docs URL (which by default is nodejs.org/docs)
+ *
+ * Note that this is a manual Environment Variable defined by us if necessary.
+ */
+export const DOCS_URL =
+  process.env.NEXT_PUBLIC_DOCS_URL || 'https://nodejs.org/docs/';
 
 /**
  * Supports a manual override of the base path of the Website
@@ -44,7 +60,7 @@ export const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL
  *
  * Note that this is a manual Environment Variable defined by us if necessary.
  */
-export const BASE_PATH = process.env.NEXT_BASE_PATH || '';
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
 /**
  * This ReGeX is used to remove the `index.md(x)` suffix of a name and to remove

--- a/util/downloadUrlByOS.ts
+++ b/util/downloadUrlByOS.ts
@@ -1,3 +1,4 @@
+import { DIST_URL } from '../next.constants.mjs';
 import type { UserOS } from '../types/userOS';
 
 export const downloadUrlByOS = (
@@ -5,7 +6,7 @@ export const downloadUrlByOS = (
   os: UserOS,
   bitness: number
 ): string => {
-  const baseURL = `https://nodejs.org/dist/${versionWithPrefix}`;
+  const baseURL = `${DIST_URL}${versionWithPrefix}`;
 
   switch (os) {
     case 'MAC':

--- a/util/getNodeApiLink.ts
+++ b/util/getNodeApiLink.ts
@@ -1,15 +1,16 @@
 import semVer from 'semver';
+import { DOCS_URL, DIST_URL } from '../next.constants.mjs';
 
 export const getNodeApiLink = (version: string) => {
   if (semVer.satisfies(version, '>=0.3.1 <0.5.1')) {
-    return `https://nodejs.org/docs/${version}/api/`;
+    return `${DOCS_URL}${version}/api/`;
   }
 
   if (semVer.satisfies(version, '>=0.1.14 <0.3.1')) {
-    return `https://nodejs.org/docs/${version}/api.html`;
+    return `${DOCS_URL}${version}/api.html`;
   }
 
   return semVer.satisfies(version, '>=1.0.0 <4.0.0')
     ? `https://iojs.org/dist/${version}/docs/api/`
-    : `https://nodejs.org/dist/${version}/docs/api/`;
+    : `${DIST_URL}${version}/docs/api/`;
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR introduces Environment-defined constants that can be used to define custom URLs that should be used for the Node.js Distribution CDN (nodejs.org/dist) and Node.js API Docs URL (nodejs.org/docs).

Note that these changes only affect JavaScript and TypeScript files, not any Markdown pages. Which is fine as in the future, these pages will get replaced. 

Also, these environment variables should at best be used for testing.

## Related Issues

Relates to https://github.com/nodejs/build/issues/3366