### PR TITLE
fix: blog pagination

### DIFF
--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -11,7 +11,7 @@ const getCurrentCategory = (pathname: string) => {
   // We split the pathname to retrieve the blog category from it since the
   // URL is usually blog/{category} the second path piece is usually the
   // category name
-  const [_pathname, category] = pathname.split('/');
+  const [_, _pathname, category] = pathname.split('/');
 
   if (_pathname === 'blog' && category && category.length) {
     return category;

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -11,7 +11,7 @@ const getCurrentCategory = (pathname: string) => {
   // We split the pathname to retrieve the blog category from it since the
   // URL is usually blog/{category} the second path piece is usually the
   // category name
-  const [_, _pathname, category] = pathname.split('/');
+  const [, _pathname, category] = pathname.split('/');
 
   if (_pathname === 'blog' && category && category.length) {
     return category;

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -9,8 +9,8 @@ import getBlogData from '@/next-data/blogData';
 
 const getCurrentCategory = (pathname: string) => {
   // We split the pathname to retrieve the blog category from it since the
-  // URL is usually blog/{category} the second path piece is usually the
-  // category name
+  // URL is usually /blog/{category} the second path piece is usually the
+  // category name, which usually year-YYYY
   const [, _pathname, category] = pathname.split('/');
 
   if (_pathname === 'blog' && category && category.length) {


### PR DESCRIPTION
## Description

The current blog pagination is broken. It just add `year-YYYY` to the url, but it still fetch the current year.

![image](https://github.com/rizqirizqi/nodejs.org/assets/6806365/81569856-95b8-4be3-b3e6-71a3943d0906)

When I look into the [code](https://github.com/nodejs/nodejs.org/blob/main/app/%5Blocale%5D/%5B%5B...path%5D%5D/page.tsx#L105C18-L105C18), it looks like the pathname is prefixed with slash `/`. So it must be `/blog/year-2023` for example.

## Validation

Tested on my local:

https://github.com/rizqirizqi/nodejs.org/assets/6806365/57f572ca-27bb-4d03-95c9-b5377a055d4a

## Related Issues

-

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
