### PR TITLE
Add SPDX identifier to  LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 The original contents of the nodejs.org repo are licensed for use as follows:
 
 """


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a SPDX identifier to the nodejs.org repo.

This has a number of benefits.

GitHub will display the license info more succinctly for users. This helps users understand our license faster (though it matters less than a consumable library)

Check this out from one of my [other](https://github.com/bmuenzenmeyer/eleventy-plugin-inline-link-favicon/blob/main/LICENSE) projects.

![image](https://github.com/nodejs/nodejs.org/assets/298435/e6046519-c19a-4933-95ff-bfcec51b7ae1)

GitHub will show the license file in the sidebar.

![image](https://github.com/nodejs/nodejs.org/assets/298435/e5c6df91-ae36-4cfa-897d-903134106ed3)

The OpenSSF scorecard will be able to identify the license. There is an open "issue" about this right now.

https://github.com/nodejs/nodejs.org/security/code-scanning/58 (I know not everyone may be able to see that)

---

If this works out, I will consider contributing it to nodejs/node for the same reasons.

## Validation

N/A

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
