### PR TITLE
chore: better cache on actions

### DIFF
--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -47,12 +47,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}
-          restore-keys: cache-
+          key: cache-${{ hashFiles('package-lock.json') }}-
+          restore-keys: |
+            cache-${{ hashFiles('package-lock.json') }}-
+            cache-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
@@ -86,7 +84,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}
+          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.next/cache/**') }}
 
   analysis:
     name: Analysis
@@ -100,12 +98,9 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}
-          restore-keys: cache-
+          restore-keys: |
+            cache-${{ hashFiles('package-lock.json') }}-
+            cache-
 
       - name: Download PR Bundle Analysis
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -51,6 +51,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-
@@ -105,6 +106,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          key: cache-${{ hashFiles('package-lock.json') }}-
+          path: |
+            ~/.npm
+            .next/cache
+            node_modules/.cache
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-
@@ -98,6 +101,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
+          path: |
+            ~/.npm
+            .next/cache
+            node_modules/.cache
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          key: cache-${{ hashFiles('package-lock.json') }}-
+          path: |
+            ~/.npm
+            .next/cache
+            node_modules/.cache
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-
@@ -74,7 +77,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          key: cache-${{ hashFiles('package-lock.json') }}
+          path: |
+            ~/.npm
+            .next/cache
+            node_modules/.cache
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,12 +31,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}-
-          restore-keys: cache-
+          restore-keys: |
+            cache-${{ hashFiles('package-lock.json') }}-
+            cache-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
@@ -76,12 +74,10 @@ jobs:
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
           key: cache-${{ hashFiles('package-lock.json') }}
-          restore-keys: cache-
+          restore-keys: |
+            cache-${{ hashFiles('package-lock.json') }}-
+            cache-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-
@@ -81,6 +82,7 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
             cache-


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates the `actions/cache` rules better to reflect the latest version of the full NPM cache with the latest Next.js build metadata.

This is done because GitHub Actions **does not** support updating existing cache's, and since our cache rules were only `package-lock` based, cache with actual Next.js content would not be up-to-date.

This PR also removes the `paths` from `actions/cache/restore` actions as we always want to restore the full cache and not specific paths. This also should speed the cache restore process.

## Validation

If each Next.js build (or at least when has for `.next/cache` has changes) results on a new cache. And that the unpacked (restored) files are correct
