### PR TITLE
tune sentry collection rates per docs

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -7,12 +7,12 @@ init({
   enabled: !!VERCEL_ENV,
   // Tell Sentry where to send events
   dsn: SENTRY_DSN,
-  // Percentage of events to send to Sentry (all of them) (for performance metrics)
-  tracesSampleRate: 1,
+  // Percentage of events to send to Sentry (1% of them) (for performance metrics)
+  tracesSampleRate: 0.01,
+  // Percentage of sessions to sample (1%)
+  replaysSessionSampleRate: 0.01,
   // Percentage of errors to sample (all of them)
   replaysOnErrorSampleRate: 1.0,
-  // Percentage of sessionsto sample (10%)
-  replaysSessionSampleRate: 0.1,
   // Support replaying client sessions to capture unhappy paths
   integrations: [new Replay()],
   // We only want to capture errors from _next folder on production

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -7,6 +7,6 @@ init({
   enabled: !!VERCEL_ENV,
   // Tell Sentry where to send events
   dsn: SENTRY_DSN,
-  // Percentage of events to send to Sentry (all of them) (for performance metrics)
-  tracesSampleRate: 1,
+  // Percentage of events to send to Sentry (1% of them) (for performance metrics)
+  tracesSampleRate: 0.01,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,9 +8,10 @@ init({
   enabled: !!VERCEL_ENV,
   // Tell Sentry where to send events
   dsn: SENTRY_DSN,
-  // Percentage of events to send to Sentry (all of them) (for performance metrics)
-  tracesSampleRate: 1,
+  // Percentage of events to send to Sentry (1% of them) (for performance metrics)
+  tracesSampleRate: 0.01,
   // Percentage of events to send to Sentry (all of them) (for profiling metrics)
+  // This number is relative to tracesSampleRate - so all traces get profiled
   profilesSampleRate: 1.0,
   // Add profiling integration to capture performance metrics
   integrations: [new ProfilingIntegration()],


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR tunes down the sentry collection rates

Sentry was kind enough to reset our quote, but https://docs.sentry.io/platforms/javascript/performance/ and https://docs.sentry.io/platforms/javascript/session-replay/ suggest to lower the rate once setup is complete.

with this change we are:

- tracing at 1%
- sampling at 1%
- recording errors at 100%

This work can sit until we talk with the Sentry folks, and serve as a useful outcome of any ongoing discussion. I'll be emailing them a link to it.


## Validation

- Locally the app still runs
- Sentry should still collect.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
