### PR TITLE
Added Microsoft logo to site assets for Node.js website redesign (#5897)

### DIFF
--- a/components/__design__/platform-logos.stories.tsx
+++ b/components/__design__/platform-logos.stories.tsx
@@ -18,6 +18,14 @@ export default {
         </div>
         <div>
           <Image
+            src="/static/images/logos/platform-microsoft.svg"
+            alt="Microsoft Logo"
+            width={64}
+            height={64}
+          />
+        </div>
+        <div>
+          <Image
             src="/static/images/logos/platform-homebrew.svg"
             alt="Homebrew Logo"
             width={64}

--- a/public/static/images/logos/platform-microsoft.svg
+++ b/public/static/images/logos/platform-microsoft.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill="#FEBA08" d="M17 17h10v10H17z"/><path fill="#05A6F0" d="M5 17h10v10H5z"/><path fill="#80BC06" d="M17 5h10v10H17z"/><path fill="#F25325" d="M5 5h10v10H5z"/></svg>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR adds the Microsoft logo to the site assets as requested in issue #5897.

## Validation

I have validated this change by performing the following steps:
- Added the Microsoft logo as `platform-microsoft.svg` to the `public/static/images/logos` directory.
- Created a Storybook story to preview the Microsoft logo.
- Ran `npm run storybook` and verified that the Microsoft logo is displayed correctly in the Storybook preview.
![Screenshot 2023-09-29 231832](https://github.com/nodejs/nodejs.org/assets/96189881/18c15b00-aea1-494c-a335-6fbec0de4c51)


## Related Issues

Related to #5897

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
