### PR TITLE
fix: add missing releases page link

### DIFF
--- a/next.rewrites.mjs
+++ b/next.rewrites.mjs
@@ -24,6 +24,11 @@ const redirects = async () => [
     permanent: true,
   },
   {
+    source: '/en/about/releases',
+    destination: 'https://github.com/nodejs/release#release-schedule',
+    permanent: true,
+  },
+  {
     source: '/about/security',
     destination:
       'https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security',


### PR DESCRIPTION
## Description

Our GCP Node SDK references the NodeJS releases page and as part of our CI, we check for broken links when generating documentation pages. With some recent changes, the link to `nodejs.org/en/about/releases` stopped working, which broke our CI pipeline.

Also, searching on Github, seems like multiple projects references the same page: 
* https://github.com/search?q=%22https%3A%2F%2Fnodejs.org%2Fen%2Fabout%2Freleases%22&type=code (28k hits)

I've added the extra route in the `next.rewrites.mjs` file accordingly to PR  https://github.com/nodejs/nodejs.org/pull/5580, which also reference the file https://github.com/nodejs/build/blob/f7e0f90a55b0c866041668e4285a16274f1e36f7/ansible/www-standalone/resources/config/nodejs.org?plain=1#L338. And we can see that `/en/about/releases` is indeed missing from the new rewrite logic.

## Validation

Manual Testing that the Rewrites Work.

## Related Issues

* A SDK release on hold due to that: https://github.com/googleapis/nodejs-bigquery/pull/1231
* We started a fix for our internal repository template, which will cause all of our Node repos to be updated: https://github.com/googleapis/synthtool/pull/1841

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [ ] I've covered new added functionality with unit tests if necessary.
