### PR TITLE
Fix: don't use cache on next-data

### DIFF
--- a/next-data/blogData.ts
+++ b/next-data/blogData.ts
@@ -15,7 +15,9 @@ const getBlogData = (category: string): Promise<BlogDataRSC> => {
   // When we're on RSC with Server capabilities we prefer using Next.js Data Fetching
   // as this will load cached data from the server instead of generating data on the fly
   // this is extremely useful for ISR and SSG as it will not generate this data on every request
-  return fetch(`${NEXT_DATA_URL}blog-data/${category}`).then(r => r.json());
+  return fetch(`${NEXT_DATA_URL}blog-data/${category}`, {
+    cache: 'no-cache',
+  }).then(r => r.json());
 };
 
 export default getBlogData;

--- a/next-data/releaseData.ts
+++ b/next-data/releaseData.ts
@@ -15,7 +15,9 @@ const getReleaseData = (): Promise<NodeRelease[]> => {
   // When we're on RSC with Server capabilities we prefer using Next.js Data Fetching
   // as this will load cached data from the server instead of generating data on the fly
   // this is extremely useful for ISR and SSG as it will not generate this data on every request
-  return fetch(`${NEXT_DATA_URL}release-data`).then(r => r.json());
+  return fetch(`${NEXT_DATA_URL}release-data`, { cache: 'no-cache' }).then(r =>
+    r.json()
+  );
 };
 
 export default getReleaseData;


### PR DESCRIPTION
## Description

The bug on issues it's just because next use "old" cache.

Nextjs [doc](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating)

## Validation

it's should work as expected

## Related Issues

#6148 

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- NA I've covered new added functionality with unit tests if necessary.
