### PR TITLE
fix: mobile resolution content overflow

### DIFF
--- a/styles/old/layout/main.css
+++ b/styles/old/layout/main.css
@@ -13,6 +13,7 @@
   #main {
     .container {
       margin: 1em 20px;
+      width: calc(100% - 40px);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR aims to fix the content overflow problem on Learn and Blog detail pages in mobile resolution

## Validation

Need to compare the pages in the preview with the sample pages below;

- https://nodejs.org/en/blog/release/v20.8.1
- https://nodejs.org/en/learn/getting-started/introduction-to-nodejs
- https://nodejs.org/en/about

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.