### PR TITLE
meta: remove nodejs/collaborators from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,9 +13,6 @@ next.dynamic.mjs @nodejs/web-infra
 /pages/en/blog/release @nodejs/releasers
 /pages/en/blog/announcements @nodejs/releasers
 
-# Node.js Core Guides
-/pages/en/guides @nodejs/collaborators
-
 # Package Ecosystem
 package.json @nodejs/nodejs-website
 turbo.json @nodejs/nodejs-website @nodejs/web-infra


### PR DESCRIPTION
Mentioning nodejs/collaborators on every `/pages/en/guides` change is extremely frustrating for people who don't want to get notified, or has already a huge amount of notifications in their backlog. Rather than being `opt-out`, I **strongly** believe that this should be an `opt-in` thing. Basically, whenever the Node.js website team wants/interested in asking for opinion, they should request a review from the appropriate team, or depending on the severity from TSC.

cc @nodejs/tsc 