### PR TITLE
fix: Banner component text color and spacing

### DIFF
--- a/components/Common/Banner/index.module.css
+++ b/components/Common/Banner/index.module.css
@@ -5,12 +5,15 @@
     items-center
     justify-center
     gap-2
+    px-8
     py-3
     text-sm
     text-white;
 
   a {
-    @apply underline;
+    @apply w-fit
+      text-white
+      underline;
   }
 
   svg {


### PR DESCRIPTION
## Description

Fixes unstyled banner anchor and small screen spacing

## Validation
<img width="429" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/d8d10a24-c898-4358-9f28-c4afed3d4c6e">


### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
