### PR TITLE
Fix debugging guide header

### DIFF
--- a/pages/ar/docs/guides/debugging-getting-started.md
+++ b/pages/ar/docs/guides/debugging-getting-started.md
@@ -204,7 +204,7 @@ ssh -L 9221:localhost:9229 user@remote.example.com
 
 إن بروتوكول التصحيح الخاص بالـ V8 لم تعد يتم صيانته أو توثيقه دوريا.
 
-### [مصحح الأخطاء المبني ضمنيا](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [مصحح الأخطاء المبني ضمنيا](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 قم بتنفيذ الأمر <span dir="ltr">`node debug script_name.js`</span> لبدء النص البرمجي الخاص بك عن طريق مصحح الأخطاء المبني ضمنيا في Node.
 يمكن للنص البرمجي الخاص بك أن يبدأ في عملية Node اخرى باستعمال <span dir="ltr">`--debug-brk`</span> كما تشغل عملية Node

--- a/pages/en/docs/guides/debugging-getting-started.md
+++ b/pages/en/docs/guides/debugging-getting-started.md
@@ -225,7 +225,7 @@ couple popular ones are listed below.
 
 The V8 Debugging Protocol is no longer maintained or documented.
 
-### [Built-in Debugger](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [Built-in Debugger](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under the builtin
 command-line debugger. Your script starts in another Node.js process started with

--- a/pages/id/docs/guides/debugging-getting-started.md
+++ b/pages/id/docs/guides/debugging-getting-started.md
@@ -173,7 +173,7 @@ Saat dimulai dengan sakelar **--debug** atau **--debug-brk** di versi 7 dan sebe
 
 Protokol Debugging V8 tidak lagi dipertahankan atau didokumentasikan.
 
-### [Debugger Bawaan](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [Debugger Bawaan](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Mulai `node debug script_name.js` untuk memulai skrip Anda di bawah bawaan debugger baris perintah. Skrip Anda dimulai dalam proses Node.js lain yang dimulai dengan opsi `--debug-brk`, dan proses Node.js awal menjalankan `_debugger.js` script dan menghubungkan ke target Anda.
 

--- a/pages/ja/docs/guides/debugging-getting-started.md
+++ b/pages/ja/docs/guides/debugging-getting-started.md
@@ -479,7 +479,7 @@ Node.js は TCP ポートで廃止された V8 デバッグプロトコルで定
 V8 デバッグプロトコルは、もはや保守もドキュメンテーションもされていません。
 
 <!--
-#### [Built-in Debugger](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+#### [Built-in Debugger](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
@@ -488,7 +488,7 @@ script and connects to your target.
 
 -->
 
-### [組み込みデバッガ](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [組み込みデバッガ](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Node の組み込みコマンドラインデバッガの下でスクリプトを起動するには、
 `node debug script_name.js` を起動します。

--- a/pages/ka/docs/guides/debugging-getting-started.md
+++ b/pages/ka/docs/guides/debugging-getting-started.md
@@ -175,7 +175,7 @@ ssh -L 9221:localhost:9229 user@remote.example.com
 
 V8 გამართვის პროტოკოლი აღარ არის მხარდაჭერილი და მისი დოკუმენტირებაც აღარ ხორციელდება.
 
-### [ჩაშენებული გამმართველი](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [ჩაშენებული გამმართველი](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 იმისათვის, რომ თქვენი სკრიპტი გაუშვათ ჩაშენებულ CLI-გამმართველთან ერთად, შეიყვანეთ ბრძანება `node debug script_name.js`. ამით, თქვენი სკრიპტი გაეშვება `--debug-brk` პარამეტრით სხვა Node-პროცესში, ხოლო საწყისი Node-პროცესი გაუშვებს `_debugger.js` სკრიპტს და დაუკავშირდება თქვენს სამიზნეს (_თქვენს სამიზნე სკრიპტს_).
 

--- a/pages/ko/docs/guides/debugging-getting-started.md
+++ b/pages/ko/docs/guides/debugging-getting-started.md
@@ -428,7 +428,7 @@ TCP 포트(기본 `5858`)로 지금은 중단된 V8 디버깅 프로토콜에서
 V8 디버깅 프로토콜은 더는 관리되지 않고 문서화도 되지 않습니다.
 
 <!--
-#### [Built-in Debugger](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+#### [Built-in Debugger](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with
@@ -442,7 +442,7 @@ which translates the Inspector Protocol used in Chromium to the V8 Debugger
 protocol used in Node.js.
 -->
 
-### [내장 디버거](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [내장 디버거](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Node의 내장 명령형 디버거로 스크립트를 실행하려면 `node debug script_name.js`로 실행하세요.
 스크립트가 다른 Node 프로세스에서 `--debug-brk` 옵션으로 시작되고 원래의 Node 프로세스는

--- a/pages/pt-br/docs/guides/debugging-getting-started.md
+++ b/pages/pt-br/docs/guides/debugging-getting-started.md
@@ -302,7 +302,7 @@ que já foi descontinuado, em uma porta TCP que, por padrão, é a `5858`. Qualq
 que conversa com esse protocolo pode conectar a ele e debugar um processo sendo executado; abaixo temos
 alguns dos mais populares.
 
-### [Debugger nativo](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [Debugger nativo](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 <!-- Start `node debug script_name.js` to start your script under Node's builtin
 command-line debugger. Your script starts in another Node process started with

--- a/pages/ru/docs/guides/debugging-getting-started.md
+++ b/pages/ru/docs/guides/debugging-getting-started.md
@@ -231,7 +231,7 @@ Node.js прослушивает команды отладки, определе
 
 Протокол отладки V8 более не поддерживается и не документируется.
 
-### [Встроенный отладчик](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [Встроенный отладчик](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 Введите `node debug script_name.js` для запуска скрипта со встроенным CLI отладчиком.
 Сам скрипт будет запущен с флагом `--debug-brk` в другом процессе Node, а первоначальный

--- a/pages/zh-cn/docs/guides/debugging-getting-started.md
+++ b/pages/zh-cn/docs/guides/debugging-getting-started.md
@@ -173,11 +173,11 @@ ssh -L 9221:localhost:9229 user@remote.example.com
 
 在版本 7 以及更早的版本使用 **--debug** 或 **--debug-brk** 开关启动调试时，Node.js 侦听由中断定义的调试命令，TCP 端口上的 V8 调试协议，默认为 `5858`。任何遵守此协议的调试客户端都可以连接并调试运行这个进程，下面有一些热门的说明。
 
-### [内置调试器](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [内置调试器](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 V8 调试协议再也不维护或是归档了。
 
-### [node 监视器](https://nodejs.org/dist/{#var currentVersion}/docs/api/debugger.html)
+### [node 监视器](https://nodejs.org/dist/latest/docs/api/debugger.html)
 
 在 Node.js 内置命令行调试器中用 `node debug script_name.js` 启动你的脚本。你的脚本就在 Node 另外一个进程中随着 `--debug-brk` 启动了起来，并且初始化的 Node 进程运行 `_debugger.js` 脚本连接上你的目标。
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the penultimate header on the [debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started#node-inspector) has malformed markdown, which made the link unclickable.

## Validation

**Before**:
<img width="775" alt="Screenshot 2023-10-14 at 13 38 06" src="https://github.com/nodejs/nodejs.org/assets/3824954/6f77da17-67f5-47a1-b112-82b0edc15ff5">

**After**:
<img width="765" alt="Screenshot 2023-10-14 at 13 38 19" src="https://github.com/nodejs/nodejs.org/assets/3824954/28caa25b-c446-4f19-b416-214adfbcfc04">


## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
