### PR TITLE
fix: Blog pagination / Blog category listing

### DIFF
--- a/components/withLayout.tsx
+++ b/components/withLayout.tsx
@@ -14,7 +14,7 @@ import type { LegacyLayouts } from '@/types';
 const layoutComponents = {
   'docs.hbs': DocsLayout,
   'about.hbs': AboutLayout,
-  'blog-categpry.hbs': BlogCategoryLayout,
+  'blog-category.hbs': BlogCategoryLayout,
   'blog-post.hbs': BlogPostLayout,
   'contribute.hbs': ContributeLayout,
   'download.hbs': DownloadLayout,

--- a/hooks/useBaseBlogData.ts
+++ b/hooks/useBaseBlogData.ts
@@ -25,10 +25,10 @@ export const useBaseBlogData = (pathname: string) => {
   };
 
   const currentCategory = useMemo(() => {
-    // We split the pathname to retrieve the blog category from it
-    // since the URL is usually /{languageCode}/blog/{category}
-    // the third path piece is usually the category name
-    const [, _pathname, category] = pathname.split('/');
+    // We split the pathname to retrieve the blog category from it since the
+    // URL is usually blog/{category} the second path piece is usually the
+    // category name
+    const [_pathname, category] = pathname.split('/');
 
     if (_pathname === 'blog' && category && category.length) {
       return category;

--- a/pages/en/blog/advisory-board/index.md
+++ b/pages/en/blog/advisory-board/index.md
@@ -1,4 +1,4 @@
 ---
 title: Advisory Board
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/announcements/index.md
+++ b/pages/en/blog/announcements/index.md
@@ -1,4 +1,4 @@
 ---
 title: Announcements
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/community/index.md
+++ b/pages/en/blog/community/index.md
@@ -1,4 +1,4 @@
 ---
 title: Community
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/feature/index.md
+++ b/pages/en/blog/feature/index.md
@@ -1,4 +1,4 @@
 ---
 title: Features
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/index.md
+++ b/pages/en/blog/index.md
@@ -1,4 +1,4 @@
 ---
 title: News
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/module/index.md
+++ b/pages/en/blog/module/index.md
@@ -1,4 +1,4 @@
 ---
 title: Modules
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/npm/index.md
+++ b/pages/en/blog/npm/index.md
@@ -1,4 +1,4 @@
 ---
 title: NPM
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/pagination.md
+++ b/pages/en/blog/pagination.md
@@ -1,5 +1,5 @@
 ---
 title: News from
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 author: The Node.js Project
 ---

--- a/pages/en/blog/release/index.md
+++ b/pages/en/blog/release/index.md
@@ -1,4 +1,4 @@
 ---
 title: Releases
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/uncategorized/index.md
+++ b/pages/en/blog/uncategorized/index.md
@@ -1,4 +1,4 @@
 ---
 title: Uncategorized
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/video/index.md
+++ b/pages/en/blog/video/index.md
@@ -1,4 +1,4 @@
 ---
 title: Videos
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/vulnerability/index.md
+++ b/pages/en/blog/vulnerability/index.md
@@ -1,4 +1,4 @@
 ---
 title: Vulnerabilities
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/pages/en/blog/weekly-updates/index.md
+++ b/pages/en/blog/weekly-updates/index.md
@@ -1,4 +1,4 @@
 ---
 title: Weekly Updates
-layout: blog-categpry.hbs
+layout: blog-category.hbs
 ---

--- a/types/layouts.ts
+++ b/types/layouts.ts
@@ -2,7 +2,7 @@
 export type LegacyLayouts =
   | 'about.hbs'
   | 'learn.hbs'
-  | 'blog-categpry.hbs'
+  | 'blog-category.hbs'
   | 'blog-post.hbs'
   | 'contribute.hbs'
   | 'index.hbs'


### PR DESCRIPTION
## Description

This PR fixes the pagination and category listings on blog category pages

## Validation

In the preview; 
- The Blog category page, `Newer`, `Older` buttons should work properly.
- Blog category pages should work properly. (`/en/blog/announcements`, `/en/blog/release`, etc.)
- In general checking blog pages would be great

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
