### PR TITLE
fix: render openssf badge by parsing as mdx

### DIFF
--- a/pages/en/about/security-reporting.mdx
+++ b/pages/en/about/security-reporting.mdx
@@ -75,6 +75,14 @@ If you have suggestions on how this process could be improved please submit a
 
 ## OpenSSF Best Practices
 
-<a href="https://bestpractices.coreinfrastructure.org/projects/29" style="display: inline-flex;"><img src="https://bestpractices.coreinfrastructure.org/projects/29/badge" style="display: inline;"></a>
+<a
+  href="https://bestpractices.coreinfrastructure.org/projects/29"
+  style={{ display: 'inline-flex' }}
+>
+  <img
+    src="https://bestpractices.coreinfrastructure.org/projects/29/badge"
+    style={{ display: 'inline' }}
+  />
+</a>
 
 The Open Source Security Foundation (OpenSSF) [Best Practices badge](https://github.com/coreinfrastructure/best-practices-badge) is a way for Free/Libre and Open Source Software (FLOSS) projects to show that they follow best practices. Projects can voluntarily self-certify how they follow each best practice. Consumers of the badge can quickly assess which FLOSS projects are following best practices and as a result are more likely to produce higher-quality secure software.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

https://github.com/nodejs/nodejs.org/pull/6071 removed `rehype-raw` which we were relying on to render the raw `<img/>` tag inside our security-reporting.md file.  This change restores the rendered image by using MDX.


<!-- Write a brief description of the changes introduced by this PR -->

## Validation

The badge is visible again. 

![image](https://github.com/nodejs/nodejs.org/assets/298435/a9a9a0c3-f3af-4866-b57a-3032c196ecb6)


<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
