### PR TITLE
fix: add trailing slash to urls in previous releases table

### DIFF
--- a/components/Downloads/DownloadReleasesTable.tsx
+++ b/components/Downloads/DownloadReleasesTable.tsx
@@ -37,7 +37,7 @@ const DownloadReleasesTable: FC = () => {
             <td data-label="NODE_MODULE_VERSION">{release.modules}</td>
             <td className="download-table-last">
               <a
-                href={`https://nodejs.org/download/release/${release.versionWithPrefix}`}
+                href={`https://nodejs.org/download/release/${release.versionWithPrefix}/`}
               >
                 {t('components.downloadReleasesTable.releases')}
               </a>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Add a trailing slash to the links to the "Release" links in the downloads table. The release URLs now return a 404 without them.

## Related Issues

Fixes #6110

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
