### PR TITLE
rename list and logos stories

### DIFF
--- a/components/__design__/list.stories.tsx
+++ b/components/__design__/list.stories.tsx
@@ -24,4 +24,4 @@ export const UnorderedLists: StoryObj = {
   ),
 };
 
-export default { title: 'Design System/Lists' } as MetaObj;
+export default { title: 'Design System' } as MetaObj;

--- a/components/__design__/node-logos.stories.tsx
+++ b/components/__design__/node-logos.stories.tsx
@@ -75,4 +75,4 @@ export const JSSymbols: StoryObj = {
   ),
 };
 
-export default { title: 'Design System/Node.js Logos' } as MetaObj;
+export default { title: 'Design System' } as MetaObj;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Renamed two stories to better group the storybook design system.

Especially in Chromatic, the way they are currently named caused a strange grouping:

![image](https://github.com/nodejs/nodejs.org/assets/298435/1e7e40a1-c62d-468a-9834-9585743383a4)
Only two


![image](https://github.com/nodejs/nodejs.org/assets/298435/873c7db4-54e3-41f7-be9c-27e408de696e)
Others?


## Validation

###

Before

![image](https://github.com/nodejs/nodejs.org/assets/298435/8ce94297-aa76-44e7-a7c0-13d0afacb449)


After

![image](https://github.com/nodejs/nodejs.org/assets/298435/6dd48d62-e920-4c91-b590-d385b4255381)


One could argue that it looks better BEFORE, but I feel like it's oddly inconsistent with the other Design System stories and I'd rather we pick one pattern and go with it. I suppose, the crux of the problem is chormatics rendering, not local.


Chromatic... https://www.chromatic.com/library?appId=64c7d71358830e9105808652&branch=stories-fix

Is this better? Lemme know in the reviews - I won't be offended with "no" 😄 



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
