### PR TITLE
fix: fixed theme flash on page load

### DIFF
--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -92,6 +92,19 @@ export const DEFAULT_LOCALE_CODE = nextLocales.defaultLocale.code;
 export const LEGACY_JAVASCRIPT_FILE = `${BASE_PATH}/static/js/legacyMain.js`;
 
 /**
+ * This script source replaces the logic for the initial theme set in the Legacy Javascript File.
+ *
+ * @deprecated This theme script is a temporal fix until the Legacy Website is removed.
+ */
+export const INITIAL_THEME_SCRIPT = `!(function () {
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const theme = localStorage.getItem('theme') ?? systemTheme;
+  document.querySelector('html').setAttribute('data-theme', theme);
+  document.body.className = theme;
+  window.localStorage.setItem('theme', theme);
+})();`;
+
+/**
  * This is a list of all static routes or pages from the Website that we do not
  * want to allow to be statically built on our Static Export Build.
  *

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -15,6 +15,13 @@ const Document = () => (
         src={nextConstants.LEGACY_JAVASCRIPT_FILE}
       />
 
+      <script
+        id="initial-theme-script"
+        dangerouslySetInnerHTML={{
+          __html: nextConstants.INITIAL_THEME_SCRIPT,
+        }}
+      />
+
       <a rel="me" href="https://social.lfx.dev/@nodejs" />
     </body>
   </Html>

--- a/public/static/js/legacyMain.js
+++ b/public/static/js/legacyMain.js
@@ -80,19 +80,12 @@ const listenScrollToTopButton = () => {
   });
 };
 
-const setCurrentTheme = () =>
-  setTheme(getTheme() || (preferredColorScheme.matches ? 'dark' : 'light'));
-
 const startLegacyApp = () => {
-  setCurrentTheme();
-
   watchThemeChanges();
 
   listenLanguagePickerButton();
   listenThemeToggleButton();
   listenScrollToTopButton();
 };
-
-setCurrentTheme();
 
 window.startLegacyApp = startLegacyApp;


### PR DESCRIPTION
## Description

This PR introduces a simple fix for addressing the theme flashing that is noticeable when the page loads. It uses a custom script that mimics the `setCurrentTheme` function in the `legacyMain.js` script but directly injects into the head element. This way, the page does not need to wait for the `legacyMain.js` script to load to apply the theme as the script is already in the html response.

## Validation

To ensure this fix works you can either do a simple page refresh, or head to the Performance tab in the developer tools and perform a profiler start with page refresh and see that there is no theme flash present.