### PR TITLE
fix: Blog page broken url

### DIFF
--- a/pages/en/blog/announcements/v20-release-announce.md
+++ b/pages/en/blog/announcements/v20-release-announce.md
@@ -13,7 +13,7 @@ The project continues to make progress across a number of areas, with many new f
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 20.0.0, visit: </download/current/>. You can find the release post at </blog/release/v20.0.0>, which contains the full list of commits included in this release.
+To download Node.js 20.0.0, visit: <https://nodejs.org/en/download/current/>. You can find the release post at <https://nodejs.org/en/blog/release/v20.0.0>, which contains the full list of commits included in this release.
 
 As a reminder, Node.js 20 will enter long-term support (LTS) in October, but until then, it will be the "Current" release for the next six months.
 We encourage you to explore the new features and benefits offered by this latest release and evaluate their potential impact on your applications.
@@ -188,7 +188,7 @@ Try out the new Node.js 20 release! We’re always happy to hear your feedback. 
 
 Also of note is that Node.js 14 will go End-of-Life in April 2023, so we advise you to start planning to upgrade to Node.js 18 (LTS) or Node.js 20 (soon to be LTS).
 
-Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at </blog/announcements/nodejs16-eol/>.
+Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at <https://nodejs.org/en/blog/announcements/nodejs16-eol/>.
 
 Looking to the future, the [Next-10](https://github.com/nodejs/next-10) team is running a survey to gather info from the ecosystem. Help shape the future of Node.js by participating. Submit your feedback [here](https://linuxfoundation.surveymonkey.com/r/XJ35LYF).
 

--- a/pages/en/blog/announcements/v20-release-announce.md
+++ b/pages/en/blog/announcements/v20-release-announce.md
@@ -13,7 +13,7 @@ The project continues to make progress across a number of areas, with many new f
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 20.0.0, visit: [/download/current/](/download/current/). You can find the release post at [/blog/release/v20.0.0](/blog/release/v20.0.0), which contains the full list of commits included in this release.
+To download Node.js 20.0.0, visit: [https://nodejs.org/download/current/](/download/current/). You can find the release post at [https://nodejs.org/blog/release/v20.0.0](/blog/release/v20.0.0), which contains the full list of commits included in this release.
 
 As a reminder, Node.js 20 will enter long-term support (LTS) in October, but until then, it will be the "Current" release for the next six months.
 We encourage you to explore the new features and benefits offered by this latest release and evaluate their potential impact on your applications.
@@ -188,7 +188,7 @@ Try out the new Node.js 20 release! We’re always happy to hear your feedback. 
 
 Also of note is that Node.js 14 will go End-of-Life in April 2023, so we advise you to start planning to upgrade to Node.js 18 (LTS) or Node.js 20 (soon to be LTS).
 
-Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at [/blog/announcements/nodejs16-eol/](/blog/announcements/nodejs16-eol/).
+Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at [https://nodejs.org/blog/announcements/nodejs16-eol/](/blog/announcements/nodejs16-eol/).
 
 Looking to the future, the [Next-10](https://github.com/nodejs/next-10) team is running a survey to gather info from the ecosystem. Help shape the future of Node.js by participating. Submit your feedback [here](https://linuxfoundation.surveymonkey.com/r/XJ35LYF).
 

--- a/pages/en/blog/announcements/v20-release-announce.md
+++ b/pages/en/blog/announcements/v20-release-announce.md
@@ -13,7 +13,7 @@ The project continues to make progress across a number of areas, with many new f
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 20.0.0, visit: <https://nodejs.org/en/download/current/>. You can find the release post at <https://nodejs.org/en/blog/release/v20.0.0>, which contains the full list of commits included in this release.
+To download Node.js 20.0.0, visit: [/download/current/](/download/current/). You can find the release post at [/blog/release/v20.0.0](/blog/release/v20.0.0), which contains the full list of commits included in this release.
 
 As a reminder, Node.js 20 will enter long-term support (LTS) in October, but until then, it will be the "Current" release for the next six months.
 We encourage you to explore the new features and benefits offered by this latest release and evaluate their potential impact on your applications.
@@ -188,7 +188,7 @@ Try out the new Node.js 20 release! We’re always happy to hear your feedback. 
 
 Also of note is that Node.js 14 will go End-of-Life in April 2023, so we advise you to start planning to upgrade to Node.js 18 (LTS) or Node.js 20 (soon to be LTS).
 
-Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at <https://nodejs.org/en/blog/announcements/nodejs16-eol/>.
+Please, consider that Node.js 16 (LTS) will go End-of-Life in September 2023, which was brought forward from April 2024 to coincide with the end of support of OpenSSL 1.1.1. You can read more details about that decision at [/blog/announcements/nodejs16-eol/](/blog/announcements/nodejs16-eol/).
 
 Looking to the future, the [Next-10](https://github.com/nodejs/next-10) team is running a survey to gather info from the ecosystem. Help shape the future of Node.js by participating. Submit your feedback [here](https://linuxfoundation.surveymonkey.com/r/XJ35LYF).
 

--- a/pages/en/blog/announcements/v21-release-announce.md
+++ b/pages/en/blog/announcements/v21-release-announce.md
@@ -19,7 +19,7 @@ work since the last major release. This blog post will add some additional conte
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 21.0.0, visit: </download/current/>. You can find the release post at </blog/release/v21.0.0>,
+To download Node.js 21.0.0, visit: <https://nodejs.org/en/download/current/>. You can find the release post at <https://nodejs.org/en/blog/release/v21.0.0>,
 which contains the full list of commits included in this release.
 
 ## Notable Changes

--- a/pages/en/blog/announcements/v21-release-announce.md
+++ b/pages/en/blog/announcements/v21-release-announce.md
@@ -19,7 +19,7 @@ work since the last major release. This blog post will add some additional conte
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 21.0.0, visit: <https://nodejs.org/en/download/current/>. You can find the release post at <https://nodejs.org/en/blog/release/v21.0.0>,
+To download Node.js 21.0.0, visit: [/download/current/](/download/current/). You can find the release post at [/blog/release/v21.0.0](/blog/release/v21.0.0),
 which contains the full list of commits included in this release.
 
 ## Notable Changes

--- a/pages/en/blog/announcements/v21-release-announce.md
+++ b/pages/en/blog/announcements/v21-release-announce.md
@@ -19,7 +19,7 @@ work since the last major release. This blog post will add some additional conte
 
 You can read more about our release policy at <https://github.com/nodejs/release>.
 
-To download Node.js 21.0.0, visit: [/download/current/](/download/current/). You can find the release post at [/blog/release/v21.0.0](/blog/release/v21.0.0),
+To download Node.js 21.0.0, visit: [https://nodejs.org/download/current/](/download/current/). You can find the release post at [https://nodejs.org/blog/release/v21.0.0](/blog/release/v21.0.0),
 which contains the full list of commits included in this release.
 
 ## Notable Changes

--- a/pages/en/blog/release/v0.10.46.md
+++ b/pages/en/blog/release/v0.10.46.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [https://nodejs.org/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [https://nodejs.org/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
 
 ### Commits:
 

--- a/pages/en/blog/release/v0.10.46.md
+++ b/pages/en/blog/release/v0.10.46.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
 
 ### Commits:
 

--- a/pages/en/blog/release/v0.10.46.md
+++ b/pages/en/blog/release/v0.10.46.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at </blog/vulnerability/june-2016-security-releases/>.
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at </blog/vulnerability/june-2016-security-releases/>.
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
 
 ### Commits:
 

--- a/pages/en/blog/release/v0.12.15.md
+++ b/pages/en/blog/release/v0.12.15.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [https://nodejs.org/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [https://nodejs.org/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
 
 ### Commits:
 

--- a/pages/en/blog/release/v0.12.15.md
+++ b/pages/en/blog/release/v0.12.15.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at [/blog/vulnerability/june-2016-security-releases/](/blog/vulnerability/june-2016-security-releases/).
 
 ### Commits:
 

--- a/pages/en/blog/release/v0.12.15.md
+++ b/pages/en/blog/release/v0.12.15.md
@@ -15,8 +15,8 @@ author: Rod Vagg
 
 This is a security release. All Node.js users should consult the security release summary at /blog/vulnerability/june-2016-security-releases/ for details on patched vulnerabilities.
 
-- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at </blog/vulnerability/june-2016-security-releases/>.
-- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at </blog/vulnerability/june-2016-security-releases/>.
+- **libuv**: (CVE-2014-9748) Fixes a bug in the read/write locks implementation for Windows XP and Windows 2003 that can lead to undefined and potentially unsafe behaviour. More information can be found at https://github.com/libuv/libuv/issues/515 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
+- **V8**: (CVE-2016-1669) Fixes a potential Buffer overflow vulnerability discovered in V8, more details can be found in the CVE at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1669 or at <https://nodejs.org/en/blog/vulnerability/june-2016-security-releases/>.
 
 ### Commits:
 

--- a/pages/en/blog/release/v14.19.3.md
+++ b/pages/en/blog/release/v14.19.3.md
@@ -8,7 +8,7 @@ author: Richard Lau
 
 ### Notable Changes
 
-- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See </blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
+- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
 - The list of GPG keys used to sign releases has been synchronized with the main branch.
 
 ### Commits

--- a/pages/en/blog/release/v14.19.3.md
+++ b/pages/en/blog/release/v14.19.3.md
@@ -8,7 +8,7 @@ author: Richard Lau
 
 ### Notable Changes
 
-- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
+- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
 - The list of GPG keys used to sign releases has been synchronized with the main branch.
 
 ### Commits

--- a/pages/en/blog/release/v14.19.3.md
+++ b/pages/en/blog/release/v14.19.3.md
@@ -8,7 +8,7 @@ author: Richard Lau
 
 ### Notable Changes
 
-- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
+- This release updates OpenSSL to 1.1.1o. This update is not being treated as a security release as the issues addressed in OpenSSL 1.1.1o were assessed to not affect Node.js 14. See [https://nodejs.org/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affects other Node.js release lines.
 - The list of GPG keys used to sign releases has been synchronized with the main branch.
 
 ### Commits

--- a/pages/en/blog/release/v17.9.1.md
+++ b/pages/en/blog/release/v17.9.1.md
@@ -13,7 +13,7 @@ author: Ruy Adorno
 #### Update to OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 17.
-See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 ### Commits
 

--- a/pages/en/blog/release/v17.9.1.md
+++ b/pages/en/blog/release/v17.9.1.md
@@ -13,7 +13,7 @@ author: Ruy Adorno
 #### Update to OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 17.
-See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See [https://nodejs.org/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 ### Commits
 

--- a/pages/en/blog/release/v17.9.1.md
+++ b/pages/en/blog/release/v17.9.1.md
@@ -13,7 +13,7 @@ author: Ruy Adorno
 #### Update to OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 17.
-See </blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 ### Commits
 

--- a/pages/en/blog/release/v18.2.0.md
+++ b/pages/en/blog/release/v18.2.0.md
@@ -11,7 +11,7 @@ author: Rafael Gonzaga
 #### OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 18.
-See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 - \[[`8e54c19a6e`](https://github.com/nodejs/node/commit/8e54c19a6e)] - **deps**: update archs files for quictls/openssl-3.0.3+quic (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)
 - \[[`6365bf808e`](https://github.com/nodejs/node/commit/6365bf808e)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.3 (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)

--- a/pages/en/blog/release/v18.2.0.md
+++ b/pages/en/blog/release/v18.2.0.md
@@ -11,7 +11,7 @@ author: Rafael Gonzaga
 #### OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 18.
-See </blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See <https://nodejs.org/en/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/> for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 - \[[`8e54c19a6e`](https://github.com/nodejs/node/commit/8e54c19a6e)] - **deps**: update archs files for quictls/openssl-3.0.3+quic (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)
 - \[[`6365bf808e`](https://github.com/nodejs/node/commit/6365bf808e)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.3 (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)

--- a/pages/en/blog/release/v18.2.0.md
+++ b/pages/en/blog/release/v18.2.0.md
@@ -11,7 +11,7 @@ author: Rafael Gonzaga
 #### OpenSSL 3.0.3
 
 This update can be treated as a security release as the issues addressed in OpenSSL 3.0.3 slightly affect Node.js 18.
-See [/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
+See [https://nodejs.org/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/](/blog/vulnerability/openssl-fixes-in-regular-releases-may2022/) for more information on how the May 2022 OpenSSL releases affect other Node.js release lines.
 
 - \[[`8e54c19a6e`](https://github.com/nodejs/node/commit/8e54c19a6e)] - **deps**: update archs files for quictls/openssl-3.0.3+quic (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)
 - \[[`6365bf808e`](https://github.com/nodejs/node/commit/6365bf808e)] - **deps**: upgrade openssl sources to quictls/openssl-3.0.3 (RafaelGSS) [#43022](https://github.com/nodejs/node/pull/43022)

--- a/pages/en/blog/vulnerability/june-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/june-2023-security-releases.md
@@ -212,6 +212,6 @@ Releases will be available on, or shortly after, Tuesday June 20 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at </security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at <https://nodejs.org/en/security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

--- a/pages/en/blog/vulnerability/june-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/june-2023-security-releases.md
@@ -212,6 +212,6 @@ Releases will be available on, or shortly after, Tuesday June 20 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at [/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at [https://nodejs.org/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

--- a/pages/en/blog/vulnerability/june-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/june-2023-security-releases.md
@@ -212,6 +212,6 @@ Releases will be available on, or shortly after, Tuesday June 20 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at <https://nodejs.org/en/security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at [/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

--- a/pages/en/blog/vulnerability/october-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/october-2023-security-releases.md
@@ -122,6 +122,6 @@ Releases will be available on, or shortly after, Friday October 13 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at [/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at [https://nodejs.org/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

--- a/pages/en/blog/vulnerability/october-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/october-2023-security-releases.md
@@ -122,6 +122,6 @@ Releases will be available on, or shortly after, Friday October 13 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at <https://nodejs.org/en/security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at [/security/](/security/). Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

--- a/pages/en/blog/vulnerability/october-2023-security-releases.md
+++ b/pages/en/blog/vulnerability/october-2023-security-releases.md
@@ -122,6 +122,6 @@ Releases will be available on, or shortly after, Friday October 13 2023.
 
 ## Contact and future updates
 
-The current Node.js security policy can be found at </security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
+The current Node.js security policy can be found at <https://nodejs.org/en/security/>. Please follow the process outlined in <https://github.com/nodejs/node/security/policy> if you wish to report a vulnerability in Node.js.
 
 Subscribe to the low-volume announcement-only nodejs-sec mailing list at <https://groups.google.com/forum/#!forum/nodejs-sec> to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.


### PR DESCRIPTION
## Description

Fixes broken blog links

## Validation

In preview the links on the pages below should work without any problems;

https://nodejs.org/en/blog/announcements/v20-release-announce
https://nodejs.org/en/blog/announcements/v21-release-announce
https://nodejs.org/en/blog/release/v0.10.46
https://nodejs.org/en/blog/release/v0.12.15
https://nodejs.org/en/blog/release/v14.19.3
https://nodejs.org/en/blog/release/v17.9.1
https://nodejs.org/en/blog/release/v18.2.0
https://nodejs.org/en/blog/vulnerability/june-2023-security-releases
https://nodejs.org/en/blog/vulnerability/october-2023-security-releases

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
