### PR TITLE
fix: Don't pass JSON files to eslint in Translations workflow

### DIFF
--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run `npx lint:md --fix`
         # This runs a specific version of ESLint with only the Translation Pages Globbing
         # This avoid that unrelated changes get linted/modified within this PR
-        run: npx eslint "{pages,i18n}/**/*.{json,md,mdx}" --fix
+        run: npx eslint "pages/**/*.{md,mdx}" --fix
 
       - name: Run `npx prettier --write`
         # This runs a specific version of Prettier with only the Translation Pages Globbing


### PR DESCRIPTION
## Description

This PR removes JSON files from `eslint` command in Translations workflow as `eslint` couldn't parse them correclty.

## Validation

Updated command from workflow passed locally after change.

## Related Issues

#5748, #5782