### PR TITLE
fix: symmetric git diff due to head behind base

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
-        run: echo "turbo_args=--filter=\"[HEAD~${{ steps.calculate_current_commits.outputs.fetch_depth }}...HEAD]\" --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
+        run: echo "turbo_args=--filter=\"[HEAD~${{ github.event.pull_request.commits }}...HEAD]\" --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
         # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
-        run: echo "turbo_args=--filter=\"...[${{ github.event.pull_request.base.sha }}]\" --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
+        run: echo "turbo_args=--filter=\"[HEAD~${{ steps.calculate_current_commits.outputs.fetch_depth }}...HEAD]\" --cache-dir=.turbo/cache" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This is a hot-fix for "git diff" giving symmetric commits as the `base.sha` refers to a commit that is not fetched (checked out) during our shallow clone. Hence we update the `--filter` command to use the relative comparison of `HEAD~N...HEAD` where `N` amount of commits of the current Pull Request.
