### PR TITLE
fix(theme): Conform theme logic with OS theme preference

### DIFF
--- a/components/Common/ThemeToggle/index.tsx
+++ b/components/Common/ThemeToggle/index.tsx
@@ -11,7 +11,7 @@ type ThemeToggleProps = {
 const ThemeToggle: FC<ThemeToggleProps> = ({ onClick = () => {} }) => {
   const t = useTranslations();
 
-  const ariaLabel = t('components.header.buttons.toggleDarkMode');
+  const ariaLabel = t('components.header.buttons.toggleTheme');
 
   return (
     <button

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,13 +15,13 @@ import { availableLocales } from '@/next.locales.mjs';
 const Header = () => {
   const { navigationItems } = useSiteNavigation();
   const [showLangPicker, setShowLangPicker] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   const pathname = usePathname();
   const t = useTranslations();
 
   const toggleLanguage = t('components.header.buttons.toggleLanguage');
-  const toggleDarkMode = t('components.header.buttons.toggleDarkMode');
+  const toggleTheme = t('components.header.buttons.toggleTheme');
 
   return (
     <header aria-label="Primary">
@@ -50,11 +50,13 @@ const Header = () => {
 
         <div className="switchers">
           <button
-            className="dark-theme-switcher"
+            className="theme-switcher"
             type="button"
-            title={toggleDarkMode}
-            aria-label={toggleDarkMode}
-            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            title={toggleTheme}
+            aria-label={toggleTheme}
+            onClick={() =>
+              setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+            }
           >
             <Image
               priority
@@ -62,7 +64,7 @@ const Header = () => {
               height="28"
               className="dark-image"
               src={`${BASE_PATH}/static/images/light-mode.svg`}
-              alt="Dark Theme Switcher"
+              alt="Theme Switcher"
             />
 
             <Image
@@ -71,7 +73,7 @@ const Header = () => {
               height="28"
               className="light-image"
               src={`${BASE_PATH}/static/images/dark-mode.svg`}
-              alt="Dark Theme Switcher"
+              alt="Theme Switcher"
             />
           </button>
 

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/id.json
+++ b/i18n/locales/id.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/ka.json
+++ b/i18n/locales/ka.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/pt-br.json
+++ b/i18n/locales/pt-br.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/tr.json
+++ b/i18n/locales/tr.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/uk.json
+++ b/i18n/locales/uk.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -67,7 +67,7 @@
       },
       "buttons": {
         "toggleLanguage": "Toggle Language",
-        "toggleDarkMode": "Toggle dark/light mode"
+        "toggleTheme": "Toggle dark/light mode"
       }
     },
     "navigation": {

--- a/providers/themeProvider.tsx
+++ b/providers/themeProvider.tsx
@@ -8,9 +8,9 @@ import { THEME_STORAGE_KEY } from '@/next.constants.mjs';
 export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => (
   <NextThemeProvider
     attribute="data-theme"
-    defaultTheme="dark"
+    defaultTheme="system"
     storageKey={THEME_STORAGE_KEY}
-    enableSystem={false}
+    enableSystem={true}
   >
     {children}
   </NextThemeProvider>

--- a/styles/old/layout/dark-theme.css
+++ b/styles/old/layout/dark-theme.css
@@ -2,7 +2,7 @@ html[data-theme='dark'] {
   background-color: $dark-black;
   color: $white;
 
-  .dark-theme-switcher {
+  .theme-switcher {
     img.light-image {
       display: none;
     }
@@ -40,7 +40,7 @@ html[data-theme='dark'] {
   }
 
   header,
-  .dark-theme-switcher img,
+  .theme-switcher img,
   .lang-picker-toggler img {
     background-color: $dark-black2;
   }

--- a/styles/old/page-modules/header.css
+++ b/styles/old/page-modules/header.css
@@ -1,5 +1,5 @@
 header,
-.dark-theme-switcher img,
+.theme-switcher img,
 .lang-picker-toggler img {
   background-color: $node-gray;
 }
@@ -47,7 +47,7 @@ header {
     top: 0;
   }
 
-  .dark-theme-switcher {
+  .theme-switcher {
     border: none;
     cursor: pointer;
     margin: 0 8px 0 0;


### PR DESCRIPTION
## Description

It looks like after [these changes in themeProvider.tsx](https://github.com/nodejs/nodejs.org/pull/6092/files) initial conformity between app theme and OS theme preference was broken, so the app completely disregarded OS level theme user preference having a dark theme as default always.

## Validation
**Before:**

![os_pref_theme_before](https://github.com/nodejs/nodejs.org/assets/5207710/527aa5e7-467d-491c-aeed-8a36a87e81f6)

**After:**

![os_pref_theme_after](https://github.com/nodejs/nodejs.org/assets/5207710/5cbedb35-ef55-4824-a75c-eabe3ebc3d9c)


## Related Issues

The issue was introduced here https://github.com/nodejs/nodejs.org/pull/6092

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
