### PR TITLE
fix: 404 generation and circular dependencies

### DIFF
--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -100,8 +100,6 @@ export const STATIC_ROUTES_IGNORES = [
   route => !route.localised && /^blog\//.test(route.pathname),
   // This is used to ignore the blog/pagination meta route
   route => /^blog\/pagination/.test(route.pathname),
-  // This is used to ignore all 404 localised routes
-  route => /^404/.test(route.pathname),
 ];
 
 /**
@@ -113,8 +111,6 @@ export const STATIC_ROUTES_IGNORES = [
 export const DYNAMIC_ROUTES_IGNORES = [
   // This is used to ignore the blog/pagination route
   /^blog\/pagination/,
-  // This is used to ignore all 404 routes
-  /^404/,
 ];
 
 /**

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 import Theme from '@/theme';
+import type { GetStaticProps } from 'next';
 
 const NotFound = () => (
   <Theme>
@@ -13,3 +14,7 @@ const NotFound = () => (
 );
 
 export default NotFound;
+
+// We require `getStaticProps` to ensure that this component is not rendered on server-side
+// as the router will always treat the path as /404 despite the actual URL path not being /404
+export const getStaticProps: GetStaticProps = () => ({ props: {} });

--- a/theme.tsx
+++ b/theme.tsx
@@ -28,5 +28,10 @@ export default memo(
   // that comes from `getStaticProps`. This means that the `props` should never change.
   // At least the `props.content` should never. We should not calculate based on `children`
   // As this component should never have a dynamic children
-  (prev, next) => JSON.stringify(prev) === JSON.stringify(next)
+  (
+    { content: pContent, frontmatter: pFrontmatter },
+    { content: nContent, frontmatter: nFrontmatter }
+  ) =>
+    JSON.stringify([pContent, pFrontmatter]) ===
+    JSON.stringify([nContent, nFrontmatter])
 );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes the 404 generation for our Statically Exported Website, as NGINX loads the /{locale}/404.html file, but that was not being generated anymore.

Besides that, for pages that import the `Theme` component and have `children` we should only compare the `content` and `frontmatter` as Stringifying `children` will cause circular dependencies within the JSON lookup.

Finally, we fixed the server-side and client-side mismatch of the default Next.js 404's page (which is used on our SSR server, differently from the statically generated 404 pages (which should eventually be removed) as Next.js (for some reason) will always tell to the server that the URL when on a 404 page is `/404` even tho the server has the context of the actual URL/route. Causing server/client render mismatch.

## Validation

- 404 files should be generated statically with `npm run deploy`
- Custom `404.tsx` page (SSR) should be rendered without errors
