### PR TITLE
hotfix: properly fallback to most recent year with blog posts

### DIFF
--- a/app/[locale]/next-data/blog-data/[category]/route.ts
+++ b/app/[locale]/next-data/blog-data/[category]/route.ts
@@ -12,12 +12,9 @@ type StaticParams = { params: { category: string; locale: string } };
 // this includes the `year-XXXX` categories for yearly archives (pagination)
 // @see https://nextjs.org/docs/app/building-your-application/routing/router-handlers
 export const GET = async (_: Request, { params }: StaticParams) => {
-  const { posts, pagination } = await provideBlogData(params.category);
+  const data = await provideBlogData(params.category);
 
-  return Response.json(
-    { posts, pagination },
-    { status: posts.length ? 200 : 404 }
-  );
+  return Response.json(data, { status: data.posts.length ? 200 : 404 });
 };
 
 // This function generates the static paths that come from the dynamic segments

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -7,7 +7,6 @@ import { Time } from '@/components/Common/Time';
 import Link from '@/components/Link';
 import Pagination from '@/components/Pagination';
 import getBlogData from '@/next-data/blogData';
-import type { BlogDataRSC } from '@/types';
 
 const getCategoryData = async (pathname: string) => {
   // We split the pathname to retrieve the blog category from it since the
@@ -27,10 +26,10 @@ const getCategoryData = async (pathname: string) => {
   // or, if there is no category in the URL,
   //   which happens when we're on the blog overview page (index),
   // then we return the most recent year with blog posts
-  let year = new Date().getFullYear() + 1;
-  let data: BlogDataRSC | undefined;
-  while (!data || (data.posts.length === 0 && year)) {
-    year -= 1;
+  let year = new Date().getFullYear();
+  let data = await getBlogData(`year-${year}`);
+  if (!data.posts.length && data.meta.pagination.length) {
+    year = Math.max(...data.meta.pagination);
     data = await getBlogData(`year-${year}`);
   }
   return {

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -22,14 +22,19 @@ const getCategoryData = async (pathname: string) => {
   //   which should not happen (as this hook should only be used in blog pages),
   // or, if there is no category in the URL,
   //   which happens when we're on the blog overview page (index),
-  // then we return the most recent year with blog posts
+  // then we attempt to get the posts for the current year
   // @TODO: Year-based pagination is deprecated and going away soon
   let year = `year-${new Date().getFullYear()}`;
   let data = await getBlogData(year);
+
+  // If there are no posts in the current year,
+  //   and there is at least one year in the pagination array,
+  // we'll get the posts for the most recent year
   if (!data.posts.length && data.meta.pagination.length) {
     year = `year-${Math.max(...data.meta.pagination)}`;
     data = await getBlogData(year);
   }
+
   return { ...data, category: year };
 };
 

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -7,23 +7,36 @@ import { Time } from '@/components/Common/Time';
 import Link from '@/components/Link';
 import Pagination from '@/components/Pagination';
 import getBlogData from '@/next-data/blogData';
+import type { BlogDataRSC } from '@/types';
 
-const getCurrentCategory = (pathname: string) => {
+const getCategoryData = async (pathname: string) => {
   // We split the pathname to retrieve the blog category from it since the
   // URL is usually /blog/{category} the second path piece is usually the
   // category name, which usually year-YYYY
   const [, _pathname, category] = pathname.split('/');
-
   if (_pathname === 'blog' && category && category.length) {
-    return category;
+    const data = await getBlogData(category);
+    return {
+      ...data,
+      category,
+    };
   }
 
-  // if either the pathname does not match to a blog page
-  // which should not happen (as this hook should only be used in blog pages)
-  // or if there is no category in the URL we return the previous year as category name
-  // which is always the default category (for example, the blog index)
-  // see https://github.com/nodejs/nodejs.org/issues/6205 for a permanent solution
-  return `year-${new Date().getFullYear() - 1}`;
+  // If the pathname does not match to a blog page,
+  //   which should not happen (as this hook should only be used in blog pages),
+  // or, if there is no category in the URL,
+  //   which happens when we're on the blog overview page (index),
+  // then we return the most recent year with blog posts
+  let year = new Date().getFullYear() + 1;
+  let data: BlogDataRSC | undefined;
+  while (!data || (data.posts.length === 0 && year)) {
+    year -= 1;
+    data = await getBlogData(`year-${year}`);
+  }
+  return {
+    ...data,
+    category: `year-${year}`,
+  };
 };
 
 // This is a React Async Server Component
@@ -31,22 +44,21 @@ const getCurrentCategory = (pathname: string) => {
 // Async Components do not get re-rendered at all.
 const BlogCategoryLayout: FC = async () => {
   const { frontmatter, pathname } = getClientContext();
-  const category = getCurrentCategory(pathname);
 
   const t = await getTranslations();
 
-  const { posts, pagination } = await getBlogData(category);
+  const { posts, pagination, category } = await getCategoryData(pathname);
 
   // This only applies if current category is a year category
   const year = category.replace('year-', '');
-
   const title = category.startsWith('year-')
     ? t('layouts.blogIndex.currentYear', { year })
     : frontmatter.title;
 
   // This ensures that whenever we're running on dynamic generation (SSG)
   // that invalid categories or categories/pages without posts will redirect to the 404 page
-  if (posts.length === 0) {
+  // however, the blog overview page (index) will always be generated, even if there are no posts
+  if (posts.length === 0 && pathname !== '/blog') {
     return notFound();
   }
 

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -23,6 +23,7 @@ const getCategoryData = async (pathname: string) => {
   // or, if there is no category in the URL,
   //   which happens when we're on the blog overview page (index),
   // then we return the most recent year with blog posts
+  // @TODO: Year-based pagination is deprecated and going away soon
   let year = `year-${new Date().getFullYear()}`;
   let data = await getBlogData(year);
   if (!data.posts.length && data.meta.pagination.length) {

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -23,13 +23,13 @@ const getCategoryData = async (pathname: string) => {
   // or, if there is no category in the URL,
   //   which happens when we're on the blog overview page (index),
   // then we return the most recent year with blog posts
-  let year = new Date().getFullYear();
-  let data = await getBlogData(`year-${year}`);
+  let year = `year-${new Date().getFullYear()}`;
+  let data = await getBlogData(year);
   if (!data.posts.length && data.meta.pagination.length) {
-    year = Math.max(...data.meta.pagination);
-    data = await getBlogData(`year-${year}`);
+    year = `year-${Math.max(...data.meta.pagination)}`;
+    data = await getBlogData(year);
   }
-  return { ...data, category: `year-${year}` };
+  return { ...data, category: year };
 };
 
 // This is a React Async Server Component

--- a/layouts/BlogCategoryLayout.tsx
+++ b/layouts/BlogCategoryLayout.tsx
@@ -15,10 +15,7 @@ const getCategoryData = async (pathname: string) => {
   const [, _pathname, category] = pathname.split('/');
   if (_pathname === 'blog' && category && category.length) {
     const data = await getBlogData(category);
-    return {
-      ...data,
-      category,
-    };
+    return { ...data, category };
   }
 
   // If the pathname does not match to a blog page,
@@ -32,10 +29,7 @@ const getCategoryData = async (pathname: string) => {
     year = Math.max(...data.meta.pagination);
     data = await getBlogData(`year-${year}`);
   }
-  return {
-    ...data,
-    category: `year-${year}`,
-  };
+  return { ...data, category: `year-${year}` };
 };
 
 // This is a React Async Server Component


### PR DESCRIPTION
## Description

Follow-up to #6206 that properly handles falling back to the most recent year with blog posts if we're on the blog index page.

As part of this, this fixes up the `blog-data` JSON routes, so that the data returned that is later consumed by the `getBlogData` method actually contains everything that TypeScript proclaims it should have based on the `BlogDataRSC` type (previously, `meta` was missing).

## Validation

By default on this branch, `/blog` should show 2023 posts. The "older" link will take you to 2022. Attempting to navigate to `/blog/year-2024` will correctly show a 404.

If you edit a post to have a 2024 date and restart, `/blog` should now show the 2024 posts. The "older" link will take you to 2023. Navigating to `/blog/year-2024` will work as expected.

## Related Issues

Closes #6207

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
