### PR TITLE
meta: workflow updates (heavy documentation + local storybook + turbo remote cache fixes)

### DIFF
--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -1,15 +1,16 @@
+# Security Notes
+# Only selected Actions are allowed within this repository. Please refer to (https://github.com/nodejs/nodejs.org/settings/actions)
+# for the full list of available actions. If you want to add a new one, please reach out a maintainer with Admin permissions.
+# REVIEWERS, please always double-check security practices before merging a PR that contains Workflow changes!!
+# AUTHORS, please only use actions with explicit SHA references, and avoid using `@master` or `@main` references or `@version` tags.
+
 name: Build and Analysis Checks
 
 on:
   push:
     branches:
       - main
-  # This trigger ensures that the GitHub Action Workflow metadata that is fetched comes from the `main` branch
-  # This is important to disallow this Workflow from being modified in forks and PRs
-  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
 
 defaults:
   run:
@@ -22,18 +23,27 @@ permissions:
   # This permission is required by `peter-evans/create-or-update-comment`
   pull-requests: write
 
-env:
-  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepo's cache that include optimised cache
-  # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--token
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-
 jobs:
+  base:
+    name: Base Tasks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Provide Turborepo Arguments
+        id: turborepo_arguments
+        # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
+        # It verifies if any change was done to any of the including `glob` patterns described for a said command on `turbo.json`
+        # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
+        # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
+        # commit on the base branch that this pull_request refers to.
+        # We also set the Turborepo Cache to the `.turbo` folder
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        run: echo "turbo_args=\"--filter=\\\"...[${{ github.event.pull_request.base.sha }}]\\\" --cache-dir=\\\".turbo\\\"\"" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: [base]
 
     strategy:
       fail-fast: false
@@ -41,28 +51,20 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      # This ensures that we run an optimised version of `tar` that is more efficient
-      # In unzipping the cache files
-      - name: Use GNU tar instead BSD tar
-        if: matrix.os == 'windows-latest'
-        shell: cmd
-        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
-
-      - name: Git Checkout
+      - name: Git Checkout (`base_ref`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # We only need to fetch the current commit for the build steps
-          fetch_depth: 1
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
+          # We only need to fetch the last commit from the base_ref
+          # for installing our dependencies in safe mode and other safe operations
+          fetch-depth: 1
+          # This ensures we're checkint out the base_ref and not the pull request codebase
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            ~/.npm
+            .turbo
             .next/cache
             node_modules/.cache
           # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
@@ -79,14 +81,28 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages
+      - name: Install NPM packages (`base_ref`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
-        # For the build step we also omit `devDependencies` as they're not needed for the build step
-        run: npm i --no-audit --no-fund --omit=dev
+        run: npm i --no-audit --no-fund
+
+      - name: Git Checkout (`head_sha`)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          # We only need to fetch the last commit from the head_ref
+          # since we're not using the `--filter` operation from turborepo
+          fetch-depth: 1
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install NPM packages (`base_ref`)
+        # We want to ignore-scripts from code checked out from the user as it might be dangerous
+        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 
       - name: Build Next.js
-        run: npx turbo build
+        run: npm exec --package=turbo@latest -- turbo build ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
         env:
           # We want to ensure we have enough RAM allocated to the Node.js process
           # this should be a last resort in case by any chances the build memory gets too high
@@ -99,7 +115,7 @@ jobs:
       - name: Analyse Build
         # We generate a Bundle Analysis Report
         # See https://github.com/hashicorp/nextjs-bundle-analysis
-        run: npx -p nextjs-bundle-analysis report
+        run: npm exec --package=nextjs-bundle-analysis@0.5.0 report
 
       - name: Upload Build Analysis
         # We upload the Bundle Analysis Artifact to be used on the next step
@@ -114,7 +130,6 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            ~/.npm
             .next/cache
             node_modules/.cache
           # Most of sibling Pull Requests will use the cache key based on the package-lock.json
@@ -129,15 +144,14 @@ jobs:
     needs: [build]
 
     steps:
-      - name: Git Checkout
+      - name: Git Checkout (`base_ref`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # We only need to fetch the current commit for the build steps
+          # We only need to fetch the latest commit of the `base_ref` here for the analysis steps
           fetch_depth: 1
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
+          # For this step we don't need to checkout on the userland codebase
+          # As we can simply checkout on the latest commit of the `base_ref` for the analysis steps
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Download PR Bundle Analysis
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
@@ -171,12 +185,12 @@ jobs:
           mkdir -p .next/analyze/base/bundle/
           cp .next/analyze/__bundle_analysis.json .next/analyze/base/bundle/__bundle_analysis.json
 
-      - name: Compare with base branch bundle
+      - name: Compare Analysis Bundle (Base vs HEAD)
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         if: success() && github.event.number
         run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
 
-      - name: Get Comment Body
+      - name: Generate Bundle Analysis Comment
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         id: get-comment-body
         if: success() && github.event.number
@@ -185,7 +199,7 @@ jobs:
           echo "$(cat .next/analyze/__bundle_analysis_comment.txt)" >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
 
-      - name: Find Comment
+      - name: Find Existing Bundle Analysis Comment
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1
         if: success() && github.event.number
@@ -194,7 +208,7 @@ jobs:
           issue-number: ${{ github.event.number }}
           body-includes: '<!-- __NEXTJS_BUNDLE_nodejs.org -->'
 
-      - name: Create Comment
+      - name: Create Bundle Analysis Comment (if does not exist)
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa
         if: success() && github.event.number && steps.find-comment-id.outputs.comment-id == 0
@@ -202,7 +216,7 @@ jobs:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
 
-      - name: Update Comment
+      - name: Update Bundle Analysis Comment (if does exist)
         # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa
         if: success() && github.event.number && steps.find-comment-id.outputs.comment-id != 0

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
       - main
+  # This trigger ensures that the GitHub Action Workflow metadata that is fetched comes from the `main` branch
+  # This is important to disallow this Workflow from being modified in forks and PRs
+  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   pull_request_target:
     branches:
       - main
-  workflow_dispatch:
 
 defaults:
   run:
+    # This ensures that the working directory is the root of the repository
     working-directory: ./
 
 permissions:
@@ -18,6 +21,14 @@ permissions:
   actions: read
   # This permission is required by `peter-evans/create-or-update-comment`
   pull-requests: write
+
+env:
+  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepoe's cache that include optimised cache
+  # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--token
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   build:
@@ -30,6 +41,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      # This ensures that we run an optimised version of `tar` that is more efficient
+      # In unzipping the cache files
       - name: Use GNU tar instead BSD tar
         if: matrix.os == 'windows-latest'
         shell: cmd
@@ -38,8 +51,11 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Since we use `pull_request_target` we want to checkout the current ref
-          # If this Workflow is running on main this will return an empty string
+          # We only need to fetch the current commit for the build steps
+          fetch_depth: 1
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Cache
@@ -49,6 +65,8 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
+          # As this should reduce build times, and the overall time for installing packages or running operations
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
@@ -57,35 +75,52 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
         with:
+          # We want to ensure that the Node.js version running here respects our supported versions
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install NPM packages
-        run: npm ci --no-audit --no-fund --omit=dev
+        # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
+        # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
+        # For the build step we also omit `devDependencies` as they're not needed for the build step
+        run: npm i --no-audit --no-fund --omit=dev
 
       - name: Build Next.js
-        run: npx turbo build --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}"
+        run: npx turbo build
         env:
-          TURBO_FORCE: true
+          # We want to ensure we have enough RAM allocated to the Node.js process
+          # this should be a last resort in case by any chances the build memory gets too high
+          # but in general this should never happen
           NODE_OPTIONS: '--max_old_space_size=4096'
+          # We want to avoid having Next.js's Telemetry to kick-in during this build
+          # See https://nextjs.org/telemetry
           NEXT_TELEMETRY_DISABLED: 1
 
       - name: Analyse Build
+        # We generate a Bundle Analysis Report
+        # See https://github.com/hashicorp/nextjs-bundle-analysis
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload Build Analysis
+        # We upload the Bundle Analysis Artifact to be used on the next step
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: bundle-analysis
           path: .next/analyze/__bundle_analysis.json
 
       - name: Save Cache
+        # We only save Job caches on the Build Step as it's the only one that produces cache
+        # because it contains relevant Next.js's cache metadata
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
             ~/.npm
             .next/cache
             node_modules/.cache
+          # Most of sibling Pull Requests will use the cache key based on the package-lock.json
+          # We do also add a hashFiles for `.next/cache` as GitHub Actions only allows
+          # One cache with same key to exist, so to ensure we always have a cache from the latest build
+          # We add the hashFiles of `.next/cache` to the cache key of the Cache Entry
           key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.next/cache/**') }}
 
   analysis:
@@ -97,17 +132,22 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Since we use `pull_request_target` we want to checkout the current ref
-          # If this Workflow is running on main this will return an empty string
+          # We only need to fetch the current commit for the build steps
+          fetch_depth: 1
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download PR Bundle Analysis
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: bundle-analysis
           path: .next/analyze
 
       - name: Download Base Bundle Analysis
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
         if: success() && github.event.number
         with:
@@ -117,22 +157,27 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Check Base Bundle Analysis File
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         id: check-base-bundle-analysis-file
         uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
         with:
           files: .next/analyze/base/bundle/__bundle_analysis.json
 
       - name: Copy PR Bundle Analysis (Fallback)
+        # In case a Analysis of the base branch does not exist, we don't want to fail the CI action
+        # Hence we simply fallback to the Bundle Analysis of the current Build
         if: steps.check-base-bundle-analysis-file.outputs.files_exists == 'false'
         run: |
           mkdir -p .next/analyze/base/bundle/
           cp .next/analyze/__bundle_analysis.json .next/analyze/base/bundle/__bundle_analysis.json
 
       - name: Compare with base branch bundle
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         if: success() && github.event.number
         run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
 
       - name: Get Comment Body
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         id: get-comment-body
         if: success() && github.event.number
         run: |
@@ -141,6 +186,7 @@ jobs:
           echo EOF >> $GITHUB_OUTPUT
 
       - name: Find Comment
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1
         if: success() && github.event.number
         id: find-comment-id
@@ -149,6 +195,7 @@ jobs:
           body-includes: '<!-- __NEXTJS_BUNDLE_nodejs.org -->'
 
       - name: Create Comment
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa
         if: success() && github.event.number && steps.find-comment-id.outputs.comment-id == 0
         with:
@@ -156,6 +203,7 @@ jobs:
           body: ${{ steps.get-comment-body.outputs.body }}
 
       - name: Update Comment
+        # This Step is Auto Generated by https://github.com/hashicorp/nextjs-bundle-analysis
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa
         if: success() && github.event.number && steps.find-comment-id.outputs.comment-id != 0
         with:

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -27,6 +27,8 @@ jobs:
   base:
     name: Base Tasks
     runs-on: ubuntu-latest
+    outputs:
+      turbo_args: ${{ steps.turborepo_arguments.outputs.turbo_args }}
 
     steps:
       - name: Provide Turborepo Arguments
@@ -102,7 +104,9 @@ jobs:
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 
       - name: Build Next.js
-        run: npm exec --package=turbo@latest -- turbo build ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
+        # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
+        # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo build ${{ needs.base.outputs.turbo_args }}
         env:
           # We want to ensure we have enough RAM allocated to the Node.js process
           # this should be a last resort in case by any chances the build memory gets too high

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           # We only need to fetch the latest commit of the `base_ref` here for the analysis steps
-          fetch_depth: 1
+          fetch-depth: 1
           # For this step we don't need to checkout on the userland codebase
           # As we can simply checkout on the latest commit of the `base_ref` for the analysis steps
           ref: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build Next.js
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo build ${{ needs.base.outputs.turbo_args }}
+        run: npx --package=turbo@latest -- turbo build ${{ needs.base.outputs.turbo_args }}
         env:
           # We want to ensure we have enough RAM allocated to the Node.js process
           # this should be a last resort in case by any chances the build memory gets too high
@@ -104,7 +104,7 @@ jobs:
       - name: Analyse Build
         # We generate a Bundle Analysis Report
         # See https://github.com/hashicorp/nextjs-bundle-analysis
-        run: npm exec --package=nextjs-bundle-analysis@0.5.0 report
+        run: npx --package=nextjs-bundle-analysis@0.5.0 report
 
       - name: Upload Build Analysis
         # We upload the Bundle Analysis Artifact to be used on the next step

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -33,14 +33,10 @@ jobs:
     steps:
       - name: Provide Turborepo Arguments
         id: turborepo_arguments
-        # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
-        # It verifies if any change was done to any of the including `glob` patterns described for a said command on `turbo.json`
-        # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
-        # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
-        # commit on the base branch that this pull_request refers to.
         # We also set the Turborepo Cache to the `.turbo` folder
-        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        run: echo "turbo_args=\"--filter=\\\"...[${{ github.event.pull_request.base.sha }}]\\\" --cache-dir=\\\".turbo\\\"\"" >> "$GITHUB_OUTPUT"
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
+        run: echo "turbo_args=--force=true --cache-dir=.turbo" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build on ${{ matrix.os }}

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         # We also set the Turborepo Cache to the `.turbo` folder
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
-        run: echo "turbo_args=--force=true --cache-dir=.turbo" >> "$GITHUB_OUTPUT"
+        run: echo "turbo_args=--force=true --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build on ${{ matrix.os }}
@@ -54,9 +54,10 @@ jobs:
         with:
           # We only need to fetch the last commit from the head_ref
           # since we're not using the `--filter` operation from turborepo
+          # We don't use the `--filter` as we always want to force builds regardless of having changes or not
+          # this ensures that our bundle analysis script always runs and that we always ensure next.js is building
+          # regardless of having code changes or not
           fetch-depth: 1
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -64,7 +65,7 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             .next/cache
             node_modules/.cache
           # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
@@ -116,7 +117,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             .next/cache
             node_modules/.cache
           # Most of sibling Pull Requests will use the cache key based on the package-lock.json

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -49,14 +49,16 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - name: Git Checkout (`base_ref`)
+      - name: Git Checkout (`head_sha`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # We only need to fetch the last commit from the base_ref
-          # for installing our dependencies in safe mode and other safe operations
+          # We only need to fetch the last commit from the head_ref
+          # since we're not using the `--filter` operation from turborepo
           fetch-depth: 1
-          # This ensures we're checkint out the base_ref and not the pull request codebase
-          ref: ${{ github.event.pull_request.base.ref }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Build Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -79,28 +81,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
         # We also use `--omit=dev` to avoid installing devDependencies as we don't need them during the build step
-        run: npm i --no-audit --no-fund  --omit=dev
-
-      - name: Git Checkout (`head_sha`)
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          # We only need to fetch the last commit from the head_ref
-          # since we're not using the `--filter` operation from turborepo
-          fetch-depth: 1
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
-          # We do not want to cleanup after already checking out base branch
-          clean: false
-
-      - name: Install NPM packages (`head_sha`)
-        # We want to ignore-scripts from code checked out from the user as it might be dangerous
-        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null --omit=dev
+        run: npm i --no-audit --no-fund --userconfig=/dev/null --omit=dev
 
       - name: Build Next.js
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -58,7 +58,7 @@ jobs:
           # This ensures we're checkint out the base_ref and not the pull request codebase
           ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Restore Cache
+      - name: Restore Build Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
@@ -67,10 +67,10 @@ jobs:
             node_modules/.cache
           # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
           # As this should reduce build times, and the overall time for installing packages or running operations
-          key: cache-${{ hashFiles('package-lock.json') }}-
+          key: cache-build-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
-            cache-${{ hashFiles('package-lock.json') }}-
-            cache-
+            cache-build-${{ hashFiles('package-lock.json') }}-
+            cache-build-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
@@ -127,19 +127,18 @@ jobs:
           name: bundle-analysis
           path: .next/analyze/__bundle_analysis.json
 
-      - name: Save Cache
-        # We only save Job caches on the Build Step as it's the only one that produces cache
-        # because it contains relevant Next.js's cache metadata
+      - name: Save Build Cache
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
+            .turbo
             .next/cache
             node_modules/.cache
           # Most of sibling Pull Requests will use the cache key based on the package-lock.json
           # We do also add a hashFiles for `.next/cache` as GitHub Actions only allows
           # One cache with same key to exist, so to ensure we always have a cache from the latest build
           # We add the hashFiles of `.next/cache` to the cache key of the Cache Entry
-          key: cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.next/cache/**') }}
+          key: cache-build-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.next/cache/**') }}
 
   analysis:
     name: Analysis

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -82,7 +82,8 @@ jobs:
       - name: Install NPM packages (`base_ref`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
-        run: npm i --no-audit --no-fund
+        # We also use `--omit=dev` to avoid installing devDependencies as we don't need them during the build step
+        run: npm i --no-audit --no-fund  --omit=dev
 
       - name: Git Checkout (`head_sha`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
@@ -99,7 +100,7 @@ jobs:
 
       - name: Install NPM packages (`head_sha`)
         # We want to ignore-scripts from code checked out from the user as it might be dangerous
-        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
+        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null --omit=dev
 
       - name: Build Next.js
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -49,6 +49,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      - name: Use GNU tar instead BSD tar
+        # This ensures that we use GNU `tar` which is more efficient for extracting caches's
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+
       - name: Git Checkout (`head_sha`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
@@ -102,11 +108,13 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
 
       - name: Analyse Build
+        if: matrix.os == 'ubuntu-latest'
         # We generate a Bundle Analysis Report
         # See https://github.com/hashicorp/nextjs-bundle-analysis
         run: npx --package=nextjs-bundle-analysis@0.5.0 report
 
       - name: Upload Build Analysis
+        if: matrix.os == 'ubuntu-latest'
         # We upload the Bundle Analysis Artifact to be used on the next step
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 env:
-  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepoe's cache that include optimised cache
+  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepo's cache that include optimised cache
   # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
   # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/build-and-analysis.yml
+++ b/.github/workflows/build-and-analysis.yml
@@ -94,8 +94,10 @@ jobs:
           # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
+          # We do not want to cleanup after already checking out base branch
+          clean: false
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to ignore-scripts from code checked out from the user as it might be dangerous
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,9 @@ jobs:
   base:
     name: Base Tasks
     runs-on: ubuntu-latest
+    outputs:
+      fetch_depth: ${{ steps.calculate_current_commits.outputs.fetch_depth }}
+      turbo_args: ${{ steps.turborepo_arguments.outputs.turbo_args }}
 
     steps:
       - name: Calculate Commits to Checkout
@@ -49,7 +52,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: base
+    needs: [base]
 
     steps:
       - name: Git Checkout (`base_ref`)
@@ -91,7 +94,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
           # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
           # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
@@ -110,18 +113,18 @@ jobs:
 
       - name: Run `turbo lint`
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
-        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo lint ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
+        # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo lint ${{ needs.base.outputs.turbo_args }}
 
       - name: Run `turbo prettier`
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
-        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo prettier ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
+        # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo prettier ${{ needs.base.outputs.turbo_args }}
 
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    needs: base
+    needs: [base]
 
     steps:
       - name: Git Checkout (`base_ref`)
@@ -163,7 +166,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
           # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
           # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
@@ -175,8 +178,8 @@ jobs:
 
       - name: Run Unit Tests
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
-        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo test:unit ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }} -- --ci --coverage
+        # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo test:unit ${{ needs.base.outputs.turbo_args }} -- --ci --coverage
 
       - name: Jest Coverage Comment
         # This comments the current Jest Coverage Report containing JUnit XML reports
@@ -189,5 +192,5 @@ jobs:
 
       - name: Run Storybook Tests
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
-        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo test:storybook:local ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }} -- --ci
+        # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo test:storybook:local ${{ needs.base.outputs.turbo_args }} -- --ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
-        run: echo "turbo_args=--filter=\"...[${{ github.event.pull_request.base.sha }}]\" --cache-dir=.turbo" >> "$GITHUB_OUTPUT"
+        run: echo "turbo_args=--filter=\"...[${{ github.event.pull_request.base.sha }}]\" --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint
@@ -62,8 +62,6 @@ jobs:
         with:
           # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
           fetch-depth: ${{ needs.base.outputs.fetch_depth }}
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -71,12 +69,12 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             node_modules/.cache
           # We want to restore Turborepo Cache and ESlint and Prettier Cache
-          key: cache-lint-${{ hashFiles('package-lock.json') }}
+          key: cache-lint-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
-            cache-lint-${{ hashFiles('package-lock.json') }}
+            cache-lint-${{ hashFiles('package-lock.json') }}-
             cache-lint-
 
       - name: Set up Node.js
@@ -105,9 +103,9 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             node_modules/.cache
-          key: cache-lint-${{ hashFiles('package-lock.json') }}
+          key: cache-lint-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.turbo/cache/**') }}
 
   tests:
     name: Tests
@@ -129,12 +127,12 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             node_modules/.cache
           # We want to restore Turborepo Cache and Storybook Cache
-          key: cache-tests-${{ hashFiles('package-lock.json') }}
+          key: cache-tests-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
-            cache-tests-${{ hashFiles('package-lock.json') }}
+            cache-tests-${{ hashFiles('package-lock.json') }}-
             cache-tests-
 
       - name: Set up Node.js
@@ -172,6 +170,6 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            .turbo
+            .turbo/cache
             node_modules/.cache
-          key: cache-tests-${{ hashFiles('package-lock.json') }}
+          key: cache-tests-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.turbo/cache/**') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,13 +108,6 @@ jobs:
         # We want to ignore-scripts from code checked out from the user as it might be dangerous
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 
-      - name: Ensure Turborepo is installed
-        # This removes any attempt of local hijack of the Turbo binary and forces an install of Turborepo on
-        # the current NPM scope without being added to `package.json`
-        run: |
-          rm -rf node_modules/bin/turbo
-          npm i --no-audit --no-fund --no-save turbo@latest
-
       - name: Run `turbo lint`
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -114,16 +114,5 @@ jobs:
           junitxml-path: ./junit.xml
           junitxml-title: Unit Test Report
 
-      - name: Capture Deployment URL
-        id: vercel_storybook_preview_url
-        uses: zentered/vercel-preview-url@e5fb141da2e3d62692b38e6c7c17477aad214165
-        with:
-          vercel_project_id: ${{ secrets.TURBO_PROJECT_ID }}
-          vercel_team_id: ${{ secrets.TURBO_TEAM }}
-        env:
-          VERCEL_TOKEN: ${{ secrets.TURBO_TOKEN }}
-
       - name: Run Storybook Tests
-        run: npx turbo test:storybook --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}" -- --ci
-        env:
-          TARGET_URL: 'https://${{ steps.vercel_storybook_preview_url.outputs.preview_url }}'
+        run: npx turbo test:storybook:local --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}" -- --ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ env:
   # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
   # commit on the base branch that this pull_request refers to.
   TURBO_REF_FILTER: ${{ github.event.pull_request.base.sha }}
-  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepoe's cache that include optimised cache
+  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepo's cache that include optimised cache
   # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
   # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,9 @@ jobs:
         # commit on the base branch that this pull_request refers to.
         # We also set the Turborepo Cache to the `.turbo` folder
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        run: echo "turbo_args=\"--filter=\\\"...[${{ github.event.pull_request.base.sha }}]\\\" --cache-dir=\\\".turbo\\\"\"" >> "$GITHUB_OUTPUT"
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
+        run: echo "turbo_args=--filter=\"...[${{ github.event.pull_request.base.sha }}]\" --cache-dir=.turbo" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
-  # It verifies if any change was done to any of the including `glob` patterns described for a siad command on `turbo.json`
+  # It verifies if any change was done to any of the including `glob` patterns described for a said command on `turbo.json`
   # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
   # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
   # commit on the base branch that this pull_request refers to.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,14 +57,15 @@ jobs:
     needs: [base]
 
     steps:
-      - name: Git Checkout (`base_ref`)
+      - name: Git Checkout (`head_sha`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # We only need to fetch the last commit from the base_ref
-          # for installing our dependencies in safe mode and other safe operations
-          fetch-depth: 1
-          # This ensures we're checkint out the base_ref and not the pull request codebase
-          ref: ${{ github.event.pull_request.base.ref }}
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Lint Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -85,25 +86,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
-        run: npm i --no-audit --no-fund
-
-      - name: Git Checkout (`head_sha`)
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
-          # We do not want to cleanup after already checking out base branch
-          clean: false
-
-      - name: Install NPM packages (`head_sha`)
-        # We want to ignore-scripts from code checked out from the user as it might be dangerous
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 
       - name: Run `turbo lint`
@@ -130,14 +115,15 @@ jobs:
     needs: [base]
 
     steps:
-      - name: Git Checkout (`base_ref`)
+      - name: Git Checkout (`head_sha`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # We only need to fetch the last commit from the base_ref
-          # for installing our dependencies in safe mode and other safe operations
-          fetch-depth: 1
-          # This ensures we're checkint out the base_ref and not the pull request codebase
-          ref: ${{ github.event.pull_request.base.ref }}
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Tests Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -158,26 +144,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
-        run: npm i --no-audit --no-fund
-
-      - name: Git Checkout (`head_sha`)
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ needs.base.outputs.fetch_depth }}
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
-          # We do not want to cleanup after already checking out base branch
-          clean: false
-
-      - name: Install NPM packages (`head_sha`)
-        # We want to ignore-scripts from code checked out from the user as it might be dangerous
-        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
+        run: npm i --no-audit --no-fund --userconfig=/dev/null
 
       - name: Run Unit Tests
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,19 +66,17 @@ jobs:
           # This ensures we're checkint out the base_ref and not the pull request codebase
           ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Restore Cache
+      - name: Restore Lint Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
             .turbo
-            .next/cache
             node_modules/.cache
-          # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
-          # As this should reduce build times, and the overall time for installing packages or running operations
-          key: cache-${{ hashFiles('package-lock.json') }}-
+          # We want to restore Turborepo Cache and ESlint and Prettier Cache
+          key: cache-lint-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            cache-${{ hashFiles('package-lock.json') }}-
-            cache-
+            cache-lint-${{ hashFiles('package-lock.json') }}
+            cache-lint-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
@@ -118,6 +116,14 @@ jobs:
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
         run: npm exec --package=turbo@latest -- turbo prettier ${{ needs.base.outputs.turbo_args }}
 
+      - name: Save Lint Cache
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: |
+            .turbo
+            node_modules/.cache
+          key: cache-lint-${{ hashFiles('package-lock.json') }}
+
   tests:
     name: Tests
     runs-on: ubuntu-latest
@@ -133,19 +139,17 @@ jobs:
           # This ensures we're checkint out the base_ref and not the pull request codebase
           ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Restore Cache
+      - name: Restore Tests Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
             .turbo
-            .next/cache
             node_modules/.cache
-          # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
-          # As this should reduce build times, and the overall time for installing packages or running operations
-          key: cache-${{ hashFiles('package-lock.json') }}-
+          # We want to restore Turborepo Cache and Storybook Cache
+          key: cache-tests-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            cache-${{ hashFiles('package-lock.json') }}-
-            cache-
+            cache-tests-${{ hashFiles('package-lock.json') }}
+            cache-tests-
 
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
@@ -193,3 +197,11 @@ jobs:
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
         run: npm exec --package=turbo@latest -- turbo test:storybook:local ${{ needs.base.outputs.turbo_args }} -- --ci
+
+      - name: Save Tests Cache
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: |
+            .turbo
+            node_modules/.cache
+          key: cache-tests-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,12 +1,13 @@
+# Security Notes
+# Only selected Actions are allowed within this repository. Please refer to (https://github.com/nodejs/nodejs.org/settings/actions)
+# for the full list of available actions. If you want to add a new one, please reach out a maintainer with Admin permissions.
+# REVIEWERS, please always double-check security practices before merging a PR that contains Workflow changes!!
+# AUTHORS, please only use actions with explicit SHA references, and avoid using `@master` or `@main` references or `@version` tags.
+
 name: Pull Request Checks
 
 on:
-  # This trigger ensures that the GitHub Action Workflow metadata that is fetched comes from the `main` branch
-  # This is important to disallow this Workflow from being modified in forks and PRs
-  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
 
 defaults:
   run:
@@ -18,20 +19,6 @@ permissions:
   actions: read
   # This permission is required by `MishaKav/jest-coverage-comment`
   pull-requests: write
-
-env:
-  # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
-  # It verifies if any change was done to any of the including `glob` patterns described for a said command on `turbo.json`
-  # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
-  # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
-  # commit on the base branch that this pull_request refers to.
-  TURBO_REF_FILTER: ${{ github.event.pull_request.base.sha }}
-  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepo's cache that include optimised cache
-  # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--token
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   base:
@@ -48,27 +35,37 @@ jobs:
         # We need all the commits of the PR so that `turbo --filter` works correctly
         run: echo "fetch_depth=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "$GITHUB_OUTPUT"
 
+      - name: Provide Turborepo Arguments
+        id: turborepo_arguments
+        # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
+        # It verifies if any change was done to any of the including `glob` patterns described for a said command on `turbo.json`
+        # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
+        # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
+        # commit on the base branch that this pull_request refers to.
+        # We also set the Turborepo Cache to the `.turbo` folder
+        # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        run: echo "turbo_args=\"--filter=\\\"...[${{ github.event.pull_request.base.sha }}]\\\" --cache-dir=\\\".turbo\\\"\"" >> "$GITHUB_OUTPUT"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
     needs: base
 
     steps:
-      - name: Git Checkout
+      - name: Git Checkout (`base_ref`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
+          # We only need to fetch the last commit from the base_ref
+          # for installing our dependencies in safe mode and other safe operations
+          fetch-depth: 1
+          # This ensures we're checkint out the base_ref and not the pull request codebase
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            ~/.npm
+            .turbo
             .next/cache
             node_modules/.cache
           # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
@@ -85,16 +82,41 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages
+      - name: Install NPM packages (`base_ref`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
         run: npm i --no-audit --no-fund
 
-      - name: Run Linting
-        run: npx turbo lint --filter="...[$TURBO_REF_FILTER]"
+      - name: Git Checkout (`head_sha`)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run Prettier
-        run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
+      - name: Install NPM packages (`base_ref`)
+        # We want to ignore-scripts from code checked out from the user as it might be dangerous
+        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
+
+      - name: Ensure Turborepo is installed
+        # This removes any attempt of local hijack of the Turbo binary and forces an install of Turborepo on
+        # the current NPM scope without being added to `package.json`
+        run: |
+          rm -rf node_modules/bin/turbo
+          npm i --no-audit --no-fund --no-save turbo@latest
+
+      - name: Run `turbo lint`
+        # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
+        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo lint ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
+
+      - name: Run `turbo prettier`
+        # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
+        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo prettier ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}
 
   tests:
     name: Tests
@@ -102,21 +124,20 @@ jobs:
     needs: base
 
     steps:
-      - name: Git Checkout
+      - name: Git Checkout (`base_ref`)
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
-          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
-          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
-          # command will checkout `main` instead of the current pull_request ref
-          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
-          ref: ${{ github.event.pull_request.head.sha }}
+          # We only need to fetch the last commit from the base_ref
+          # for installing our dependencies in safe mode and other safe operations
+          fetch-depth: 1
+          # This ensures we're checkint out the base_ref and not the pull request codebase
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Restore Cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: |
-            ~/.npm
+            .turbo
             .next/cache
             node_modules/.cache
           # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
@@ -133,13 +154,29 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install NPM packages
+      - name: Install NPM packages (`base_ref`)
         # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
         # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
         run: npm i --no-audit --no-fund
 
+      - name: Git Checkout (`head_sha`)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install NPM packages (`base_ref`)
+        # We want to ignore-scripts from code checked out from the user as it might be dangerous
+        run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
+
       - name: Run Unit Tests
-        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage
+        # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
+        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo test:unit ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }} -- --ci --coverage
 
       - name: Jest Coverage Comment
         # This comments the current Jest Coverage Report containing JUnit XML reports
@@ -151,4 +188,6 @@ jobs:
           junitxml-title: Unit Test Report
 
       - name: Run Storybook Tests
-        run: npx turbo test:storybook:local --filter="...[$TURBO_REF_FILTER]" -- --ci
+        # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
+        # the `${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }}` is a string substitution happening from the base job
+        run: npm exec --package=turbo@latest -- turbo test:storybook:local ${{ jobs.base.steps.turborepo_arguments.outputs.turbo_args }} -- --ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,12 +92,12 @@ jobs:
       - name: Run `turbo lint`
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo lint ${{ needs.base.outputs.turbo_args }}
+        run: npx --package=turbo@latest -- turbo lint ${{ needs.base.outputs.turbo_args }}
 
       - name: Run `turbo prettier`
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo prettier ${{ needs.base.outputs.turbo_args }}
+        run: npx --package=turbo@latest -- turbo prettier ${{ needs.base.outputs.turbo_args }}
 
       - name: Save Lint Cache
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -150,7 +150,7 @@ jobs:
       - name: Run Unit Tests
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo test:unit ${{ needs.base.outputs.turbo_args }} -- --ci --coverage
+        run: npx --package=turbo@latest -- turbo test:unit ${{ needs.base.outputs.turbo_args }} -- --ci --coverage
 
       - name: Jest Coverage Comment
         # This comments the current Jest Coverage Report containing JUnit XML reports
@@ -164,7 +164,7 @@ jobs:
       - name: Run Storybook Tests
         # We want to enforce that the actual `turbo@latest` package is used instead of a possible hijack from the user
         # the `${{ needs.base.outputs.turbo_args }}` is a string substitution happening from the base job
-        run: npm exec --package=turbo@latest -- turbo test:storybook:local ${{ needs.base.outputs.turbo_args }} -- --ci
+        run: npx --package=turbo@latest -- turbo test:storybook:local ${{ needs.base.outputs.turbo_args }} -- --ci
 
       - name: Save Tests Cache
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,13 +1,16 @@
 name: Pull Request Checks
 
 on:
+  # This trigger ensures that the GitHub Action Workflow metadata that is fetched comes from the `main` branch
+  # This is important to disallow this Workflow from being modified in forks and PRs
+  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   pull_request_target:
     branches:
       - main
-  workflow_dispatch:
 
 defaults:
   run:
+    # This ensures that the working directory is the root of the repository
     working-directory: ./
 
 permissions:
@@ -16,22 +19,49 @@ permissions:
   # This permission is required by `MishaKav/jest-coverage-comment`
   pull-requests: write
 
+env:
+  # `--filter` flag allows us to tell TurboRepo to only run a said command if there were any changes found in a given --filter range
+  # It verifies if any change was done to any of the including `glob` patterns described for a siad command on `turbo.json`
+  # By default in this Workflow we use the `...[$TURBO_REF_FILTER]` as a value to the filter flag which tells Turborepo to look changes
+  # between the latest base branch commit and all the commits of this PR; That's why we use the `pull_request.base.sha` as a ref to the last
+  # commit on the base branch that this pull_request refers to.
+  TURBO_REF_FILTER: ${{ github.event.pull_request.base.sha }}
+  # We pass the `--team` and `--token` flags to the TurboRepo CLI so that it can retrieve remote Tuborepoe's cache that include optimised cache
+  # For specific commands (provided within each `turbo.json` -> `outputs`) and extra layer of cache that Turborepo defines
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--team
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--token
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
 jobs:
-  lint:
-    name: Lint
+  base:
+    name: Base Tasks
     runs-on: ubuntu-latest
 
     steps:
       - name: Calculate Commits to Checkout
-        # This is the amount of commits we should fetch
-        run: echo "GIT_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+        id: calculate_current_commits
+        # This calculates the amount of commits we should fetch during our shallow clone
+        # This calculates the amount of commits this PR produced diverged from the base branch + 1
+        # Which should include the "merge" commit reference
+        # In other words, the GitHub Action will always have the full history of the current PR
+        # We need all the commits of the PR so that `turbo --filter` works correctly
+        run: echo "fetch_depth=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "$GITHUB_OUTPUT"
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: base
+
+    steps:
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Get enough fetch-depth so that `turbo --filter` works correctly
-          fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
-          # Since we use `pull_request_target` we want to checkout the current ref
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Cache
@@ -41,6 +71,8 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
+          # As this should reduce build times, and the overall time for installing packages or running operations
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
@@ -49,38 +81,35 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
         with:
+          # We want to ensure that the Node.js version running here respects our supported versions
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install NPM packages
-        run: npm ci --no-audit --no-fund
+        # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
+        # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
+        run: npm i --no-audit --no-fund
 
       - name: Run Linting
-        run: npx turbo lint --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}"
+        run: npx turbo lint --filter="...[$TURBO_REF_FILTER]"
 
       - name: Run Prettier
-        run: npx turbo prettier --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}"
+        run: npx turbo prettier --filter="...[$TURBO_REF_FILTER]"
 
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    needs: base
 
     steps:
-      - name: Use GNU tar instead BSD tar
-        if: matrix.os == 'windows-latest'
-        shell: cmd
-        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
-
-      - name: Calculate Commits to Checkout
-        # This is the amount of commits we should fetch
-        run: echo "GIT_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-
       - name: Git Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          # Get enough fetch-depth so that `turbo --filter` works correctly
-          fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
-          # Since we use `pull_request_target` we want to checkout the current ref
+          # Here we apply the Environment Variable created above on the "Calculate Commits to Checkout"
+          fetch-depth: ${{ jobs.base.steps.calculate_current_commits.outputs.fetch_depth }}
+          # Since we use the `pull_request_target` event we want to checkout the current ref as by default this
+          # command will checkout `main` instead of the current pull_request ref
+          # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore Cache
@@ -90,6 +119,8 @@ jobs:
             ~/.npm
             .next/cache
             node_modules/.cache
+          # We want to restore cache from local .npm caches, .next/cache and node_modules/.cache
+          # As this should reduce build times, and the overall time for installing packages or running operations
           key: cache-${{ hashFiles('package-lock.json') }}-
           restore-keys: |
             cache-${{ hashFiles('package-lock.json') }}-
@@ -98,16 +129,21 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
         with:
+          # We want to ensure that the Node.js version running here respects our supported versions
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install NPM packages
-        run: npm ci --no-audit --no-fund
+        # We want to avoid NPM from running the Audit Step and Funding messages on a CI environment
+        # We also use `npm i` instead of `npm ci` so that the node_modules/.cache folder doesn't get deleted
+        run: npm i --no-audit --no-fund
 
       - name: Run Unit Tests
-        run: npx turbo test:unit --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}" -- --ci --coverage
+        run: npx turbo test:unit --filter="...[$TURBO_REF_FILTER]" -- --ci --coverage
 
       - name: Jest Coverage Comment
+        # This comments the current Jest Coverage Report containing JUnit XML reports
+        # and a Code Coverage Summary
         uses: MishaKav/jest-coverage-comment@41b5ca01d1250de84537448d248b8d18152cb277
         with:
           title: 'Unit Test Coverage Report'
@@ -115,4 +151,4 @@ jobs:
           junitxml-title: Unit Test Report
 
       - name: Run Storybook Tests
-        run: npx turbo test:storybook:local --filter="...[HEAD^]" --team="${{ secrets.TURBO_TEAM }}" --token="${{ secrets.TURBO_TEAM }}" -- --ci
+        run: npx turbo test:storybook:local --filter="...[$TURBO_REF_FILTER]" -- --ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,8 +101,10 @@ jobs:
           # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
+          # We do not want to cleanup after already checking out base branch
+          clean: false
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to ignore-scripts from code checked out from the user as it might be dangerous
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 
@@ -173,8 +175,10 @@ jobs:
           # command will checkout `main` instead of the current pull_request ref
           # We checkout the head.sha to get the latest commit, instead of head.ref that gives the current ref of the branch
           ref: ${{ github.event.pull_request.head.sha }}
+          # We do not want to cleanup after already checking out base branch
+          clean: false
 
-      - name: Install NPM packages (`base_ref`)
+      - name: Install NPM packages (`head_sha`)
         # We want to ignore-scripts from code checked out from the user as it might be dangerous
         run: npm i --no-audit --no-fund --ignore-scripts --userconfig=/dev/null
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "remark-gfm": "~3.0.1",
         "semver": "~7.5.4",
         "sharp": "0.32.1",
-        "turbo": "^1.10.7",
+        "turbo": "^1.10.12",
         "typescript": "~5.1.6"
       },
       "devDependencies": {
@@ -28297,26 +28297,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.7.tgz",
-      "integrity": "sha512-xm0MPM28TWx1e6TNC3wokfE5eaDqlfi0G24kmeHupDUZt5Wd0OzHFENEHMPqEaNKJ0I+AMObL6nbSZonZBV2HA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.12.tgz",
+      "integrity": "sha512-WM3+jTfQWnB9W208pmP4oeehZcC6JQNlydb/ZHMRrhmQa+htGhWLCzd6Q9rLe0MwZLPpSPFV2/bN5egCLyoKjQ==",
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.10.7",
-        "turbo-darwin-arm64": "1.10.7",
-        "turbo-linux-64": "1.10.7",
-        "turbo-linux-arm64": "1.10.7",
-        "turbo-windows-64": "1.10.7",
-        "turbo-windows-arm64": "1.10.7"
+        "turbo-darwin-64": "1.10.12",
+        "turbo-darwin-arm64": "1.10.12",
+        "turbo-linux-64": "1.10.12",
+        "turbo-linux-arm64": "1.10.12",
+        "turbo-windows-64": "1.10.12",
+        "turbo-windows-arm64": "1.10.12"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.7.tgz",
-      "integrity": "sha512-N2MNuhwrl6g7vGuz4y3fFG2aR1oCs0UZ5HKl8KSTn/VC2y2YIuLGedQ3OVbo0TfEvygAlF3QGAAKKtOCmGPNKA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.12.tgz",
+      "integrity": "sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==",
       "cpu": [
         "x64"
       ],
@@ -28326,9 +28326,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.7.tgz",
-      "integrity": "sha512-WbJkvjU+6qkngp7K4EsswOriO3xrNQag7YEGRtfLoDdMTk4O4QTeU6sfg2dKfDsBpTidTvEDwgIYJhYVGzrz9Q==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.12.tgz",
+      "integrity": "sha512-3JliEESLNX2s7g54SOBqqkqJ7UhcOGkS0ywMr5SNuvF6kWVTbuUq7uBU/sVbGq8RwvK1ONlhPvJne5MUqBCTCQ==",
       "cpu": [
         "arm64"
       ],
@@ -28338,9 +28338,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.7.tgz",
-      "integrity": "sha512-x1CF2CDP1pDz/J8/B2T0hnmmOQI2+y11JGIzNP0KtwxDM7rmeg3DDTtDM/9PwGqfPotN9iVGgMiMvBuMFbsLhg==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.12.tgz",
+      "integrity": "sha512-siYhgeX0DidIfHSgCR95b8xPee9enKSOjCzx7EjTLmPqPaCiVebRYvbOIYdQWRqiaKh9yfhUtFmtMOMScUf1gg==",
       "cpu": [
         "x64"
       ],
@@ -28350,9 +28350,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.7.tgz",
-      "integrity": "sha512-JtnBmaBSYbs7peJPkXzXxsRGSGBmBEIb6/kC8RRmyvPAMyqF8wIex0pttsI+9plghREiGPtRWv/lfQEPRlXnNQ==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.12.tgz",
+      "integrity": "sha512-K/ZhvD9l4SslclaMkTiIrnfcACgos79YcAo4kwc8bnMQaKuUeRpM15sxLpZp3xDjDg8EY93vsKyjaOhdFG2UbA==",
       "cpu": [
         "arm64"
       ],
@@ -28362,9 +28362,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.7.tgz",
-      "integrity": "sha512-7A/4CByoHdolWS8dg3DPm99owfu1aY/W0V0+KxFd0o2JQMTQtoBgIMSvZesXaWM57z3OLsietFivDLQPuzE75w==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.12.tgz",
+      "integrity": "sha512-7FSgSwvktWDNOqV65l9AbZwcoueAILeE4L7JvjauNASAjjbuzXGCEq5uN8AQU3U5BOFj4TdXrVmO2dX+lLu8Zg==",
       "cpu": [
         "x64"
       ],
@@ -28374,9 +28374,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.7.tgz",
-      "integrity": "sha512-D36K/3b6+hqm9IBAymnuVgyePktwQ+F0lSXr2B9JfAdFPBktSqGmp50JNC7pahxhnuCLj0Vdpe9RqfnJw5zATA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.12.tgz",
+      "integrity": "sha512-gCNXF52dwom1HLY9ry/cneBPOKTBHhzpqhMylcyvJP0vp9zeMQQkt6yjYv+6QdnmELC92CtKNp2FsNZo+z0pyw==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "remark-gfm": "~3.0.1",
     "semver": "~7.5.4",
     "sharp": "0.32.1",
-    "turbo": "^1.10.7",
+    "turbo": "^1.10.12",
     "typescript": "~5.1.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR reverts an experiment of using the remote Storybook Build that Vercel automatically does as the endpoint that our `test-storybook` runner should run against.

The primary motivation here is that the Storybook build will only finish after we reach the step of testing Stories.

This PR also fixes a few issues within Turborepo caching that were happening on PRs and also fixes the Turborepo `--filter` flag.

Lastly, this PR updates the inline documentation of our GitHub Action Workflows.
