### PR TITLE
Replace Node.js Foundation with Node.js project

### DIFF
--- a/pages/en/get-involved/index.md
+++ b/pages/en/get-involved/index.md
@@ -14,7 +14,7 @@ layout: contribute.hbs
     * The [OpenJSF Slack](https://slack-invite.openjsf.org/) is a Foundation run Slack with several Node.js channels (channels prefixed by `#nodejs-` are related to the project).
     * [Node Slackers](https://www.nodeslackers.com/) is a Node.js-focused Slack community.
 * The official Node.js Twitter account is [nodejs](https://twitter.com/nodejs).
-* The [Node.js Foundation calendar](https://nodejs.org/calendar) with all public team meetings.
+* The [Node.js project calendar](https://nodejs.org/calendar) with all public team meetings.
 
 ## Learning
 


### PR DESCRIPTION
The Google calendar has been renamed in the same way and the Node.js Foundation does not exist anymore, for better or for worse.