### PR TITLE
fix: main download button for linux incorrect

### DIFF
--- a/util/downloadUrlByOS.ts
+++ b/util/downloadUrlByOS.ts
@@ -13,6 +13,8 @@ export const downloadUrlByOS = (
       return `${baseURL}/node-${versionWithPrefix}.pkg`;
     case 'WIN':
       return `${baseURL}/node-${versionWithPrefix}-x${bitness}.msi`;
+    case 'LINUX':
+      return `${baseURL}/node-${versionWithPrefix}-linux-x64.tar.xz`;
     default:
       return `${baseURL}/node-${versionWithPrefix}.tar.xz`;
   }

--- a/util/downloadUrlByOS.ts
+++ b/util/downloadUrlByOS.ts
@@ -14,6 +14,6 @@ export const downloadUrlByOS = (
     case 'WIN':
       return `${baseURL}/node-${versionWithPrefix}-x${bitness}.msi`;
     default:
-      return `${baseURL}/node-${versionWithPrefix}.tar.gz`;
+      return `${baseURL}/node-${versionWithPrefix}.tar.xz`;
   }
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes https://github.com/nodejs/nodejs.org/issues/5610 - the download button for Linux on the front page of the website links to the source tar archive, not the built node.js for that platform as it should.

## Validation

Main download link is for the binary, not the source, when connecting from a Linux web browser.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing, and/or `npx turbo test:snapshot` to update snapshots if I created and/or updated React Components.
- [ ] I've covered new added functionality with unit tests if necessary.
