### PR TITLE
fix: use next-themes for the legacy website

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import Image from 'next/image';
+import { useTheme } from 'next-themes';
 import { useIntl } from 'react-intl';
 
 import { useLocale } from '@/hooks/useLocale';
@@ -13,6 +14,7 @@ const Header = () => {
   const { navigationItems } = useNavigation();
   const { formatMessage } = useIntl();
   const { asPath, basePath } = useRouter();
+  const { theme, setTheme } = useTheme();
 
   const getLinkClassName = (href: string) =>
     classNames({ active: isCurrentLocaleRoute(href, href !== '/') });
@@ -57,6 +59,7 @@ const Header = () => {
             type="button"
             title={toggleDarkMode}
             aria-label={toggleDarkMode}
+            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
           >
             <Image
               priority
@@ -66,6 +69,7 @@ const Header = () => {
               src={`${basePath}/static/images/light-mode.svg`}
               alt="Dark Theme Switcher"
             />
+
             <Image
               priority
               width="28"

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -153,3 +153,8 @@ export const EXTERNAL_LINKS_SITEMAP = [
   'https://trademark-list.openjsf.org/',
   'https://www.linuxfoundation.org/cookies',
 ];
+
+/**
+ * The `localStorage` key to store the theme choice of `next-themes`
+ */
+export const THEME_LOCAL_STORAGE_KEY = 'theme';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import { BlogDataProvider } from '@/providers/blogDataProvider';
 import { LocaleProvider } from '@/providers/localeProvider';
 import { NodeReleasesProvider } from '@/providers/nodeReleasesProvider';
 import { SiteProvider } from '@/providers/siteProvider';
+import { ThemeProvider } from '@/providers/themeProvider';
 
 import '@/styles/old/index.css';
 
@@ -17,7 +18,7 @@ const sourceSans = Source_Sans_3({
 });
 
 const App = ({ Component, pageProps }: AppProps) => (
-  <>
+  <ThemeProvider>
     <LocaleProvider>
       <SiteProvider>
         <NodeReleasesProvider>
@@ -37,7 +38,7 @@ const App = ({ Component, pageProps }: AppProps) => (
         }
       `}
     </style>
-  </>
+  </ThemeProvider>
 );
 
 export default App;

--- a/providers/themeProvider.tsx
+++ b/providers/themeProvider.tsx
@@ -1,10 +1,15 @@
 import { ThemeProvider as NextThemeProvider } from 'next-themes';
 import type { FC, PropsWithChildren } from 'react';
 
+import { THEME_LOCAL_STORAGE_KEY } from '@/next.constants.mjs';
+
 export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => (
-  <>
-    <NextThemeProvider enableSystem={true} enableColorScheme={true}>
-      {children}
-    </NextThemeProvider>
-  </>
+  <NextThemeProvider
+    attribute="data-theme"
+    storageKey={THEME_LOCAL_STORAGE_KEY}
+    enableSystem={true}
+    enableColorScheme={true}
+  >
+    {children}
+  </NextThemeProvider>
 );

--- a/public/static/js/legacyMain.js
+++ b/public/static/js/legacyMain.js
@@ -1,14 +1,3 @@
-const themeAttr = 'data-theme';
-
-const setTheme = theme => {
-  document.querySelector('html').setAttribute(themeAttr, theme);
-  window.localStorage.setItem('theme', theme);
-};
-
-const preferredColorScheme = window.matchMedia('(prefers-color-scheme: dark)');
-
-const getTheme = () => window.localStorage.getItem('theme');
-
 const listenLanguagePickerButton = () => {
   const langPickerTogglerElement = document.querySelector(
     '.lang-picker-toggler'
@@ -26,25 +15,6 @@ const listenLanguagePickerButton = () => {
   };
 
   langPickerTogglerElement.addEventListener('click', toggleFunction);
-};
-
-const watchThemeChanges = () =>
-  preferredColorScheme.addEventListener(
-    'change',
-    event => getTheme() || setTheme(event.matches ? 'dark' : 'light')
-  );
-
-const listenThemeToggleButton = () => {
-  const darkThemeSwitcherElement = document.querySelector(
-    '.dark-theme-switcher'
-  );
-
-  darkThemeSwitcherElement.addEventListener('click', () => {
-    const currentTheme =
-      getTheme() || (preferredColorScheme.matches ? 'dark' : 'light');
-
-    setTheme(currentTheme === 'light' ? 'dark' : 'light');
-  });
 };
 
 const listenScrollToTopButton = () => {
@@ -67,19 +37,9 @@ const listenScrollToTopButton = () => {
   });
 };
 
-const setCurrentTheme = () =>
-  setTheme(getTheme() || (preferredColorScheme.matches ? 'dark' : 'light'));
-
 const startLegacyApp = () => {
-  setCurrentTheme();
-
-  watchThemeChanges();
-
   listenLanguagePickerButton();
-  listenThemeToggleButton();
   listenScrollToTopButton();
 };
-
-setCurrentTheme();
 
 window.startLegacyApp = startLegacyApp;

--- a/styles/old/layout/dark-theme.css
+++ b/styles/old/layout/dark-theme.css
@@ -1,7 +1,6 @@
 html[data-theme='dark'] {
   background-color: $dark-black;
   color: $white;
-  color-scheme: dark;
 
   .dark-theme-switcher {
     img.light-image {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR removes the theme-related code from `legacyMain.js` as it is causing enough trouble for us. (Our policy is to not update the current legacy website), but I've seen at least 3 PRs, so that I will change this.

This PR adds our existing ThemeProvider, updates its settings to reflect, and makes it future-proof (for both the redesign and current legacy functionality).

Then we add an onClick handler on the Theme Button on `Header.tsx`

## Validation

- Should respect your System color-scheme on 1st visit
- Should restore existing theme selection from `localStorage.theme` if exists
- Should switch from themes easily without flickering (on production/preview mode, on dev mode, the CSS is injected via JavaScript, which might cause a tiny, very rapid flicker from when CSS is still loading (cause the background-color from Chrome's dark color scheme!= our background colour)
- Clicking to change the Theme should work and persist on page refreshes