### PR TITLE
fix: Use Next.js' way of adding webpack plugins

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@
 
 import { withSentryConfig } from '@sentry/nextjs';
 import withNextIntl from 'next-intl/plugin';
-import webpack from 'webpack';
 
 import {
   BASE_PATH,
@@ -48,7 +47,7 @@ const nextConfig = {
   // we also configure ESLint to run its lint checking on all files (next lint)
   eslint: { dirs: ['.'], ignoreDuringBuilds: true },
   // Adds custom WebPack configuration to our Next.hs setup
-  webpack: function (config) {
+  webpack: function (config, { webpack }) {
     // Next.js WebPack Bundler does not know how to handle `.mjs` files on `node_modules`
     // This is not an issue when using TurboPack as it uses SWC and it is ESM-only
     // Once Next.js uses Turbopack for their build process we can remove this

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodejs.org",
+  "name": "nodejs-org-fork",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -17,7 +17,7 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
-        "@sentry/nextjs": "~7.80.1",
+        "@sentry/nextjs": "~7.84.0",
         "@types/node": "20.8.10",
         "@vcarl/remark-headings": "~0.1.0",
         "@vercel/analytics": "~1.1.1",
@@ -5278,28 +5278,28 @@
       "dev": true
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.80.1.tgz",
-      "integrity": "sha512-5gZ4LPIj2vpQl2/dHBM4uXMi9OI5E0VlOhJQt0foiuN6JJeiOjdpJFcfVqJk69wrc0deVENTtgKKktxqMwVeWQ==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.84.0.tgz",
+      "integrity": "sha512-y9bGYA0OM6PEREfd+nk4UURZy29tpIw+7vQwpxWfEVs2fqq0/5TBFX/tKFb8AKUI9lVM8v0bcF0bNSCnuPQZHQ==",
       "dependencies": {
-        "@sentry/core": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1"
+        "@sentry/core": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.80.1.tgz",
-      "integrity": "sha512-1dPR6vPJ9vOTzgXff9HGheb178XeEv5hyjBNhCO1f6rjCgnVj99XGNZIgO1Ee1ALJbqlfPWaeV+uSWbbcmgJMA==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.84.0.tgz",
+      "integrity": "sha512-X50TlTKY9WzAnHsYc4FYrCWgm+CdVo0h02ggmodVBUpRLUBjj+cs5Q1plov/v/XeorSwmorNEMUu/n+XZNSsrA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.80.1",
-        "@sentry/core": "7.80.1",
-        "@sentry/replay": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1"
+        "@sentry-internal/tracing": "7.84.0",
+        "@sentry/core": "7.84.0",
+        "@sentry/replay": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0"
       },
       "engines": {
         "node": ">=8"
@@ -5326,25 +5326,25 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.80.1.tgz",
-      "integrity": "sha512-3Yh+O9Q86MxwIuJFYtuSSoUCpdx99P1xDAqL0FIPTJ+ekaVMiUJq9NmyaNh9uN2myPSmxvEXW6q3z37zta9ZHg==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.84.0.tgz",
+      "integrity": "sha512-tbuwunbBx2kSex15IHCqHDnrMfIlqPc6w/76fwkGqokz3oh9GSEGlLICwmBWL8AypWimUg13IDtFpD0TJTriWA==",
       "dependencies": {
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1"
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.80.1.tgz",
-      "integrity": "sha512-9C+CBwgFZZUkBYLrPTHaDr3kyknfSs0ejF/00RucvPZjiUPoxfslnh4IjWnN90ELEy2u09kcJY+dTCFVKd0UPQ==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.84.0.tgz",
+      "integrity": "sha512-aUu95BhnHSf/W/F4BvsFnf4x+piHiah5a180YTMqWcHMkJr7MnCWNIad9RJuHlcINSfyHtUr5+Z4Bajzqg60lw==",
       "dependencies": {
-        "@sentry/core": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1",
+        "@sentry/core": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -5352,19 +5352,19 @@
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.80.1.tgz",
-      "integrity": "sha512-zA1gqwpxQCRJ0wXFFdwPWbKQ3qsdv52ASrGdpJ4ZHDiRD8R52yj08eynJisBQXg8DGuTfKpeOQ/qND1wKE5bHA==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.84.0.tgz",
+      "integrity": "sha512-MjOGR3AZDVYfBQX2jZaxBMl7JaDSbu6uoiycdT+cMCYq722aB9Wv8vUzsCTzzV4/JmCjJFbfSis7S2Vkw7/9FA==",
       "dependencies": {
         "@rollup/plugin-commonjs": "24.0.0",
-        "@sentry/core": "7.80.1",
-        "@sentry/integrations": "7.80.1",
-        "@sentry/node": "7.80.1",
-        "@sentry/react": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1",
-        "@sentry/vercel-edge": "7.80.1",
-        "@sentry/webpack-plugin": "1.20.0",
+        "@sentry/core": "7.84.0",
+        "@sentry/integrations": "7.84.0",
+        "@sentry/node": "7.84.0",
+        "@sentry/react": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0",
+        "@sentry/vercel-edge": "7.84.0",
+        "@sentry/webpack-plugin": "1.21.0",
         "chalk": "3.0.0",
         "resolve": "1.22.8",
         "rollup": "2.78.0",
@@ -5385,14 +5385,14 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.80.1.tgz",
-      "integrity": "sha512-0NWfcZMlyQphKWsvyzfhGm2dCBk5DUPqOGW/vGx18G4tCCYtFcAIj/mCp/4XOEcZRPQgb9vkm+sidGD6DnwWlA==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.84.0.tgz",
+      "integrity": "sha512-Xm3fIXT3TZOQi+6uQBavI8iOehD3PkY7v0y3hog0d4lQTH88vQK9BBsI+jZEq81Em+RG/u7vZNiFo6YMTnWF7Q==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.80.1",
-        "@sentry/core": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1",
+        "@sentry-internal/tracing": "7.84.0",
+        "@sentry/core": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0",
         "https-proxy-agent": "^5.0.0"
       },
       "engines": {
@@ -5400,13 +5400,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.80.1.tgz",
-      "integrity": "sha512-AZjROgfJsYmI/Htb+giRQuVTCNofsLKGz6nYmJS2cYDZYKP4KU1l1SapF5F8r5Pu7c/6ZvULNj7MeHOXq2SEYA==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.84.0.tgz",
+      "integrity": "sha512-VQZrEHwPKCYTSbRYXD2ohXcQg99G1Hgs8eevRUuRpdChmA2e3z/RvT00NlaSNNZrS86wPyKpAK6kickB/eSYrw==",
       "dependencies": {
-        "@sentry/browser": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1",
+        "@sentry/browser": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -5417,57 +5417,58 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.80.1.tgz",
-      "integrity": "sha512-yjpftIyybQeWD2i0Nd7C96tZwjNbSMRW515EL9jwlNxYbQtGtMs0HavP9Y7uQvQrzwSHY0Wp+ooe9PMuvzqbHw==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.84.0.tgz",
+      "integrity": "sha512-c4PxT0ZpvkR9zXNfmAk3ojkm6eZ9+NlDze09RFBOCNo69QwIN90hnvbjXFC1+vRIJsfgo78Zr0ya/Wzb3Rog7Q==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.80.1",
-        "@sentry/core": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1"
+        "@sentry-internal/tracing": "7.84.0",
+        "@sentry/core": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.80.1.tgz",
-      "integrity": "sha512-CVu4uPVTOI3U9kYiOdA085R7jX5H1oVODbs9y+A8opJ0dtJTMueCXgZyE8oXQ0NjGVs6HEeaLkOuiV0mj8X3yw==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.84.0.tgz",
+      "integrity": "sha512-VqGLIF3JOUrk7yIXjLXJvAORkZL1e3dDX0Q1okRehwyt/5CRE+mdUTeJZkBo9P9mBwgMyvtwklzOGGrzjb4eMA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.80.1.tgz",
-      "integrity": "sha512-bfFm2e/nEn+b9++QwjNEYCbS7EqmteT8uf0XUs7PljusSimIqqxDtK1pfD9zjynPgC8kW/fVBKv0pe2LufomeA==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.84.0.tgz",
+      "integrity": "sha512-qdUVuxnRBvaf05AU+28R+xYtZmi/Ymf8os3Njq9g4XuA+QEkZLbzmIpRK5W9Ja7vUtjOeg29Xgg43A8znde9LQ==",
       "dependencies": {
-        "@sentry/types": "7.80.1"
+        "@sentry/types": "7.84.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "7.80.1",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-7.80.1.tgz",
-      "integrity": "sha512-V1XdiMxMBIU82gGPDt9mXXmOU/P4RHjXMWPx2ClkRg5aoBi1ewLpTcIRY8tYWawSAS4CMGimQcs3895Zzyvusg==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-7.84.0.tgz",
+      "integrity": "sha512-vabN7aUYdTFTbufoPBnp8DdD3PaaWmlSuGnFQWmAl8AXaR+tB/3wQPfNqcVDdVoyoe8MADHtmU4KHJdMJYgzhg==",
       "dependencies": {
-        "@sentry/core": "7.80.1",
-        "@sentry/types": "7.80.1",
-        "@sentry/utils": "7.80.1"
+        "@sentry-internal/tracing": "7.84.0",
+        "@sentry/core": "7.84.0",
+        "@sentry/types": "7.84.0",
+        "@sentry/utils": "7.84.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/webpack-plugin": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.20.0.tgz",
-      "integrity": "sha512-Ssj1mJVFsfU6vMCOM2d+h+KQR7QHSfeIP16t4l20Uq/neqWXZUQ2yvQfe4S3BjdbJXz/X4Rw8Hfy1Sd0ocunYw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.21.0.tgz",
+      "integrity": "sha512-x0PYIMWcsTauqxgl7vWUY6sANl+XGKtx7DCVnnY7aOIIlIna0jChTAPANTfA2QrK+VK+4I/4JxatCEZBnXh3Og==",
       "dependencies": {
-        "@sentry/cli": "^1.74.6",
+        "@sentry/cli": "^1.77.1",
         "webpack-sources": "^2.0.0 || ^3.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
-    "@sentry/nextjs": "~7.80.1",
+    "@sentry/nextjs": "~7.84.0",
     "@types/node": "20.8.10",
     "@vcarl/remark-headings": "~0.1.0",
     "@vercel/analytics": "~1.1.1",


### PR DESCRIPTION
Next.js has a slightly different way it wants you to define webpack plugins (it actually would like you not to define any at all but w/e) and this seems necessary in order not to get webpack build warnings when using the DefinePlugin in some instances.