### PR TITLE
Fix: broken link (about page) blocking vs. non-blocking

### DIFF
--- a/pages/en/about/index.md
+++ b/pages/en/about/index.md
@@ -61,7 +61,7 @@ communicate with. Built upon that same interface is the [`cluster`][] module,
 which allows you to share sockets between processes to enable load balancing
 over your cores.
 
-[blocking vs. non-blocking]: /learn/overview-of-blocking-vs-non-blocking/
+[blocking vs. non-blocking]: /docs/guides/blocking-vs-non-blocking
 [`child_process.fork()`]: /api/child_process/
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event machine]: https://github.com/eventmachine/eventmachine


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The URL for the "Overview of Blocking vs Non-Blocking" in about page of this current docs was not working. 
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
I fixed the link in the file "/pages/en/about/index.md" that was directing to "en/learn/overview-of-blocking-vs-non-blocking" (which was not being found). Now it is directing to "en/docs/guides/blocking-vs-non-blocking"
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
