### PR TITLE
fix: some npm settings tweaks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# See bug in peerdeps resolution: https://github.com/npm/cli/issues/2999
+legacy-peer-deps = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "~2.0.18",
+        "@mdx-js/react": "^2.3.0",
         "@nodevu/core": "~0.1.0",
         "@types/node": "18.17.17",
         "@vcarl/remark-headings": "~0.1.0",
@@ -31,6 +32,8 @@
         "postcss-import": "~15.1.0",
         "postcss-mixins": "~9.0.4",
         "postcss-simple-vars": "~7.0.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-intl": "~6.4.7",
         "rehype-autolink-headings": "~7.0.0",
         "rehype-pretty-code": "^0.10.1",
@@ -40,7 +43,8 @@
         "shiki": "^0.14.3",
         "tailwindcss": "^3.3.3",
         "turbo": "^1.10.14",
-        "typescript": "~5.2.2"
+        "typescript": "~5.2.2",
+        "vfile": "^5.3.7"
       },
       "devDependencies": {
         "@storybook/addon-controls": "~7.4.3",
@@ -80,12 +84,6 @@
       },
       "engines": {
         "node": "v18"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^2.3.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "vfile": "^5.3.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -21723,7 +21721,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21784,7 +21781,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -23036,7 +23032,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "nodejs.org",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "~2.0.18",
@@ -24,9 +23,9 @@
         "gray-matter": "~4.0.3",
         "husky": "8.0.3",
         "lint-staged": "14.0.1",
-        "next": "^13.5.2",
-        "next-mdx-remote": "^4.4.1",
-        "next-themes": "^0.2.1",
+        "next": "~13.5.3",
+        "next-mdx-remote": "~4.4.1",
+        "next-themes": "~0.2.1",
         "postcss": "~8.4.30",
         "postcss-calc": "~9.0.1",
         "postcss-import": "~15.1.0",
@@ -59,7 +58,7 @@
         "@typescript-eslint/eslint-plugin": "6.7.2",
         "@typescript-eslint/parser": "6.7.2",
         "eslint": "8.49.0",
-        "eslint-config-next": "13.5.2",
+        "eslint-config-next": "~13.5.3",
         "eslint-config-prettier": "9.0.0",
         "eslint-plugin-mdx": "2.2.0",
         "eslint-plugin-no-relative-import-paths": "^1.5.2",
@@ -4057,14 +4056,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.2.tgz",
-      "integrity": "sha512-dUseBIQVax+XtdJPzhwww4GetTjlkRSsXeQnisIJWBaHsnxYcN2RGzsPHi58D6qnkATjnhuAtQTJmR1hKYQQPg=="
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.3.tgz",
+      "integrity": "sha512-X4te86vsbjsB7iO4usY9jLPtZ827Mbx+WcwNBGUOIuswuTAKQtzsuoxc/6KLxCMvogKG795MhrR1LDhYgDvasg=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.2.tgz",
-      "integrity": "sha512-Ew8DOUerJYGRo8pI84SVwn9wxxx8sH92AanCXSkkLJM2W0RJEWy+BqWSCfrlA/3ZIczEl4l4o4lOeTGBPYfBJg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.3.tgz",
+      "integrity": "sha512-lbZOoEjzSuTtpk9UgV9rOmxYw+PsSfNR+00mZcInqooiDMZ1u+RqT1YQYLsEZPW1kumZoQe5+exkCBtZ2xn0uw==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -4091,9 +4090,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.2.tgz",
-      "integrity": "sha512-7eAyunAWq6yFwdSQliWMmGhObPpHTesiKxMw4DWVxhm5yLotBj8FCR4PXGkpRP2tf8QhaWuVba+/fyAYggqfQg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz",
+      "integrity": "sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==",
       "cpu": [
         "arm64"
       ],
@@ -4106,9 +4105,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.2.tgz",
-      "integrity": "sha512-WxXYWE7zF1ch8rrNh5xbIWzhMVas6Vbw+9BCSyZvu7gZC5EEiyZNJsafsC89qlaSA7BnmsDXVWQmc+s1feSYbQ==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz",
+      "integrity": "sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==",
       "cpu": [
         "x64"
       ],
@@ -4121,9 +4120,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.2.tgz",
-      "integrity": "sha512-URSwhRYrbj/4MSBjLlefPTK3/tvg95TTm6mRaiZWBB6Za3hpHKi8vSdnCMw5D2aP6k0sQQIEG6Pzcfwm+C5vrg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz",
+      "integrity": "sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==",
       "cpu": [
         "arm64"
       ],
@@ -4136,9 +4135,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.2.tgz",
-      "integrity": "sha512-HefiwAdIygFyNmyVsQeiJp+j8vPKpIRYDlmTlF9/tLdcd3qEL/UEBswa1M7cvO8nHcr27ZTKXz5m7dkd56/Esg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz",
+      "integrity": "sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==",
       "cpu": [
         "arm64"
       ],
@@ -4151,9 +4150,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.2.tgz",
-      "integrity": "sha512-htGVVroW0tdHgMYwKWkxWvVoG2RlAdDXRO1RQxYDvOBQsaV0nZsgKkw0EJJJ3urTYnwKskn/MXm305cOgRxD2w==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz",
+      "integrity": "sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==",
       "cpu": [
         "x64"
       ],
@@ -4166,9 +4165,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.2.tgz",
-      "integrity": "sha512-UBD333GxbHVGi7VDJPPDD1bKnx30gn2clifNJbla7vo5nmBV+x5adyARg05RiT9amIpda6yzAEEUu+s774ldkw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz",
+      "integrity": "sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==",
       "cpu": [
         "x64"
       ],
@@ -4181,9 +4180,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.2.tgz",
-      "integrity": "sha512-Em9ApaSFIQnWXRT3K6iFnr9uBXymixLc65Xw4eNt7glgH0eiXpg+QhjmgI2BFyc7k4ZIjglfukt9saNpEyolWA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz",
+      "integrity": "sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==",
       "cpu": [
         "arm64"
       ],
@@ -4196,9 +4195,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.2.tgz",
-      "integrity": "sha512-TBACBvvNYU+87X0yklSuAseqdpua8m/P79P0SG1fWUvWDDA14jASIg7kr86AuY5qix47nZLEJ5WWS0L20jAUNw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz",
+      "integrity": "sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==",
       "cpu": [
         "ia32"
       ],
@@ -4211,9 +4210,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.2.tgz",
-      "integrity": "sha512-LfTHt+hTL8w7F9hnB3H4nRasCzLD/fP+h4/GUVBTxrkMJOnh/7OZ0XbYDKO/uuWwryJS9kZjhxcruBiYwc5UDw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz",
+      "integrity": "sha512-2Vz2tYWaLqJvLcWbbTlJ5k9AN6JD7a5CN2pAeIzpbecK8ZF/yobA39cXtv6e+Z8c5UJuVOmaTldEAIxvsIux/Q==",
       "cpu": [
         "x64"
       ],
@@ -5196,19 +5195,19 @@
       }
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.4.3.tgz",
-      "integrity": "sha512-ROlhxTQxBtMvfUU8ZTZZ6M0ALbUuChm2Fkau9inZyLgaE/HJbjAUCU7TbHFQ7GgdqA3/Lnw0Soox8cmjI4QQWA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.4.5.tgz",
+      "integrity": "sha512-FkjJWmPN/+duLSkRwfa2bwlwjKfY6yCXYn7CRzn3rb64B8f50NB79zAgVLHjkJh9l6T3DIlWtol6vqPHj1aRpw==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
@@ -5236,21 +5235,21 @@
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-7.4.3.tgz",
-      "integrity": "sha512-wlfr0Yx27GzQqb5iINQTwL8wCW1NK8+4bJ/HQe4SQOY1FpybOK59B421V6YyQ3tafDWU5MMKh2sElMY9z5Deqw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-7.4.5.tgz",
+      "integrity": "sha512-Mxs56jt44HIbZ4gJa0AII1U8GqEGFsvcM5Iob0ETNpxCW5Kj5iHly/4Ws0RFWPH/krrQKaLpWXaUxKmbtEzhJA==",
       "dev": true,
       "dependencies": {
-        "@storybook/blocks": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/core-events": "7.4.3",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/blocks": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/core-events": "7.4.5",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "lodash": "^4.17.21",
         "ts-dedent": "^2.0.0"
       },
@@ -5272,21 +5271,21 @@
       }
     },
     "node_modules/@storybook/addon-interactions": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.4.3.tgz",
-      "integrity": "sha512-72Uy7FGr3UbEq44D44ML/o/kC8jUuBETDgnNTC/J7n35OzHcBcas9cHzam87IG/M8uxTwKtuUlEzwyoNUjI3MA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.4.5.tgz",
+      "integrity": "sha512-KDdV/THxj38VsuOevrUefev0rZPhzqUXCgrw1Jc2PsJGidHf9d9nnB7wbA9ZFYsxTz90M/Vk5sm7i1QkMmsquA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "7.4.3",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/instrumenter": "7.4.5",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "jest-mock": "^27.0.6",
         "polished": "^4.2.2",
         "ts-dedent": "^2.2.0"
@@ -5309,18 +5308,18 @@
       }
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-7.4.3.tgz",
-      "integrity": "sha512-36ubGLGGt6Y9vLLfGVUtcXhaMu/eqLZFTBsX5B2yPTR+xLPyrBDdH6FNBJ9KOA+PAOU+bNgEXbkFjodEc+q/HA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-7.4.5.tgz",
+      "integrity": "sha512-mn9CEW2TARTLY3EoFw7pu8LEmZ6WupIBgDr3vLBIvtqp0tTGp+RopCpuFnCmHUJD7tDiMWNBIk64oPsWJb1GAQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-events": "7.4.3",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-events": "7.4.5",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -5341,18 +5340,18 @@
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.4.3.tgz",
-      "integrity": "sha512-jDRG6ZMZ4ATOXiJQcXTpolTtIi8oAhbk6mbJyj65nClXgWqfZxMK9PMfJw5R7zHhAmrKoWNTDc72eayFOIHaNg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-7.4.5.tgz",
+      "integrity": "sha512-SBLnUMIztVrqJ0fRCsVg9KZ29APLIxqAvTsYHF3twy5KB2naeCFuX3K9LxSH7vbROI6zHEfnPduz/Ykyvu9yUg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.7.2"
       },
@@ -5374,14 +5373,14 @@
       }
     },
     "node_modules/@storybook/addons": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.4.3.tgz",
-      "integrity": "sha512-6XvXE3sRl78MceRDAnfPd6N6j9ltMCuTITjjqU2GU8iyAexJ4bYodfKcmUmAQmixuc+6UPbWmlrQKNmBDlp3rw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.4.5.tgz",
+      "integrity": "sha512-jmdQf39XhwVi8d0J99qpk51fOAwNhYlCtVctvFWPX4qC1cq1d1pxLmTb5OBV2VHQ11BKwlKLzA7coiOgAQmNRg==",
       "dev": true,
       "dependencies": {
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/types": "7.4.3"
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/types": "7.4.5"
       },
       "funding": {
         "type": "opencollective",
@@ -5393,22 +5392,22 @@
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.4.3.tgz",
-      "integrity": "sha512-uyZVx3er1qOPFpKJtsbozBwt1Os3zqiq+2se7xDBK6ERr07zaRHLgRci7+kI8T5mdlCxYiGV+kzx5Vx5/7XaXg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.4.5.tgz",
+      "integrity": "sha512-FhAIkCT2HrzJcKsC3mL5+uG3GrbS23mYAT1h3iyPjCliZzxfCCI9UCMUXqYx4Z/FmAGJgpsQQXiBFZuoTHO9aQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/channels": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/csf": "^0.1.0",
-        "@storybook/docs-tools": "7.4.3",
+        "@storybook/docs-tools": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/lodash": "^4.14.167",
         "color-convert": "^2.0.1",
         "dequal": "^2.0.2",
@@ -5432,15 +5431,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.4.3.tgz",
-      "integrity": "sha512-6jzxZ2J1jFaZXn7ZucEgV6XyUe+FJ9uuoMRZcZefoCKeXK/BOPCefijYWP3DPgqqVh3/JLUglIpz0MH9k8cBaw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.4.5.tgz",
+      "integrity": "sha512-Jhql8iZgK9cxDmG9NSTejsj5FptHni2TBa5Sea2Uz1NIBQ0OpzNdUfYVX6TN/PEq3QrWXTrAEKPqsL2qGjOrxw==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/manager": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/manager": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
         "@types/ejs": "^3.1.1",
         "@types/find-cache-dir": "^3.2.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
@@ -5460,28 +5459,28 @@
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-7.4.3.tgz",
-      "integrity": "sha512-nTv4Y2QnLHcUWZMsNE/0MYrJ4BzL44QzyPJOFwoNpRbR45Gp+/tDyCclXTYs4FGG6JkPdaV0+jcU0GhjwP1rvA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-7.4.5.tgz",
+      "integrity": "sha512-XSZLZ2kNlZaOJ3i2uZ9vI25cJkmQhmTVHPER+FPKM/yliqsQj7p2P9zYz/Mn0LepUheK1Y+aWWiead1r2DnNMg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
-        "@storybook/addons": "7.4.3",
-        "@storybook/channels": "7.4.3",
-        "@storybook/client-api": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/components": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/core-events": "7.4.3",
-        "@storybook/core-webpack": "7.4.3",
+        "@storybook/addons": "7.4.5",
+        "@storybook/channels": "7.4.5",
+        "@storybook/client-api": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/components": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/core-events": "7.4.5",
+        "@storybook/core-webpack": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/preview": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/router": "7.4.3",
-        "@storybook/store": "7.4.3",
-        "@storybook/theming": "7.4.3",
+        "@storybook/manager-api": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/preview": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/router": "7.4.5",
+        "@storybook/store": "7.4.5",
+        "@storybook/theming": "7.4.5",
         "@swc/core": "^1.3.49",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.4",
@@ -5525,19 +5524,19 @@
       }
     },
     "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/channels": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
-      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.5.tgz",
+      "integrity": "sha512-zWPZn4CxPFXsrrSRQ9JD8GmTeWeFYgr3sTBpe23hnhYookCXVNJ6AcaXogrT9b2ALfbB6MiFDbZIHHTgIgbWpg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/global": "^5.0.0",
         "qs": "^6.10.0",
         "telejson": "^7.2.0",
@@ -5549,23 +5548,23 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.4.3.tgz",
-      "integrity": "sha512-/lGtXbzNropsCF4srEGxiHzCU7b2wlV13LrSj3H3zOnHEAJlFcNpyNzO+4jKHfNTjjqEtcRGJ1OxrSYuGZTVjg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.4.5.tgz",
+      "integrity": "sha512-PlTkcHdKCugg3pD1zkBP/oFazcZsr7F3wdEmTvygfH0Cx/sQWg5wXBZCYKmf0ONRK4RKL3LVM8DRpeYiQVEFWg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@babel/types": "^7.22.5",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/core-events": "7.4.3",
-        "@storybook/core-server": "7.4.3",
-        "@storybook/csf-tools": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/telemetry": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/codemod": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/core-events": "7.4.5",
+        "@storybook/core-server": "7.4.5",
+        "@storybook/csf-tools": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/telemetry": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -5630,13 +5629,13 @@
       }
     },
     "node_modules/@storybook/client-api": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-7.4.3.tgz",
-      "integrity": "sha512-ZLKQY55GOqwngZnQSj2MlOiB8znLnYXY8UcuCzwu+tZVGJshxwrMasiLMYE55ni8Yp54qbbwrlYeWZYIW+j/Gw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-7.4.5.tgz",
+      "integrity": "sha512-8gUglsmlGNA0U9Ec/GJDOrqRfSIjm7uJJrq7TrmvfkLTLR1diYpoIljoXyNHU+Nhk/ebUiQkzflqzYKNzbkcYw==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/preview-api": "7.4.3"
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/preview-api": "7.4.5"
       },
       "funding": {
         "type": "opencollective",
@@ -5644,9 +5643,9 @@
       }
     },
     "node_modules/@storybook/client-logger": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
-      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.5.tgz",
+      "integrity": "sha512-Bn6eTAjhPDUfLpvuxhKkpDpOtkadfkSmkBNBZRu3r0Dzk2J1nNyKV5K6D8dOU4PFVof4z/gXYj5bktT29jKsmw==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -5657,18 +5656,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.4.3.tgz",
-      "integrity": "sha512-UwnsyVeUa+wLIeE/zO0slV3mwsPgS3DstZAWbjWUfFlJKZjgg1++Zkv0GmxkEyirsnf/g4r6Aq+KhIdIHmdzag==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.4.5.tgz",
+      "integrity": "sha512-gyI2xliSv4vvnfNQN+0e3tRmT7beiq8q8iGjcBtpOhA2xrStyCR7PjbOfLXtRx2I/b50MDZMRTcckzeM3BLoWQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@babel/types": "^7.22.5",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/csf-tools": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
         "globby": "^11.0.2",
@@ -5698,18 +5697,18 @@
       }
     },
     "node_modules/@storybook/components": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.4.3.tgz",
-      "integrity": "sha512-qwRW8wGUuM+H6oKUXXoIDrZECXh/lzowrWXFAzZiocovYEhPtZfl/yvJLWHjOwtka3n7lA7J7EtcjWe8/tueJQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.4.5.tgz",
+      "integrity": "sha512-boskkfvMBB8CFYY9+1ofFNyKrdWXTY/ghzt7oK80dz6f2Eseo/WXK3OsCdCq5vWbLRCdbgJ8zXG8pAFi4yBsxA==",
       "dev": true,
       "dependencies": {
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-toolbar": "^1.0.4",
-        "@storybook/client-logger": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "memoizerific": "^1.11.3",
         "use-resize-observer": "^9.1.0",
         "util-deprecate": "^1.0.2"
@@ -5724,13 +5723,13 @@
       }
     },
     "node_modules/@storybook/core-client": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.4.3.tgz",
-      "integrity": "sha512-YRt07TxC+HUtnyvbpJbY8d2+2QfFExBL7zRbms9tIRorddWfPBq+lA2RS9zcjUJJJtNSz1+ST70FuGr1N3AXGg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.4.5.tgz",
+      "integrity": "sha512-d/qiCUZeOKY0HX/YmomxlccxJ2NKC3ttRrAsAXzJGypClKabv20X+qbeO/E7Kp5UQxIEJx1wuwJPcnlCvjgPDA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/preview-api": "7.4.3"
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/preview-api": "7.4.5"
       },
       "funding": {
         "type": "opencollective",
@@ -5738,14 +5737,14 @@
       }
     },
     "node_modules/@storybook/core-common": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.3.tgz",
-      "integrity": "sha512-jwIBUnWitZzw0VfKC77yN8DvTyePLVnAjbA2lPMbMIdO9ZY2lfD4AQ4QpuWsxJyAllFC4slOFDNgCDHx2AlYWw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.5.tgz",
+      "integrity": "sha512-c4pBuILMD4YhSpJ+QpKtsUZpK+/rfolwOvzXfJwlN5EpYzMz6FjVR/LyX0cCT2YLI3X5YWRoCdvMxy5Aeryb8g==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-events": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/core-events": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/find-cache-dir": "^3.2.1",
         "@types/node": "^16.0.0",
         "@types/node-fetch": "^2.6.4",
@@ -5773,15 +5772,15 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/core-events": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
-      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.5.tgz",
+      "integrity": "sha512-Jzy/adSC95saYCZlgXE5j7jmiMLAXYpnBFBxEtBdXwSWEBb0zt21n1nyWBEAv9s/k2gqDXlPHKHeL5Mn6y40zA==",
       "dev": true,
       "dependencies": {
         "ts-dedent": "^2.0.0"
@@ -5792,26 +5791,26 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.4.3.tgz",
-      "integrity": "sha512-yl9HaVwk/xJV9zq76n/oR1cE39wAFmNmKVPOJAtr3+c7wS0tnBkw7T+GqZ2Seyv+xkcZUWS8KRH74HqwPwG0Bw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.4.5.tgz",
+      "integrity": "sha512-cW+Qx9Ls823577bd/s9Kv4M1MdKS8mkk6/+nYbwtAwH3hkdlb077rlk/ue0X4O9NZmCrtaJ84KNrBkeDUdFyLQ==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "7.4.3",
-        "@storybook/channels": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/builder-manager": "7.4.5",
+        "@storybook/channels": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.4.3",
+        "@storybook/csf-tools": "7.4.5",
         "@storybook/docs-mdx": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/telemetry": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/manager": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/telemetry": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/detect-port": "^1.3.0",
         "@types/node": "^16.0.0",
         "@types/pretty-hrtime": "^1.0.0",
@@ -5846,20 +5845,20 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-7.4.3.tgz",
-      "integrity": "sha512-Z7A1qml7mcV/MjYEoRXvtOgPR81cnHyYH2e7frvv9Sh0iIysvZ1+BAleD9JhiW6u6EG+TcFea2RdwsdfT6Pp0Q==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-7.4.5.tgz",
+      "integrity": "sha512-W4F5/BE6Q/1hbdseSRlhi4BGIKWp0CuU9UwCL2uF4zqcDOd9QdbntUq9wAw4DpRsonQjpbnzJABlNeh7MPxPMw==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/node": "^16.0.0",
         "ts-dedent": "^2.0.0"
       },
@@ -5869,9 +5868,9 @@
       }
     },
     "node_modules/@storybook/core-webpack/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/csf": {
@@ -5884,9 +5883,9 @@
       }
     },
     "node_modules/@storybook/csf-tools": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.3.tgz",
-      "integrity": "sha512-nkVakGx2kzou91lGcxnyFNiSEdnpx1a53lQTl/DLm0QpDbqQuu3ZbZWXZCpXV97t/6YPeCCnGLXodnI7PZyZBA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.5.tgz",
+      "integrity": "sha512-xbm5HGYvlwF0Efivx37v9rO7Exel1/Tdb/Yv/vXn4D/hQeljNVLNz4Bomfy4EQ207rRsrGDSOHEhLUbHDimnxg==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.22.9",
@@ -5894,7 +5893,7 @@
         "@babel/traverse": "^7.22.8",
         "@babel/types": "^7.22.5",
         "@storybook/csf": "^0.1.0",
-        "@storybook/types": "7.4.3",
+        "@storybook/types": "7.4.5",
         "fs-extra": "^11.1.0",
         "recast": "^0.23.1",
         "ts-dedent": "^2.0.0"
@@ -5911,14 +5910,14 @@
       "dev": true
     },
     "node_modules/@storybook/docs-tools": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.4.3.tgz",
-      "integrity": "sha512-T9oU10vIY3mC6Up+9rjN5LfBydhhIFhKzHPtUT9PfN1iEa0lO2TkT4m+vf2kcokPppUZNVbqiGjy9t/WYnpeZg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.4.5.tgz",
+      "integrity": "sha512-ctK+yGb2nvWISSvCCzj3ZhDaAb7I2BLjbxuBGTyNPvl4V9UQ9LBYzdJwR50q+DfscxdwSHMSOE/0OnzmJdaSJA==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/doctrine": "^0.0.3",
         "doctrine": "^3.0.0",
         "lodash": "^4.17.21"
@@ -5935,16 +5934,16 @@
       "dev": true
     },
     "node_modules/@storybook/instrumenter": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-7.4.3.tgz",
-      "integrity": "sha512-XVctoUOFthTCea2+BKFKeUbhWrRY+1I8THgsZx67X3MQDt9bafwQdFR9jTGBeC31oNi1b7nmTuaox0lneNlghA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-7.4.5.tgz",
+      "integrity": "sha512-VLFOcmG75QhWa7MtmfEybIJEz5oT2Ry8xAy/pIVhQwyBaeW0kRT0MHWkixRTtWQmJs/78FmHE3FlgMnqpa5JoA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/channels": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "7.4.3"
+        "@storybook/preview-api": "7.4.5"
       },
       "funding": {
         "type": "opencollective",
@@ -5952,9 +5951,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.4.3.tgz",
-      "integrity": "sha512-7U92tYwjt0DIKX7vCKNSZefuEavdnJYa5/zSjdlo0LtfBmGRBak1eq/sVLGfzrZ+wKIlCXgNh3f8OLy8RMnOOw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.4.5.tgz",
+      "integrity": "sha512-yoqVktWzzC0f8cXsxErOEUfT+VFfWV/W7soytIPQuJFqNaq+BqR5A7WCeoY7BIv3mdpRjo4GKwerCsgoHYeHhg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5962,19 +5961,19 @@
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.4.3.tgz",
-      "integrity": "sha512-o5oiL2cJKlY+HNBCdUo5QKT8yXTyYYvBKibSS3YfDKcjeR9RXP+RhdF5lLLh6TzPwfdtLrXQoVI4A/61v2kurQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.4.5.tgz",
+      "integrity": "sha512-8Hdh5Tutet8xRy2fAknczfvpshz09eVnLd8m34vcFceUOYvEnvDbWerufhlEzovsF4v7U32uqbDHKdKTamWEQQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/channels": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/router": "7.4.3",
-        "@storybook/theming": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/router": "7.4.5",
+        "@storybook/theming": "7.4.5",
+        "@storybook/types": "7.4.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "memoizerific": "^1.11.3",
@@ -5993,9 +5992,9 @@
       }
     },
     "node_modules/@storybook/nextjs": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-7.4.3.tgz",
-      "integrity": "sha512-WIriIT0AHtIVGaQVpYfuZ/Pyep/7PaoJBGBWiiVV7/oPy8BoLK2G+s39f0FjtOvCCWYMEIGudaAW8ueBXc3rHQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-7.4.5.tgz",
+      "integrity": "sha512-NXO9AwuyekD/BjP+DD0Bupa3gXAJGiYWoWvtRGntewhvDEXllX7ohrv5ldnwxeCsAM7a8Iih+Vs+aKsSLeGN8Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
@@ -6011,13 +6010,13 @@
         "@babel/preset-react": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@storybook/addon-actions": "7.4.3",
-        "@storybook/builder-webpack5": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/preset-react-webpack": "7.4.3",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/react": "7.4.3",
+        "@storybook/addon-actions": "7.4.5",
+        "@storybook/builder-webpack5": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/preset-react-webpack": "7.4.5",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/react": "7.4.5",
         "@types/node": "^16.0.0",
         "css-loader": "^6.7.3",
         "find-up": "^5.0.0",
@@ -6073,9 +6072,9 @@
       "dev": true
     },
     "node_modules/@storybook/node-logger": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
-      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.5.tgz",
+      "integrity": "sha512-fJSykphbryuEYj1qihbaTH5oOzD4NkptRxyf2uyBrpgkr5tCTq9d7GHheqaBuIdi513dsjlcIR7z5iHxW7ZD+Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6083,18 +6082,18 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-7.4.3.tgz",
-      "integrity": "sha512-Cp6jNqmvElHs3z/+4mNWL+uB6vvCPZYpaK4MB6SO50i8FySANFgH1WCRYRqcnpbV462Cy+NUEbIOPxOhd2XxLA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-7.4.5.tgz",
+      "integrity": "sha512-8mYHag0sGOHCjPHdEuLPM8U/FTCBIp5LaTxmpkJcNs/LprzSDI6OFWqbe+q8X7qkAL2Iz1YyqrYb4NgweqpZiA==",
       "dev": true,
       "dependencies": {
         "@babel/preset-flow": "^7.22.5",
         "@babel/preset-react": "^7.22.5",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.5",
-        "@storybook/core-webpack": "7.4.3",
-        "@storybook/docs-tools": "7.4.3",
-        "@storybook/node-logger": "7.4.3",
-        "@storybook/react": "7.4.3",
+        "@storybook/core-webpack": "7.4.5",
+        "@storybook/docs-tools": "7.4.5",
+        "@storybook/node-logger": "7.4.5",
+        "@storybook/react": "7.4.5",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.4",
@@ -6127,15 +6126,15 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/preview": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.4.3.tgz",
-      "integrity": "sha512-dItyGcql/rD6CWTKGUm58MguWC7L4KjlfNJmxxaHXnHRbaEjXPaRi9ztfmimIpAaBdBmreAZrZJYhLvOGG3CfA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.4.5.tgz",
+      "integrity": "sha512-hCVFoPJP0d7vFCJKaWEsDMa6LcRFcEikQ8Cy6Vo+trS8xXwvwE+vIBqyuPozl4O/MYD9iOlzjgZFNwaUUgX0Jg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6143,17 +6142,17 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.4.3.tgz",
-      "integrity": "sha512-qKwfH2+qN1Zpz2UX6dQLiTU5x2JH3o/+jOY4GYF6c3atTm5WAu1OvCYAJVb6MdXfAhZNuPwDKnJR8VmzWplWBg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.4.5.tgz",
+      "integrity": "sha512-6xXQZPyilkGVddfZBI7tMbMMgOyIoZTYgTnwSPTMsXxO0f0TvtNDmGdwhn0I1nREHKfiQGpcQe6gwddEMnGtSg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.4.3",
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-events": "7.4.3",
+        "@storybook/channels": "7.4.5",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-events": "7.4.5",
         "@storybook/csf": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/types": "7.4.3",
+        "@storybook/types": "7.4.5",
         "@types/qs": "^6.9.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
@@ -6169,18 +6168,18 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.4.3.tgz",
-      "integrity": "sha512-koF1GLPBY5rm8t+6i70Iw6Ep/6T2C+XAlnP1dO/ZJAv8mmeQmOw+Kwh6nNPG8bthm0l1nImgqRw2ZwCD2AFoSA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.4.5.tgz",
+      "integrity": "sha512-Tiylrs3uFO8QSvH1w3ueSxlAgh2fteH0edRVKaX01M/h47+QqEiZqq/dYkVDvLHngF+CCCwE3OY8nNe6L14Xkw==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-client": "7.4.3",
-        "@storybook/docs-tools": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-client": "7.4.5",
+        "@storybook/docs-tools": "7.4.5",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "7.4.3",
-        "@storybook/react-dom-shim": "7.4.3",
-        "@storybook/types": "7.4.3",
+        "@storybook/preview-api": "7.4.5",
+        "@storybook/react-dom-shim": "7.4.5",
+        "@storybook/types": "7.4.5",
         "@types/escodegen": "^0.0.6",
         "@types/estree": "^0.0.51",
         "@types/node": "^16.0.0",
@@ -6234,9 +6233,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.4.3.tgz",
-      "integrity": "sha512-d8kkZU4kqmNluuOx65l5H0L9lRn8Ji5rVxu+4MUCWrn82dxRLvVcFG0sfGUzOTNfX1/yajL2MxVJ2hx9fzLutQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.4.5.tgz",
+      "integrity": "sha512-/hGe8yuiWbT7L3ZsllmJPgxT9MEQE3k23FhliyKx6IGHsWoYaEsPYPZ9tygqtKY8RpqqMUKWz8+kbO79zUxaoQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6248,18 +6247,18 @@
       }
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "16.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
-      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "version": "16.18.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.55.tgz",
+      "integrity": "sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==",
       "dev": true
     },
     "node_modules/@storybook/router": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.4.3.tgz",
-      "integrity": "sha512-1ab1VTYzzOsBGKeT8xm1kLriIsIsiB/l3t7DdARJxLmPbddKyyXE018w17gfrARCWQ8SM99Ko6+pLmlZ2sm8ug==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.4.5.tgz",
+      "integrity": "sha512-IM4IhiPiXsx3FAUeUOAB47uiuUS8Yd37VQcNlXLBO28GgHoTSYOrjS+VTGLIV5cAGKr8+H5pFB+q35BnlFUpkQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
         "memoizerific": "^1.11.3",
         "qs": "^6.10.0"
       },
@@ -6273,13 +6272,13 @@
       }
     },
     "node_modules/@storybook/store": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/store/-/store-7.4.3.tgz",
-      "integrity": "sha512-cW5PBQ37tEmSKhyu2YpMlQUrL5SEXiJbWuCfNtN15mExeeOfYj4zxrXborxZwT2kMaES5RUdqgOz4oebKU9t8g==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/store/-/store-7.4.5.tgz",
+      "integrity": "sha512-uK9y9aT/PI4xjhw0gG3geTk5/JPiSNfdxy57N+HRn04ofin3dnBSYM5gxuQxVeHR2EVpvVhoM5nQsImyIQuPUg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/preview-api": "7.4.3"
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/preview-api": "7.4.5"
       },
       "funding": {
         "type": "opencollective",
@@ -6287,14 +6286,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.4.3.tgz",
-      "integrity": "sha512-gA7QfQSdDocNKP0KfrmIhD8ZgW5G4zZD/NL0OsATlkL3H/DehH3Ugjfffh7Ao2JZRXogHp8p9EQCVfPW7iKgBQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.4.5.tgz",
+      "integrity": "sha512-JbhQXZF5sqS2c7Cf+vAtuKTdTSBDco+liUP2UGQFjqdacTRLVzxyj+YY2UH4aAQn7wpmnQ67iHnqFp0+fdYmAA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.4.3",
-        "@storybook/core-common": "7.4.3",
-        "@storybook/csf-tools": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
+        "@storybook/core-common": "7.4.5",
+        "@storybook/csf-tools": "7.4.5",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -6307,13 +6306,13 @@
       }
     },
     "node_modules/@storybook/theming": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.4.3.tgz",
-      "integrity": "sha512-u5wLwWmhGcTmkcs6f2wDGv+w8wzwbNJat0WaIIbwdJfX7arH6nO5HkBhNxvl6FUFxX0tovp/e9ULzxVPc356jw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.4.5.tgz",
+      "integrity": "sha512-QSIJDIMzOegzlhubIBaYIovf4mlf+AVL0SmQOskPS8GZ6s9t77yUUI6gZTEjO+S4eB3djXRsfTTijQ8+z4XmRA==",
       "dev": true,
       "dependencies": {
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-        "@storybook/client-logger": "7.4.3",
+        "@storybook/client-logger": "7.4.5",
         "@storybook/global": "^5.0.0",
         "memoizerific": "^1.11.3"
       },
@@ -6327,12 +6326,12 @@
       }
     },
     "node_modules/@storybook/types": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
-      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.5.tgz",
+      "integrity": "sha512-DTWFNjfRTpncjufDoUs0QnNkgHG2qThGKWL1D6sO18cYI02zWPyHWD8/cbqlvtT7XIGe3s1iUEfCTdU5GcwWBA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.4.3",
+        "@storybook/channels": "7.4.5",
         "@types/babel__core": "^7.0.0",
         "@types/express": "^4.7.0",
         "file-system-cache": "2.3.0"
@@ -6343,13 +6342,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.86.tgz",
-      "integrity": "sha512-bEXUtm37bcmJ3q+geG7Zy4rJNUzpxalXQUrrqX1ZoGj3HRtzdeVZ0L/um3fG2j16qe61t8TX/OIZ2G6j6dkG/w==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.90.tgz",
+      "integrity": "sha512-wptBxP4PldOnhmyDVj8qUcn++GRqyw1qc9wOTGtPNHz8cpuTfdfIgYGlhI4La0UYqecuaaIfLfokyuNePOMHPg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@swc/types": "^0.1.4"
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
       },
       "engines": {
         "node": ">=10"
@@ -6359,16 +6359,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.86",
-        "@swc/core-darwin-x64": "1.3.86",
-        "@swc/core-linux-arm-gnueabihf": "1.3.86",
-        "@swc/core-linux-arm64-gnu": "1.3.86",
-        "@swc/core-linux-arm64-musl": "1.3.86",
-        "@swc/core-linux-x64-gnu": "1.3.86",
-        "@swc/core-linux-x64-musl": "1.3.86",
-        "@swc/core-win32-arm64-msvc": "1.3.86",
-        "@swc/core-win32-ia32-msvc": "1.3.86",
-        "@swc/core-win32-x64-msvc": "1.3.86"
+        "@swc/core-darwin-arm64": "1.3.90",
+        "@swc/core-darwin-x64": "1.3.90",
+        "@swc/core-linux-arm-gnueabihf": "1.3.90",
+        "@swc/core-linux-arm64-gnu": "1.3.90",
+        "@swc/core-linux-arm64-musl": "1.3.90",
+        "@swc/core-linux-x64-gnu": "1.3.90",
+        "@swc/core-linux-x64-musl": "1.3.90",
+        "@swc/core-win32-arm64-msvc": "1.3.90",
+        "@swc/core-win32-ia32-msvc": "1.3.90",
+        "@swc/core-win32-x64-msvc": "1.3.90"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -6380,9 +6380,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.86.tgz",
-      "integrity": "sha512-hMvSDms0sJJHNtRa3Vhmr9StWN1vmikbf5VE0IZUYGnF1/JZTkXU1h6CdNUY4Hr6i7uCZjH6BEhxFHX1JtKV4w==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.90.tgz",
+      "integrity": "sha512-he0w74HvcoufE6CZrB/U/VGVbc7021IQvYrn1geMACnq/OqMBqjdczNtdNfJAy87LZ4AOUjHDKEIjsZZu7o8nQ==",
       "cpu": [
         "arm64"
       ],
@@ -6396,9 +6396,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.86.tgz",
-      "integrity": "sha512-Jro6HVH4uSOBM7tTDaQNKLNc8BJV7n+SO+Ft2HAZINyeKJS/8MfEYneG7Vmqg18gv00c6dz9AOCcyz+BR7BFkQ==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.90.tgz",
+      "integrity": "sha512-hKNM0Ix0qMlAamPe0HUfaAhQVbZEL5uK6Iw8v9ew0FtVB4v7EifQ9n41wh+yCj0CjcHBPEBbQU0P6mNTxJu/RQ==",
       "cpu": [
         "x64"
       ],
@@ -6412,9 +6412,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.86.tgz",
-      "integrity": "sha512-wYB9m0pzXJVSzedXSl4JwS3gKtvcPinpe9MbkddezpqL7OjyDP6pHHW9qIucsfgCrtMtbPC2nqulXLPtAAyIjw==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.90.tgz",
+      "integrity": "sha512-HumvtrqTWE8rlFuKt7If0ZL7145H/jVc4AeziVjcd+/ajpqub7IyfrLCYd5PmKMtfeSVDMsxjG0BJ0HLRxrTJA==",
       "cpu": [
         "arm"
       ],
@@ -6428,9 +6428,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.86.tgz",
-      "integrity": "sha512-fR44IyK5cdCaO8cC++IEH0Jn03tWnunJnjzA99LxlE5TRInSIOvFm+g5OSUQZDAvEXmQ38sd31LO2HOoDS1Edw==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.90.tgz",
+      "integrity": "sha512-tA7DqCS7YCwngwXZQeqQhhMm8BbydpaABw8Z/EDQ7KPK1iZ1rNjZw+aWvSpmNmEGmH1RmQ9QDS9mGRDp0faAeg==",
       "cpu": [
         "arm64"
       ],
@@ -6444,9 +6444,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.86.tgz",
-      "integrity": "sha512-EUPfdbK4dUk/nkX3Vmv/47XH+DqHOa9JI0CTthvJ8/ZXei1MKDUsUc+tI1zMQX2uCuSkSWsEIEpCmA0tMwFhtw==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.90.tgz",
+      "integrity": "sha512-p2Vtid5BZA36fJkNUwk5HP+HJlKgTru+Ghna7pRe45ghKkkRIUk3fhkgudEvfKfhT+3AvP+GTVQ+T9k0gc9S8w==",
       "cpu": [
         "arm64"
       ],
@@ -6460,9 +6460,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.86.tgz",
-      "integrity": "sha512-snVZZWv8XgNVaKrTxtO3rUN+BbbB6I8Fqwe8zM/DWGJ096J13r89doQ48x5ZyO+bW4D48eZIWP5pdfSW7oBE3w==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.90.tgz",
+      "integrity": "sha512-J6pDtWaulYGXuANERuvv4CqmUbZOQrRZBCRQGZQJ6a86RWpesZqckBelnYx48wYmkgvMkF95Y3xbI3WTfoSHzw==",
       "cpu": [
         "x64"
       ],
@@ -6476,9 +6476,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.86.tgz",
-      "integrity": "sha512-PnnksUJymEJkdnbV2orOSOSB441UqsxYbJge9zbr5UTRXUfWO3eFRV0iTBegjTlOQGbW6yN+YRSDkenTbmCI6g==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.90.tgz",
+      "integrity": "sha512-3Gh6EA3+0K+l3MqnRON7h5bZ32xLmfcVM6QiHHJ9dBttq7YOEeEoMOCdIPMaQxJmK1VfLgZCsPYRd66MhvUSkw==",
       "cpu": [
         "x64"
       ],
@@ -6492,9 +6492,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.86.tgz",
-      "integrity": "sha512-XlGEGyHwLndm08VvgeAPGj40L+Hx575MQC+2fsyB1uSNUN+uf7fvke+wc7k50a92CaQe/8foLyIR5faayozEJA==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.90.tgz",
+      "integrity": "sha512-BNaw/iJloDyaNOFV23Sr53ULlnbmzSoerTJ10v0TjSZOEIpsS0Rw6xOK1iI0voDJnRXeZeWRSxEC9DhefNtN/g==",
       "cpu": [
         "arm64"
       ],
@@ -6508,9 +6508,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.86.tgz",
-      "integrity": "sha512-U1BhZa1x9yn+wZGTQmt1cYR79a0FzW/wL6Jas1Pn0bykKLxdRU4mCeZt2P+T3buLm8jr8LpPWiCrbvr658PzwA==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.90.tgz",
+      "integrity": "sha512-SiyTethWAheE/JbxXCukAAciU//PLcmVZ2ME92MRuLMLmOhrwksjbaa7ukj9WEF3LWrherhSqTXnpj3VC1l/qw==",
       "cpu": [
         "ia32"
       ],
@@ -6524,9 +6524,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.86.tgz",
-      "integrity": "sha512-wRoQUajqpE3wITHhZVj/6BPu/QwHriFHLHuJA+9y6PeGtUtTmntL42aBKXIFhfL767dYFtohyNg1uZ9eqbGyGQ==",
+      "version": "1.3.90",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.90.tgz",
+      "integrity": "sha512-OpWAW5ljKcPJ3SQ0pUuKqYfwXv7ssIhVgrH9XP9ONtdgXKWZRL9hqJQkcL55FARw/gDjKanoCM47wsTNQL+ZZA==",
       "cpu": [
         "x64"
       ],
@@ -6538,6 +6538,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
+      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+      "dev": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -6787,15 +6793,15 @@
       "dev": true
     },
     "node_modules/@types/ejs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
-      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.3.tgz",
+      "integrity": "sha512-mv5T/JI/bu+pbfz1o+TLl1NF0NIBbjS0Vl6Ppz1YY9DkXfzZT0lelXpfS5i3ZS3U/p90it7uERQpBvLYoK8e4A==",
       "dev": true
     },
     "node_modules/@types/emscripten": {
-      "version": "1.39.7",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.7.tgz",
-      "integrity": "sha512-tLqYV94vuqDrXh515F/FOGtBcRMTPGvVV1LzLbtYDcQmmhtpf/gLYf+hikBbQk8MzOHNz37wpFfJbYAuSn8HqA==",
+      "version": "1.39.8",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.8.tgz",
+      "integrity": "sha512-Rk0HKcMXFUuqT32k1kXHZWgxiMvsyYsmlnjp0rLKa0MMoqXLE3T9dogDBTRfuc3SAsXu97KD3k4SKR1lHqd57w==",
       "dev": true
     },
     "node_modules/@types/escodegen": {
@@ -6838,9 +6844,9 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
@@ -6850,9 +6856,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.36",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz",
-      "integrity": "sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==",
+      "version": "4.17.37",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
+      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -7006,9 +7012,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -7025,15 +7031,15 @@
       "integrity": "sha512-76CqzuD6Q7LC+AtbPqrvD9AqsN0k8bsYo2bM2J8pmNldP1aIPAbzUQ7QbobyXL4eLr1wK5x8FZFe8eF/ubRuBg=="
     },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
+      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
       "dev": true
     },
     "node_modules/@types/mime-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
-      "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.2.tgz",
+      "integrity": "sha512-q9QGHMGCiBJCHEvd4ZLdasdqXv570agPsUW0CeIm/B8DzhxsYMerD0l3IlI+EQ1A2RWHY2mmM9x1YIuuWxisCg==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -7053,9 +7059,9 @@
       "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -7092,9 +7098,9 @@
       "dev": true
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
       "dev": true
     },
     "node_modules/@types/react": {
@@ -7128,9 +7134,9 @@
       "dev": true
     },
     "node_modules/@types/send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
       "dev": true,
       "dependencies": {
         "@types/mime": "^1",
@@ -7138,9 +7144,9 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
-      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
+      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
       "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
@@ -11876,12 +11882,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.2.tgz",
-      "integrity": "sha512-kCF7k7fHBtFtxfP6J6AP6Mo0vW3CrFeoIuoZ7NHGIvLFc/RUaIspJ6inO/R33zE1o9t/lbJgTnsqnRB++sxCUQ==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.3.tgz",
+      "integrity": "sha512-VN2qbCpq2DMWgs7SVF8KTmc8bVaWz3s4nmcFqRLs7PNBt5AXejOhJuZ4zg2sCEHOvz5RvqdwLeI++NSCV6qHVg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.5.2",
+        "@next/eslint-plugin-next": "13.5.3",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -13249,9 +13255,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.216.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.216.1.tgz",
-      "integrity": "sha512-wstw46/C/8bRv/8RySCl15lK376j8DHxm41xFjD9eVL+jSS1UmVpbdLdA0LzGuS2v5uGgQiBLEj6mgSJQwW+MA==",
+      "version": "0.217.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.217.2.tgz",
+      "integrity": "sha512-O+nt/FLXa1hTwtW0O9h36iZjbL84G8e1uByx5dDXMC97AJEbZXwJ4ohfaE8BNWrYFyYX0NGfz1o8AtLQvaaD/Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -13446,9 +13452,9 @@
       "dev": true
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
       "dev": true
     },
     "node_modules/fs.realpath": {
@@ -19410,11 +19416,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.2.tgz",
-      "integrity": "sha512-vog4UhUaMYAzeqfiAAmgB/QWLW7p01/sg+2vn6bqc/CxHFYizMzLv6gjxKzl31EVFkfl/F+GbxlKizlkTE9RdA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.3.tgz",
+      "integrity": "sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==",
       "dependencies": {
-        "@next/env": "13.5.2",
+        "@next/env": "13.5.3",
         "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -19430,15 +19436,15 @@
         "node": ">=16.14.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.2",
-        "@next/swc-darwin-x64": "13.5.2",
-        "@next/swc-linux-arm64-gnu": "13.5.2",
-        "@next/swc-linux-arm64-musl": "13.5.2",
-        "@next/swc-linux-x64-gnu": "13.5.2",
-        "@next/swc-linux-x64-musl": "13.5.2",
-        "@next/swc-win32-arm64-msvc": "13.5.2",
-        "@next/swc-win32-ia32-msvc": "13.5.2",
-        "@next/swc-win32-x64-msvc": "13.5.2"
+        "@next/swc-darwin-arm64": "13.5.3",
+        "@next/swc-darwin-x64": "13.5.3",
+        "@next/swc-linux-arm64-gnu": "13.5.3",
+        "@next/swc-linux-arm64-musl": "13.5.3",
+        "@next/swc-linux-x64-gnu": "13.5.3",
+        "@next/swc-linux-x64-musl": "13.5.3",
+        "@next/swc-win32-arm64-msvc": "13.5.3",
+        "@next/swc-win32-ia32-msvc": "13.5.3",
+        "@next/swc-win32-x64-msvc": "13.5.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -23610,12 +23616,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.4.3.tgz",
-      "integrity": "sha512-afp7trR23jKt8ruGMPjkNAk3A/4CaLo20iPWAODznlF7u+XWnqGm1S+ZUiJFf13Jzj8jmJf/d7/xDHxY3qVMUA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.4.5.tgz",
+      "integrity": "sha512-J7fidphTJ6SJHlR8f/USQE30K6ipbynLVLsTOz0bNYW/0Ua2t9u6dAYGbbq6bLikl3zxzQbdm9lXMUzmaYAdIA==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "7.4.3"
+        "@storybook/cli": "7.4.5"
       },
       "bin": {
         "sb": "index.js",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "test:unit": "cross-env NODE_NO_WARNINGS=1 jest --passWithNoTests",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test": "npm run test:unit",
-    "prepare": "husky install",
-    "postinstall": "npx next telemetry disable"
+    "prepare": "husky install"
   },
   "dependencies": {
     "@heroicons/react": "~2.0.18",
@@ -55,9 +54,9 @@
     "gray-matter": "~4.0.3",
     "husky": "8.0.3",
     "lint-staged": "14.0.1",
-    "next": "^13.5.2",
-    "next-mdx-remote": "^4.4.1",
-    "next-themes": "^0.2.1",
+    "next": "~13.5.3",
+    "next-mdx-remote": "~4.4.1",
+    "next-themes": "~0.2.1",
     "postcss": "~8.4.30",
     "postcss-calc": "~9.0.1",
     "postcss-import": "~15.1.0",
@@ -96,7 +95,7 @@
     "@typescript-eslint/eslint-plugin": "6.7.2",
     "@typescript-eslint/parser": "6.7.2",
     "eslint": "8.49.0",
-    "eslint-config-next": "13.5.2",
+    "eslint-config-next": "~13.5.3",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-mdx": "2.2.0",
     "eslint-plugin-no-relative-import-paths": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@heroicons/react": "~2.0.18",
+    "@mdx-js/react": "^2.3.0",
     "@nodevu/core": "~0.1.0",
     "@types/node": "18.17.17",
     "@vcarl/remark-headings": "~0.1.0",
@@ -62,6 +63,8 @@
     "postcss-import": "~15.1.0",
     "postcss-mixins": "~9.0.4",
     "postcss-simple-vars": "~7.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-intl": "~6.4.7",
     "rehype-autolink-headings": "~7.0.0",
     "rehype-pretty-code": "^0.10.1",
@@ -71,12 +74,7 @@
     "shiki": "^0.14.3",
     "tailwindcss": "^3.3.3",
     "turbo": "^1.10.14",
-    "typescript": "~5.2.2"
-  },
-  "peerDependencies": {
-    "@mdx-js/react": "^2.3.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "typescript": "~5.2.2",
     "vfile": "^5.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is a permanent solution for issues such as https://github.com/nodejs/nodejs.org/issues/5921 caused by Legacy NPM peerDependencies configuration.

Since this is a change that will override user-driven settings, I wanted to make a PR instead of a hot-fix to see if this is the best course of actions.

I've also removed the manual telemetry disable on installs here, as this bypasses the freedom of end-users of deciding if they want telemetry on or off.

Finally, I've changed `next` (Next.js) related dependencies to use `~` as since they are the core infrastructure of this repository, we want to avoid having accidental breaking changes on version updates (I know dependabot ignores that, and that's fine)

I know Vercel folks respect Semver very well, but having patch changes by default feels safer. (Even tho Dependabot will always suggest and make new PRs for any new update, including major ones, which is OK, and allows us to always check a new dependency on a case-per-case inspection).

cc @nodejs/web-infra 