### PR TITLE
fix: make prettier fix style files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
   "**/*.{mjs,ts,tsx,md,mdx}": ["eslint --fix"],
-  "**/*.{mjs,ts,tsx,md,mdx,json,yml}": ["prettier --write"]
+  "**/*.{mjs,ts,tsx,md,mdx,json,yml,css,sass,scss}": ["prettier --write"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:scss": "stylelint --config .stylelintrc.json \"**/*.{css,sass,scss}\"",
     "lint": "npm run lint:js && npm run lint:md && npm run lint:scss",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:md -- --fix && npm run lint:scss -- --fix",
-    "prettier": "prettier \"**/*.{mjs,ts,tsx,md,mdx,json,yml}\" --check --cache --cache-strategy metadata",
+    "prettier": "prettier \"**/*.{mjs,ts,tsx,md,mdx,json,yml,css,sass,scss}\" --check --cache --cache-strategy metadata",
     "prettier:fix": "npm run prettier -- --write",
     "format": "npm run lint:fix && npm run prettier:fix",
     "storybook": "cross-env NODE_NO_WARNINGS=1 storybook dev -p 6006 --quiet",


### PR DESCRIPTION
Stylelint no longer indent files (https://stylelint.io/migration-guide/to-15/); hence, this PR fixes the indentation not happening by making prettier take care of it.