### PR TITLE
refactor: lazy-load sentry

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -97,10 +97,12 @@ const sentryConfig = {
   hideSourceMaps: false,
   // Tree shake Sentry stuff from the bundle
   disableLogger: true,
+  // Applies same WebPack Transpilation as Next.js
+  transpileClientSDK: true,
 };
 
 // Next.js Configuration with `next.intl` enabled
-const nextWithIntl = withNextIntl()(nextConfig);
+const nextWithIntl = withNextIntl('./i18n.tsx')(nextConfig);
 
 // Next.js Configuration with `sentry` enabled
 const nextWithSentry = withSentryConfig(

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -190,3 +190,9 @@ export const DEFAULT_VIEWPORT = {
  */
 export const SENTRY_DSN =
   'https://02884d0745aecaadf5f780278fe5fe70@o4506191161786368.ingest.sentry.io/4506191307735040';
+
+/**
+ * This states if Sentry should be enabled and bundled within our App
+ */
+export const SENTRY_ENABLE =
+  process.env.NODE_ENV === 'development' || !!VERCEL_ENV;

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -13,21 +13,5 @@ import('@sentry/nextjs').then(({ init }) =>
     // We only want to capture errors from _next folder on production
     // We don't want to capture errors from preview branches here
     allowUrls: ['https://nodejs.org/_next'],
-    // Filter-out Events/Errors that are invalid for us
-    beforeSend: (event, hint) => {
-      const originalException = hint.originalException as Error;
-
-      // All the Events we send must have a message and stack trace
-      if (originalException?.message && originalException?.stack) {
-        // All our Events come eventually from code that originates on node_modules
-        // so everything else should be discarded
-        // Even React Errors or other errors will eventually have node_modules in the code
-        if (String(originalException.stack).includes('node_modules')) {
-          return event;
-        }
-      }
-
-      return null;
-    },
   })
 );

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,37 +1,33 @@
-import { init, Replay } from '@sentry/nextjs';
+import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 
-import { SENTRY_DSN, VERCEL_ENV } from '@/next.constants.mjs';
+// This lazy-loads Sentry on the Browser
+import('@sentry/nextjs').then(({ init }) =>
+  init({
+    // Only run Sentry on Vercel Environment
+    enabled: SENTRY_ENABLE,
+    // Tell Sentry where to send events
+    dsn: SENTRY_DSN,
+    // Disable Sentry Tracing as we don't need to have it
+    // as Vercel already does Web Vitals and Performance Measurement on Client-Side
+    enableTracing: false,
+    // We only want to capture errors from _next folder on production
+    // We don't want to capture errors from preview branches here
+    allowUrls: ['https://nodejs.org/_next'],
+    // Filter-out Events/Errors that are invalid for us
+    beforeSend: (event, hint) => {
+      const originalException = hint.originalException as Error;
 
-init({
-  // Only run Sentry on Vercel Environment
-  enabled: !!VERCEL_ENV,
-  // Tell Sentry where to send events
-  dsn: SENTRY_DSN,
-  // Percentage of events to send to Sentry (1% of them) (for performance metrics)
-  tracesSampleRate: 0.01,
-  // Percentage of sessions to sample (1%)
-  replaysSessionSampleRate: 0.01,
-  // Percentage of errors to sample (all of them)
-  replaysOnErrorSampleRate: 1.0,
-  // Support replaying client sessions to capture unhappy paths
-  integrations: [new Replay()],
-  // We only want to capture errors from _next folder on production
-  // We don't want to capture errors from preview branches here
-  allowUrls: ['https://nodejs.org/_next'],
-  // Filter-out Events/Errors that are invalid for us
-  beforeSend: (event, hint) => {
-    const originalException = hint.originalException as Error;
-
-    // All the Events we send must have a message and stack trace
-    if (originalException?.message && originalException?.stack) {
-      // All our Events come eventually from code that originates on node_modules
-      // so everything else should be discarded
-      // Even React Errors or other errors will eventually have node_modules in the code
-      if (String(originalException.stack).includes('node_modules')) {
-        return event;
+      // All the Events we send must have a message and stack trace
+      if (originalException?.message && originalException?.stack) {
+        // All our Events come eventually from code that originates on node_modules
+        // so everything else should be discarded
+        // Even React Errors or other errors will eventually have node_modules in the code
+        if (String(originalException.stack).includes('node_modules')) {
+          return event;
+        }
       }
-    }
 
-    return null;
-  },
-});
+      return null;
+    },
+  })
+);

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,10 +1,10 @@
 import { init } from '@sentry/nextjs';
 
-import { SENTRY_DSN, VERCEL_ENV } from '@/next.constants.mjs';
+import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 
 init({
   // Only run Sentry on Vercel Environment
-  enabled: !!VERCEL_ENV,
+  enabled: SENTRY_ENABLE,
   // Tell Sentry where to send events
   dsn: SENTRY_DSN,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,11 +1,11 @@
 import { init } from '@sentry/nextjs';
 import { ProfilingIntegration } from '@sentry/profiling-node';
 
-import { SENTRY_DSN, VERCEL_ENV } from '@/next.constants.mjs';
+import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 
 init({
   // Only run Sentry on Vercel Environment
-  enabled: !!VERCEL_ENV,
+  enabled: SENTRY_ENABLE,
   // Tell Sentry where to send events
   dsn: SENTRY_DSN,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Sentry has an obnoxious big bundle-size which is non-tree-shakeable (mostly) due to its tracing/replay features.

After pondering a bit I've concluded the following:

- We don't need Sentry Tracing (Web Vitals / Client-Side Performance Analysis) as we already have Vercel Web Vitals and Performance Analysis (through `vercel/analytics`)
- We can lazy-load Sentry, as client-side errors should mostly not happen during-load. By lazy-loading (dynamic imports) we're just reducing the priority that Sentry has during load, and will delegate the Application to bootstrap first rather than Sentry
- I also disabled Sentry Replays as they use a big bundle size and for our use cases I doubt we really would benefit from Replays
- This change reduces the initial bundle size (pre-gzip) (and just an estimate) from 240Kb unto 150Kb and the first JS Load from 140 Kb to 90 Kb

## Validation

We should still see Sentry reporting Errors on client-side and it should still do `/monitoring` API calls
