### PR TITLE
chore: fix robots generation and updated ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,13 +6,8 @@ node_modules
 .swc
 build
 
-# Files that should not be parsed
-CODEOWNERS
-
 # Legacy Public Files
-public/en/user-survey-report
 public/static/documents
-public/static/legacy
 
 # We don't want to lint/prettify the Coverage Results
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build
 # Next.js Generated Files
 public/robots.txt
 public/sitemap.xml
+public/default-sitemap.xml
 public/en/feed/*.xml
 
 # Jest

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,9 +10,7 @@ build
 CODEOWNERS
 
 # Legacy Public Files
-public/en/user-survey-report
 public/static/documents
-public/static/legacy
 public/node-releases-data.json
 
 # We don't want to lint/prettify the Coverage Results

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,10 +5,15 @@ import * as nextRewrites from './next.rewrites.mjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // This configures all the Next.js rewrites
-  rewrites: nextRewrites.rewrites,
+  // This configures all the Next.js rewrites, which are used for rewriting internal URLs into other internal Endpoints
+  // This feature is not supported within static export builds, hence we pass an empty array if static exports are enabled
+  rewrites: !nextConstants.ENABLE_STATIC_EXPORT
+    ? nextRewrites.rewrites
+    : undefined,
   // This configures all Next.js redirects
-  redirects: nextRewrites.redirects,
+  redirects: !nextConstants.ENABLE_STATIC_EXPORT
+    ? nextRewrites.redirects
+    : undefined,
   // We intentionally disable Next.js's built-in i18n support
   // as we dom have our own i18n and internationalisation engine
   i18n: null,

--- a/next.rewrites.mjs
+++ b/next.rewrites.mjs
@@ -1,6 +1,9 @@
 'use strict';
 
-import { availableLocales } from './next.locales.mjs';
+import * as nextLocales from './next.locales.mjs';
+
+// We only need Locale Codes for our URL redirects and rewrties
+const localeCodes = nextLocales.availableLocales.map(locale => locale.code);
 
 // This allows us to prefix redirect with all available locale codes, so that redirects are not bound to a single locale
 // This also transforms the locale itself as a matching group that can be used for rewrites
@@ -8,14 +11,14 @@ import { availableLocales } from './next.locales.mjs';
 // Example: /:locale(ar/|ca/|de/|en/|es/|fa/|fr/|)about/security
 // Would match /ar/about/security, /ar/about/security/ for every language code (replace "ar") and
 // it would also match /about/security (without any language prefix)
-const localesMatch = `/:locale(${availableLocales
-  .map(locale => locale.code)
-  .join('|')}|)?/`;
+const localesMatch = `/:locale(${localeCodes.join('|')}|)?/`;
 
 /**
  * These are external redirects that happen before we check dynamic routes and rewrites
  * These are sourced originally from https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/config/nodejs.org?plain=1
  * and were then converted to Next.js rewrites. Note that only relevant rewrites were added and some were modified to match Next.js's syntax
+ *
+ * @TODO: These values should be no-code; These should be imported from a JSON file or something similar
  *
  * @type {import('next').NextConfig['redirects']}
  */
@@ -145,6 +148,8 @@ const redirects = async () => [
  * These should be used either for internal or external rewrite rules (like NGINX, for example)
  * These are sourced originally from https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/config/nodejs.org?plain=1
  * and were then converted to Next.js rewrites. Note that only relevant rewrites were added and some were modified to match Next.js's syntax
+ *
+ * @TODO: These values should be no-code; These should be imported from a JSON file or something similar
  *
  * @type {import('next').NextConfig['rewrites']}
  */

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "postbuild": "npm run scripts:generate-robots",
     "start": "cross-env NODE_NO_WARNINGS=1 next start",
     "deploy": "cross-env NEXT_STATIC_EXPORT=true npm run build",
-    "postdeploy": "npm run scripts:generate-robots",
     "lint:js": "eslint \"**/*.{mjs,ts,tsx}\" --cache --cache-file .eslintjscache --report-unused-disable-directives",
     "lint:md": "eslint \"**/*.md?(x)\" --cache --cache-file .eslintmdcache",
     "lint:scss": "stylelint --config .stylelintrc.json \"**/*.{css,sass,scss}\"",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
   "scripts": {
     "scripts:release-post": "cross-env NODE_NO_WARNINGS=1 node scripts/release-post/index.mjs",
     "scripts:generate-next-data": "cross-env NODE_NO_WARNINGS=1 node scripts/generate-next-data/index.mjs",
+    "scripts:generate-robots": "cross-env NODE_NO_WARNINGS=1 next-sitemap --config=robots.config.mjs",
     "preserve": "npm run scripts:generate-next-data",
     "serve": "cross-env NODE_NO_WARNINGS=1 next dev",
     "prebuild": "npm run scripts:generate-next-data",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
+    "postbuild": "npm run scripts:generate-robots",
     "start": "cross-env NODE_NO_WARNINGS=1 next start",
     "deploy": "cross-env NEXT_STATIC_EXPORT=true npm run build",
+    "postdeploy": "npm run scripts:generate-robots",
     "lint:js": "eslint \"**/*.{mjs,ts,tsx}\" --cache --cache-file .eslintjscache --report-unused-disable-directives",
     "lint:md": "eslint \"**/*.md?(x)\" --cache --cache-file .eslintmdcache",
     "lint:scss": "stylelint --config .stylelintrc.json \"**/*.{css,sass,scss}\"",
@@ -37,7 +40,8 @@
     "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test": "npm run test:unit",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "npx next telemetry disable"
   },
   "dependencies": {
     "@nodevu/core": "~0.1.0",

--- a/robots.config.mjs
+++ b/robots.config.mjs
@@ -1,0 +1,28 @@
+'use strict';
+
+import * as nextConstants from './next.constants.mjs';
+
+/** @type {import('next-sitemap').IConfig} */
+const sitemapConfig = {
+  siteUrl: `${nextConstants.BASE_URL}${nextConstants.BASE_PATH}`,
+  output: nextConstants.ENABLE_STATIC_EXPORT ? 'export' : undefined,
+  // This "default" sitemap is a fallback for when our dynamic Sitemap Generation failed
+  // In general this is not used, and should NOT be used
+  sitemapBaseFileName: 'default-sitemap',
+  // We don't need an "index" sitemap file, it is fine to simply have all in just one file
+  // even thought we have a lot of routes on our siotemap
+  generateIndexSitemap: false,
+  // We want to enable `robots.txt` generation, and we define their rules on the `robotsTxtOptions` object
+  generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        disallow: ['/dist/', '/docs/'],
+        allow: ['/dist/latest/', '/dist/latest/docs/api/', '/api/'],
+      },
+    ],
+  },
+};
+
+export default sitemapConfig;

--- a/robots.config.mjs
+++ b/robots.config.mjs
@@ -6,6 +6,9 @@ import * as nextConstants from './next.constants.mjs';
 const sitemapConfig = {
   siteUrl: `${nextConstants.BASE_URL}${nextConstants.BASE_PATH}`,
   output: nextConstants.ENABLE_STATIC_EXPORT ? 'export' : undefined,
+  // During Static Builds we want to output the sitemap files to the "build" directory whilst with regular Builds
+  // we simply output the file to the public folder (which is the default)
+  outDir: nextConstants.ENABLE_STATIC_EXPORT ? 'build' : 'public',
   // This "default" sitemap is a fallback for when our dynamic Sitemap Generation failed
   // In general this is not used, and should NOT be used
   sitemapBaseFileName: 'default-sitemap',


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes the missing generation of a `robots.txt` file for both regular builds and static builds.

This PR also fixes static builds that were broken due to `rewrites` and `redirects` not being supported by static builds (obviously)

## Validation

- `npm run deploy` should work as normal
  - We might want to add static builds to our CI pipeline to ensure they still work
- `robotx.txt` is generated on `build` folder for static builds or `public` for regular ones