### PR TITLE
add openssf badge to new security page

### DIFF
--- a/pages/en/about/security-reporting.md
+++ b/pages/en/about/security-reporting.md
@@ -72,3 +72,9 @@ Security notifications will be distributed via the following methods.
 If you have suggestions on how this process could be improved please submit a
 [pull request](https://github.com/nodejs/nodejs.org) or
 [file an issue](https://github.com/nodejs/security-wg/issues/new) to discuss.
+
+## OpenSSF Best Practices
+
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/29/badge)](https://bestpractices.coreinfrastructure.org/projects/29)
+
+The Open Source Security Foundation (OpenSSF) [Best Practices badge](https://github.com/coreinfrastructure/best-practices-badge) is a way for Free/Libre and Open Source Software (FLOSS) projects to show that they follow best practices. Projects can voluntarily self-certify how they follow each best practice. Consumers of the badge can quickly assess which FLOSS projects are following best practices and as a result are more likely to produce higher-quality secure software.

--- a/pages/en/about/security-reporting.md
+++ b/pages/en/about/security-reporting.md
@@ -75,6 +75,6 @@ If you have suggestions on how this process could be improved please submit a
 
 ## OpenSSF Best Practices
 
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/29/badge)](https://bestpractices.coreinfrastructure.org/projects/29)
+<a href="https://bestpractices.coreinfrastructure.org/projects/29" style="display: inline;"><img src="https://bestpractices.coreinfrastructure.org/projects/29/badge" style="display: inline;"></a>
 
 The Open Source Security Foundation (OpenSSF) [Best Practices badge](https://github.com/coreinfrastructure/best-practices-badge) is a way for Free/Libre and Open Source Software (FLOSS) projects to show that they follow best practices. Projects can voluntarily self-certify how they follow each best practice. Consumers of the badge can quickly assess which FLOSS projects are following best practices and as a result are more likely to produce higher-quality secure software.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds the openssf badge to the security page, as all previous conversation has led to.


## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

![image](https://github.com/nodejs/nodejs.org/assets/298435/7a863c9b-fcef-4fdf-97ea-0f910c900f4c)


## Related Issues

closes #5432
supercedes #6030

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
