### PR TITLE
fix: de-emphasize copy to clipboard button

### DIFF
--- a/components/Common/Button/index.module.css
+++ b/components/Common/Button/index.module.css
@@ -9,6 +9,26 @@
     @apply cursor-not-allowed;
   }
 
+  &.neutral {
+    @apply rounded
+      bg-neutral-900
+      text-white
+      dark:text-neutral-200;
+
+    &:hover {
+      @apply bg-neutral-800;
+    }
+
+    &[aria-disabled='true'] {
+      @apply bg-neutral-900
+        opacity-50;
+    }
+
+    &:focus {
+      @apply bg-neutral-800;
+    }
+  }
+
   &.primary {
     @apply rounded
       border

--- a/components/Common/Button/index.stories.tsx
+++ b/components/Common/Button/index.stories.tsx
@@ -5,6 +5,14 @@ import Button from '@/components/Common/Button';
 type Story = StoryObj<typeof Button>;
 type Meta = MetaObj<typeof Button>;
 
+export const Neutral: Story = {
+  args: {
+    kind: 'neutral',
+    children: 'Download Node (LTS)',
+    disabled: false,
+  },
+};
+
 export const Primary: Story = {
   args: {
     kind: 'primary',

--- a/components/Common/Button/index.tsx
+++ b/components/Common/Button/index.tsx
@@ -6,7 +6,7 @@ import Link from '@/components/Link';
 import styles from './index.module.css';
 
 type ButtonProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  kind?: 'primary' | 'secondary' | 'special';
+  kind?: 'neutral' | 'primary' | 'secondary' | 'special';
   // We have an extra `disabled` prop as we simulate a button
   disabled?: boolean;
 };

--- a/components/Common/CodeBox/index.module.css
+++ b/components/Common/CodeBox/index.module.css
@@ -67,18 +67,11 @@
 
     & > .action {
       @apply flex
-        cursor-pointer
         items-center
         gap-2
-        border-none
-        bg-neutral-900
         px-3
         py-1.5
         font-medium;
-
-      &:hover {
-        @apply bg-neutral-800;
-      }
     }
   }
 }

--- a/components/Common/CodeBox/index.module.css
+++ b/components/Common/CodeBox/index.module.css
@@ -70,8 +70,15 @@
         cursor-pointer
         items-center
         gap-2
+        border-none
+        bg-neutral-900
         px-3
-        py-1.5;
+        py-1.5
+        font-medium;
+
+      &:hover {
+        @apply bg-neutral-800;
+      }
     }
   }
 }

--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -99,7 +99,7 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
           <span className={styles.language}>{language}</span>
 
           {showCopyButton && (
-            <Button className={styles.action} onClick={onCopy}>
+            <Button kind="neutral" className={styles.action} onClick={onCopy}>
               <DocumentDuplicateIcon className={styles.icon} />
               {t('components.common.codebox.copy')}
             </Button>

--- a/layouts/New/layouts.module.css
+++ b/layouts/New/layouts.module.css
@@ -29,10 +29,10 @@
       bg-gradient-subtle
       p-12
       grid-in-[main]
+      dark:bg-gradient-subtle-dark
       xl:px-18
       xs:bg-none
       xs:p-4
-      dark:bg-gradient-subtle-dark
       xs:dark:bg-none;
   }
 
@@ -104,8 +104,8 @@
           @apply text-center
             text-sm
             text-neutral-800
-            xs:text-xs
-            dark:text-neutral-400;
+            dark:text-neutral-400
+            xs:text-xs;
         }
       }
     }
@@ -139,8 +139,8 @@
     w-full
     justify-center
     bg-gradient-subtle
-    xs:bg-none
     dark:bg-gradient-subtle-dark
+    xs:bg-none
     xs:dark:bg-none;
 
   main {
@@ -177,11 +177,11 @@
       bg-gradient-subtle
       px-4
       py-14
+      dark:bg-gradient-subtle-dark
       md:px-14
       lg:px-28
       xs:bg-none
       xs:pb-4
-      dark:bg-gradient-subtle-dark
       xs:dark:bg-none;
 
     main {

--- a/layouts/New/layouts.module.css
+++ b/layouts/New/layouts.module.css
@@ -29,10 +29,10 @@
       bg-gradient-subtle
       p-12
       grid-in-[main]
-      dark:bg-gradient-subtle-dark
       xl:px-18
       xs:bg-none
       xs:p-4
+      dark:bg-gradient-subtle-dark
       xs:dark:bg-none;
   }
 
@@ -104,44 +104,31 @@
           @apply text-center
             text-sm
             text-neutral-800
-            dark:text-neutral-400
-            xs:text-xs;
+            xs:text-xs
+            dark:text-neutral-400;
         }
       }
     }
 
     &:nth-of-type(2) {
       @apply flex
-        max-w-md
-        flex-[1_1]
-        flex-col
-        items-center
-        gap-4
-        md:max-w-2xl
-        lg:max-w-3xl;
+          max-w-md
+          flex-[1_1]
+          flex-col
+          items-center
+          gap-4
+          md:max-w-2xl
+          lg:max-w-3xl;
 
       > div {
         @apply w-fit;
-
-        div[data-state='active'] a {
-          @apply border-none
-            bg-neutral-900
-            px-3
-            py-1.5
-            text-sm
-            font-medium;
-
-          &:hover {
-            @apply bg-neutral-800;
-          }
-        }
       }
 
       > p {
         @apply text-center
-          text-sm
-          text-neutral-800
-          dark:text-neutral-200;
+            text-sm
+            text-neutral-800
+            dark:text-neutral-200;
       }
     }
   }
@@ -152,8 +139,8 @@
     w-full
     justify-center
     bg-gradient-subtle
-    dark:bg-gradient-subtle-dark
     xs:bg-none
+    dark:bg-gradient-subtle-dark
     xs:dark:bg-none;
 
   main {
@@ -190,11 +177,11 @@
       bg-gradient-subtle
       px-4
       py-14
-      dark:bg-gradient-subtle-dark
       md:px-14
       lg:px-28
       xs:bg-none
       xs:pb-4
+      dark:bg-gradient-subtle-dark
       xs:dark:bg-none;
 
     main {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

De-emphasizes the copy to clipboard button. also removed the homepage customization. yes, this is a deviation of the figma- but now met with real content, especially repeated examples are distracting. this is a tertiary act for the site, it should not have primary/action color

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

same homepage

![image](https://github.com/nodejs/nodejs.org/assets/298435/3d0e9f2a-9eb3-43b6-a403-0b3acac45255)

less busy examples within content

| Old | New |
| - | - |
| ![image](https://github.com/nodejs/nodejs.org/assets/298435/d8c5159c-1530-46e3-a1bd-e770afe6e056)  |![image](https://github.com/nodejs/nodejs.org/assets/298435/c725123d-77dd-4151-8d50-75639bfcc208) |





## Related Issues

closes #6244

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
