### PR TITLE
Added Mastadon logo to site assets for Node.js website redesign (#5896)

### DIFF
--- a/components/__design__/social-logos.stories.tsx
+++ b/components/__design__/social-logos.stories.tsx
@@ -18,6 +18,14 @@ export default {
         </div>
         <div>
           <Image
+            src="/static/images/logos/social-mastadon.svg"
+            alt="Mastadon Logo"
+            width={64}
+            height={64}
+          />
+        </div>
+        <div>
+          <Image
             src="/static/images/logos/social-linkedin.svg"
             alt="LinkedIn Logo"
             width={64}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR adds the Mastadon logo to the site assets as requested in issue #5896.

## Validation

I have validated this change by performing the following steps:
- Added the Mastadon logo as `social-mastadon.svg` to the `public/static/images/logos` directory.
- Created a Storybook story to preview the Mastadon logo.
- Ran `npm run storybook` and verified that the Mastadon logo is displayed correctly in the Storybook preview.
![Screenshot 2023-09-30 000108](https://github.com/nodejs/nodejs.org/assets/96189881/dd9cf738-cf0a-4342-affe-f0815731dacc)

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Related to #5896 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
