### PR TITLE
fix: sitemap url for production deployments

### DIFF
--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -32,11 +32,12 @@ export const ENABLE_STATIC_EXPORT =
  *
  * @see https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#framework-environment-variables
  */
-export const BASE_URL = process.env.VERCEL_ENV === 'production'
-  ? 'https://nodejs.org'
-  : process.env.NEXT_PUBLIC_VERCEL_URL
-  ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-  : process.env.NEXT_PUBLIC_BASE_URL || 'https://nodejs.org';
+export const BASE_URL =
+  process.env.VERCEL_ENV === 'production'
+    ? 'https://nodejs.org'
+    : process.env.NEXT_PUBLIC_VERCEL_URL
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+    : process.env.NEXT_PUBLIC_BASE_URL || 'https://nodejs.org';
 
 /**
  * This is used for any place that requires the Node.js distribution URL (which by default is nodejs.org/dist)

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -32,7 +32,9 @@ export const ENABLE_STATIC_EXPORT =
  *
  * @see https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#framework-environment-variables
  */
-export const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL
+export const BASE_URL = process.env.VERCEL_ENV === 'production'
+  ? 'https://nodejs.org'
+  : process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : process.env.NEXT_PUBLIC_BASE_URL || 'https://nodejs.org';
 

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -32,12 +32,11 @@ export const ENABLE_STATIC_EXPORT =
  *
  * @see https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#framework-environment-variables
  */
-export const BASE_URL =
-  process.env.VERCEL_ENV === 'production'
-    ? 'https://nodejs.org'
-    : process.env.NEXT_PUBLIC_VERCEL_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-    : process.env.NEXT_PUBLIC_BASE_URL || 'https://nodejs.org';
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+  ? process.env.NEXT_PUBLIC_BASE_URL
+  : process.env.NEXT_PUBLIC_VERCEL_URL
+  ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+  : 'https://nodejs.org';
 
 /**
  * This is used for any place that requires the Node.js distribution URL (which by default is nodejs.org/dist)


### PR DESCRIPTION
## Description

The sitemap for production deployments point to the wrong url.

You can see this by visiting https://nodejs.org/sitemap.xml 

![image](https://github.com/nodejs/nodejs.org/assets/229881/f4b489f2-675d-4941-8f54-40d1db6074d9)

## Validation

You'll need to set the `NEXT_PUBLIC_BASE_URL` env var and then visit `/sitemap.xml` to see the impact.

You can set the env var in the Vercel dashboard and redeploy, or you can try it locally via `next dev` by creating `.env.local`.

## Related Issues

https://twitter.com/mayankistyping/status/1686288768326914048

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [ ] I've covered new added functionality with unit tests if necessary.
