### PR TITLE
feat: Button component with icon

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { captureException } from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
@@ -37,7 +38,10 @@ const ErrorPage: FC<{ error: Error }> = ({ error }) => {
         <p className="-mt-4 max-w-sm text-center text-lg">
           {t('layouts.error.internalServerError.description')}
         </p>
-        <Button href="/">{t('layouts.error.backToHome')}</Button>
+        <Button href="/">
+          {t('layouts.error.backToHome')}
+          <ArrowRightIcon />
+        </Button>
       </main>
     </CenteredLayout>
   );

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
@@ -32,7 +33,10 @@ const NotFoundPage: FC = () => {
         <p className="-mt-4 max-w-sm text-center text-lg">
           {t('layouts.error.notFound.description')}
         </p>
-        <Button href="/">{t('layouts.error.backToHome')}</Button>
+        <Button href="/">
+          {t('layouts.error.backToHome')}
+          <ArrowRightIcon />
+        </Button>
       </main>
     </CenteredLayout>
   );

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { captureException } from '@sentry/nextjs';
 import ErrorComponent from 'next/error';
 import type { FC } from 'react';
@@ -39,7 +40,10 @@ const GlobalErrorPage: FC<{ error: Error }> = ({ error }) => {
               <p className="-mt-4 max-w-sm text-center text-lg">
                 This page has thrown a non-recoverable error.
               </p>
-              <Button href="/">Back to Home</Button>
+              <Button href="/">
+                Back to Home
+                <ArrowRightIcon />
+              </Button>
             </main>
           </CenteredLayout>
         </BaseLayout>

--- a/components/Common/Button/index.module.css
+++ b/components/Common/Button/index.module.css
@@ -1,9 +1,16 @@
 .button {
   @apply relative
+    inline-flex
+    items-center
+    gap-2
     px-4.5
     py-2.5
     text-center
     font-semibold;
+
+  svg {
+    @apply size-5;
+  }
 
   &[aria-disabled='true'] {
     @apply cursor-not-allowed;

--- a/components/Common/Button/index.stories.tsx
+++ b/components/Common/Button/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ClipboardDocumentCheckIcon } from '@heroicons/react/24/solid';
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
 import Button from '@/components/Common/Button';
@@ -17,12 +17,7 @@ export const Neutral: Story = {
 export const Primary: Story = {
   args: {
     kind: 'primary',
-    children: (
-      <>
-        Download Node (LTS)
-        <ClipboardDocumentCheckIcon />
-      </>
-    ),
+    children: 'Download Node (LTS)',
     disabled: false,
   },
 };
@@ -48,8 +43,8 @@ export const WithIcon: Story = {
     kind: 'primary',
     children: (
       <>
-        Copy to clipboard
-        <ClipboardDocumentCheckIcon />
+        Back to Home
+        <ArrowRightIcon />
       </>
     ),
     disabled: false,

--- a/components/Common/Button/index.stories.tsx
+++ b/components/Common/Button/index.stories.tsx
@@ -1,3 +1,4 @@
+import { ClipboardDocumentCheckIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
 import Button from '@/components/Common/Button';
@@ -16,7 +17,12 @@ export const Neutral: Story = {
 export const Primary: Story = {
   args: {
     kind: 'primary',
-    children: 'Download Node (LTS)',
+    children: (
+      <>
+        Download Node (LTS)
+        <ClipboardDocumentCheckIcon />
+      </>
+    ),
     disabled: false,
   },
 };
@@ -33,6 +39,19 @@ export const Special: Story = {
   args: {
     kind: 'special',
     children: 'Download Node (LTS)',
+    disabled: false,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    kind: 'primary',
+    children: (
+      <>
+        Copy to clipboard
+        <ClipboardDocumentCheckIcon />
+      </>
+    ),
     disabled: false,
   },
 };

--- a/components/Common/CodeBox/index.module.css
+++ b/components/Common/CodeBox/index.module.css
@@ -66,10 +66,7 @@
     }
 
     & > .action {
-      @apply flex
-        items-center
-        gap-2
-        px-3
+      @apply px-3
         py-1.5
         font-medium;
     }

--- a/components/Common/Pagination/index.module.css
+++ b/components/Common/Pagination/index.module.css
@@ -10,10 +10,7 @@
 
 .previousButton,
 .nextButton {
-  @apply flex
-    items-center
-    gap-2
-    text-sm;
+  @apply text-sm;
 }
 
 .previousButton {

--- a/components/Downloads/DownloadButton/index.module.css
+++ b/components/Downloads/DownloadButton/index.module.css
@@ -1,11 +1,17 @@
 .downloadButton {
-  @apply flex-row
-    items-center
-    justify-center
-    gap-2;
+  @apply justify-center;
+
+  &.primary {
+    @apply inline-flex
+      dark:hidden;
+  }
+
+  &.special {
+    @apply hidden
+      dark:inline-flex;
+  }
 
   svg {
-    @apply size-5
-      dark:opacity-50;
+    @apply dark:opacity-50;
   }
 }

--- a/components/Downloads/DownloadButton/index.tsx
+++ b/components/Downloads/DownloadButton/index.tsx
@@ -25,7 +25,7 @@ const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
       <Button
         kind="special"
         href={downloadLink}
-        className={classNames(styles.downloadButton, 'hidden dark:flex')}
+        className={classNames(styles.downloadButton, styles.special)}
       >
         {children}
 
@@ -35,7 +35,7 @@ const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
       <Button
         kind="primary"
         href={downloadLink}
-        className={classNames(styles.downloadButton, 'flex dark:hidden')}
+        className={classNames(styles.downloadButton, styles.primary)}
       >
         {children}
 


### PR DESCRIPTION
## Description

This PR provides the ability to add icons to buttons by default

Affected components;

- Codebox
- Button
- Pagination
- DownloadButton

Affected pages;

- Not Found
- Error
- Global Error
- Home
- Blog Listing


## Validation

The pages/components should work and look same on local deployments with `npm run serve:redesign`

## Related Issues

fixes #6247, #6246

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
