### PR TITLE
fix: Revert download link labels

### DIFF
--- a/pages/ja/download/current.md
+++ b/pages/ja/download/current.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
   currentVersion: 最新のバージョン
-  buildInstructions: 同梱
-  WindowsInstaller: Building Node.js from source on supported platforms
-  WindowsBinary: Windows Installer
-  MacOSInstaller: Windows Binary
-  MacOSBinary: macOS Installer
-  LinuxBinaries: macOS Binary
-  SourceCode: Linux Binaries
+  buildInstructions: Building Node.js from source on supported platforms
+  WindowsInstaller: Windows Installer
+  WindowsBinary: Windows Binary
+  MacOSInstaller: macOS Installer
+  MacOSBinary: macOS Binary
+  LinuxBinaries: Linux Binaries
+  SourceCode: Source Code
 additional:
   headline: その他のプラットフォーム
   intro: >

--- a/pages/ja/download/index.md
+++ b/pages/ja/download/index.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Node.js のソースコードをダウンロードするか、事前にビルドされたインストーラーを利用して、今日から開発を始めましょう。
   currentVersion: 最新のバージョン
-  buildInstructions: 同梱
-  WindowsInstaller: Building Node.js from source on supported platforms
-  WindowsBinary: Windows Installer
-  MacOSInstaller: Windows Binary
-  MacOSBinary: macOS Installer
-  LinuxBinaries: macOS Binary
-  SourceCode: Linux Binaries
+  buildInstructions: Building Node.js from source on supported platforms
+  WindowsInstaller: Windows Installer
+  WindowsBinary: Windows Binary
+  MacOSInstaller: macOS Installer
+  MacOSBinary: macOS Binary
+  LinuxBinaries: Linux Binaries
+  SourceCode: Source Code
 additional:
   headline: その他のプラットフォーム
   intro: >

--- a/pages/ru/download/current.md
+++ b/pages/ru/download/current.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Загрузите исходный код Node.js или готовый установщик для вашей платформы и начните разработку уже сегодня.
   currentVersion: Последняя текущая версия
-  buildInstructions: Содержит
-  WindowsInstaller: Сборка Node.js из исходного кода на поддерживаемых платформах
-  WindowsBinary: Установщик Windows
-  MacOSInstaller: Бинарный Windows
-  MacOSBinary: Установщик macOS
-  LinuxBinaries: Бинарный macOS
-  SourceCode: Бинарный Linux
+  buildInstructions: Сборка Node.js из исходного кода на поддерживаемых платформах
+  WindowsInstaller: Установщик Windows
+  WindowsBinary: Бинарный Windows
+  MacOSInstaller: Установщик macOS
+  MacOSBinary: Бинарный macOS
+  LinuxBinaries: Бинарный Linux
+  SourceCode: Исходный код
 additional:
   headline: Дополнительные платформы
   intro: >

--- a/pages/ru/download/index.md
+++ b/pages/ru/download/index.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Загрузите исходный код Node.js или готовый установщик для вашей платформы и начните разработку уже сегодня.
   currentVersion: Последняя текущая версия
-  buildInstructions: Содержит
-  WindowsInstaller: Сборка Node.js из исходного кода на поддерживаемых платформах
-  WindowsBinary: Установщик Windows
-  MacOSInstaller: Бинарный Windows
-  MacOSBinary: Установщик macOS
-  LinuxBinaries: Бинарный macOS
-  SourceCode: Бинарный Linux
+  buildInstructions: Сборка Node.js из исходного кода на поддерживаемых платформах
+  WindowsInstaller: Установщик Windows
+  WindowsBinary: Бинарный Windows
+  MacOSInstaller: Установщик macOS
+  MacOSBinary: Бинарный macOS
+  LinuxBinaries: Бинарный Linux
+  SourceCode: Исходный код
 additional:
   headline: Дополнительные платформы
   intro: >

--- a/pages/uk/download/current.md
+++ b/pages/uk/download/current.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Завантажте початковий код Node.js або інсталятор для вашої платформи та почніть розробку сьогодні.
   currentVersion: Поточна версія
-  buildInstructions: Містить
-  WindowsInstaller: Building Node.js from source on supported platforms
-  WindowsBinary: Windows Installer
-  MacOSInstaller: Windows Binary
-  MacOSBinary: macOS Installer
-  LinuxBinaries: macOS Binary
-  SourceCode: Linux Binaries
+  buildInstructions: Building Node.js from source on supported platforms
+  WindowsInstaller: Windows Installer
+  WindowsBinary: Windows Binary
+  MacOSInstaller: macOS Installer
+  MacOSBinary: macOS Binary
+  LinuxBinaries: Linux Binaries
+  SourceCode: Source Code
 additional:
   headline: Додаткові платформи
   intro: >

--- a/pages/uk/download/index.md
+++ b/pages/uk/download/index.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     Завантажте початковий код Node.js або інсталятор для вашої платформи та почніть розробку сьогодні.
   currentVersion: Поточна версія
-  buildInstructions: Містить
-  WindowsInstaller: Побудова Node.js з вихідного коду на платформах, що підтримуються
-  WindowsBinary: Інсталятор для Windows
-  MacOSInstaller: Бінарний файл для Windows
-  MacOSBinary: Інсталятор для macOS
-  LinuxBinaries: Бінарний файл для macOS
-  SourceCode: Бінарні файли для Linux
+  buildInstructions: Побудова Node.js з вихідного коду на платформах, що підтримуються
+  WindowsInstaller: Інсталятор для Windows
+  WindowsBinary: Бінарний файл для Windows
+  MacOSInstaller: Інсталятор для macOS
+  MacOSBinary: Бінарний файл для macOS
+  LinuxBinaries: Бінарні файли для Linux
+  SourceCode: Вихідний код
 additional:
   headline: Додаткові платформи
   intro: >

--- a/pages/zh-tw/download/current.md
+++ b/pages/zh-tw/download/current.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     下載適合您平台的 Node.js 原始碼或安裝套件。立刻開始使用 Node.js。
   currentVersion: 最新版
-  buildInstructions: 包含
-  WindowsInstaller: 在支援的平台上，使用原始碼建構 Node.js
-  WindowsBinary: Windows 安裝包
-  MacOSInstaller: Windows 二進位檔案
-  MacOSBinary: macOS 安裝包
-  LinuxBinaries: macOS 二進位檔案
-  SourceCode: Linux 二進位檔案
+  buildInstructions: 在支援的平台上，使用原始碼建構 Node.js
+  WindowsInstaller: Windows 安裝包
+  WindowsBinary: Windows 二進位檔案
+  MacOSInstaller: macOS 安裝包
+  MacOSBinary: macOS 二進位檔案
+  LinuxBinaries: Linux 二進位檔案
+  SourceCode: 原始碼
 additional:
   headline: 其它平台
   intro: >

--- a/pages/zh-tw/download/index.md
+++ b/pages/zh-tw/download/index.md
@@ -12,13 +12,13 @@ downloads:
   intro: >
     下載適合您平台的 Node.js 原始碼或安裝套件。立刻開始使用 Node.js。
   currentVersion: 最新版
-  buildInstructions: 包含
-  WindowsInstaller: 在支援的平台上，使用原始碼建構 Node.js
-  WindowsBinary: Windows 安裝程式
-  MacOSInstaller: Windows 二進位檔案
-  MacOSBinary: macOS 安裝程式
-  LinuxBinaries: macOS 二進位檔案
-  SourceCode: Linux 二進位檔案
+  buildInstructions: 在支援的平台上，使用原始碼建構 Node.js
+  WindowsInstaller: Windows 安裝程式
+  WindowsBinary: Windows 二進位檔案
+  MacOSInstaller: macOS 安裝程式
+  MacOSBinary: macOS 二進位檔案
+  LinuxBinaries: Linux 二進位檔案
+  SourceCode: 原始碼
 additional:
   headline: 其它平台
   intro: >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Download link labels were inadvertently changed in below commit and have been reverted.

https://github.com/nodejs/nodejs.org/commit/8b4f69838aeb3b2dd0a2d87cd239e0c1a413dfa8#diff-aa3f90eea12523db330a01d926a8648195725fdef9e6efe69613ce3451cfaf6a

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

#6013 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
