### PR TITLE
feat: enable sentry features

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import type { FC } from 'react';
+
+const ErrorPage: FC<{ error: Error }> = ({ error }) => (
+  <div className="container">
+    <h2>500: Internal Server Error</h2>
+    <h3>This Page has thrown a non-recoverable Error</h3>
+    <small>
+      Details: <br />
+      <pre>
+        <code>${error.message}</code>
+      </pre>
+    </small>
+  </div>
+);
+
+export default ErrorPage;

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -2,16 +2,10 @@
 
 import type { FC } from 'react';
 
-const ErrorPage: FC<{ error: Error }> = ({ error }) => (
+const ErrorPage: FC<{ error: Error }> = () => (
   <div className="container">
     <h2>500: Internal Server Error</h2>
     <h3>This Page has thrown a non-recoverable Error</h3>
-    <small>
-      Details: <br />
-      <pre>
-        <code>${error.message}</code>
-      </pre>
-    </small>
   </div>
 );
 

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,4 +1,3 @@
-import { withErrorBoundary } from '@sentry/nextjs';
 import { Analytics } from '@vercel/analytics/react';
 import { Source_Sans_3 } from 'next/font/google';
 import { useLocale } from 'next-intl';
@@ -25,7 +24,7 @@ const RootLayout: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <html className={sourceSans.className} dir={langDir} lang={hrefLang}>
-      <body>
+      <body suppressHydrationWarning>
         <LocaleProvider>
           <ThemeProvider>
             <BaseLayout>{children}</BaseLayout>
@@ -40,7 +39,4 @@ const RootLayout: FC<PropsWithChildren> = ({ children }) => {
   );
 };
 
-// Exports the Default Layout with an Error Boundary
-export default withErrorBoundary(RootLayout, {
-  fallback: <p>An Internal Error has occured.</p>,
-});
+export default RootLayout;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { withErrorBoundary } from '@sentry/nextjs';
 import { Analytics } from '@vercel/analytics/react';
 import { Source_Sans_3 } from 'next/font/google';
 import { useLocale } from 'next-intl';
@@ -39,4 +40,7 @@ const RootLayout: FC<PropsWithChildren> = ({ children }) => {
   );
 };
 
-export default RootLayout;
+// Exports the Default Layout with an Error Boundary
+export default withErrorBoundary(RootLayout, {
+  fallback: <p>An Internal Error has occured.</p>,
+});

--- a/components/withNodeRelease.tsx
+++ b/components/withNodeRelease.tsx
@@ -16,5 +16,9 @@ export const WithNodeRelease: FC<WithNodeReleaseProps> = ({
     [status].flat().includes(release.status)
   );
 
-  return <Component release={matchingRelease!} />;
+  if (matchingRelease !== undefined) {
+    return <Component release={matchingRelease!} />;
+  }
+
+  return null;
 };

--- a/layouts/BaseLayout.tsx
+++ b/layouts/BaseLayout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { FC, PropsWithChildren } from 'react';
 
 import Footer from '@/components/Footer';

--- a/next-data/generateNodeReleasesJson.mjs
+++ b/next-data/generateNodeReleasesJson.mjs
@@ -63,8 +63,6 @@ const generateNodeReleasesJson = async () => {
     };
   });
 
-  console.timeEnd('g');
-
   return writeFile(
     jsonFilePath,
     JSON.stringify(

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ import {
   SENTRY_DSN,
   SENTRY_ENABLE,
   SENTRY_EXTENSIONS,
-  VERCEL_ENV,
+  SENTRY_TUNNEL,
 } from './next.constants.mjs';
 import { redirects, rewrites } from './next.rewrites.mjs';
 
@@ -100,7 +100,7 @@ const sentryConfig = {
   // Upload Next.js or third-party code in addition to our code
   widenClientFileUpload: true,
   // Attempt to circumvent ad blockers
-  tunnelRoute: VERCEL_ENV ? '/monitoring' : undefined,
+  tunnelRoute: SENTRY_TUNNEL(),
   // Prevent source map comments in built files
   hideSourceMaps: false,
   // Tree shake Sentry stuff from the bundle

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -198,6 +198,14 @@ export const SENTRY_ENABLE =
   process.env.NODE_ENV === 'development' || !!VERCEL_ENV;
 
 /**
+ * This configures the sampling rate for Sentry
+ *
+ * @note we always want to capture 100% on preview branches and development mode
+ */
+export const SENTRY_CAPTURE_RATE =
+  SENTRY_ENABLE && BASE_URL !== 'https://nodejs.org' ? 1.0 : 0.01;
+
+/**
  * This configures which Sentry features to tree-shake/remove from the Sentry bundle
  *
  * @see https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -206,6 +206,12 @@ export const SENTRY_CAPTURE_RATE =
   SENTRY_ENABLE && BASE_URL !== 'https://nodejs.org' ? 1.0 : 0.01;
 
 /**
+ * Provides the Route for Sentry's Server-Side Tunnel
+ */
+export const SENTRY_TUNNEL = (components = '') =>
+  SENTRY_ENABLE ? `/monitoring${components}` : undefined;
+
+/**
  * This configures which Sentry features to tree-shake/remove from the Sentry bundle
  *
  * @see https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -218,8 +218,8 @@ export const SENTRY_TUNNEL = (components = '') =>
  */
 export const SENTRY_EXTENSIONS = {
   __SENTRY_DEBUG__: false,
-  __SENTRY_TRACING__: true,
+  __SENTRY_TRACING__: false,
   __RRWEB_EXCLUDE_IFRAME__: true,
   __RRWEB_EXCLUDE_SHADOW_DOM__: true,
-  __SENTRY_EXCLUDE_REPLAY_WORKER__: false,
+  __SENTRY_EXCLUDE_REPLAY_WORKER__: true,
 };

--- a/next.constants.mjs
+++ b/next.constants.mjs
@@ -196,3 +196,16 @@ export const SENTRY_DSN =
  */
 export const SENTRY_ENABLE =
   process.env.NODE_ENV === 'development' || !!VERCEL_ENV;
+
+/**
+ * This configures which Sentry features to tree-shake/remove from the Sentry bundle
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/
+ */
+export const SENTRY_EXTENSIONS = {
+  __SENTRY_DEBUG__: false,
+  __SENTRY_TRACING__: true,
+  __RRWEB_EXCLUDE_IFRAME__: true,
+  __RRWEB_EXCLUDE_SHADOW_DOM__: true,
+  __SENTRY_EXCLUDE_REPLAY_WORKER__: false,
+};

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -33,8 +33,8 @@ export const sentryClient = new BrowserClient({
     new Breadcrumbs(),
     new LinkedErrors(),
   ],
-  // We only want to capture errors from _next folder on production
-  // We don't want to capture errors from preview branches here
+  // We only want to allow ingestion from these pre-selected allowed URLs
+  // Note that the vercel.app prefix is for our Pull Request Branch Previews
   allowUrls: ['https://nodejs.org/', /^https:\/\/.+\.vercel\.app/],
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
   tracesSampleRate: SENTRY_CAPTURE_RATE,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -41,7 +41,7 @@ export const sentryClient = new BrowserClient({
     const exception = hint.originalException as Error;
 
     // We only want to capture Errors that have a Stack Trace and that are not Anonymous Errors
-    if (exception?.stack && !exception.stack.includes('anonymous')) {
+    if (exception?.stack && !exception.stack.includes('<anonymous>')) {
       return event;
     }
 

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -35,6 +35,12 @@ export const sentryClient = new BrowserClient({
   allowUrls: ['https://nodejs.org/_next'],
   // Enables Sentry Tracing Feature
   enableTracing: true,
+  // Percentage of events to send to Sentry (1% of them) (for performance metrics)
+  tracesSampleRate: 0.01,
+  // Percentage of events to send to Sentry (1% of them) (for session replays)
+  replaysSessionSampleRate: 0.01,
+  // Percentage of events to send to Sentry (1% of them) (for session replays when error happens)
+  replaysOnErrorSampleRate: 1.0,
   // Adds custom filtering before sending an Event to Sentry
   beforeSend: (event, hint) => {
     // Attempts to grab the original Exception before any "magic" happens

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -35,6 +35,18 @@ export const sentryClient = new BrowserClient({
   allowUrls: ['https://nodejs.org/_next'],
   // Enables Sentry Tracing Feature
   enableTracing: true,
+  // Adds custom filtering before sending an Event to Sentry
+  beforeSend: (event, hint) => {
+    // Attempts to grab the original Exception before any "magic" happens
+    const exception = hint.originalException as Error;
+
+    // We only want to capture Errors that have a Stack Trace and that are not Anonymous Errors
+    if (exception?.stack && !exception.stack.includes('anonymous')) {
+      return event;
+    }
+
+    return null;
+  },
 });
 
 // Attaches this Browser Client to Sentry

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,17 +1,41 @@
+import {
+  BrowserClient,
+  Dedupe,
+  Replay,
+  Breadcrumbs,
+  HttpContext,
+  BrowserTracing,
+  defaultStackParser,
+  getCurrentHub,
+  makeFetchTransport,
+} from '@sentry/nextjs';
+
 import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 
-// This lazy-loads Sentry on the Browser
-import('@sentry/nextjs').then(({ init }) =>
-  init({
-    // Only run Sentry on Vercel Environment
-    enabled: SENTRY_ENABLE,
-    // Tell Sentry where to send events
-    dsn: SENTRY_DSN,
-    // Disable Sentry Tracing as we don't need to have it
-    // as Vercel already does Web Vitals and Performance Measurement on Client-Side
-    enableTracing: false,
-    // We only want to capture errors from _next folder on production
-    // We don't want to capture errors from preview branches here
-    allowUrls: ['https://nodejs.org/_next'],
-  })
-);
+// This creates a custom Sentry Client with minimal integrations
+export const sentryClient = new BrowserClient({
+  // Only run Sentry on Vercel Environment
+  enabled: SENTRY_ENABLE,
+  // Provide Sentry's Secret Key
+  dsn: SENTRY_DSN,
+  // Sentry's Error Transport Mechanism
+  transport: makeFetchTransport,
+  // Sentry's Stack Trace Parser
+  stackParser: defaultStackParser,
+  // All supported Integrations by us
+  integrations: [
+    new Replay(),
+    new Dedupe(),
+    new HttpContext(),
+    new Breadcrumbs(),
+    new BrowserTracing(),
+  ],
+  // We only want to capture errors from _next folder on production
+  // We don't want to capture errors from preview branches here
+  allowUrls: ['https://nodejs.org/_next'],
+  // Enables Sentry Tracing Feature
+  enableTracing: true,
+});
+
+// Attaches this Browser Client to Sentry
+getCurrentHub().bindClient(sentryClient);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -11,7 +11,11 @@ import {
   makeFetchTransport,
 } from '@sentry/nextjs';
 
-import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
+import {
+  SENTRY_DSN,
+  SENTRY_ENABLE,
+  SENTRY_CAPTURE_RATE,
+} from '@/next.constants.mjs';
 
 // This creates a custom Sentry Client with minimal integrations
 export const sentryClient = new BrowserClient({
@@ -34,13 +38,13 @@ export const sentryClient = new BrowserClient({
   ],
   // We only want to capture errors from _next folder on production
   // We don't want to capture errors from preview branches here
-  allowUrls: ['https://nodejs.org/_next'],
+  allowUrls: ['https://nodejs.org/', /^https:\/\/.+\.vercel\.app/],
   // Enables Sentry Tracing Feature
   enableTracing: true,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
-  tracesSampleRate: 0.01,
+  tracesSampleRate: SENTRY_CAPTURE_RATE,
   // Percentage of events to send to Sentry (1% of them) (for session replays)
-  replaysSessionSampleRate: 0.01,
+  replaysSessionSampleRate: SENTRY_CAPTURE_RATE,
   // Percentage of events to send to Sentry (1% of them) (for session replays when error happens)
   replaysOnErrorSampleRate: 1.0,
   // Adds custom filtering before sending an Event to Sentry

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -15,6 +15,7 @@ import {
   SENTRY_DSN,
   SENTRY_ENABLE,
   SENTRY_CAPTURE_RATE,
+  SENTRY_TUNNEL,
 } from '@/next.constants.mjs';
 
 // This creates a custom Sentry Client with minimal integrations
@@ -47,6 +48,10 @@ export const sentryClient = new BrowserClient({
   replaysSessionSampleRate: SENTRY_CAPTURE_RATE,
   // Percentage of events to send to Sentry (1% of them) (for session replays when error happens)
   replaysOnErrorSampleRate: 1.0,
+  // Provides a custom Sentry Tunnel Router
+  // @note these are components of the Sentry DSN string
+  // @see @sentry/nextjs/esm/client/tunnelRoute.js
+  tunnel: SENTRY_TUNNEL(`?o=4506191161786368&p=4506191307735040`),
   // Adds custom filtering before sending an Event to Sentry
   beforeSend: (event, hint) => {
     // Attempts to grab the original Exception before any "magic" happens

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,6 +4,7 @@ import {
   Replay,
   Breadcrumbs,
   HttpContext,
+  LinkedErrors,
   BrowserTracing,
   defaultStackParser,
   getCurrentHub,
@@ -28,6 +29,7 @@ export const sentryClient = new BrowserClient({
     new Dedupe(),
     new HttpContext(),
     new Breadcrumbs(),
+    new LinkedErrors(),
     new BrowserTracing(),
   ],
   // We only want to capture errors from _next folder on production

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,7 +5,7 @@ import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 init({
   // Only run Sentry on Vercel Environment
   enabled: SENTRY_ENABLE,
-  // Tell Sentry where to send events
+  // Provide Sentry's Secret Key
   dsn: SENTRY_DSN,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
   tracesSampleRate: 0.01,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,7 +6,7 @@ import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
 init({
   // Only run Sentry on Vercel Environment
   enabled: SENTRY_ENABLE,
-  // Tell Sentry where to send events
+  // Provide Sentry's Secret Key
   dsn: SENTRY_DSN,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
   tracesSampleRate: 0.01,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -12,8 +12,6 @@ init({
   enabled: SENTRY_ENABLE,
   // Provide Sentry's Secret Key
   dsn: SENTRY_DSN,
-  // Enables Sentry Tracing Feature
-  enableTracing: true,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
   tracesSampleRate: SENTRY_CAPTURE_RATE,
   // Percentage of events to send to Sentry (all of them) (for profiling metrics)

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,11 @@
 import { init } from '@sentry/nextjs';
 import { ProfilingIntegration } from '@sentry/profiling-node';
 
-import { SENTRY_DSN, SENTRY_ENABLE } from '@/next.constants.mjs';
+import {
+  SENTRY_DSN,
+  SENTRY_ENABLE,
+  SENTRY_CAPTURE_RATE,
+} from '@/next.constants.mjs';
 
 init({
   // Only run Sentry on Vercel Environment
@@ -11,7 +15,7 @@ init({
   // Enables Sentry Tracing Feature
   enableTracing: true,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
-  tracesSampleRate: 0.01,
+  tracesSampleRate: SENTRY_CAPTURE_RATE,
   // Percentage of events to send to Sentry (all of them) (for profiling metrics)
   // This number is relative to tracesSampleRate - so all traces get profiled
   profilesSampleRate: 1.0,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,6 +8,8 @@ init({
   enabled: SENTRY_ENABLE,
   // Provide Sentry's Secret Key
   dsn: SENTRY_DSN,
+  // Enables Sentry Tracing Feature
+  enableTracing: true,
   // Percentage of events to send to Sentry (1% of them) (for performance metrics)
   tracesSampleRate: 0.01,
   // Percentage of events to send to Sentry (all of them) (for profiling metrics)


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR attempts to tree-shake irrelevant Sentry parts and load a minimal Sentry Browser Client for our Next.js installation.

This PR should also disable support of UnhandledPromise rejection from Sentry

Notice that two unrelated changes in this PR are two tiny hot fixes (1 removing a console).timeEnd, 2 fixing a bug that if no static data is generated HomeDownloadButton crashes due to node release data being empty)

## Validation

I've seen no bundle increase with this setup, which is intriguing. The expected outcome here is for all Sentry features to be working correctly.

----

cc @abhiprasad @JonasBa for review from Sentry side

cc @bmuenzenmeyer for internal review
