### PR TITLE
refactor: Content scaling for `Preview` component

### DIFF
--- a/components/Common/BlogPostCard/index.tsx
+++ b/components/Common/BlogPostCard/index.tsx
@@ -53,12 +53,7 @@ const BlogPostCard: FC<BlogPostCardProps> = ({
 
   return (
     <article className={styles.container}>
-      <Preview
-        title={title}
-        type={type}
-        height="auto"
-        className={styles.preview}
-      />
+      <Preview title={title} type={type} className={styles.preview} />
       <p className={styles.subtitle}>
         <FormattedMessage id={`components.common.card.${type}`} />
       </p>

--- a/components/Common/Preview/index.module.css
+++ b/components/Common/Preview/index.module.css
@@ -1,33 +1,38 @@
 .root {
   @apply relative
     flex
+    aspect-video
     items-center
     bg-neutral-950
     bg-[url('/static/images/patterns/hexagon-grid.svg')]
     bg-contain
     bg-center
-    after:absolute
-    after:inset-0
-    after:m-auto
-    after:aspect-square
-    after:w-1/3
-    after:rounded-full
-    after:bg-gradient-radial
-    after:blur-3xl;
+    [container-type:inline-size];
 
-  &.announcement {
-    @apply after:from-green-700/90;
+  .overlay {
+    @apply absolute
+      inset-0
+      m-auto
+      aspect-square
+      w-1/4
+      rounded-full
+      bg-gradient-radial
+      blur-4xl;
+
+    &.announcement {
+      @apply bg-green-700;
+    }
+
+    &.release {
+      @apply bg-info-600;
+    }
+
+    &.vulnerability {
+      @apply bg-warning-600;
+    }
   }
 
-  &.release {
-    @apply after:from-info-600/90;
-  }
-
-  &.vulnerability {
-    @apply after:from-warning-600/90;
-  }
-
-  & > .container {
+  .container {
     @apply z-10
       mx-auto
       flex
@@ -39,8 +44,49 @@
       font-semibold
       text-white;
 
-    & > .logo {
-      @apply mx-auto;
+    .logo {
+      @apply relative
+        mx-auto
+        h-20
+        w-16;
+
+      .image {
+        @apply mx-auto;
+      }
+    }
+  }
+
+  @container (max-width: 40rem) {
+    .overlay {
+      @apply blur-3xl;
+    }
+
+    .container {
+      @apply max-w-xs
+        gap-7
+        text-lg;
+
+      .logo {
+        @apply h-11
+          w-10;
+      }
+    }
+  }
+
+  @container (max-width: 24rem) {
+    .overlay {
+      @apply blur-2xl;
+    }
+
+    .container {
+      @apply max-w-[12rem]
+        gap-4
+        text-xs;
+
+      .logo {
+        @apply h-6
+          w-5;
+      }
     }
   }
 }

--- a/components/Common/Preview/index.module.css
+++ b/components/Common/Preview/index.module.css
@@ -1,7 +1,7 @@
 .root {
   @apply relative
     flex
-    aspect-video
+    aspect-[75/39.375]
     items-center
     bg-neutral-950
     bg-[url('/static/images/patterns/hexagon-grid.svg')]

--- a/components/Common/Preview/index.stories.tsx
+++ b/components/Common/Preview/index.stories.tsx
@@ -23,7 +23,7 @@ export const Announcement: Story = {
 export const Release: Story = {
   args: {
     type: 'release',
-    title: <h1>Node v20.5.0 (Current)</h1>,
+    title: 'Node v20.5.0 (Current)',
   },
 };
 

--- a/components/Common/Preview/index.stories.tsx
+++ b/components/Common/Preview/index.stories.tsx
@@ -23,7 +23,7 @@ export const Announcement: Story = {
 export const Release: Story = {
   args: {
     type: 'release',
-    title: 'Node v20.5.0 (Current)',
+    title: <h1>Node v20.5.0 (Current)</h1>,
   },
 };
 
@@ -38,8 +38,7 @@ export const CustomSize: Story = {
   args: {
     title:
       'Changing the End-of-Life Date for Node.js 16 to September 11th, 2023',
-    width: 600,
-    height: 315,
+    className: 'w-80 rounded-md',
   },
 };
 

--- a/components/Common/Preview/index.tsx
+++ b/components/Common/Preview/index.tsx
@@ -25,7 +25,6 @@ const Preview: FC<PreviewProps> = ({
           alt="Node.js"
           layout="fill"
         />
-        <h2>{title}</h2>
       </div>
       <h2>{title}</h2>
     </div>

--- a/components/Common/Preview/index.tsx
+++ b/components/Common/Preview/index.tsx
@@ -1,46 +1,34 @@
 import classNames from 'classnames';
 import Image from 'next/image';
-import type { CSSProperties, ComponentProps, FC, ReactNode } from 'react';
-
-import { useRouter } from '@/hooks/useRouter';
+import type { FC, ReactNode } from 'react';
 
 import styles from './index.module.css';
 
 type PreviewProps = {
   type?: 'announcement' | 'release' | 'vulnerability';
   title: ReactNode;
-  height?: CSSProperties['height'];
-  width?: CSSProperties['width'];
-} & Omit<ComponentProps<'div'>, 'children'>;
+  className?: string;
+};
 
 const Preview: FC<PreviewProps> = ({
   type = 'announcement',
   title,
-  height = 630,
-  width = 1200,
-  ...props
-}) => {
-  const { basePath } = useRouter();
-
-  return (
-    <div
-      {...props}
-      style={{ width, height, ...props.style }}
-      className={classNames(styles.root, styles[type], props.className)}
-    >
-      <div className={styles.container}>
+  className,
+}) => (
+  <div className={classNames(styles.root, className)}>
+    <span className={classNames(styles.overlay, styles[type])} />
+    <div className={styles.container}>
+      <div className={styles.logo}>
         <Image
-          className={styles.logo}
-          priority
-          width="71"
-          height="80"
-          src={`${basePath}/static/images/logos/js-white.svg`}
+          className={styles.image}
+          src="/static/images/logos/js-white.svg"
           alt="Node.js"
+          layout="fill"
         />
-        <h1>{title}</h1>
       </div>
+      {title}
     </div>
-  );
-};
+  </div>
+);
 
 export default Preview;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -129,6 +129,9 @@ export default {
       aria: {
         current: 'current="page"',
       },
+      blur: {
+        '4xl': '128px',
+      },
     },
   },
   darkMode: ['class', '[data-theme="dark"]'],


### PR DESCRIPTION
## Description

In Figma, the Preview component is used on multiple pages by scaling them in different resolutions.
Even if we can give width and height in current use, the content must also scale according to the container.

With this PR, the content for `40rem` and `24rem` resolutions was scaled according to the container size.

### Decide / Discuss

- Tailwind has a first-party [container query plugin](https://github.com/tailwindlabs/tailwindcss-container-queries), but I'm not a fan of pinning a library at the first need. If we proceed this way and see that it makes sense for us, I am in favor of using it. Of course, I am also open to alternative solutions under this draft PR

## Validation

<img width="422" alt="mobile image" src="https://github.com/nodejs/nodejs.org/assets/14062599/0e59e04a-b638-43d6-b89b-83f50d2b9640">

<img width="524" alt="desktop free layout" src="https://github.com/nodejs/nodejs.org/assets/14062599/10ad0056-62a9-45f1-9f8a-6c298194299e">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
