### PR TITLE
feat: Blockquote component

### DIFF
--- a/components/Common/Blockquote/index.module.css
+++ b/components/Common/Blockquote/index.module.css
@@ -1,0 +1,30 @@
+.wrapper {
+  @apply flex
+    max-w-2xl
+    flex-col
+    items-start
+    gap-4
+    self-stretch
+    border-l-2
+    border-green-600
+    py-2
+    pl-5
+    text-neutral-900
+    dark:border-green-400
+    dark:text-white;
+
+  & p {
+    @apply text-lg
+      font-semibold;
+  }
+
+  & cite {
+    @apply text-base
+      font-regular
+      not-italic;
+
+    &::before {
+      @apply content-['—_'];
+    }
+  }
+}

--- a/components/Common/Blockquote/index.module.css
+++ b/components/Common/Blockquote/index.module.css
@@ -9,14 +9,11 @@
     border-green-600
     py-2
     pl-5
+    text-lg
+    font-semibold
     text-neutral-900
     dark:border-green-400
     dark:text-white;
-
-  & p {
-    @apply text-lg
-      font-semibold;
-  }
 
   & cite {
     @apply text-base

--- a/components/Common/Blockquote/index.stories.tsx
+++ b/components/Common/Blockquote/index.stories.tsx
@@ -1,0 +1,56 @@
+import Blockquote from './';
+import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
+type Story = StoryObj<typeof Blockquote>;
+type Meta = MetaObj<typeof Blockquote>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <p>
+          “An expert is a person who has made all the mistakes that can be made
+          in a very narrow field.”
+        </p>
+        <cite>Niels Bohr</cite>
+      </>
+    ),
+  },
+};
+
+export const Without_Attribution: Story = {
+  args: {
+    children: (
+      <p>
+        “Commander Keen soared through the stars, leaving behind a galaxy of
+        memories, adventure, and boundless imagination. In the realm of gaming,
+        his farewell echoes as a timeless voyage into the hearts of those who
+        dare to dream and explore the unknown.”
+      </p>
+    ),
+  },
+};
+
+export const Nested: Story = {
+  args: {
+    children: (
+      <>
+        <p>
+          “Words can be like X-rays, if you use them properly—they’ll go through
+          anything. You read and you’re pierced.”
+        </p>
+        <Blockquote>
+          <p>
+            “A thinker sees his own actions as experiments and questions--as
+            attempts to find out something. Success and failure are for him
+            answers above all.”
+          </p>
+          <cite>Friedrich Nietzsche</cite>
+        </Blockquote>
+        <cite>Aldous Huxley, Brave New World</cite>
+      </>
+    ),
+  },
+};
+
+export default { component: Blockquote } as Meta;

--- a/components/Common/Blockquote/index.stories.tsx
+++ b/components/Common/Blockquote/index.stories.tsx
@@ -8,10 +8,8 @@ export const Default: Story = {
   args: {
     children: (
       <>
-        <p>
-          “An expert is a person who has made all the mistakes that can be made
-          in a very narrow field.”
-        </p>
+        “An expert is a person who has made all the mistakes that can be made in
+        a very narrow field.”
         <cite>Niels Bohr</cite>
       </>
     ),
@@ -20,14 +18,8 @@ export const Default: Story = {
 
 export const Without_Attribution: Story = {
   args: {
-    children: (
-      <p>
-        “Commander Keen soared through the stars, leaving behind a galaxy of
-        memories, adventure, and boundless imagination. In the realm of gaming,
-        his farewell echoes as a timeless voyage into the hearts of those who
-        dare to dream and explore the unknown.”
-      </p>
-    ),
+    children:
+      '“Commander Keen soared through the stars, leaving behind a galaxy of memories, adventure, and boundless imagination. In the realm of gaming, his farewell echoes as a timeless voyage into the hearts of those who dare to dream and explore the unknown.”',
   },
 };
 
@@ -35,16 +27,12 @@ export const Nested: Story = {
   args: {
     children: (
       <>
-        <p>
-          “Words can be like X-rays, if you use them properly—they’ll go through
-          anything. You read and you’re pierced.”
-        </p>
+        “Words can be like X-rays, if you use them properly—they’ll go through
+        anything. You read and you’re pierced.”
         <Blockquote>
-          <p>
-            “A thinker sees his own actions as experiments and questions--as
-            attempts to find out something. Success and failure are for him
-            answers above all.”
-          </p>
+          “A thinker sees his own actions as experiments and questions--as
+          attempts to find out something. Success and failure are for him
+          answers above all.”
           <cite>Friedrich Nietzsche</cite>
         </Blockquote>
         <cite>Aldous Huxley, Brave New World</cite>

--- a/components/Common/Blockquote/index.tsx
+++ b/components/Common/Blockquote/index.tsx
@@ -4,13 +4,8 @@ import styles from './index.module.css';
 
 type BlockquoteProps = ComponentProps<'blockquote'>;
 
-const Blockquote: FC<PropsWithChildren<BlockquoteProps>> = ({
-  children,
-  cite,
-}) => (
-  <blockquote className={styles.wrapper} cite={cite}>
-    {children}
-  </blockquote>
+const Blockquote: FC<PropsWithChildren<BlockquoteProps>> = ({ children }) => (
+  <blockquote className={styles.wrapper}>{children}</blockquote>
 );
 
 export default Blockquote;

--- a/components/Common/Blockquote/index.tsx
+++ b/components/Common/Blockquote/index.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+
+import styles from './index.module.css';
+
+type BlockquoteProps = ComponentProps<'blockquote'>;
+
+const Blockquote: FC<PropsWithChildren<BlockquoteProps>> = ({
+  children,
+  cite,
+}) => (
+  <blockquote className={styles.wrapper} cite={cite}>
+    {children}
+  </blockquote>
+);
+
+export default Blockquote;


### PR DESCRIPTION
## Description

This pull request addresses the issue(#5820)  by adding a new directory called Blockquote within the Common directory. This new directory contains all the code necessary for the Blockquote component.

### Changes

- Created a new directory: `Common/Blockquote`.
- Implemented the Blockquote component using the new Tailwind color, typography system, and Figma design.
- Added a Storybook story file: `components/Common/Blockquote/index.stories.tsx`, which exercises each of the Blockquote component's states.
	- Default
	- Without Attribution
	- Nested

## Validation

<img width="677" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/cd1343d5-836f-4fd3-84b7-ba2fed60ea36">
<img width="677" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/acac050f-8bbe-487b-b0b8-489f91ffe9de">


## Related Issues

fixes #5820 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.