### PR TITLE
tests: remove some warnings

### DIFF
--- a/components/Common/ActiveLocalizedLink/__tests__/index.test.tsx
+++ b/components/Common/ActiveLocalizedLink/__tests__/index.test.tsx
@@ -25,7 +25,10 @@ describe('ActiveLocalizedLink', () => {
       </IntlProvider>
     );
 
-    expect(screen.getByText('Link')).toHaveAttribute('href', '/en/link');
+    expect(screen.findByText('Link')).resolves.toHaveAttribute(
+      'href',
+      '/en/link'
+    );
   });
 
   it('ignores active class when href not matches location.href', () => {
@@ -41,7 +44,7 @@ describe('ActiveLocalizedLink', () => {
       </IntlProvider>
     );
 
-    expect(screen.getByText('Link')).toHaveAttribute('class', 'link');
+    expect(screen.findByText('Link')).resolves.toHaveAttribute('class', 'link');
   });
 
   it('sets active class when href matches location.href', () => {
@@ -57,6 +60,9 @@ describe('ActiveLocalizedLink', () => {
       </IntlProvider>
     );
 
-    expect(screen.getByText('Link')).toHaveAttribute('class', 'link active');
+    expect(screen.findByText('Link')).resolves.toHaveAttribute(
+      'class',
+      'link active'
+    );
   });
 });

--- a/components/Learn/PreviousNextLink/__tests__/index.test.tsx
+++ b/components/Learn/PreviousNextLink/__tests__/index.test.tsx
@@ -14,8 +14,8 @@ jest.mock('next/router', () => ({
 describe('PrevNextLink component', () => {
   test('renders nothing if neither previous nor next are provided', () => {
     render(<PrevNextLink />);
-    const component = screen.queryByRole('list');
-    expect(component).not.toBeInTheDocument;
+    const component = screen.findByRole('list');
+    expect(component).resolves.not.toBeInTheDocument;
   });
 
   test('renders previous link if previous is provided', () => {
@@ -25,8 +25,8 @@ describe('PrevNextLink component', () => {
         <PrevNextLink previous={previous} />
       </IntlProvider>
     );
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', `/en${previous.slug}`);
+    const link = screen.findByRole('link');
+    expect(link).resolves.toHaveAttribute('href', `/en${previous.slug}`);
   });
 
   test('renders next link if next is provided', () => {
@@ -36,11 +36,11 @@ describe('PrevNextLink component', () => {
         <PrevNextLink next={next} />
       </IntlProvider>
     );
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', `/en${next.slug}`);
+    const link = screen.findByRole('link');
+    expect(link).resolves.toHaveAttribute('href', `/en${next.slug}`);
   });
 
-  test('renders both previous and next links if both are provided', () => {
+  test('renders both previous and next links if both are provided', async () => {
     const previous = { slug: '/previous-page' };
     const next = { slug: '/next-page' };
     render(
@@ -48,7 +48,7 @@ describe('PrevNextLink component', () => {
         <PrevNextLink previous={previous} next={next} />
       </IntlProvider>
     );
-    const links = screen.getAllByRole('link');
+    const links = await screen.findAllByRole('link');
     expect(links[0]).toHaveAttribute('href', `/en${previous.slug}`);
     expect(links[1]).toHaveAttribute('href', `/en${next.slug}`);
   });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Remove all warnings like this from unit tests: `Warning: An update to ForwardRef() inside a test was not wrapped in act`. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [x] I've covered new added functionality with unit tests if necessary.
