### PR TITLE
feat: jest comments, remote storybook and only ubuntu runners

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,6 +16,7 @@ public/static/legacy
 
 # We don't want to lint/prettify the Coverage Results
 coverage
+junit.xml
 
 # MDX Plugin enforces Prettier formatting which should
 # be done in the future as we don't want to update the Markdown file

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -16,11 +16,15 @@ defaults:
 permissions:
   contents: read
   actions: read
+  # This permission is required by `peter-evans/create-or-update-comment`
   pull-requests: write
 
 env:
+  # This is explicitly used on the `npx turbo` commands
   TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+  # This is implicitly used by `npx turbo` itself
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # This is implicitly used by `npx turbo` itself and `zentered/vercel-preview-url`
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
@@ -42,6 +46,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
+          # Get the whole git history so that Turborepo `--filter` works correctly
           fetch-depth: 0
 
       - name: Restore Cache
@@ -96,21 +101,6 @@ jobs:
     needs: [build]
 
     steps:
-      - name: Git Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-
-      - name: Restore Cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}-
-          restore-keys: |
-            cache-${{ hashFiles('package-lock.json') }}-
-            cache-
-
       - name: Download PR Bundle Analysis
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,11 +11,14 @@ defaults:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 
 env:
   TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  VERCEL_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_PROJECT_ID: ${{ secrets.TURBO_PROJECT_ID }}
 
 jobs:
   lint:
@@ -55,7 +58,7 @@ jobs:
       - name: Run Prettier
         run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
 
-  unit-tests:
+  tests:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -98,16 +101,27 @@ jobs:
 
       - name: Run Unit Tests (Windows)
         if: matrix.os == 'windows-latest'
-        run: npx turbo test:unit --filter="...[$env:TURBO_REF_FILTER]" -- --coverage
+        run: npx turbo test:unit --filter="...[$env:TURBO_REF_FILTER]" -- --ci --coverage --reporters=default --reporters=jest-junit
 
       - name: Run Unit Tests (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --coverage
+        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage --reporters=default --reporters=jest-junit
 
-      - name: Run Storybook Tests (Windows)
-        if: matrix.os == 'windows-latest'
-        run: npx turbo test:storybook --filter="...[$env:TURBO_REF_FILTER]"
+      - name: Jest Coverage Comment
+        uses: MishaKav/jest-coverage-comment@41b5ca01d1250de84537448d248b8d18152cb277
+        with:
+          title: 'Unit Test Coverage Report'
+          junitxml-path: ./junit.xml
+          junitxml-title: Unit Test Report
 
-      - name: Run Storybook Tests (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: npx turbo test:storybook --filter="...[$TURBO_REF_FILTER]"
+      - name: Capture Deployment URL
+        id: vercel_storybook_preview_url
+        uses: zentered/vercel-preview-url@e5fb141da2e3d62692b38e6c7c17477aad214165
+        with:
+          vercel_project_id: ${{ env.TURBO_PROJECT_ID }}
+          vercel_team_id: ${{ env.TURBO_TEAM }}
+
+      - name: Run Storybook Tests
+        run: npx test-storybook --no-index-json --ci
+        env:
+          TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,12 @@
 name: Pull Request Checks
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,12 +1,7 @@
 name: Pull Request Checks
 
 on:
-  push:
-    branches:
-      - main
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Run Prettier
         run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
 
-  unit-tests:
-    name: Unit Tests
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -117,38 +117,6 @@ jobs:
           junitxml-path: ./junit.xml
           junitxml-title: Unit Test Report
 
-  visual-tests:
-    name: Visual Regression Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          # Get the whole git history so that Turborepo `--filter` works correctly
-          fetch-depth: 0
-
-      - name: Restore Cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: |
-            ~/.npm
-            .next/cache
-            node_modules/.cache
-          key: cache-${{ hashFiles('package-lock.json') }}-
-          restore-keys: |
-            cache-${{ hashFiles('package-lock.json') }}-
-            cache-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install NPM packages
-        run: npm ci --no-audit --no-fund
-
       - name: Capture Deployment URL
         id: vercel_storybook_preview_url
         uses: zentered/vercel-preview-url@e5fb141da2e3d62692b38e6c7c17477aad214165
@@ -156,7 +124,7 @@ jobs:
           vercel_project_id: ${{ env.TURBO_PROJECT_ID }}
           vercel_team_id: ${{ env.TURBO_TEAM }}
 
-      - name: Run Storybook Tests (Ubuntu)
+      - name: Run Storybook Tests
         run: npx turbo test:storybook --filter="...[$TURBO_REF_FILTER]" -- --ci
         env:
           TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,12 +102,7 @@ jobs:
       - name: Install NPM packages
         run: npm ci --no-audit --no-fund
 
-      - name: Run Unit Tests (Windows)
-        if: matrix.os == 'windows-latest'
-        run: npx turbo test:unit --filter="...[$env:TURBO_REF_FILTER]" -- --ci --coverage
-
-      - name: Run Unit Tests (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Run Unit Tests
         run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage
 
       - name: Jest Coverage Comment

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,11 +101,11 @@ jobs:
 
       - name: Run Unit Tests (Windows)
         if: matrix.os == 'windows-latest'
-        run: npx turbo test:unit --filter="...[$env:TURBO_REF_FILTER]" -- --ci --coverage --reporters=default --reporters=jest-junit
+        run: npx turbo test:unit --filter="...[$env:TURBO_REF_FILTER]" -- --ci --coverage
 
       - name: Run Unit Tests (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage --reporters=default --reporters=jest-junit
+        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage
 
       - name: Jest Coverage Comment
         uses: MishaKav/jest-coverage-comment@41b5ca01d1250de84537448d248b8d18152cb277
@@ -122,6 +122,6 @@ jobs:
           vercel_team_id: ${{ env.TURBO_TEAM }}
 
       - name: Run Storybook Tests
-        run: npx test-storybook --no-index-json --ci
+        run: npx test-storybook --ci --no-index-json
         env:
           TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -121,7 +121,14 @@ jobs:
           vercel_project_id: ${{ env.TURBO_PROJECT_ID }}
           vercel_team_id: ${{ env.TURBO_TEAM }}
 
-      - name: Run Storybook Tests
-        run: npx test-storybook --ci --no-index-json
+      - name: Run Storybook Tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: npx turbo test:storybook --filter="...[$env:TURBO_REF_FILTER]" -- --ci
+        env:
+          TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'
+
+      - name: Run Storybook Tests (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx turbo test:storybook --filter="...[$TURBO_REF_FILTER]" -- --ci
         env:
           TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,13 +16,19 @@ defaults:
 permissions:
   contents: read
   actions: read
+  # This permission is required by `MishaKav/jest-coverage-comment`
   pull-requests: write
 
 env:
+  # This is explicitly used on the `npx turbo` commands
   TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+  # This is implicitly used by `npx turbo` itself
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # This is implicitly used by `npx turbo` itself and `zentered/vercel-preview-url`
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  # This is implicitly used by `zentered/vercel-preview-url`
   VERCEL_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # This is explicitly used `zentered/vercel-preview-url`
   TURBO_PROJECT_ID: ${{ secrets.TURBO_PROJECT_ID }}
 
 jobs:
@@ -34,6 +40,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
+          # Get the whole git history so that Turborepo `--filter` works correctly
           fetch-depth: 0
 
       - name: Restore Cache
@@ -63,7 +70,7 @@ jobs:
       - name: Run Prettier
         run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
 
-  tests:
+  unit-tests:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -81,6 +88,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
+          # Get the whole git history so that Turborepo `--filter` works correctly
           fetch-depth: 0
 
       - name: Restore Cache
@@ -119,6 +127,38 @@ jobs:
           junitxml-path: ./junit.xml
           junitxml-title: Unit Test Report
 
+  visual-tests:
+    name: Visual Regression Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          # Get the whole git history so that Turborepo `--filter` works correctly
+          fetch-depth: 0
+
+      - name: Restore Cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: |
+            ~/.npm
+            .next/cache
+            node_modules/.cache
+          key: cache-${{ hashFiles('package-lock.json') }}-
+          restore-keys: |
+            cache-${{ hashFiles('package-lock.json') }}-
+            cache-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install NPM packages
+        run: npm ci --no-audit --no-fund
+
       - name: Capture Deployment URL
         id: vercel_storybook_preview_url
         uses: zentered/vercel-preview-url@e5fb141da2e3d62692b38e6c7c17477aad214165
@@ -126,14 +166,7 @@ jobs:
           vercel_project_id: ${{ env.TURBO_PROJECT_ID }}
           vercel_team_id: ${{ env.TURBO_TEAM }}
 
-      - name: Run Storybook Tests (Windows)
-        if: matrix.os == 'windows-latest'
-        run: npx turbo test:storybook --filter="...[$env:TURBO_REF_FILTER]" -- --ci
-        env:
-          TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'
-
       - name: Run Storybook Tests (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
         run: npx turbo test:storybook --filter="...[$TURBO_REF_FILTER]" -- --ci
         env:
           TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,13 +66,8 @@ jobs:
         run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
 
   unit-tests:
-    name: Tests on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Unit Tests
+    runs-on: ubuntu-latest
 
     steps:
       - name: Use GNU tar instead BSD tar

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ public/en/feed/*.xml
 # Jest
 coverage
 .swc
+junit.xml
 
 # Storybook
 storybook-static

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ public/node-releases-data.json
 
 # We don't want to lint/prettify the Coverage Results
 coverage
+junit.xml
 
 # MDX Plugin enforces Prettier formatting which should
 # be done in the future as we don't want to update the Markdown file

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
   features: { storyStoreV7: true },
   docs: { autodocs: 'tag' },
   staticDirs: ['../public'],
+  logLevel: 'error',
   core: { disableTelemetry: true },
   webpackFinal: async config => {
     config.resolve!.modules = [resolve(__dirname, '..'), 'node_modules'];

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -14,11 +14,11 @@ const config: TestRunnerConfig = {
     // We wait for the document to have its initial looading finished
     await page.waitForLoadState('domcontentloaded');
     await page.waitForLoadState('load');
-
-    // This is the minimum time we've noticed for the content to safely be rendered
-    await page.waitForTimeout(1000);
   },
   postRender: async page => {
+    // This is the minimum time we've noticed for the content to safely be rendered
+    await page.waitForTimeout(1000);
+
     // We attempt to get the Storybook root Element
     const rootElement = await page.locator(STORYBOOK_ELEMENT_ID);
 

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,26 +1,35 @@
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
-const STORYBOOK_ELEMENT_ID = '[data-test-id="story-root"]';
+// This is the PlayWright Selector for getting the first Element from
+// the Storybook Root Element. Which allows us to focus directly on the main Element
+const STORYBOOK_ELEMENT_ID = '[data-test-id="story-root"] > *';
 
 const config: TestRunnerConfig = {
   // This method replaces Storybook's Test Runner default `prepare` method
   // This is a lightweight method with extra checks of content loading
   prepare: async ({ page }) => {
+    // We want a small viewport as we don't need something big for our Components
+    await page.setViewportSize({ width: 768, height: 1024 });
+
+    // We get the URL of the current Story from the current process.env variable
     const targetURL = process.env.TARGET_URL;
+
+    // We append the targetURL to the iframeURL and then we navigate to the Iframe
     const iframeURL = new URL('iframe.html', targetURL).toString();
 
+    // Navigates to the Story's Iframe and waits for the page to render
     await page.goto(iframeURL);
 
     // We wait for the document to have its initial looading finished
     await page.waitForLoadState('domcontentloaded');
     await page.waitForLoadState('load');
   },
-  postRender: async page => {
+  postRender: async (page, context) => {
     // This is the minimum time we've noticed for the content to safely be rendered
     await page.waitForTimeout(1000);
 
     // We attempt to get the Storybook root Element
-    const rootElement = await page.locator(STORYBOOK_ELEMENT_ID);
+    const rootElement = await page.$(STORYBOOK_ELEMENT_ID);
 
     // Then we rewrite the inner HTML content
     const content = await rootElement.innerHTML();

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -27,7 +27,7 @@ const config: TestRunnerConfig = {
 
     expect(content).toBeDefined();
 
-    // We stripe specific HTML tags whose values are auto-generated or can change from deployment to deployment
+    // We remove specific HTML tags whose values are auto-generated or can change from deployment to deployment
     // this reduces the effectiveness of the stories but it's a trade-off we have to make
     expect(content.replace(/(class|src|href)="(.*?)"/gm, '')).toMatchSnapshot();
   },

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -3,11 +3,22 @@ import type { TestRunnerConfig } from '@storybook/test-runner';
 const STORYBOOK_ELEMENT_ID = '[data-test-id="story-root"]';
 
 const config: TestRunnerConfig = {
-  postRender: async page => {
-    // We wait for the page to load for at least one second
-    // as there's no reliable way globally to ensure everything loaded correctly
-    await page.waitForTimeout(1000);
+  // This method replaces Storybook's Test Runner default `prepare` method
+  // This is a lightweight method with extra checks of content loading
+  prepare: async ({ page }) => {
+    const targetURL = process.env.TARGET_URL;
+    const iframeURL = new URL('iframe.html', targetURL).toString();
 
+    await page.goto(iframeURL);
+
+    // We wait for the document to have its initial looading finished
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('load');
+
+    // This is the minimum time we've noticed for the content to safely be rendered
+    await page.waitForTimeout(1000);
+  },
+  postRender: async page => {
     // We attempt to get the Storybook root Element
     const rootElement = await page.locator(STORYBOOK_ELEMENT_ID);
 
@@ -16,8 +27,8 @@ const config: TestRunnerConfig = {
 
     expect(content).toBeDefined();
 
-    // We strip the `class` tags from the HTML content as we do not want
-    // to pollute the snapshots with generated class names
+    // We stripe specific HTML tags whose values are auto-generated or can change from deployment to deployment
+    // this reduces the effectiveness of the stories but it's a trade-off we have to make
     expect(content.replace(/(class|src|href)="(.*?)"/gm, '')).toMatchSnapshot();
   },
 };

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -6,7 +6,7 @@ const config: TestRunnerConfig = {
   postRender: async page => {
     // We wait for the page to load for at least one second
     // as there's no reliable way globally to ensure everything loaded correctly
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1000);
 
     // We attempt to get the Storybook root Element
     const rootElement = await page.locator(STORYBOOK_ELEMENT_ID);

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -6,7 +6,7 @@ const config: TestRunnerConfig = {
   postRender: async page => {
     // We wait for the page to load for at least one second
     // as there's no reliable way globally to ensure everything loaded correctly
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(500);
 
     // We attempt to get the Storybook root Element
     const rootElement = await page.locator(STORYBOOK_ELEMENT_ID);
@@ -18,7 +18,7 @@ const config: TestRunnerConfig = {
 
     // We strip the `class` tags from the HTML content as we do not want
     // to pollute the snapshots with generated class names
-    expect(content.replace(/class="(.*?)"/gm, '')).toMatchSnapshot();
+    expect(content.replace(/(class|src|href)="(.*?)"/gm, '')).toMatchSnapshot();
   },
 };
 

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,8 +1,7 @@
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
-// This is the PlayWright Selector for getting the first Element from
-// the Storybook Root Element. Which allows us to focus directly on the main Element
-const STORYBOOK_ELEMENT_ID = '[data-test-id="story-root"] > *';
+// This is the PlayWright Selector for getting the Storybook root Element
+const STORYBOOK_ELEMENT_ID = '[data-test-id="story-root"]';
 
 const config: TestRunnerConfig = {
   // This method replaces Storybook's Test Runner default `prepare` method

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,8 @@ This repository contains several scripts and commands for performing numerous ta
 - `npx turbo test` runs all tests locally
   - `npx turbo test:unit` runs jest (unit-tests) locally
   - `npx turbo test:storybook` runs storybook test-runner tests
+    - `npx turbo test:storybook:local` runs storybook test-runner tests with local storybook
+    - `npx turbo test:storybook:watch` keeps running storybook test-runner locally on every story change
     - `npx turbo test:storybook:snapshot` generates and updates snapshots for all storybook components.
 
 </details>

--- a/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
@@ -12,7 +12,7 @@ exports[`Article/AuthorList/Author Default smoke-test 1`] = `
        decoding="async"
        data-nimg="1"
        srcset="https://github.com/nodejs.png?size=60?w=64&amp;q=75 1x, https://github.com/nodejs.png?size=60?w=128&amp;q=75 2x"
-       style="color: transparent;"
+       style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
   >
 </a>
 `;
@@ -28,8 +28,8 @@ exports[`Article/AuthorList/Author WithourUsername smoke-test 1`] = `
        height="0"
        decoding="async"
        data-nimg="1"
-       srcset="/static/images/placeholder-img.png?w=16&amp;q=75 1x"
-       style
+       srcset="https://github.com/.png?size=0?w=16&amp;q=75 1x"
+       style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
   >
 </a>
 `;

--- a/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
@@ -12,7 +12,7 @@ exports[`Article/AuthorList/Author Default smoke-test 1`] = `
        decoding="async"
        data-nimg="1"
        srcset="https://github.com/nodejs.png?size=60?w=64&amp;q=75 1x, https://github.com/nodejs.png?size=60?w=128&amp;q=75 2x"
-       style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+       style="color: transparent;"
   >
 </a>
 `;
@@ -28,8 +28,8 @@ exports[`Article/AuthorList/Author WithourUsername smoke-test 1`] = `
        height="0"
        decoding="async"
        data-nimg="1"
-       srcset="https://github.com/.png?size=0?w=16&amp;q=75 1x"
-       style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+       srcset="/static/images/placeholder-img.png?w=16&amp;q=75 1x"
+       style
   >
 </a>
 `;

--- a/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/Author/__snapshots__/index.stories.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Article/AuthorList/Author Default smoke-test 1`] = `
-<a href="https://github.com/nodejs"
-   aria-label="nodejs Github - opens in new tab"
+<a aria-label="nodejs Github - opens in new tab"
    target="_blank"
    rel="noopener noreferrer"
 >
@@ -13,15 +12,13 @@ exports[`Article/AuthorList/Author Default smoke-test 1`] = `
        decoding="async"
        data-nimg="1"
        srcset="https://github.com/nodejs.png?size=60?w=64&amp;q=75 1x, https://github.com/nodejs.png?size=60?w=128&amp;q=75 2x"
-       src="https://github.com/nodejs.png?size=60?w=128&amp;q=75"
        style="color: transparent;"
   >
 </a>
 `;
 
 exports[`Article/AuthorList/Author WithourUsername smoke-test 1`] = `
-<a href="https://github.com/"
-   aria-label=" Github - opens in new tab"
+<a aria-label=" Github - opens in new tab"
    target="_blank"
    rel="noopener noreferrer"
 >
@@ -32,7 +29,6 @@ exports[`Article/AuthorList/Author WithourUsername smoke-test 1`] = `
        decoding="async"
        data-nimg="1"
        srcset="/static/images/placeholder-img.png?w=16&amp;q=75 1x"
-       src="http://127.0.0.1:6006/static/images/placeholder-img.png?w=16&amp;q=75"
        style
   >
 </a>

--- a/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
@@ -16,7 +16,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/flaviocopes.png?size=60?w=64&amp;q=75 1x, https://github.com/flaviocopes.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent;"
+             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
         >
       </a>
     </li>
@@ -32,7 +32,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/MarkPieszak.png?size=60?w=64&amp;q=75 1x, https://github.com/MarkPieszak.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent;"
+             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
         >
       </a>
     </li>
@@ -48,7 +48,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/mcollina.png?size=60?w=64&amp;q=75 1x, https://github.com/mcollina.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent;"
+             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
         >
       </a>
     </li>
@@ -63,8 +63,8 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              height="60"
              decoding="async"
              data-nimg="1"
-             srcset="/static/images/placeholder-img.png?w=64&amp;q=75 1x, /static/images/placeholder-img.png?w=128&amp;q=75 2x"
-             style
+             srcset="https://github.com/unavailable-author.png?size=60?w=64&amp;q=75 1x, https://github.com/unavailable-author.png?size=60?w=128&amp;q=75 2x"
+             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
         >
       </a>
     </li>

--- a/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
@@ -16,7 +16,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/flaviocopes.png?size=60?w=64&amp;q=75 1x, https://github.com/flaviocopes.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+             style="color: transparent;"
         >
       </a>
     </li>
@@ -32,7 +32,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/MarkPieszak.png?size=60?w=64&amp;q=75 1x, https://github.com/MarkPieszak.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+             style="color: transparent;"
         >
       </a>
     </li>
@@ -48,7 +48,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/mcollina.png?size=60?w=64&amp;q=75 1x, https://github.com/mcollina.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+             style="color: transparent;"
         >
       </a>
     </li>
@@ -63,8 +63,8 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              height="60"
              decoding="async"
              data-nimg="1"
-             srcset="https://github.com/unavailable-author.png?size=60?w=64&amp;q=75 1x, https://github.com/unavailable-author.png?size=60?w=128&amp;q=75 2x"
-             style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat; background-image: url(&quot;/static/images/placeholder-img.png&quot;);"
+             srcset="/static/images/placeholder-img.png?w=64&amp;q=75 1x, /static/images/placeholder-img.png?w=128&amp;q=75 2x"
+             style
         >
       </a>
     </li>

--- a/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/AuthorList/__snapshots__/index.stories.tsx.snap
@@ -5,8 +5,7 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
   Article Authors
   <ul>
     <li>
-      <a href="https://github.com/flaviocopes"
-         aria-label="flaviocopes Github - opens in new tab"
+      <a aria-label="flaviocopes Github - opens in new tab"
          target="_blank"
          rel="noopener noreferrer"
       >
@@ -17,14 +16,12 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/flaviocopes.png?size=60?w=64&amp;q=75 1x, https://github.com/flaviocopes.png?size=60?w=128&amp;q=75 2x"
-             src="https://github.com/flaviocopes.png?size=60?w=128&amp;q=75"
              style="color: transparent;"
         >
       </a>
     </li>
     <li>
-      <a href="https://github.com/MarkPieszak"
-         aria-label="MarkPieszak Github - opens in new tab"
+      <a aria-label="MarkPieszak Github - opens in new tab"
          target="_blank"
          rel="noopener noreferrer"
       >
@@ -35,14 +32,12 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/MarkPieszak.png?size=60?w=64&amp;q=75 1x, https://github.com/MarkPieszak.png?size=60?w=128&amp;q=75 2x"
-             src="https://github.com/MarkPieszak.png?size=60?w=128&amp;q=75"
              style="color: transparent;"
         >
       </a>
     </li>
     <li>
-      <a href="https://github.com/mcollina"
-         aria-label="mcollina Github - opens in new tab"
+      <a aria-label="mcollina Github - opens in new tab"
          target="_blank"
          rel="noopener noreferrer"
       >
@@ -53,14 +48,12 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="https://github.com/mcollina.png?size=60?w=64&amp;q=75 1x, https://github.com/mcollina.png?size=60?w=128&amp;q=75 2x"
-             src="https://github.com/mcollina.png?size=60?w=128&amp;q=75"
              style="color: transparent;"
         >
       </a>
     </li>
     <li>
-      <a href="https://github.com/unavailable-author"
-         aria-label="unavailable-author Github - opens in new tab"
+      <a aria-label="unavailable-author Github - opens in new tab"
          target="_blank"
          rel="noopener noreferrer"
       >
@@ -71,7 +64,6 @@ exports[`Article/AuthorList Default smoke-test 1`] = `
              decoding="async"
              data-nimg="1"
              srcset="/static/images/placeholder-img.png?w=64&amp;q=75 1x, /static/images/placeholder-img.png?w=128&amp;q=75 2x"
-             src="http://127.0.0.1:6006/static/images/placeholder-img.png?w=128&amp;q=75"
              style
         >
       </a>

--- a/components/Article/EditLink/__snapshots__/index.stories.tsx.snap
+++ b/components/Article/EditLink/__snapshots__/index.stories.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Article/EditLink Default smoke-test 1`] = `
 <div>
-  <a href="https://github.com/nodejs/nodejs.org/edit/major/website-redesign/pages/en/get-involved/contribute.md">
+  <a>
     <span>
       Edit this page on GitHub
     </span>

--- a/components/Blog/BlogCard/__snapshots__/index.stories.tsx.snap
+++ b/components/Blog/BlogCard/__snapshots__/index.stories.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Blog/BlogCard Default smoke-test 1`] = `
 <div>
   <div>
-    <a href="/en/blog/category-mock/sample-blog">
+    <a>
       Sample Test Blog
     </a>
     <div>
-      <a href="/en/blog/category-mock">
+      <a>
         category-mock
       </a>
       <span>

--- a/components/Common/AnimatedPlaceholder/__snapshots__/index.stories.tsx.snap
+++ b/components/Common/AnimatedPlaceholder/__snapshots__/index.stories.tsx.snap
@@ -12,10 +12,3 @@ exports[`Common/AnimatedPlaceholder Default smoke-test 1`] = `
   </div>
 </div>
 `;
-
-exports[`Common/AnimatedPlaceholder WithLoaderSkeleton smoke-test 1`] = `
-<div>
-  <div>
-  </div>
-</div>
-`;

--- a/components/Common/AnimatedPlaceholder/index.stories.tsx
+++ b/components/Common/AnimatedPlaceholder/index.stories.tsx
@@ -6,10 +6,4 @@ type Meta = MetaObj<typeof AnimatedPlaceholder>;
 
 export const Default: Story = {};
 
-export const WithLoaderSkeleton: Story = {
-  args: {
-    children: <div className="animated-placeholder__image" />,
-  },
-};
-
 export default { component: AnimatedPlaceholder } as Meta;

--- a/components/Common/Banner/__snapshots__/index.stories.tsx.snap
+++ b/components/Common/Banner/__snapshots__/index.stories.tsx.snap
@@ -2,8 +2,7 @@
 
 exports[`Common/Banner WithHTML smoke-test 1`] = `
 <div>
-  <a href="https://nodejs.org/en/"
-     target="_blank"
+  <a target="_blank"
      rel="noopener noreferrer"
   >
     <p>
@@ -15,13 +14,10 @@ exports[`Common/Banner WithHTML smoke-test 1`] = `
 
 exports[`Common/Banner WithHTMLImage smoke-test 1`] = `
 <div>
-  <a href="https://nodejs.org/en/"
-     target="_blank"
+  <a target="_blank"
      rel="noopener noreferrer"
   >
-    <img src="/static/images/nodejs-training.png"
-         alt="Banner Image"
-    >
+    <img alt="Banner Image">
   </a>
 </div>
 `;
@@ -29,8 +25,7 @@ exports[`Common/Banner WithHTMLImage smoke-test 1`] = `
 exports[`Common/Banner WithText smoke-test 1`] = `
 <div>
   <p>
-    <a href="https://nodejs.org/en/"
-       target="_blank"
+    <a target="_blank"
        rel="noopener noreferrer"
     >
       Read More

--- a/components/Learn/PreviousNextLink/__snapshots__/index.stories.tsx.snap
+++ b/components/Learn/PreviousNextLink/__snapshots__/index.stories.tsx.snap
@@ -3,9 +3,7 @@
 exports[`Learn/PreviousNextLink Default smoke-test 1`] = `
 <ul>
   <li>
-    <a rel="prev"
-       href="/en/previous"
-    >
+    <a rel="prev">
       <svg stroke="currentColor"
            fill="currentColor"
            stroke-width="0"
@@ -22,9 +20,7 @@ exports[`Learn/PreviousNextLink Default smoke-test 1`] = `
     </a>
   </li>
   <li>
-    <a rel="next"
-       href="/en/next"
-    >
+    <a rel="next">
       NEXT
       <svg stroke="currentColor"
            fill="currentColor"
@@ -46,9 +42,7 @@ exports[`Learn/PreviousNextLink Default smoke-test 1`] = `
 exports[`Learn/PreviousNextLink WithoutNext smoke-test 1`] = `
 <ul>
   <li>
-    <a rel="prev"
-       href="/en/previous"
-    >
+    <a rel="prev">
       <svg stroke="currentColor"
            fill="currentColor"
            stroke-width="0"
@@ -74,9 +68,7 @@ exports[`Learn/PreviousNextLink WithoutPrevious smoke-test 1`] = `
   <li>
   </li>
   <li>
-    <a rel="next"
-       href="/en/next"
-    >
+    <a rel="next">
       NEXT
       <svg stroke="currentColor"
            fill="currentColor"

--- a/components/Sections/NewFooter/__snapshots__/index.stories.tsx.snap
+++ b/components/Sections/NewFooter/__snapshots__/index.stories.tsx.snap
@@ -5,7 +5,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
   <ul>
     <li>
       <a target="_blank"
-         href="https://trademark-policy.openjsf.org/"
          rel="noopener noreferrer"
          aria-label="Node.js Trademark Policy - PDF (Opens in new tab)"
       >
@@ -14,7 +13,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://privacy-policy.openjsf.org/"
          rel="noopener noreferrer"
          aria-label="Node.js Privacy Policy - PDF (Opens in new tab)"
       >
@@ -23,24 +21,23 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
          rel="noopener noreferrer"
       >
         Code of Conduct
       </a>
     </li>
     <li>
-      <a href="/en/about/security">
+      <a>
         Security
       </a>
     </li>
     <li>
-      <a href="/en/about">
+      <a>
         About
       </a>
     </li>
     <li>
-      <a href="/en/blog">
+      <a>
         Blog
       </a>
     </li>
@@ -51,7 +48,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://github.com/nodejs/node"
          rel="noopener noreferrer"
          aria-label="Node.js Github Page (opens in new tab)"
       >
@@ -70,7 +66,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://mastodon.social/@nodejs@social.lfx.dev"
          rel="noopener noreferrer"
          aria-label="Node.js Mastodon (opens in new tab)"
       >
@@ -89,7 +84,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://twitter.com/nodejs"
          rel="noopener noreferrer"
          aria-label="Node.js Twitter (opens in new tab)"
       >
@@ -108,7 +102,6 @@ exports[`Sections/NewFooter Default smoke-test 1`] = `
     </li>
     <li>
       <a target="_blank"
-         href="https://slack.openjsf.org"
          rel="noopener noreferrer"
          aria-label="Node.js Slack (opens in new tab)"
       >

--- a/components/Sections/NewHeader/__snapshots__/index.stories.tsx.snap
+++ b/components/Sections/NewHeader/__snapshots__/index.stories.tsx.snap
@@ -4,9 +4,7 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
 <nav aria-label="Primary">
   <div>
     <div>
-      <a aria-label="Homepage"
-         href="/en"
-      >
+      <a aria-label="Homepage">
         <div>
           <div>
             <img alt="light-logo"
@@ -16,7 +14,6 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
                  decoding="async"
                  data-nimg="1"
                  srcset="static/images/logo-light.svg?w=128&amp;q=75 1x, static/images/logo-light.svg?w=256&amp;q=75 2x"
-                 src="static/images/logo-light.svg?w=256&amp;q=75"
                  style="color: transparent;"
             >
           </div>
@@ -28,7 +25,6 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
                  decoding="async"
                  data-nimg="1"
                  srcset="static/images/logo.svg?w=128&amp;q=75 1x, static/images/logo.svg?w=256&amp;q=75 2x"
-                 src="static/images/logo.svg?w=256&amp;q=75"
                  style="color: transparent;"
             >
           </div>
@@ -37,27 +33,27 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
     </div>
     <ul>
       <li>
-        <a href="/en/learn">
+        <a>
           Learn
         </a>
       </li>
       <li>
-        <a href="/en/download">
+        <a>
           Downloads
         </a>
       </li>
       <li>
-        <a href="/en/docs">
+        <a>
           API Docs
         </a>
       </li>
       <li>
-        <a href="/en/about">
+        <a>
           About
         </a>
       </li>
       <li>
-        <a href="https://openjsf.org/certification/">
+        <a>
           Certification
         </a>
       </li>
@@ -260,7 +256,6 @@ exports[`Sections/NewHeader Default smoke-test 1`] = `
         </li>
         <li>
           <a target="_blank"
-             href="https://github.com/nodejs/nodejs.org"
              rel="noopener noreferrer"
              aria-label="Nodejs.org Github Page (opens in new tab)"
           >

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,6 +10,8 @@ const customJestConfig = {
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['**/__tests__/*.test.mjs'],
+  coverageReporters: ['json', 'json-summary'],
+  reporters: ['default', 'jest-junit'],
 };
 
 export default createJestConfig(customJestConfig);

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "prettier": "prettier \"**/*.{mjs,ts,tsx,md,mdx,json,yml,css,sass,scss}\" --check --cache --cache-strategy metadata",
     "prettier:fix": "npm run prettier -- --write",
     "format": "npm run lint:fix && npm run prettier:fix",
-    "storybook": "cross-env NODE_NO_WARNINGS=1 storybook dev -p 6006 --quiet",
+    "storybook": "cross-env NODE_NO_WARNINGS=1 storybook dev -p 6006 --quiet --no-open",
     "storybook:build": "cross-env NODE_NO_WARNINGS=1 storybook build --quiet",
     "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:storybook": "test-storybook --no-index-json",
-    "test:storybook:local": "concurrently -P -k -s first -n \"storybook,test-storybook\" -c \"magenta,blue\" \"npm:storybook -- --ci\" \"wait-on http://localhost:6006 && npm run test:storybook\"",
+    "test:storybook:local": "concurrently -P -r -k -s first npm:storybook \"wait-on http://localhost:6006 && npm run test:storybook -- {@}\"",
     "test:storybook:snapshot": "npm run test:storybook:local -- -- --updateSnapshot",
     "test:storybook:watch": "npm run test:storybook:local -- -- --watch",
-    "test": "concurrently -s all -n \"test:unit,test:storybook\" -c \"yellow,green\" \"npm:test:unit\" \"npm:test:storybook:local\"",
+    "test": "concurrently -r -s all npm:test:unit npm:test:storybook:local",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format": "npm run lint:fix && npm run prettier:fix",
     "storybook": "cross-env NODE_NO_WARNINGS=1 storybook dev -p 6006 --quiet",
     "storybook:build": "cross-env NODE_NO_WARNINGS=1 storybook build --quiet --loglevel warn",
-    "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests --coverage",
+    "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:storybook": "concurrently -P -k -s first -n \"storybook,test-storybook\" -c \"magenta,blue\" \"npm:storybook -- --ci\" \"wait-on http://localhost:6006 && test-storybook {@}\"",
     "test:storybook:snapshot": "npm run test:storybook -- -- --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier:fix": "npm run prettier -- --write",
     "format": "npm run lint:fix && npm run prettier:fix",
     "storybook": "cross-env NODE_NO_WARNINGS=1 storybook dev -p 6006 --quiet",
-    "storybook:build": "cross-env NODE_NO_WARNINGS=1 storybook build --quiet --loglevel warn",
+    "storybook:build": "cross-env NODE_NO_WARNINGS=1 storybook build --quiet",
     "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:storybook": "test-storybook --no-index-json",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "storybook:build": "cross-env NODE_NO_WARNINGS=1 storybook build --quiet --loglevel warn",
     "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
-    "test:storybook": "concurrently -P -k -s first -n \"storybook,test-storybook\" -c \"magenta,blue\" \"npm:storybook -- --ci\" \"wait-on http://localhost:6006 && test-storybook {@}\"",
-    "test:storybook:snapshot": "npm run test:storybook -- -- --updateSnapshot",
-    "test:storybook:watch": "npm run test:storybook -- -- --watch",
-    "test": "concurrently -s all -n \"test:unit,test:storybook\" -c \"yellow,green\" \"npm:test:unit\" \"npm:test:storybook\"",
+    "test:storybook": "test-storybook --no-index-json",
+    "test:storybook:local": "concurrently -P -k -s first -n \"storybook,test-storybook\" -c \"magenta,blue\" \"npm:storybook -- --ci\" \"wait-on http://localhost:6006 && npm run test:storybook\"",
+    "test:storybook:snapshot": "npm run test:storybook:local -- -- --updateSnapshot",
+    "test:storybook:watch": "npm run test:storybook:local -- -- --watch",
+    "test": "concurrently -s all -n \"test:unit,test:storybook\" -c \"yellow,green\" \"npm:test:unit\" \"npm:test:storybook:local\"",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -181,6 +181,16 @@
         "*.{md,mdx,json,ts,tsx,mjs,yml}"
       ]
     },
+    "test:storybook:local": {
+      "inputs": [
+        "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx,mjs}",
+        "{app,components,layouts,pages,styles}/**/*.{css,sass,scss}",
+        "{next-data,scripts,i18n}/**/*.{mjs,json}",
+        "{.storybook,public}/**/*.{ts,js,css,json}",
+        "{app,pages}/**/*.{mdx,md}",
+        "*.{md,mdx,json,ts,tsx,mjs,yml}"
+      ]
+    },
     "test": {
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx,mjs}",

--- a/turbo.json
+++ b/turbo.json
@@ -168,7 +168,8 @@
         "{next-data,scripts,i18n}/**/*.{mjs,json}",
         "{app,pages}/**/*.{mdx,md}",
         "*.{md,mdx,json,ts,tsx,mjs,yml}"
-      ]
+      ],
+      "outputs": ["coverage/**", "junit.xml"]
     },
     "test:storybook": {
       "inputs": [
@@ -188,7 +189,8 @@
         "{.storybook,public}/**/*.{ts,js,css,json}",
         "{app,pages}/**/*.{mdx,md}",
         "*.{md,mdx,json,ts,tsx,mjs,yml}"
-      ]
+      ],
+      "outputs": ["coverage/**", "junit.xml"]
     }
   }
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR introduces a few significant changes to the Pull Request Template.

- Introduces a Jest Code Coverage Comment
  - Gives Code Coverage Insights
- Uses the remote deployment of Storybook Branch Previews on Vercel for our Storybook Test Runner
  - Reduces testing time as building storybook is not needed anymore
- Changes Unit Tests and Visual Regression Tests to only run on Ubuntu
  - No need to run Unit Tests on Windows, and Storybook is deployed remotely now
- Adds minor inline documentation to some statements for clarification
- Changes the Pull Request trigger to be locked. (Changes on PRs to the `pull_request` template will not result in any change (similar to the build one)
  - This will be done on a commit after this PR which essentially uses the same `on` triggers as our `build-and-analysis` workflow

## Validation

Pull Request Workflow works as expected
