### PR TITLE
feat: add OpenSSF badge to current footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -46,6 +46,18 @@ const Footer: FC<FooterProps> = ({ className }) => (
             &nbsp;|&nbsp;
             <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a>
           </p>
+          <p>
+            <a
+              href="https://bestpractices.coreinfrastructure.org/projects/29"
+              style={{ display: 'inline-block' }}
+            >
+              {/*eslint-disable-next-line @next/next/no-img-element*/}
+              <img
+                src="https://bestpractices.coreinfrastructure.org/projects/29/badge"
+                alt="A badge showing the OpenSSF best practices level for the nodejs/node project."
+              />
+            </a>
+          </p>
           <div className="openjsfoundation-footer-edit"></div>
         </div>
       </div>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds the OpenSSF best practices badge to the current site's footer. This is a stop-gap measure while the new site is being designed - but furthers efforts from the @nodejs/security working group started within https://github.com/nodejs/security-wg/issues/859

## Validation

https://nodejs-xhjbbt8kf-openjs.vercel.app/en

![image](https://github.com/nodejs/nodejs.org/assets/298435/2c3841b0-ebd2-4d0c-b4a4-c262dafb9ab3)


## Related Issues

closes #5432

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
