### PR TITLE
fix: Syntax highlighter empty line

### DIFF
--- a/styles/old/index.css
+++ b/styles/old/index.css
@@ -127,6 +127,10 @@ a:hover .color-lightgray {
   }
 }
 
+.shiki .line {
+  min-height: 1rem;
+}
+
 html[dir='rtl'] {
   .has-side-nav {
     nav {

--- a/styles/old/index.css
+++ b/styles/old/index.css
@@ -129,6 +129,10 @@ a:hover .color-lightgray {
 
 .shiki .line {
   min-height: 1rem;
+
+  &:last-child {
+    min-height: initial;
+  }
 }
 
 html[dir='rtl'] {


### PR DESCRIPTION
## Description

This PR aims to make empty lines visible again in syntax highlighter

## Validation

<img width="780" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/d337b058-2eb6-428a-b59d-358ca0a8a0ea">

Empty lines should shown in Vercel preview.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
