### PR TITLE
meta: Is misspelling ellipsis a bug?

### DIFF
--- a/components/Common/Pagination/useGetPageElements.tsx
+++ b/components/Common/Pagination/useGetPageElements.tsx
@@ -86,7 +86,7 @@ export const useGetPageElements = (
 
     return [
       ...createPaginationListItems(leftPages),
-      <Ellipsis key="elipsis" />,
+      <Ellipsis key="ellipsis" />,
       ...createPaginationListItems(parsedPages.slice(lastIndex)),
     ];
   }
@@ -101,7 +101,7 @@ export const useGetPageElements = (
       ...createPaginationListItems(
         parsedPages.slice(firstIndex, firstIndex + 1)
       ),
-      <Ellipsis key="elipsis" />,
+      <Ellipsis key="ellipsis" />,
       ...createPaginationListItems(rightPages),
     ];
   }
@@ -116,9 +116,9 @@ export const useGetPageElements = (
       ...createPaginationListItems(
         parsedPages.slice(firstIndex, firstIndex + 1)
       ),
-      <Ellipsis key="elipsis-1" />,
+      <Ellipsis key="ellipsis-1" />,
       ...createPaginationListItems(middlePages),
-      <Ellipsis key="elipsis-2" />,
+      <Ellipsis key="ellipsis-2" />,
       ...createPaginationListItems(parsedPages.slice(lastIndex)),
     ];
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Is misspelling ellipsis in `useGetPageElements.tsx` a bug?  I am unsure if this is a typo or if it is intentional.

The left side is spelled correctly and the right side is not.
```diff
-      <Ellipsis key="elipsis" />,
+      <Ellipsis key="ellipsis" />,

-      <Ellipsis key="elipsis" />,
+      <Ellipsis key="ellipsis" />,

-      <Ellipsis key="elipsis-1" />,
+      <Ellipsis key="ellipsis-1" />,

-      <Ellipsis key="elipsis-2" />,
+      <Ellipsis key="ellipsis-2" />,
```
## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

* #6262 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this checklist to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
