### PR TITLE
fix(SEO): html lang

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,13 @@
 import Script from 'next/script';
 import { Html, Head, Main, NextScript } from 'next/document';
 import { LEGACY_JAVASCRIPT_FILE } from '@/next.constants.mjs';
+import type { DocumentProps } from 'next/document';
 
-const Document = () => (
-  <Html>
+const Document = ({ __NEXT_DATA__ }: DocumentProps) => (
+  <Html lang={__NEXT_DATA__.query.path ? __NEXT_DATA__.query.path[0] : 'en'}>
     <Head />
     <body>
       <Main />
-
       <NextScript />
 
       <Script strategy="beforeInteractive" src={LEGACY_JAVASCRIPT_FILE} />


### PR DESCRIPTION
## Description

`<html>` tags need `lang` attribute. It's not mandatory but it's good for SEO. So I add id.
FYI: This way of doing things is undocumented and unconventional. Because normally the lang is handle by nextjs internal I18n system.

[Better understanding of `lang` attribute](https://dequeuniversity.com/rules/axe/4.7/html-has-lang)

## Validation

* ✅ tested some page if `__NEXT_DATA__.query.path[0]` is an valid lang
* ✅ tested what happens when you're on root. it's why I have add `?` logical operator.

## Related Issues

No related issue

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- **NA** I've covered new added functionality with unit tests if necessary.
