### PR TITLE
fix: lint-staged to run stylelint

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,8 @@
 {
-  "**/*.{mjs,ts,tsx,md,mdx}": ["prettier --write", "eslint --fix"],
-  "**/*.{json,yml}": ["prettier --write"],
-  "**/*.{css,sass,scss}": ["prettier --write", "stylelint --config .stylelintrc.json"],
+  "**/*.{mjs,ts,tsx,md,mdx}": ["eslint --fix", "prettier --write"],
+  "**/*.{css,sass,scss}": [
+    "stylelint --config .stylelintrc.json",
+    "prettier --write"
+  ],
+  "**/*.{json,yml}": ["prettier --write"]
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,5 @@
 {
-  "**/*.{mjs,ts,tsx,md,mdx}": ["eslint --fix"],
-  "**/*.{mjs,ts,tsx,md,mdx,json,yml,css,sass,scss}": ["prettier --write"]
+  "**/*.{mjs,ts,tsx,md,mdx}": ["prettier --write", "eslint --fix"],
+  "**/*.{json,yml}": ["prettier --write"],
+  "**/*.{css,sass,scss}": ["prettier --write", "stylelint --config .stylelintrc.json"],
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes lint-staged not running `stylelint` on style files such as (CSS, Sass and SCSS).

This PR also rearranges matching patterns so patterns can be reused.

## Validation

Lint-Staged should work as expected. (This must be tested locally)