### PR TITLE
fix: typo githuh -> github

### DIFF
--- a/pages/en/blog/vulnerability/june-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/june-2023-security-releases.md
@@ -84,7 +84,7 @@ This vulnerability affects all users using the experimental permission model in 
 
 Please note that at the time this CVE was issued, the permission model is an experimental feature of Node.js.
 
-Thanks to [Colin Ihrig](https://github.com/cjihrig) for reporting this vulnerability and to [Rafael Gonzaga](https://githuh.com/RafaelGSS) for fixing it.
+Thanks to [Colin Ihrig](https://github.com/cjihrig) for reporting this vulnerability and to [Rafael Gonzaga](https://github.com/RafaelGSS) for fixing it.
 
 ## fs.openAsBlob bypass in experimental permission model (Medium) (CVE-2023-30583)
 
@@ -93,7 +93,7 @@ fs.openAsBlob() can bypass the experimental permission model when using the file
 
 This vulnerability affects all users using the experimental permission model in Node.js 20.
 
-Thanks to [Colin Ihrig](https://github.com/cjihrig) for reporting this vulnerability and to [Rafael Gonzaga](https://githuh.com/RafaelGSS) for fixing it.
+Thanks to [Colin Ihrig](https://github.com/cjihrig) for reporting this vulnerability and to [Rafael Gonzaga](https://github.com/RafaelGSS) for fixing it.
 
 Please note that at the time this CVE was issued, the permission model is an experimental feature of Node.js.
 


### PR DESCRIPTION
As titled