### PR TITLE
Fix typo in Japanese download page

### DIFF
--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -18,7 +18,7 @@
   "components.navigation.getInvolved.links.contribute": "貢献する",
   "components.navigation.getInvolved.links.codeOfConduct": "行動規範",
   "components.downloadList.links.previousReleases": "バージョンの一覧",
-  "components.downloadList.links.packageManager": "Iパッケージマネージャを使用したダウンロード",
+  "components.downloadList.links.packageManager": "パッケージマネージャを使用したインストール",
   "components.downloadList.links.shaSums": "リリースファイルのための SHASUM 署名",
   "components.downloadList.links.shaSums.howToVerify": " (How to verify)",
   "components.downloadList.links.allDownloads": "All download options",


### PR DESCRIPTION
## Description
When I saw the [Japanese download page](https://nodejs.org/ja/download), I found that there two mistakes.

<img width="692" alt="Screenshot 2023-09-12 at 0 08 56" src="https://github.com/nodejs/nodejs.org/assets/20310935/2e08d831-a712-4d39-9513-8c70ce24e73d">

As we can see on [the English page](https://nodejs.org/en/download), the sentence is "Installing Node.js via package manager" but the Japanese sentence means "Download using I package manager".
Therefore, I removed "I" from the sentense and replaced "Download(ダウンロード)" with "Install(インストール)".

The Japanese sentence does not contain the word "Node.js", but it is acceptable because obvious text tends to be removed in the Japanese language.

## Validation

<img width="832" alt="Screenshot 2023-09-12 at 0 14 37" src="https://github.com/nodejs/nodejs.org/assets/20310935/9a1875ab-dd09-4f00-ab1a-d5b84242d08f">

## Related Issues
None

### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [] I've covered new added functionality with unit tests if necessary.
