### PR TITLE
Updation of Nodejs package available for OpenSUSE TumbleWeed

### DIFF
--- a/pages/en/download/package-manager.md
+++ b/pages/en/download/package-manager.md
@@ -320,7 +320,7 @@ pkg_add node
 Node.js is available in the main repositories under the following packages:
 
 - **openSUSE Leap 15.2**: `nodejs10`, `nodejs12`, `nodejs14`
-- **openSUSE Tumbleweed**: `nodejs21`
+- **openSUSE Tumbleweed**: `nodejs20`
 - **SUSE Linux Enterprise Server (SLES) 12**: `nodejs10`, `nodejs12`, and `nodejs14`
   (The "Web and Scripting Module" must be [enabled](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP5/#intro-modulesExtensionsRelated).)
 - **SUSE Linux Enterprise Server (SLES) 15 SP2**: `nodejs10`, `nodejs12`, and `nodejs14`

--- a/pages/en/download/package-manager.md
+++ b/pages/en/download/package-manager.md
@@ -320,7 +320,7 @@ pkg_add node
 Node.js is available in the main repositories under the following packages:
 
 - **openSUSE Leap 15.2**: `nodejs10`, `nodejs12`, `nodejs14`
-- **openSUSE Tumbleweed**: `nodejs16`
+- **openSUSE Tumbleweed**: `nodejs21`
 - **SUSE Linux Enterprise Server (SLES) 12**: `nodejs10`, `nodejs12`, and `nodejs14`
   (The "Web and Scripting Module" must be [enabled](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP5/#intro-modulesExtensionsRelated).)
 - **SUSE Linux Enterprise Server (SLES) 15 SP2**: `nodejs10`, `nodejs12`, and `nodejs14`


### PR DESCRIPTION
## Description

This PR changes the version of the Nodejs package listed for OpenSUSE Tumbleweed from nodejs14 to nodejs21 

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
![nodejsupdated](https://github.com/nodejs/nodejs.org/assets/61793278/e2ddff8f-ebbf-4553-b6ba-3ce0e418f568)
Change made reflected in local build
## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this checklist to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
