### PR TITLE
docs: fix technicalities in CONTENT_VS_CODE

### DIFF
--- a/CONTENT_VS_CODE.md
+++ b/CONTENT_VS_CODE.md
@@ -2,8 +2,8 @@
 
 The **Website Team** (@nodejs/website) is primarily concerned with the code and overall structure of the website.
 
-The content of the website comes from a variety of working groups [(Release WG, Ecosystem Security WG and others)](https://github.com/nodejs/TSC/blob/main/WORKING_GROUPS.md#current-working-groups).
+The content of the website comes from Node.js core collaborators, in particular, from a variety of teams and [working groups](https://github.com/nodejs/TSC/blob/main/WORKING_GROUPS.md#current-working-groups).
 
-The Website team defers to these WGs on matters of content and routinely adds collaborators from these working groups as they add and improve content on the website. In other words, the Website team is not an **editorial** team except when no other Working Group has taken responsibility for a content area, meaning we are the default editors for that content.
+The Website team defers to these teams and WGs on matters of content and routinely adds collaborators from these teams and working groups as they add and improve content on the website. In other words, the Website team is not an **editorial** team except when no team or Working Group has taken responsibility for a content area, meaning we are the default editors for that content.
 
 An example of this policy playing out is new blog posts. Authors such as the Release WG have access to open PRs for new Node.js releases and merge them once their content is ready. No Website team approvals are needed.


### PR DESCRIPTION
WGs only make up a small portion of activity throughout the Node.js project. The mentioned "Ecosystem Security WG" does not exist anymore.

I am not sure what "routinely adds collaborators from these working groups" is supposed to mean. Are Node.js core collaborators added to something? Are the mentioned WG members added to the non-editorial website team?