### PR TITLE
Correct download name in ja index

### DIFF
--- a/pages/ja/download/current.md
+++ b/pages/ja/download/current.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
   currentVersion: 最新のバージョン
-  buildInstructions: 同梱
-  WindowsInstaller: Building Node.js from source on supported platforms
-  WindowsBinary: Windows Installer
-  MacOSInstaller: Windows Binary
-  MacOSBinary: macOS Installer
-  LinuxBinaries: macOS Binary
-  SourceCode: Linux Binaries
+  buildInstructions: Node.jsをソースからビルドします
+  WindowsInstaller: Windows Installer
+  WindowsBinary: Windows Binary
+  MacOSInstaller: macOS Intaller
+  MacOSBinary: macOS Binary
+  LinuxBinaries: Linux Binaries
+  SourceCode: Source Code
 additional:
   headline: その他のプラットフォーム
   intro: >

--- a/pages/ja/download/index.md
+++ b/pages/ja/download/index.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
   currentVersion: 最新のバージョン
-  buildInstructions: 同梱
-  WindowsInstaller: Building Node.js from source on supported platforms
-  WindowsBinary: Windows Installer
-  MacOSInstaller: Windows Binary
-  MacOSBinary: macOS Installer
-  LinuxBinaries: macOS Binary
-  SourceCode: Linux Binaries
+  buildInstructions: Node.jsをソースからビルドします
+  WindowsInstaller: Windows Installer
+  WindowsBinary: Windows Binary
+  MacOSInstaller: macOS Intaller
+  MacOSBinary: macOS Binary
+  LinuxBinaries: Linux Binaries
+  SourceCode: Source Code
 additional:
   headline: その他のプラットフォーム
   intro: >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I corrected download names in download page for ja-language.

## Validation

I checked local download page with `npx turbo serve`.

## Related Issues

Not found.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
