### PR TITLE
chore: dependabot be more precise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       timezone: 'Europe/Berlin'
-      time: '16:00'
+      time: '19:00'
       day: friday
     open-pull-requests-limit: 10
   - package-ecosystem: npm
@@ -13,7 +13,7 @@ updates:
     schedule:
       interval: weekly
       timezone: 'Europe/Berlin'
-      time: '16:00'
+      time: '19:00'
       day: friday
     commit-message:
       prefix: meta

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,18 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: monthly
+      interval: weekly
+      timezone: 'Europe/Berlin'
+      time: '16:00'
+      day: friday
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      timezone: 'Europe/Berlin'
+      time: '16:00'
+      day: friday
     commit-message:
       prefix: meta
     groups:


### PR DESCRIPTION
This PR simply changes the Dependabot configuration to run weekly and on a specified day and time.