### PR TITLE
meta: separate constants and introduce extra classes per theme

### DIFF
--- a/.storybook/constants.ts
+++ b/.storybook/constants.ts
@@ -1,0 +1,21 @@
+import { Open_Sans } from 'next/font/google';
+
+// These are the shared CSS classes between the Storybook Themes
+const THEME_COMMON_CLASSES = 'px-4 py-4 font-open-sans';
+
+// These are the theme-specific CSS classes for Storybook Themes
+export const THEME_EXTRA_CLASSES = {
+  dark: `${THEME_COMMON_CLASSES} bg-black text-white`,
+  light: `${THEME_COMMON_CLASSES} bg-white text-black`,
+  '': `${THEME_COMMON_CLASSES} bg-white text-black`,
+};
+
+// This configures the Next.js Font for Open Sans
+// We then export a variable and class name to be used
+// within Tailwind (tailwind.config.ts) and Storybook (preview.js)
+export const OPEN_SANS_FONT = Open_Sans({
+  weight: ['300', '400', '600', '700'],
+  display: 'fallback',
+  subsets: ['latin'],
+  variable: '--font-open-sans',
+});

--- a/.storybook/constants.ts
+++ b/.storybook/constants.ts
@@ -1,13 +1,39 @@
 import { Open_Sans } from 'next/font/google';
 
 // These are the shared CSS classes between the Storybook Themes
-const THEME_COMMON_CLASSES = 'px-4 py-4 font-open-sans';
+// Note: These are Tailwind Classes, and `font-open-sans` is the `open-sans`
+// font defined within the tailwind.config.ts config file
+export const COMMON_CLASSES = 'px-4 py-4 font-open-sans';
 
 // These are the theme-specific CSS classes for Storybook Themes
-export const THEME_EXTRA_CLASSES = {
-  dark: `${THEME_COMMON_CLASSES} bg-black text-white`,
-  light: `${THEME_COMMON_CLASSES} bg-white text-black`,
-  '': `${THEME_COMMON_CLASSES} bg-white text-black`,
+// Note: These are Tailwind Classes and black/white are defined within
+// the tailwind.config.ts config file as theme colors
+export const THEME_CLASSES = {
+  dark: `${COMMON_CLASSES} bg-black text-white`,
+  light: `${COMMON_CLASSES} bg-white text-black`,
+  '': `${COMMON_CLASSES} bg-white text-black`,
+};
+
+// This defines "execution" modes that Chromatic will run on the each Storybook Story
+// This allows us to test each Story with different parameters
+// @see https://www.chromatic.com/blog/introducing-story-modes/
+export const STORYBOOK_MODES = {
+  'dark mobile': {
+    theme: 'dark',
+    viewport: 'small',
+  },
+  'dark desktop': {
+    theme: 'dark',
+    viewport: 'large',
+  },
+  'light mobile': {
+    theme: 'light',
+    viewport: 'small',
+  },
+  'light desktop': {
+    theme: 'light',
+    viewport: 'large',
+  },
 };
 
 // This configures the Next.js Font for Open Sans

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -21,8 +21,8 @@ const preview: Preview = {
   parameters: {
     viewport: {
       viewports: {
-        small: { name: 'Small', styles: { width: '640px', height: '800px' } },
-        large: { name: 'Large', styles: { width: '1024px', height: '1000px' } },
+        small: { name: 'Small', styles: { width: '375px', height: '667px' } },
+        large: { name: 'Large', styles: { width: '1024px', height: '768px' } },
       },
     },
     nextjs: { router: { basePath: '' } },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,22 +1,15 @@
 import NextImage from 'next/image';
-import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import {
+  withThemeByDataAttribute,
+  withThemeByClassName,
+} from '@storybook/addon-themes';
 import { SiteProvider } from '../providers/siteProvider';
 import { ThemeProvider } from '../providers/themeProvider';
 import { LocaleProvider } from '../providers/localeProvider';
 import { OPEN_SANS_FONT, STORYBOOK_MODES, THEME_CLASSES } from './constants';
-import type { Preview, ReactRenderer, Decorator } from '@storybook/react';
+import type { Preview, ReactRenderer } from '@storybook/react';
 
 import '../styles/new/index.scss';
-
-const preview: Preview = {
-  parameters: {
-    nextjs: { router: { basePath: '' } },
-    chromatic: {
-      //🔶 Test each story for ArticleCard in two modes
-      modes: STORYBOOK_MODES,
-    },
-  },
-};
 
 // The `openSans.variable` injects the name of the Font Family to the DOM Tree
 // The `font-open-sans` variable is the actual Tailwind Classname
@@ -24,30 +17,46 @@ const preview: Preview = {
 const getStoryClasses = (theme: string) =>
   `${OPEN_SANS_FONT.variable} ${THEME_CLASSES[theme]}`;
 
-// These are extra Storybook Decorators applied to all stories
-// that introduce extra functionality such as Theme Switching
-// and all the App's Providers (Site, Theme, Locale)
-export const decorators: Decorator[] = [
-  (Story, context) => (
-    <SiteProvider>
-      <LocaleProvider>
-        <ThemeProvider>
-          <div className={getStoryClasses(context.globals.theme)}>
-            <Story />
-          </div>
-        </ThemeProvider>
-      </LocaleProvider>
-    </SiteProvider>
-  ),
-  withThemeByDataAttribute<ReactRenderer>({
-    themes: {
-      light: '',
-      dark: 'dark',
+const preview: Preview = {
+  parameters: {
+    viewport: {
+      viewports: {
+        small: { name: 'Small', styles: { width: '640px', height: '800px' } },
+        large: { name: 'Large', styles: { width: '1024px', height: '1000px' } },
+      },
     },
-    defaultTheme: 'light',
-    attributeName: 'data-theme',
-  }),
-];
+    nextjs: { router: { basePath: '' } },
+    chromatic: { modes: STORYBOOK_MODES },
+  },
+  // These are extra Storybook Decorators applied to all stories
+  // that introduce extra functionality such as Theme Switching
+  // and all the App's Providers (Site, Theme, Locale)
+  decorators: [
+    (Story, context) => {
+      console.log(context);
+
+      return (
+        <SiteProvider>
+          <LocaleProvider>
+            <ThemeProvider>
+              <div className={getStoryClasses(context.globals.theme)}>
+                <Story />
+              </div>
+            </ThemeProvider>
+          </LocaleProvider>
+        </SiteProvider>
+      );
+    },
+    withThemeByDataAttribute<ReactRenderer>({
+      themes: {
+        light: 'light',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+      attributeName: 'data-theme',
+    }),
+  ],
+};
 
 // This forces the Next.js image system to use unoptimized images
 // for all the Next.js Images (next/image) Components

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,19 +1,12 @@
 import NextImage from 'next/image';
-import { Open_Sans } from 'next/font/google';
+import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { SiteProvider } from '../providers/siteProvider';
 import { ThemeProvider } from '../providers/themeProvider';
 import { LocaleProvider } from '../providers/localeProvider';
-import { withThemeByDataAttribute } from '@storybook/addon-themes';
-import type { Preview, ReactRenderer } from '@storybook/react';
+import { OPEN_SANS_FONT, THEME_EXTRA_CLASSES } from './constants';
+import type { Preview, ReactRenderer, Decorator } from '@storybook/react';
 
 import '../styles/new/index.scss';
-
-const openSans = Open_Sans({
-  weight: ['300', '400', '600', '700'],
-  display: 'fallback',
-  subsets: ['latin'],
-  variable: '--font-open-sans',
-});
 
 const preview: Preview = {
   parameters: {
@@ -36,14 +29,18 @@ const preview: Preview = {
 // The `openSans.variable` injects the name of the Font Family to the DOM Tree
 // The `font-open-sans` variable is the actual Tailwind Classname
 // that tells that the font-family for this Component tree should be "Open Sans"
-const storyClasses = `${openSans.variable} font-open-sans`;
+const getStoryClasses = (theme: string) =>
+  `${OPEN_SANS_FONT.variable} ${THEME_EXTRA_CLASSES[theme]}`;
 
-export const decorators = [
-  Story => (
+// These are extra Storybook Decorators applied to all stories
+// that introduce extra functionality such as Theme Switching
+// and all the App's Providers (Site, Theme, Locale)
+export const decorators: Decorator[] = [
+  (Story, context) => (
     <SiteProvider>
       <LocaleProvider>
         <ThemeProvider>
-          <div className={storyClasses}>
+          <div className={getStoryClasses(context.globals.theme)}>
             <Story />
           </div>
         </ThemeProvider>
@@ -60,6 +57,8 @@ export const decorators = [
   }),
 ];
 
+// This forces the Next.js image system to use unoptimized images
+// for all the Next.js Images (next/image) Components
 Object.defineProperty(NextImage, 'default', {
   configurable: true,
   value: props => <NextImage {...props} unoptimized />,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,26 +3,18 @@ import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { SiteProvider } from '../providers/siteProvider';
 import { ThemeProvider } from '../providers/themeProvider';
 import { LocaleProvider } from '../providers/localeProvider';
-import { OPEN_SANS_FONT, THEME_EXTRA_CLASSES } from './constants';
+import { OPEN_SANS_FONT, STORYBOOK_MODES, THEME_CLASSES } from './constants';
 import type { Preview, ReactRenderer, Decorator } from '@storybook/react';
 
 import '../styles/new/index.scss';
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: '^on[A-Z].*' },
-    controls: {
-      matchers: {
-        color: /(background|color)$/i,
-        date: /Date$/,
-      },
+    nextjs: { router: { basePath: '' } },
+    chromatic: {
+      //🔶 Test each story for ArticleCard in two modes
+      modes: STORYBOOK_MODES,
     },
-    nextjs: {
-      router: {
-        basePath: '',
-      },
-    },
-    backgrounds: { disable: true },
   },
 };
 
@@ -30,7 +22,7 @@ const preview: Preview = {
 // The `font-open-sans` variable is the actual Tailwind Classname
 // that tells that the font-family for this Component tree should be "Open Sans"
 const getStoryClasses = (theme: string) =>
-  `${OPEN_SANS_FONT.variable} ${THEME_EXTRA_CLASSES[theme]}`;
+  `${OPEN_SANS_FONT.variable} ${THEME_CLASSES[theme]}`;
 
 // These are extra Storybook Decorators applied to all stories
 // that introduce extra functionality such as Theme Switching

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     './components/**/*.tsx',
     './layouts/**/*.tsx',
     './.storybook/preview.tsx',
+    './.storybook/constants.ts',
   ],
   theme: {
     colors: {


### PR DESCRIPTION
This PR introduces extra class names to be used within Storybook stories to "simulate" the text colors and background colors that would apply on the actual Website (such as a dark theme with a dark background).

This PR also extracts these extra class names into a dedicated file.