### PR TITLE
fix: language selector vertical align

### DIFF
--- a/components/Common/Dropdown/index.tsx
+++ b/components/Common/Dropdown/index.tsx
@@ -1,6 +1,8 @@
-import styles from './index.module.scss';
+import { forwardRef } from 'react';
 import type { DropdownItem } from '../../../types';
-import type { CSSProperties, FC, KeyboardEvent } from 'react';
+import type { CSSProperties, KeyboardEvent } from 'react';
+
+import styles from './index.module.scss';
 
 type DropdownProps = {
   items: Array<DropdownItem>;
@@ -8,44 +10,44 @@ type DropdownProps = {
   styles: CSSProperties;
 };
 
-const Dropdown: FC<DropdownProps> = ({
-  items,
-  shouldShow,
-  styles: extraStyles,
-}) => {
-  const mappedElements = items.map(item => {
-    const extraStyles = { fontWeight: item.active ? 'bold' : 'normal' };
+const Dropdown = forwardRef<HTMLUListElement, DropdownProps>(
+  ({ items, shouldShow, styles: extraStyles }, ref) => {
+    const mappedElements = items.map(item => {
+      const extraStyles = { fontWeight: item.active ? 'bold' : 'normal' };
 
-    const handleKeyPress = (e: KeyboardEvent<HTMLButtonElement>) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        item.onClick();
-      }
+      const handleKeyPress = (e: KeyboardEvent<HTMLButtonElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          item.onClick();
+        }
+      };
+
+      return (
+        <li key={`dropdown-item-${item.label}`}>
+          <button
+            style={extraStyles}
+            onClick={item.onClick}
+            onKeyDown={handleKeyPress}
+            type="button"
+          >
+            {item.title}
+          </button>
+        </li>
+      );
+    });
+
+    const dropdownStyles = {
+      display: shouldShow ? 'block' : 'none',
+      ...extraStyles,
     };
 
     return (
-      <li key={`dropdown-item-${item.label}`}>
-        <button
-          style={extraStyles}
-          onClick={item.onClick}
-          onKeyDown={handleKeyPress}
-          type="button"
-        >
-          {item.title}
-        </button>
-      </li>
+      <ul ref={ref} className={styles.dropdownList} style={dropdownStyles}>
+        {mappedElements}
+      </ul>
     );
-  });
+  }
+);
 
-  const dropdownStyles = {
-    display: shouldShow ? 'block' : 'none',
-    ...extraStyles,
-  };
-
-  return (
-    <ul className={styles.dropdownList} style={dropdownStyles}>
-      {mappedElements}
-    </ul>
-  );
-};
+Dropdown.displayName = 'DropdownWithRef';
 
 export default Dropdown;

--- a/components/Common/LanguageSelector/__snapshots__/index.stories.tsx.snap
+++ b/components/Common/LanguageSelector/__snapshots__/index.stories.tsx.snap
@@ -2,162 +2,160 @@
 
 exports[`Common/LanguageSelector Default smoke-test 1`] = `
 <div style="margin-left: 200px;">
-  <div>
-    <button type="button"
-            aria-expanded="false"
-            aria-label="Switch Language"
+  <button type="button"
+          aria-expanded="false"
+          aria-label="Switch Language"
+  >
+    <svg stroke="currentColor"
+         fill="currentColor"
+         stroke-width="0"
+         viewbox="0 0 24 24"
+         height="1em"
+         width="1em"
+         xmlns="http://www.w3.org/2000/svg"
     >
-      <svg stroke="currentColor"
-           fill="currentColor"
-           stroke-width="0"
-           viewbox="0 0 24 24"
-           height="1em"
-           width="1em"
-           xmlns="http://www.w3.org/2000/svg"
+      <path fill="none"
+            d="M0 0h24v24H0V0z"
       >
-        <path fill="none"
-              d="M0 0h24v24H0V0z"
-        >
-        </path>
-        <path d="M12.87 15.07l-2.54-2.51.03-.03A17.52 17.52 0 0014.07 6H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z">
-        </path>
-      </svg>
-    </button>
-    <ul style="display: none; position: absolute; top: 60%; right: 0px; margin: 0px;">
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          العربية
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Catalan
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Deutsch
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: bold;"
-        >
-          English
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Español
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          زبان فارسی
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Français
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Bahasa Indonesia
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Italiano
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          日本語
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          ქართული
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          한국어
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Português do Brasil
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          limba română
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Русский
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Türkçe
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          Українська
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          简体中文
-        </button>
-      </li>
-      <li>
-        <button type="button"
-                style="font-weight: normal;"
-        >
-          繁體中文
-        </button>
-      </li>
-    </ul>
-  </div>
+      </path>
+      <path d="M12.87 15.07l-2.54-2.51.03-.03A17.52 17.52 0 0014.07 6H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z">
+      </path>
+    </svg>
+  </button>
+  <ul style="display: none; position: absolute; top: 60%; right: 0px; margin: 0px;">
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        العربية
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Catalan
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Deutsch
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: bold;"
+      >
+        English
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Español
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        زبان فارسی
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Français
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Bahasa Indonesia
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Italiano
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        日本語
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        ქართული
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        한국어
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Português do Brasil
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        limba română
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Русский
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Türkçe
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        Українська
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        简体中文
+      </button>
+    </li>
+    <li>
+      <button type="button"
+              style="font-weight: normal;"
+      >
+        繁體中文
+      </button>
+    </li>
+  </ul>
 </div>
 `;

--- a/components/Common/LanguageSelector/index.module.scss
+++ b/components/Common/LanguageSelector/index.module.scss
@@ -10,8 +10,3 @@
     font-size: 2rem;
   }
 }
-
-.container {
-  display: inline;
-  position: relative;
-}

--- a/components/Common/LanguageSelector/index.tsx
+++ b/components/Common/LanguageSelector/index.tsx
@@ -17,7 +17,7 @@ const LanguageSelector = () => {
   const [showDropdown, setShowDropdown] = useState(false);
 
   const dropdownHandler = useCallback(() => setShowDropdown(false), []);
-  const ref = useClickOutside<HTMLDivElement>(dropdownHandler);
+  const ref = useClickOutside<HTMLUListElement>(dropdownHandler);
 
   const { availableLocales, currentLocale } = useLocale();
 
@@ -41,7 +41,7 @@ const LanguageSelector = () => {
   });
 
   return (
-    <div className={styles.container} ref={ref}>
+    <>
       <button
         type="button"
         className={styles.languageSwitch}
@@ -56,8 +56,9 @@ const LanguageSelector = () => {
         items={dropdownItems}
         shouldShow={showDropdown}
         styles={dropdownStyle}
+        ref={ref}
       />
-    </div>
+    </>
   );
 };
 

--- a/components/Sections/NewHeader/__snapshots__/index.stories.tsx.snap
+++ b/components/Sections/NewHeader/__snapshots__/index.stories.tsx.snap
@@ -102,163 +102,161 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
           </button>
         </li>
         <li>
-          <div>
-            <button type="button"
-                    aria-expanded="false"
-                    aria-label="Switch Language"
+          <button type="button"
+                  aria-expanded="false"
+                  aria-label="Switch Language"
+          >
+            <svg stroke="currentColor"
+                 fill="currentColor"
+                 stroke-width="0"
+                 viewbox="0 0 24 24"
+                 height="1em"
+                 width="1em"
+                 xmlns="http://www.w3.org/2000/svg"
             >
-              <svg stroke="currentColor"
-                   fill="currentColor"
-                   stroke-width="0"
-                   viewbox="0 0 24 24"
-                   height="1em"
-                   width="1em"
-                   xmlns="http://www.w3.org/2000/svg"
+              <path fill="none"
+                    d="M0 0h24v24H0V0z"
               >
-                <path fill="none"
-                      d="M0 0h24v24H0V0z"
-                >
-                </path>
-                <path d="M12.87 15.07l-2.54-2.51.03-.03A17.52 17.52 0 0014.07 6H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z">
-                </path>
-              </svg>
-            </button>
-            <ul style="display: none; position: absolute; top: 60%; right: 0px; margin: 0px;">
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  العربية
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Catalan
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Deutsch
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: bold;"
-                >
-                  English
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Español
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  زبان فارسی
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Français
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Bahasa Indonesia
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Italiano
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  日本語
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  ქართული
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  한국어
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Português do Brasil
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  limba română
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Русский
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Türkçe
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  Українська
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  简体中文
-                </button>
-              </li>
-              <li>
-                <button type="button"
-                        style="font-weight: normal;"
-                >
-                  繁體中文
-                </button>
-              </li>
-            </ul>
-          </div>
+              </path>
+              <path d="M12.87 15.07l-2.54-2.51.03-.03A17.52 17.52 0 0014.07 6H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z">
+              </path>
+            </svg>
+          </button>
+          <ul style="display: none; position: absolute; top: 60%; right: 0px; margin: 0px;">
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                العربية
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Catalan
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Deutsch
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: bold;"
+              >
+                English
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Español
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                زبان فارسی
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Français
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Bahasa Indonesia
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Italiano
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                日本語
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                ქართული
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                한국어
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Português do Brasil
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                limba română
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Русский
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Türkçe
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                Українська
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                简体中文
+              </button>
+            </li>
+            <li>
+              <button type="button"
+                      style="font-weight: normal;"
+              >
+                繁體中文
+              </button>
+            </li>
+          </ul>
         </li>
         <li>
           <a target="_blank"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix LanguageSelector vertical align.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [x] I've covered new added functionality with unit tests if necessary.
