### PR TITLE
feat: introduced alternate hreflangs for all the available languages

### DIFF
--- a/app/en/feed/[feed]/route.ts
+++ b/app/en/feed/[feed]/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import * as nextJson from '@/next.json.mjs';
-import * as nextData from '@/next.data.mjs';
+import { blogData } from '@/next.json.mjs';
+import { generateWebsiteFeeds } from '@/next.data.mjs';
 
 // loads all the data from the blog-posts-data.json file
-const websiteFeeds = nextData.generateWebsiteFeeds(nextJson.blogData);
+const websiteFeeds = generateWebsiteFeeds(blogData);
 
 type StaticParams = { params: { feed: string } };
 

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -9,7 +9,7 @@ import {
 } from '@/next.constants.mjs';
 
 // This is the combination of the Application Base URL and Base PATH
-const canonicalUrl = `${BASE_URL}${BASE_PATH}`;
+const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;
 
 // This method populates and generates the Website Sitemap by using `next-sitemap` SSR functionality
 // @see https://nextjs.org/docs/app/building-your-application/routing/router-handlers
@@ -28,7 +28,7 @@ export const GET = () => {
 
   return getServerSideSitemap(
     [...dynamicRoutes, ...staticPaths].sort().map(route => ({
-      loc: `${canonicalUrl}/${route}`,
+      loc: `${baseUrlAndPath}/${route}`,
       lastmod: currentDate,
       changefreq: 'always',
       // We build the alternate languages based on the source pages
@@ -36,7 +36,7 @@ export const GET = () => {
       alternateRefs: availableLocales.map(locale => ({
         hreflang: locale.code,
         hrefIsAbsolute: true,
-        href: `${canonicalUrl}/${route.replace(
+        href: `${baseUrlAndPath}/${route.replace(
           `${defaultLocale.code}/`,
           `${locale.code}/`
         )}`,

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,20 +1,26 @@
 import { getServerSideSitemap } from 'next-sitemap';
-import * as nextDynamic from '@/next.dynamic.mjs';
-import * as nextConstants from '@/next.constants.mjs';
+import { allPaths } from '@/next.dynamic.mjs';
+import { defaultLocale, availableLocales } from '@/next.locales.mjs';
+import {
+  STATIC_ROUTES_IGNORES,
+  DYNAMIC_GENERATED_ROUTES,
+  BASE_PATH,
+  BASE_URL,
+} from '@/next.constants.mjs';
 
 // This is the combination of the Application Base URL and Base PATH
-const canonicalUrl = `${nextConstants.BASE_URL}${nextConstants.BASE_PATH}`;
+const canonicalUrl = `${BASE_URL}${BASE_PATH}`;
 
 // This method populates and generates the Website Sitemap by using `next-sitemap` SSR functionality
 // @see https://nextjs.org/docs/app/building-your-application/routing/router-handlers
 export const GET = () => {
   // Retrieves all the dynamic generated paths
-  const dynamicRoutes = nextConstants.DYNAMIC_GENERATED_ROUTES();
+  const dynamicRoutes = DYNAMIC_GENERATED_ROUTES();
 
-  // Retrieves all the static paths (from next.dynamic.mjs)
-  const staticPaths = [...nextDynamic.allPaths.values()]
-    .flat()
-    .filter(route => nextConstants.STATIC_ROUTES_IGNORES.every(e => !e(route)))
+  // Retrieves all the static paths for the default locale (English)
+  // and filter out the routes that should be ignored
+  const staticPaths = [...allPaths.get(defaultLocale.code)!]
+    .filter(route => STATIC_ROUTES_IGNORES.every(e => !e(route)))
     .map(route => route.routeWithLocale);
 
   // The current date of this request
@@ -25,6 +31,16 @@ export const GET = () => {
       loc: `${canonicalUrl}/${route}`,
       lastmod: currentDate,
       changefreq: 'always',
+      // We build the alternate languages based on the source pages
+      // This allows Google to correctly index these pages
+      alternateRefs: availableLocales.map(locale => ({
+        hreflang: locale.code,
+        hrefIsAbsolute: true,
+        href: `${canonicalUrl}/${route.replace(
+          `${defaultLocale.code}/`,
+          `${locale.code}/`
+        )}`,
+      })),
     }))
   );
 };

--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -6,14 +6,17 @@ import { BASE_URL, BASE_PATH } from '@/next.constants.mjs';
 import type { LegacyFrontMatter } from '@/types';
 import type { FC } from 'react';
 
+// This is the combination of the Application Base URL and Base PATH
+const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;
+
 type HeaderProps = { frontMatter: LegacyFrontMatter };
 
 const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
   const siteConfig = useSiteConfig();
-  const { asPath, basePath } = useRouter();
+  const { asPath } = useRouter();
   const { availableLocales, currentLocale, defaultLocale } = useLocale();
 
-  const canonicalLink = `${BASE_URL}${BASE_PATH}${asPath}`;
+  const canonicalLink = `${baseUrlAndPath}${asPath}`;
 
   const pageTitle = frontMatter.title
     ? `${frontMatter.title} | ${siteConfig.title}`
@@ -36,7 +39,7 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
 
       <meta
         property="og:image"
-        content={`${basePath}${siteConfig.featuredImage}`}
+        content={`${baseUrlAndPath}${siteConfig.featuredImage}`}
       />
 
       <meta property="og:image:type" content={siteConfig.og.imgType} />
@@ -49,7 +52,7 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
 
       <meta
         name="twitter:image"
-        content={`${basePath}${siteConfig.twitter.img}`}
+        content={`${baseUrlAndPath}${siteConfig.twitter.img}`}
       />
 
       <meta name="twitter:image:alt" content={siteConfig.twitter.imgAlt} />
@@ -58,7 +61,7 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
 
       <link
         rel="icon"
-        href={`${basePath}${siteConfig.favicon}`}
+        href={`${baseUrlAndPath}${siteConfig.favicon}`}
         type="image/png"
       />
 
@@ -87,7 +90,7 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
         <link
           key={feed.file}
           title={feed.title}
-          href={`${basePath}/en/feed/${feed.file}`}
+          href={`${baseUrlAndPath}/en/feed/${feed.file}`}
           rel="alternate"
           type="application/rss+xml"
         />

--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { useSiteConfig } from '@/hooks/useSiteConfig';
 import { useRouter } from '@/hooks/useRouter';
+import { useLocale } from '@/hooks/useLocale';
 import { BASE_URL, BASE_PATH } from '@/next.constants.mjs';
 import type { LegacyFrontMatter } from '@/types';
 import type { FC } from 'react';
@@ -10,6 +11,7 @@ type HeaderProps = { frontMatter: LegacyFrontMatter };
 const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
   const siteConfig = useSiteConfig();
   const { asPath, basePath } = useRouter();
+  const { availableLocales, currentLocale, defaultLocale } = useLocale();
 
   const canonicalLink = `${BASE_URL}${BASE_PATH}${asPath}`;
 
@@ -22,12 +24,6 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
       <title>{pageTitle}</title>
 
       <meta name="theme-color" content={siteConfig.accentColor}></meta>
-
-      <link
-        rel="icon"
-        href={`${basePath}${siteConfig.favicon}`}
-        type="image/png"
-      />
 
       <meta name="robots" content={frontMatter.robots || 'index, follow'} />
 
@@ -60,12 +56,39 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
 
       <link rel="canonical" href={canonicalLink} />
 
+      <link
+        rel="icon"
+        href={`${basePath}${siteConfig.favicon}`}
+        type="image/png"
+      />
+
+      <link
+        rel="alternate"
+        hrefLang="x-default"
+        href={canonicalLink.replace(
+          `/${currentLocale.code}/`,
+          `/${defaultLocale.code}/`
+        )}
+      />
+
+      {availableLocales.map(locale => (
+        <link
+          key={locale.code}
+          rel="alternate"
+          hrefLang={locale.code}
+          href={canonicalLink.replace(
+            `/${currentLocale.code}`,
+            `/${locale.code}`
+          )}
+        />
+      ))}
+
       {siteConfig.rssFeeds.map(feed => (
         <link
           key={feed.file}
-          rel="alternate"
-          href={`${basePath}/en/feed/${feed.file}`}
           title={feed.title}
+          href={`${basePath}/en/feed/${feed.file}`}
+          rel="alternate"
           type="application/rss+xml"
         />
       ))}

--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -66,8 +66,8 @@ const HtmlHead: FC<HeaderProps> = ({ frontMatter }) => {
         rel="alternate"
         hrefLang="x-default"
         href={canonicalLink.replace(
-          `/${currentLocale.code}/`,
-          `/${defaultLocale.code}/`
+          `/${currentLocale.code}`,
+          `/${defaultLocale.code}`
         )}
       />
 

--- a/hooks/useLocale.ts
+++ b/hooks/useLocale.ts
@@ -4,8 +4,10 @@ import { LocaleContext } from '@/providers/localeProvider';
 import { linkWithLocale } from '@/util/linkWithLocale';
 
 export const useLocale = () => {
-  const { currentLocale, availableLocales } = useContext(LocaleContext);
   const { asPath } = useRouter();
+
+  const { currentLocale, availableLocales, defaultLocale } =
+    useContext(LocaleContext);
 
   const localizedLink = linkWithLocale(currentLocale.code);
 
@@ -13,8 +15,9 @@ export const useLocale = () => {
     localizedLink(route).replace(/[#|?].*$/, '');
 
   return {
-    availableLocales: availableLocales,
-    currentLocale: currentLocale,
+    availableLocales,
+    currentLocale,
+    defaultLocale,
     isCurrentLocaleRoute: (route: string, allowSubPath?: boolean) => {
       const localisedRoute = localisedPath(route);
       const asPathJustPath = asPath.replace(/[#|?].*$/, '');

--- a/hooks/useNavigation.tsx
+++ b/hooks/useNavigation.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import * as nextJson from '@/next.json.mjs';
+import { siteNavigation } from '@/next.json.mjs';
 import type { NavigationEntry, NavigationKeys } from '@/types';
 
 // Translation Context for FormattedMessage
@@ -39,13 +39,13 @@ export const useNavigation = () => {
   };
 
   return {
-    navigationItems: mapNavigationEntries(nextJson.siteNavigation),
+    navigationItems: mapNavigationEntries(siteNavigation),
     getSideNavigation: (section: NavigationKeys, context?: Context) =>
       mapNavigationEntries(
         // We need the parent and their items when making a side navigation
         {
-          [section]: nextJson.siteNavigation[section],
-          ...nextJson.siteNavigation[section].items,
+          [section]: siteNavigation[section],
+          ...siteNavigation[section].items,
         },
         context
       ),

--- a/hooks/useRouter.ts
+++ b/hooks/useRouter.ts
@@ -1,25 +1,26 @@
 import { useMemo } from 'react';
 import { useRouter as useNextRouter } from 'next/router';
-import * as nextLocales from '@/next.locales.mjs';
+import {
+  availableLocales,
+  getCurrentLocale,
+  defaultLocale,
+} from '@/next.locales.mjs';
 import type { NextRouter } from 'next/router';
 
 // Maps all available locales by only their Language Code
-const mappedLocalesByCode = nextLocales.availableLocales.map(l => l.code);
+const mappedLocalesByCode = availableLocales.map(l => l.code);
 
 export const useRouter = (): NextRouter => {
   const router = useNextRouter();
 
   return useMemo(() => {
-    const currentLocale = nextLocales.getCurrentLocale(
-      router.asPath,
-      router.query
-    );
+    const currentLocale = getCurrentLocale(router.asPath, router.query);
 
     return {
       ...router,
       locale: currentLocale.code,
       locales: mappedLocalesByCode,
-      defaultLocale: nextLocales.defaultLocale.code,
+      defaultLocale: defaultLocale.code,
     };
   }, [router]);
 };

--- a/next-data/generateWebsiteFeeds.mjs
+++ b/next-data/generateWebsiteFeeds.mjs
@@ -1,8 +1,8 @@
 'use strict';
 
 import { Feed } from 'feed';
-import * as nextJson from '../next.json.mjs';
-import * as nextConstants from '../next.constants.mjs';
+import { siteConfig } from '../next.json.mjs';
+import { BASE_URL, BASE_PATH } from '../next.constants.mjs';
 
 /**
  * This method generates RSS website feeds based on the current website configuration
@@ -11,21 +11,21 @@ import * as nextConstants from '../next.constants.mjs';
  * @param {import('../types').BlogData} blogData
  */
 const generateWebsiteFeeds = ({ posts }) => {
-  const canonicalUrl = `${nextConstants.BASE_URL}${nextConstants.BASE_PATH}/en`;
+  const canonicalUrl = `${BASE_URL}${BASE_PATH}/en`;
 
   /**
    * This generates all the Website RSS Feeds that are used for the website
    *
    * @type {[string, Feed][]}
    */
-  const websiteFeeds = nextJson.siteConfig.rssFeeds.map(
+  const websiteFeeds = siteConfig.rssFeeds.map(
     ({ category, title, description, file }) => {
       const feed = new Feed({
         id: file,
         title: title,
         language: 'en',
         link: `${canonicalUrl}/feed/${file}`,
-        description: description || nextJson.siteConfig.description,
+        description: description || siteConfig.description,
       });
 
       const blogFeedEntries = posts

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -135,7 +135,7 @@ export const getMarkdownFile = (
  *
  * @returns {Promise<{ notFound: boolean, props: any; revalidate: number | boolean }>} the props for the page
  */
-export const getStaticProps = async (source = '', filename = '') => {
+export const generateStaticProps = async (source = '', filename = '') => {
   // by default a page is not found if there's no source or filename
   const staticProps = { notFound: true, props: {}, revalidate: false };
 

--- a/pages/[...path].tsx
+++ b/pages/[...path].tsx
@@ -1,7 +1,17 @@
 import { sep } from 'node:path';
 import Theme from '@/theme';
-import * as nextDynamic from '@/next.dynamic.mjs';
-import * as nextConstants from '@/next.constants.mjs';
+import {
+  getMarkdownFile,
+  generateStaticProps,
+  allPaths,
+} from '@/next.dynamic.mjs';
+import {
+  ENABLE_STATIC_EXPORT,
+  STATIC_ROUTES_IGNORES,
+  DYNAMIC_ROUTES_IGNORES,
+  DYNAMIC_ROUTES_REWRITES,
+  DYNAMIC_GENERATED_ROUTES,
+} from '@/next.constants.mjs';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import type { DynamicStaticProps } from '@/types';
 
@@ -16,15 +26,14 @@ const getLocaleAndPathname = ([locale, ...path]: string[] = []) => [
 // This tests if the current pathname matches any expression that belongs
 // to the list of ignored routes and if it does we return `true` to indicate that
 const shouldIgnoreRoute = (pathname: string) =>
-  (pathname.length &&
-    nextConstants.DYNAMIC_ROUTES_IGNORES.some(e => e.test(pathname))) ||
+  (pathname.length && DYNAMIC_ROUTES_IGNORES.some(e => e.test(pathname))) ||
   false;
 
 // This tests if the current pathname matches any sort of rewrite rule
 // and if it does we return a the replacement expression for the pathname
 const getRouteWrite = (pathname: string) =>
   (pathname.length &&
-    nextConstants.DYNAMIC_ROUTES_REWRITES.find(([e]) => e.test(pathname))) ||
+    DYNAMIC_ROUTES_REWRITES.find(([e]) => e.test(pathname))) ||
   [];
 
 // This maps a pathname into an actual route object that can be used
@@ -48,14 +57,14 @@ export const getStaticProps: GetStaticProps<
   // We retrieve the source of the Markdown file by doing an educated guess
   // of what possible files could be the source of the page, since the extension
   // context is lost from `getStaticProps` as a limitation of Next.js itself
-  const { source, filename } = nextDynamic.getMarkdownFile(
+  const { source, filename } = getMarkdownFile(
     locale,
     rewriteRule ? rewriteRule(pathname) : pathname
   );
 
   // This parses the actual Markdown content and returns a full set of props
   // to be passed to the base page (`DynamicPage`) which will render the Markdown
-  const staticProps = await nextDynamic.getStaticProps(source, filename);
+  const staticProps = await generateStaticProps(source, filename);
 
   // This checks if either we already determined the route does not exist or if we should ignore
   // this route because it's on our ignored list
@@ -71,15 +80,15 @@ export const getStaticPaths: GetStaticPaths<DynamicStaticPaths> = async () => {
   const paths = [];
 
   // Retrieves all the dynamic generated paths
-  const dynamicRoutes = nextConstants.DYNAMIC_GENERATED_ROUTES();
+  const dynamicRoutes = DYNAMIC_GENERATED_ROUTES();
 
   // Retrieves all the static paths (from next.dynamic.mjs)
-  const staticPaths = [...nextDynamic.allPaths.values()]
+  const staticPaths = [...allPaths.values()]
     .flat()
-    .filter(route => nextConstants.STATIC_ROUTES_IGNORES.every(e => !e(route)))
+    .filter(route => STATIC_ROUTES_IGNORES.every(e => !e(route)))
     .map(route => route.routeWithLocale);
 
-  if (nextConstants.ENABLE_STATIC_EXPORT) {
+  if (ENABLE_STATIC_EXPORT) {
     paths.push(...staticPaths);
 
     paths.push(...dynamicRoutes);

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,6 @@
 import Script from 'next/script';
 import { Html, Head, Main, NextScript } from 'next/document';
-import * as nextConstants from '@/next.constants.mjs';
+import { LEGACY_JAVASCRIPT_FILE } from '@/next.constants.mjs';
 
 const Document = () => (
   <Html>
@@ -10,10 +10,7 @@ const Document = () => (
 
       <NextScript />
 
-      <Script
-        strategy="beforeInteractive"
-        src={nextConstants.LEGACY_JAVASCRIPT_FILE}
-      />
+      <Script strategy="beforeInteractive" src={LEGACY_JAVASCRIPT_FILE} />
 
       <a rel="me" href="https://social.lfx.dev/@nodejs" />
     </body>

--- a/providers/localeProvider.tsx
+++ b/providers/localeProvider.tsx
@@ -1,18 +1,21 @@
 import { createContext, useMemo } from 'react';
 import { IntlProvider } from 'react-intl';
 import { useRouter } from '@/hooks/useRouter';
-import * as nextLocales from '@/next.locales.mjs';
+import {
+  defaultLocale,
+  availableLocales,
+  getCurrentLocale,
+  getCurrentTranslations,
+} from '@/next.locales.mjs';
 import type { FC, PropsWithChildren } from 'react';
 import type { LocaleContext as LocaleContextType } from '@/types';
 
 // Initialises the Context with the default Localisation Data
 export const LocaleContext = createContext<LocaleContextType>({
-  currentLocale: nextLocales.defaultLocale,
-  availableLocales: nextLocales.availableLocales,
-  localeMessages: nextLocales.getCurrentTranslations(
-    nextLocales.defaultLocale.code
-  ),
-  defaultLocale: nextLocales.defaultLocale,
+  currentLocale: defaultLocale,
+  availableLocales: availableLocales,
+  localeMessages: getCurrentTranslations(defaultLocale.code),
+  defaultLocale: defaultLocale,
 });
 
 export const LocaleProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -20,13 +23,13 @@ export const LocaleProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const localeData = useMemo(() => {
     // Retrieves the current locale information from the route and query
-    const currentLocale = nextLocales.getCurrentLocale(asPath, query);
+    const currentLocale = getCurrentLocale(asPath, query);
 
     return {
       currentLocale: currentLocale,
-      availableLocales: nextLocales.availableLocales,
-      defaultLocale: nextLocales.defaultLocale,
-      localeMessages: nextLocales.getCurrentTranslations(currentLocale.code),
+      availableLocales: availableLocales,
+      defaultLocale: defaultLocale,
+      localeMessages: getCurrentTranslations(currentLocale.code),
     };
   }, [asPath, query]);
 

--- a/providers/localeProvider.tsx
+++ b/providers/localeProvider.tsx
@@ -12,6 +12,7 @@ export const LocaleContext = createContext<LocaleContextType>({
   localeMessages: nextLocales.getCurrentTranslations(
     nextLocales.defaultLocale.code
   ),
+  defaultLocale: nextLocales.defaultLocale,
 });
 
 export const LocaleProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -24,6 +25,7 @@ export const LocaleProvider: FC<PropsWithChildren> = ({ children }) => {
     return {
       currentLocale: currentLocale,
       availableLocales: nextLocales.availableLocales,
+      defaultLocale: nextLocales.defaultLocale,
       localeMessages: nextLocales.getCurrentTranslations(currentLocale.code),
     };
   }, [asPath, query]);

--- a/providers/siteProvider.tsx
+++ b/providers/siteProvider.tsx
@@ -1,12 +1,10 @@
 import { createContext } from 'react';
-import * as nextJson from '@/next.json.mjs';
+import { siteConfig } from '@/next.json.mjs';
 import type { FC, PropsWithChildren } from 'react';
 import type { SiteConfig } from '@/types';
 
-export const SiteContext = createContext<SiteConfig>(nextJson.siteConfig);
+export const SiteContext = createContext<SiteConfig>(siteConfig);
 
 export const SiteProvider: FC<PropsWithChildren> = ({ children }) => (
-  <SiteContext.Provider value={nextJson.siteConfig}>
-    {children}
-  </SiteContext.Provider>
+  <SiteContext.Provider value={siteConfig}>{children}</SiteContext.Provider>
 );

--- a/robots.config.mjs
+++ b/robots.config.mjs
@@ -1,14 +1,18 @@
 'use strict';
 
-import * as nextConstants from './next.constants.mjs';
+import {
+  BASE_URL,
+  BASE_PATH,
+  ENABLE_STATIC_EXPORT,
+} from './next.constants.mjs';
 
 /** @type {import('next-sitemap').IConfig} */
 const sitemapConfig = {
-  siteUrl: `${nextConstants.BASE_URL}${nextConstants.BASE_PATH}`,
-  output: nextConstants.ENABLE_STATIC_EXPORT ? 'export' : undefined,
+  siteUrl: `${BASE_URL}${BASE_PATH}`,
+  output: ENABLE_STATIC_EXPORT ? 'export' : undefined,
   // During Static Builds we want to output the sitemap files to the "build" directory whilst with regular Builds
   // we simply output the file to the public folder (which is the default)
-  outDir: nextConstants.ENABLE_STATIC_EXPORT ? 'build' : 'public',
+  outDir: ENABLE_STATIC_EXPORT ? 'build' : 'public',
   // This "default" sitemap is a fallback for when our dynamic Sitemap Generation failed
   // In general this is not used, and should NOT be used
   sitemapBaseFileName: 'default-sitemap',

--- a/types/i18n.ts
+++ b/types/i18n.ts
@@ -12,4 +12,5 @@ export interface LocaleContext {
   localeMessages: Record<string, string>;
   availableLocales: LocaleConfig[];
   currentLocale: LocaleConfig;
+  defaultLocale: LocaleConfig;
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates the `HtmlHead` by adding the alternate URLs and updates the Sitemap generation to only generated the routes in English and mark all other languages as alternate versions.

## Validation

The sitemap generation should be correct on the preview, and the HTML hreflang tags should also be included within the page.

## Related Issues

Partially Fixes https://github.com/nodejs/nodejs.org/issues/5627
