### PR TITLE
feat: new eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,14 +20,36 @@
     },
     {
       "files": ["**/*.ts?(x)"],
-      "plugins": ["@typescript-eslint", "no-relative-import-paths"],
-      "extends": "plugin:@typescript-eslint/recommended",
+      "plugins": ["@typescript-eslint", "no-relative-import-paths", "import"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended",
+        "plugin:import/recommended",
+        "plugin:import/typescript"
+      ],
       "parser": "@typescript-eslint/parser",
       "rules": {
         "@typescript-eslint/consistent-type-imports": "error",
         "no-relative-import-paths/no-relative-import-paths": [
           "warn",
           { "allowSameFolder": true, "prefix": "@" }
+        ],
+        "import/order": [
+          "error",
+          {
+            "groups": [
+              "builtin",
+              "external",
+              "internal",
+              ["sibling", "parent"],
+              "index",
+              "unknown"
+            ],
+            "newlines-between": "always",
+            "alphabetize": {
+              "order": "asc",
+              "caseInsensitive": true
+            }
+          }
         ]
       }
     },
@@ -39,6 +61,7 @@
     {
       "files": ["**/*.{mdx,tsx}"],
       "rules": {
+        "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "react/function-component-definition": [
           "error",
           {
@@ -56,8 +79,7 @@
             "selector": "ImportDeclaration[source.value='react'] :matches(ImportNamespaceSpecifier)",
             "message": "Named * React import is not allowed. Please import what you need from React with Named Imports"
           }
-        ],
-        "@typescript-eslint/consistent-type-definitions": ["error", "type"]
+        ]
       }
     }
   ]

--- a/app/en/feed/[feed]/route.ts
+++ b/app/en/feed/[feed]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { blogData } from '@/next.json.mjs';
+
 import { generateWebsiteFeeds } from '@/next.data.mjs';
+import { blogData } from '@/next.json.mjs';
 
 // loads all the data from the blog-posts-data.json file
 const websiteFeeds = generateWebsiteFeeds(blogData);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,5 @@
-import { allPaths } from '@/next.dynamic.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
+import type { MetadataRoute } from 'next';
+
 import {
   STATIC_ROUTES_IGNORES,
   DYNAMIC_GENERATED_ROUTES,
@@ -7,7 +7,8 @@ import {
   BASE_URL,
   EXTERNAL_LINKS_SITEMAP,
 } from '@/next.constants.mjs';
-import type { MetadataRoute } from 'next';
+import { allPaths } from '@/next.dynamic.mjs';
+import { defaultLocale } from '@/next.locales.mjs';
 
 // This is the combination of the Application Base URL and Base PATH
 const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;

--- a/components/Common/ActiveLocalizedLink/index.tsx
+++ b/components/Common/ActiveLocalizedLink/index.tsx
@@ -1,9 +1,10 @@
-import { useRouter } from 'next/router';
-import { useState, useEffect, type FC } from 'react';
 import classNames from 'classnames';
-import LocalizedLink from '@/components/LocalizedLink';
 import type Link from 'next/link';
-import type { ComponentProps } from 'react';
+import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
+import type { ComponentProps, FC } from 'react';
+
+import LocalizedLink from '@/components/LocalizedLink';
 
 type ActiveLocalizedLinkProps = ComponentProps<typeof Link> & {
   activeClassName: string;

--- a/components/Common/Badge/index.stories.tsx
+++ b/components/Common/Badge/index.stories.tsx
@@ -1,5 +1,6 @@
-import Badge from './';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
+import Badge from './';
 
 type Story = StoryObj<typeof Badge>;
 type Meta = MetaObj<typeof Badge>;

--- a/components/Common/Badge/index.tsx
+++ b/components/Common/Badge/index.tsx
@@ -1,7 +1,8 @@
 import ArrowRightIcon from '@heroicons/react/24/solid/ArrowRightIcon';
-import LocalizedLink from '@/components/LocalizedLink';
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import type Link from 'next/link';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+
+import LocalizedLink from '@/components/LocalizedLink';
 
 import styles from './index.module.css';
 

--- a/components/Common/Banner/index.stories.tsx
+++ b/components/Common/Banner/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
 import Banner from './';
 
 type Story = StoryObj<typeof Banner>;

--- a/components/Common/Banner/index.tsx
+++ b/components/Common/Banner/index.tsx
@@ -1,6 +1,7 @@
-import LocalizedLink from '@/components/LocalizedLink';
 import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import type { FC } from 'react';
+
+import LocalizedLink from '@/components/LocalizedLink';
 
 import styles from './index.module.css';
 

--- a/components/Common/Blockquote/index.stories.tsx
+++ b/components/Common/Blockquote/index.stories.tsx
@@ -1,5 +1,6 @@
-import Blockquote from './';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
+import Blockquote from './';
 
 type Story = StoryObj<typeof Blockquote>;
 type Meta = MetaObj<typeof Blockquote>;

--- a/components/Common/Button/index.stories.tsx
+++ b/components/Common/Button/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
 import Button from './';
 
 type Story = StoryObj<typeof Button>;

--- a/components/Common/CrossLink/index.stories.tsx
+++ b/components/Common/CrossLink/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+
 import CrossLink from './index';
 
 type Story = StoryObj<typeof CrossLink>;

--- a/components/Common/CrossLink/index.tsx
+++ b/components/Common/CrossLink/index.tsx
@@ -1,9 +1,11 @@
-import styles from './index.module.css';
 import classNames from 'classnames';
-import LocalizedLink from '@/components/LocalizedLink';
-import PrevNextArrow from '@/components/Common/PrevNextArrow';
-import { FormattedMessage } from 'react-intl';
 import type { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import PrevNextArrow from '@/components/Common/PrevNextArrow';
+import LocalizedLink from '@/components/LocalizedLink';
+
+import styles from './index.module.css';
 
 type CrossLinkProps = {
   type: 'previous' | 'next';

--- a/components/Downloads/DownloadList.tsx
+++ b/components/Downloads/DownloadList.tsx
@@ -1,8 +1,9 @@
+import type { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
+
 import LocalizedLink from '@/components/LocalizedLink';
 import { useNavigation } from '@/hooks/useNavigation';
 import type { NodeRelease } from '@/types';
-import type { FC } from 'react';
 
 const DownloadList: FC<NodeRelease> = ({ versionWithPrefix }) => {
   const { getSideNavigation } = useNavigation();

--- a/components/Downloads/DownloadReleasesTable.tsx
+++ b/components/Downloads/DownloadReleasesTable.tsx
@@ -1,8 +1,9 @@
-import { FormattedMessage } from 'react-intl';
-import { getNodejsChangelog } from '@/util/getNodeJsChangelog';
-import { getNodeApiLink } from '@/util/getNodeApiLink';
-import { useNodeReleases } from '@/hooks/useNodeReleases';
 import type { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { useNodeReleases } from '@/hooks/useNodeReleases';
+import { getNodeApiLink } from '@/util/getNodeApiLink';
+import { getNodejsChangelog } from '@/util/getNodeJsChangelog';
 
 const DownloadReleasesTable: FC = () => {
   const { releases } = useNodeReleases();

--- a/components/Downloads/PrimaryDownloadMatrix.tsx
+++ b/components/Downloads/PrimaryDownloadMatrix.tsx
@@ -1,11 +1,12 @@
 import classNames from 'classnames';
+import type { FC } from 'react';
 import semVer from 'semver';
+
 import LocalizedLink from '@/components/LocalizedLink';
 import { useDetectOS } from '@/hooks/useDetectOS';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
 import { DIST_URL } from '@/next.constants.mjs';
 import type { LegacyDownloadsFrontMatter, NodeRelease } from '@/types';
-import type { FC } from 'react';
 
 // @TODO: Instead of using a static list it should be created dynamically. This is done on `nodejs.dev`
 // since this is a temporary solution and going to be fixed in the future.

--- a/components/Downloads/SecondaryDownloadMatrix.tsx
+++ b/components/Downloads/SecondaryDownloadMatrix.tsx
@@ -1,9 +1,11 @@
-import DownloadList from './DownloadList';
-import { useLayoutContext } from '@/hooks/useLayoutContext';
-import { WithNodeRelease } from '@/providers/withNodeRelease';
-import { DIST_URL } from '@/next.constants.mjs';
-import type { LegacyDownloadsFrontMatter, NodeRelease } from '@/types';
 import type { FC } from 'react';
+
+import { useLayoutContext } from '@/hooks/useLayoutContext';
+import { DIST_URL } from '@/next.constants.mjs';
+import { WithNodeRelease } from '@/providers/withNodeRelease';
+import type { LegacyDownloadsFrontMatter, NodeRelease } from '@/types';
+
+import DownloadList from './DownloadList';
 
 // @TODO: Instead of using a static list it should be created dynamically. This is done on `nodejs.dev`
 // since this is a temporary solution and going to be fixed in the future.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,5 @@
-import { FormattedMessage } from 'react-intl';
 import type { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 type FooterProps = { className?: string };
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,12 @@
-import { useIntl } from 'react-intl';
-import Image from 'next/image';
 import classNames from 'classnames';
-import LocalizedLink from './LocalizedLink';
-import { useNavigation } from '@/hooks/useNavigation';
+import Image from 'next/image';
+import { useIntl } from 'react-intl';
+
 import { useLocale } from '@/hooks/useLocale';
+import { useNavigation } from '@/hooks/useNavigation';
 import { useRouter } from '@/hooks/useRouter';
+
+import LocalizedLink from './LocalizedLink';
 
 const Header = () => {
   const { availableLocales, isCurrentLocaleRoute } = useLocale();

--- a/components/Home/HomeDownloadButton.tsx
+++ b/components/Home/HomeDownloadButton.tsx
@@ -1,11 +1,12 @@
+import type { FC } from 'react';
+
 import LocalizedLink from '@/components/LocalizedLink';
 import { useDetectOS } from '@/hooks/useDetectOS';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
+import { DIST_URL } from '@/next.constants.mjs';
+import type { NodeRelease } from '@/types';
 import { downloadUrlByOS } from '@/util/downloadUrlByOS';
 import { getNodejsChangelog } from '@/util/getNodeJsChangelog';
-import { DIST_URL } from '@/next.constants.mjs';
-import type { FC } from 'react';
-import type { NodeRelease } from '@/types';
 
 const HomeDownloadButton: FC<NodeRelease> = ({
   major,

--- a/components/HtmlHead.tsx
+++ b/components/HtmlHead.tsx
@@ -1,10 +1,11 @@
 import Head from 'next/head';
-import { useSiteConfig } from '@/hooks/useSiteConfig';
-import { useRouter } from '@/hooks/useRouter';
+import type { FC } from 'react';
+
 import { useLocale } from '@/hooks/useLocale';
+import { useRouter } from '@/hooks/useRouter';
+import { useSiteConfig } from '@/hooks/useSiteConfig';
 import { BASE_URL, BASE_PATH } from '@/next.constants.mjs';
 import type { LegacyFrontMatter } from '@/types';
-import type { FC } from 'react';
 
 // This is the combination of the Application Base URL and Base PATH
 const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;

--- a/components/LocalizedLink.tsx
+++ b/components/LocalizedLink.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
 import Link from 'next/link';
+import { useMemo } from 'react';
+import type { FC, ComponentProps, HTMLAttributes } from 'react';
+
 import { useLocale } from '@/hooks/useLocale';
 import { linkWithLocale } from '@/util/linkWithLocale';
-import type { FC, ComponentProps, HTMLAttributes } from 'react';
 
 // This is a wrapper on HTML's `a` tag
 const HtmlLink: FC<HTMLAttributes<HTMLAnchorElement>> = ({

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,6 +1,7 @@
-import { FormattedMessage } from 'react-intl';
-import LocalizedLink from './LocalizedLink';
 import type { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import LocalizedLink from './LocalizedLink';
 
 type PaginationProps = { prevSlug?: number; nextSlug?: number };
 

--- a/components/SideNavigation.tsx
+++ b/components/SideNavigation.tsx
@@ -1,9 +1,11 @@
 import classNames from 'classnames';
-import LocalizedLink from './LocalizedLink';
+import type { FC } from 'react';
+
 import { useLocale } from '@/hooks/useLocale';
 import { useNavigation } from '@/hooks/useNavigation';
 import type { NavigationKeys } from '@/types';
-import type { FC } from 'react';
+
+import LocalizedLink from './LocalizedLink';
 
 type SideNavigationProps = {
   navigationKey: NavigationKeys;

--- a/components/__design__/hex-logos.stories.tsx
+++ b/components/__design__/hex-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const HexLogos: StoryObj = {};
 

--- a/components/__design__/horizontal-logos.stories.tsx
+++ b/components/__design__/horizontal-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const HorizontalLogos: StoryObj = {};
 

--- a/components/__design__/js-logos.stories.tsx
+++ b/components/__design__/js-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const JSLogos: StoryObj = {};
 

--- a/components/__design__/platform-logos.stories.tsx
+++ b/components/__design__/platform-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const PlatformLogos: StoryObj = {};
 

--- a/components/__design__/social-logos.stories.tsx
+++ b/components/__design__/social-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const SocialLogos: StoryObj = {};
 

--- a/components/__design__/stacked-logos.stories.tsx
+++ b/components/__design__/stacked-logos.stories.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
+import Image from 'next/image';
 
 export const StackedLogos: StoryObj = {};
 

--- a/hooks/useBlogData.ts
+++ b/hooks/useBlogData.ts
@@ -1,6 +1,8 @@
 import { useCallback, useContext, useMemo } from 'react';
-import { useRouter } from './useRouter';
+
 import { BlogDataContext } from '@/providers/blogDataProvider';
+
+import { useRouter } from './useRouter';
 
 export const useBlogData = () => {
   const { asPath } = useRouter();

--- a/hooks/useDetectOS.ts
+++ b/hooks/useDetectOS.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
+
+import type { UserOS } from '@/types/userOS';
 import { detectOS } from '@/util/detectOS';
 import { getBitness } from '@/util/getBitness';
-import type { UserOS } from '@/types/userOS';
 
 type UserOSState = {
   os: UserOS;

--- a/hooks/useLayoutContext.ts
+++ b/hooks/useLayoutContext.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { LayoutContext } from '@/providers/layoutProvider';
 
 export const useLayoutContext = () => useContext(LayoutContext);

--- a/hooks/useLocale.ts
+++ b/hooks/useLocale.ts
@@ -1,7 +1,9 @@
 import { useContext } from 'react';
-import { useRouter } from './useRouter';
+
 import { LocaleContext } from '@/providers/localeProvider';
 import { linkWithLocale } from '@/util/linkWithLocale';
+
+import { useRouter } from './useRouter';
 
 export const useLocale = () => {
   const { asPath } = useRouter();

--- a/hooks/useNavigation.tsx
+++ b/hooks/useNavigation.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+
 import { siteNavigation } from '@/next.json.mjs';
 import type { NavigationEntry, NavigationKeys } from '@/types';
 

--- a/hooks/useNodeReleases.ts
+++ b/hooks/useNodeReleases.ts
@@ -1,4 +1,5 @@
 import { useCallback, useContext } from 'react';
+
 import { NodeReleasesContext } from '@/providers/nodeReleasesProvider';
 import type { NodeReleaseStatus } from '@/types';
 

--- a/hooks/useRouter.ts
+++ b/hooks/useRouter.ts
@@ -1,11 +1,12 @@
-import { useMemo } from 'react';
 import { useRouter as useNextRouter } from 'next/router';
+import type { NextRouter } from 'next/router';
+import { useMemo } from 'react';
+
 import {
   availableLocales,
   getCurrentLocale,
   defaultLocale,
 } from '@/next.locales.mjs';
-import type { NextRouter } from 'next/router';
 
 // Maps all available locales by only their Language Code
 const mappedLocalesByCode = availableLocales.map(l => l.code);

--- a/hooks/useSiteConfig.ts
+++ b/hooks/useSiteConfig.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { SiteContext } from '@/providers/siteProvider';
 
 export const useSiteConfig = () => {

--- a/layouts/AboutLayout.tsx
+++ b/layouts/AboutLayout.tsx
@@ -1,6 +1,8 @@
-import BaseLayout from './BaseLayout';
-import SideNavigation from '@/components/SideNavigation';
 import type { FC, PropsWithChildren } from 'react';
+
+import SideNavigation from '@/components/SideNavigation';
+
+import BaseLayout from './BaseLayout';
 
 const AboutLayout: FC<PropsWithChildren> = ({ children }) => (
   <BaseLayout>

--- a/layouts/BaseLayout.tsx
+++ b/layouts/BaseLayout.tsx
@@ -1,6 +1,7 @@
+import type { FC, PropsWithChildren } from 'react';
+
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
-import type { FC, PropsWithChildren } from 'react';
 
 const BaseLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/layouts/BlogIndexLayout.tsx
+++ b/layouts/BlogIndexLayout.tsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
-import BaseLayout from './BaseLayout';
-import { Time } from '@/components/Common/Time';
-import Pagination from '@/components/Pagination';
-import LocalizedLink from '@/components/LocalizedLink';
-import { useBlogData } from '@/hooks/useBlogData';
 import type { FC, PropsWithChildren } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { Time } from '@/components/Common/Time';
+import LocalizedLink from '@/components/LocalizedLink';
+import Pagination from '@/components/Pagination';
+import { useBlogData } from '@/hooks/useBlogData';
 import type { BlogPost } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const BlogIndexLayout: FC<PropsWithChildren> = ({ children }) => {
   const { getPagination, getPostsByYear, currentCategory } = useBlogData();

--- a/layouts/BlogPostLayout.tsx
+++ b/layouts/BlogPostLayout.tsx
@@ -1,9 +1,11 @@
+import type { FC, PropsWithChildren } from 'react';
 import { FormattedMessage } from 'react-intl';
-import BaseLayout from './BaseLayout';
+
 import { Time } from '@/components/Common/Time';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
-import type { FC, PropsWithChildren } from 'react';
 import type { LegacyBlogFrontMatter } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const BlogPostLayout: FC<PropsWithChildren> = ({ children }) => {
   const { frontMatter } = useLayoutContext();

--- a/layouts/CategoryIndexLayout.tsx
+++ b/layouts/CategoryIndexLayout.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
-import BaseLayout from './BaseLayout';
+import type { FC, PropsWithChildren } from 'react';
+
 import { Time } from '@/components/Common/Time';
 import LocalizedLink from '@/components/LocalizedLink';
-import { useLayoutContext } from '@/hooks/useLayoutContext';
 import { useBlogData } from '@/hooks/useBlogData';
-import type { FC, PropsWithChildren } from 'react';
+import { useLayoutContext } from '@/hooks/useLayoutContext';
 import type { BlogPost } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const CategoryIndexLayout: FC<PropsWithChildren> = ({ children }) => {
   const { frontMatter } = useLayoutContext();

--- a/layouts/ContributeLayout.tsx
+++ b/layouts/ContributeLayout.tsx
@@ -1,6 +1,8 @@
-import BaseLayout from './BaseLayout';
-import SideNavigation from '@/components/SideNavigation';
 import type { FC, PropsWithChildren } from 'react';
+
+import SideNavigation from '@/components/SideNavigation';
+
+import BaseLayout from './BaseLayout';
 
 const ContributeLayout: FC<PropsWithChildren> = ({ children }) => (
   <BaseLayout>

--- a/layouts/DefaultLayout.tsx
+++ b/layouts/DefaultLayout.tsx
@@ -1,5 +1,6 @@
-import BaseLayout from './BaseLayout';
 import type { FC, PropsWithChildren } from 'react';
+
+import BaseLayout from './BaseLayout';
 
 const DefaultLayout: FC<PropsWithChildren> = ({ children }) => (
   <BaseLayout>

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
-import BaseLayout from './BaseLayout';
+import type { FC, PropsWithChildren } from 'react';
+
 import SideNavigation from '@/components/SideNavigation';
 import { useNodeReleases } from '@/hooks/useNodeReleases';
-import type { FC, PropsWithChildren } from 'react';
+
+import BaseLayout from './BaseLayout';
 
 const DocsLayout: FC<PropsWithChildren> = ({ children }) => {
   const { getReleaseByStatus } = useNodeReleases();

--- a/layouts/DownloadCurrentLayout.tsx
+++ b/layouts/DownloadCurrentLayout.tsx
@@ -1,10 +1,12 @@
-import BaseLayout from './BaseLayout';
+import type { FC, PropsWithChildren } from 'react';
+
 import PrimaryDownloadMatrix from '@/components/Downloads/PrimaryDownloadMatrix';
 import SecondaryDownloadMatrix from '@/components/Downloads/SecondaryDownloadMatrix';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
 import { WithNodeRelease } from '@/providers/withNodeRelease';
-import type { FC, PropsWithChildren } from 'react';
 import type { LegacyDownloadsFrontMatter } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const DownloadCurrentLayout: FC<PropsWithChildren> = ({ children }) => {
   const { frontMatter } = useLayoutContext();

--- a/layouts/DownloadLayout.tsx
+++ b/layouts/DownloadLayout.tsx
@@ -1,10 +1,12 @@
-import BaseLayout from './BaseLayout';
+import type { FC, PropsWithChildren } from 'react';
+
 import PrimaryDownloadMatrix from '@/components/Downloads/PrimaryDownloadMatrix';
 import SecondaryDownloadMatrix from '@/components/Downloads/SecondaryDownloadMatrix';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
 import { WithNodeRelease } from '@/providers/withNodeRelease';
-import type { FC, PropsWithChildren } from 'react';
 import type { LegacyDownloadsFrontMatter } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const DownloadLayout: FC<PropsWithChildren> = ({ children }) => {
   const { frontMatter } = useLayoutContext();

--- a/layouts/DownloadReleasesLayout.tsx
+++ b/layouts/DownloadReleasesLayout.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
-import BaseLayout from './BaseLayout';
-import { useLayoutContext } from '@/hooks/useLayoutContext';
-import DownloadReleasesTable from '@/components/Downloads/DownloadReleasesTable';
 import type { FC, PropsWithChildren } from 'react';
+
+import DownloadReleasesTable from '@/components/Downloads/DownloadReleasesTable';
+import { useLayoutContext } from '@/hooks/useLayoutContext';
 import type { LegacyDownloadsReleasesFrontMatter } from '@/types';
+
+import BaseLayout from './BaseLayout';
 
 const DownloadReleasesLayout: FC<PropsWithChildren> = ({ children }) => {
   const { frontMatter } = useLayoutContext();

--- a/layouts/IndexLayout.tsx
+++ b/layouts/IndexLayout.tsx
@@ -1,11 +1,13 @@
-import BaseLayout from './BaseLayout';
+import type { FC, PropsWithChildren } from 'react';
+
 import Banner from '@/components/Home/Banner';
 import HomeDownloadButton from '@/components/Home/HomeDownloadButton';
 import { useDetectOS } from '@/hooks/useDetectOS';
 import { useLayoutContext } from '@/hooks/useLayoutContext';
 import { WithNodeRelease } from '@/providers/withNodeRelease';
-import type { FC, PropsWithChildren } from 'react';
 import type { UserOS } from '@/types/userOS';
+
+import BaseLayout from './BaseLayout';
 
 const getDownloadHeadTextOS = (os: UserOS, bitness: number) => {
   switch (os) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { availableLocales } from './next.locales.mjs';
 import type { NextRequest } from 'next/server';
+
+import { availableLocales } from './next.locales.mjs';
 
 // This Middleware is responsible for handling automatic language detection from a user's Browser
 // This middleware should only run on "/" requests coming to the Website

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,7 @@
-import { FormattedMessage } from 'react-intl';
-import Theme from '@/theme';
 import type { GetStaticProps } from 'next';
+import { FormattedMessage } from 'react-intl';
+
+import Theme from '@/theme';
 
 const NotFound = () => (
   <Theme>

--- a/pages/[...path].tsx
+++ b/pages/[...path].tsx
@@ -1,10 +1,7 @@
 import { sep } from 'node:path';
-import Theme from '@/theme';
-import {
-  getMarkdownFile,
-  generateStaticProps,
-  allPaths,
-} from '@/next.dynamic.mjs';
+
+import type { GetStaticPaths, GetStaticProps } from 'next';
+
 import {
   ENABLE_STATIC_EXPORT,
   STATIC_ROUTES_IGNORES,
@@ -12,7 +9,12 @@ import {
   DYNAMIC_ROUTES_REWRITES,
   DYNAMIC_GENERATED_ROUTES,
 } from '@/next.constants.mjs';
-import type { GetStaticPaths, GetStaticProps } from 'next';
+import {
+  getMarkdownFile,
+  generateStaticProps,
+  allPaths,
+} from '@/next.dynamic.mjs';
+import Theme from '@/theme';
 import type { DynamicStaticProps } from '@/types';
 
 type DynamicStaticPaths = { path: string[] };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,12 @@
-import { Source_Sans_3 } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
-import { SiteProvider } from '@/providers/siteProvider';
-import { LocaleProvider } from '@/providers/localeProvider';
-import { BlogDataProvider } from '@/providers/blogDataProvider';
-import { NodeReleasesProvider } from '@/providers/nodeReleasesProvider';
-import { VERCEL_ENV } from '@/next.constants.mjs';
 import type { AppProps } from 'next/app';
+import { Source_Sans_3 } from 'next/font/google';
+
+import { VERCEL_ENV } from '@/next.constants.mjs';
+import { BlogDataProvider } from '@/providers/blogDataProvider';
+import { LocaleProvider } from '@/providers/localeProvider';
+import { NodeReleasesProvider } from '@/providers/nodeReleasesProvider';
+import { SiteProvider } from '@/providers/siteProvider';
 
 import '@/styles/old/index.css';
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,6 @@
-import Script from 'next/script';
 import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
+
 import { LEGACY_JAVASCRIPT_FILE } from '@/next.constants.mjs';
 
 const Document = () => (

--- a/providers/blogDataProvider.tsx
+++ b/providers/blogDataProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
-import blogData from '@/public/blog-posts-data.json';
 import type { FC, PropsWithChildren } from 'react';
+
+import blogData from '@/public/blog-posts-data.json';
 import type { BlogData } from '@/types';
 
 export const BlogDataContext = createContext<BlogData>({

--- a/providers/layoutProvider.tsx
+++ b/providers/layoutProvider.tsx
@@ -1,4 +1,6 @@
 import { createContext, useMemo } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+
 import AboutLayout from '@/layouts/AboutLayout';
 import BlogIndexLayout from '@/layouts/BlogIndexLayout';
 import BlogPostLayout from '@/layouts/BlogPostLayout';
@@ -6,11 +8,10 @@ import CategoryIndexLayout from '@/layouts/CategoryIndexLayout';
 import ContributeLayout from '@/layouts/ContributeLayout';
 import DefaultLayout from '@/layouts/DefaultLayout';
 import DocsLayout from '@/layouts/DocsLayout';
-import DownloadLayout from '@/layouts/DownloadLayout';
 import DownloadCurrentLayout from '@/layouts/DownloadCurrentLayout';
+import DownloadLayout from '@/layouts/DownloadLayout';
 import DownloadReleasesLayout from '@/layouts/DownloadReleasesLayout';
 import IndexLayout from '@/layouts/IndexLayout';
-import type { FC, PropsWithChildren } from 'react';
 import type { LegacyFrontMatter, LegacyLayouts } from '@/types';
 
 type LayoutContextProps = {

--- a/providers/localeProvider.tsx
+++ b/providers/localeProvider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useMemo } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
+
 import { useRouter } from '@/hooks/useRouter';
 import {
   defaultLocale,
@@ -7,7 +9,6 @@ import {
   getCurrentLocale,
   getCurrentTranslations,
 } from '@/next.locales.mjs';
-import type { FC, PropsWithChildren } from 'react';
 import type { LocaleContext as LocaleContextType } from '@/types';
 
 // Initialises the Context with the default Localisation Data

--- a/providers/mdxProvider.tsx
+++ b/providers/mdxProvider.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
 import { MDXProvider as BaseMDXProvider } from '@mdx-js/react';
-import { MDXRemote } from 'next-mdx-remote';
-import NodeApiVersionLinks from '@/components/Docs/NodeApiVersionLinks';
-import type { FC } from 'react';
 import type { MDXComponents } from 'mdx/types';
+import { MDXRemote } from 'next-mdx-remote';
+import { useEffect } from 'react';
+import type { FC } from 'react';
+
+import NodeApiVersionLinks from '@/components/Docs/NodeApiVersionLinks';
 
 const mdxComponents: MDXComponents = {
   NodeApiVersionLinks: NodeApiVersionLinks,

--- a/providers/nodeReleasesProvider.tsx
+++ b/providers/nodeReleasesProvider.tsx
@@ -1,8 +1,9 @@
 import { createContext, useMemo } from 'react';
-import nodeReleasesData from '@/public/node-releases-data.json';
-import { getNodeReleaseStatus } from '@/util/nodeRelease';
 import type { FC, PropsWithChildren } from 'react';
+
+import nodeReleasesData from '@/public/node-releases-data.json';
 import type { NodeReleaseSource, NodeRelease } from '@/types';
+import { getNodeReleaseStatus } from '@/util/nodeRelease';
 
 export const NodeReleasesContext = createContext<NodeRelease[]>([]);
 

--- a/providers/siteProvider.tsx
+++ b/providers/siteProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
-import { siteConfig } from '@/next.json.mjs';
 import type { FC, PropsWithChildren } from 'react';
+
+import { siteConfig } from '@/next.json.mjs';
 import type { SiteConfig } from '@/types';
 
 export const SiteContext = createContext<SiteConfig>(siteConfig);

--- a/providers/withNodeRelease.tsx
+++ b/providers/withNodeRelease.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { useNodeReleases } from '@/hooks/useNodeReleases';
-import { isNodeRelease } from '@/util/nodeRelease';
 import type { FC } from 'react';
+
+import { useNodeReleases } from '@/hooks/useNodeReleases';
 import type { NodeRelease, NodeReleaseStatus } from '@/types';
+import { isNodeRelease } from '@/util/nodeRelease';
 
 type WithNodeReleaseProps = {
   status: NodeReleaseStatus;

--- a/theme.tsx
+++ b/theme.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+
+import HtmlHead from './components/HtmlHead';
 import { LayoutProvider } from './providers/layoutProvider';
 import { MDXProvider } from './providers/mdxProvider';
-import HtmlHead from './components/HtmlHead';
-import type { FC, PropsWithChildren } from 'react';
 import type { DynamicStaticProps } from './types';
 
 type ThemeProps = PropsWithChildren<DynamicStaticProps>;

--- a/types/dynamic.ts
+++ b/types/dynamic.ts
@@ -1,4 +1,5 @@
 import type { Heading } from '@vcarl/remark-headings';
+
 import type { LegacyFrontMatter } from './frontmatter';
 
 export interface DynamicStaticProps {

--- a/util/getNodeApiLink.ts
+++ b/util/getNodeApiLink.ts
@@ -1,4 +1,5 @@
 import semVer from 'semver';
+
 import { DOCS_URL, DIST_URL } from '@/next.constants.mjs';
 
 export const getNodeApiLink = (version: string) => {


### PR DESCRIPTION
This PR adds new ESLint rules to ensure that imports are always in the order as specified within the Collaborator Guidelines.

This nullifies the need of asking contributors to fix their import orders and keeps consistency between imports.