### PR TITLE
fix: Main layout container flex direction

### DIFF
--- a/styles/old/layout/main.css
+++ b/styles/old/layout/main.css
@@ -1,6 +1,7 @@
 #main {
   .container {
     display: flex;
+    flex-direction: column;
   }
 
   .has-side-nav.container {


### PR DESCRIPTION
## Description

Fixes layout order for;
- Blog listing
- Installing Node.js via package manager

## Validation

<img width="974" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/ffba5e18-2aed-4c93-980e-2e3c640d3485">

<img width="974" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/7d3b48a5-b4cb-4552-b2c0-6867c9670b93">

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
