### PR TITLE
fix: maintenance lts in the lack of active lts

### DIFF
--- a/hooks/useNodeReleases.ts
+++ b/hooks/useNodeReleases.ts
@@ -12,5 +12,10 @@ export const useNodeReleases = () => {
     [releases]
   );
 
-  return { releases, getReleaseByStatus };
+  const getLatestIsLtsRelease = useCallback(
+    () => releases.find(release => release.isLts),
+    [releases]
+  );
+
+  return { releases, getReleaseByStatus, getLatestIsLtsRelease };
 };

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -7,11 +7,11 @@ import { useNodeReleases } from '@/hooks/useNodeReleases';
 import BaseLayout from './BaseLayout';
 
 const DocsLayout: FC<PropsWithChildren> = ({ children }) => {
-  const { getReleaseByStatus } = useNodeReleases();
+  const { getReleaseByStatus, getLatestIsLtsRelease } = useNodeReleases();
 
   const [lts, current] = useMemo(
-    () => [getReleaseByStatus('Active LTS'), getReleaseByStatus('Current')],
-    [getReleaseByStatus]
+    () => [getLatestIsLtsRelease(), getReleaseByStatus('Current')],
+    [getLatestIsLtsRelease, getReleaseByStatus]
   );
 
   const translationContext = {

--- a/layouts/DownloadLayout.tsx
+++ b/layouts/DownloadLayout.tsx
@@ -23,7 +23,7 @@ const DownloadLayout: FC<PropsWithChildren> = ({ children }) => {
 
           {children}
 
-          <WithNodeRelease status="Active LTS">
+          <WithNodeRelease status={['Active LTS', 'Maintenance LTS']}>
             {({ release }) => (
               <>
                 <PrimaryDownloadMatrix {...release} />

--- a/layouts/IndexLayout.tsx
+++ b/layouts/IndexLayout.tsx
@@ -47,7 +47,7 @@ const IndexLayout: FC<PropsWithChildren> = ({ children }) => {
 
           <h2>{downloadHeadText}</h2>
 
-          <WithNodeRelease status="Active LTS">
+          <WithNodeRelease status={['Active LTS', 'Maintenance LTS']}>
             {({ release }) => <HomeDownloadButton {...release} />}
           </WithNodeRelease>
 

--- a/next.json.mjs
+++ b/next.json.mjs
@@ -3,7 +3,15 @@
 import localeConfig from './i18n/config.json' assert { type: 'json' };
 import siteNavigation from './navigation.json' assert { type: 'json' };
 import blogData from './public/blog-posts-data.json' assert { type: 'json' };
+import releaseData from './public/node-releases-data.json' assert { type: 'json' };
 import siteRedirects from './redirects.json' assert { type: 'json' };
 import siteConfig from './site.json' assert { type: 'json' };
 
-export { siteConfig, siteNavigation, siteRedirects, localeConfig, blogData };
+export {
+  siteConfig,
+  siteNavigation,
+  siteRedirects,
+  localeConfig,
+  blogData,
+  releaseData,
+};

--- a/providers/nodeReleasesProvider.tsx
+++ b/providers/nodeReleasesProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useMemo } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
-import nodeReleasesData from '@/public/node-releases-data.json';
+import { releaseData } from '@/next.json.mjs';
 import type { NodeReleaseSource, NodeRelease } from '@/types';
 import { getNodeReleaseStatus } from '@/util/nodeRelease';
 
@@ -11,7 +11,7 @@ export const NodeReleasesProvider: FC<PropsWithChildren> = ({ children }) => {
   const releases = useMemo(() => {
     const now = new Date();
 
-    return nodeReleasesData.map((raw: NodeReleaseSource) => {
+    return releaseData.map((raw: NodeReleaseSource) => {
       const support = {
         currentStart: raw.currentStart,
         ltsStart: raw.ltsStart,

--- a/providers/withNodeRelease.tsx
+++ b/providers/withNodeRelease.tsx
@@ -6,7 +6,7 @@ import type { NodeRelease, NodeReleaseStatus } from '@/types';
 import { isNodeRelease } from '@/util/nodeRelease';
 
 type WithNodeReleaseProps = {
-  status: NodeReleaseStatus;
+  status: NodeReleaseStatus[] | NodeReleaseStatus;
   children: FC<{ release: NodeRelease }>;
 };
 
@@ -16,8 +16,12 @@ export const WithNodeRelease: FC<WithNodeReleaseProps> = ({
 }) => {
   const { getReleaseByStatus } = useNodeReleases();
 
-  const release = useMemo(
-    () => getReleaseByStatus(status),
+  const [release] = useMemo(
+    () =>
+      [status]
+        .flat()
+        .map(s => getReleaseByStatus(s))
+        .filter(s => !!s),
     [status, getReleaseByStatus]
   );
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes the missing LTS, as sometimes we only have a Maintenance LTS without having an Active LTS. This PR updates hooks and components to understand both of these items.

## Validation

LTS sections should be working again

## Related Issues

Fixes https://github.com/nodejs/nodejs.org/issues/6024
