### PR TITLE
fix: Update inspector redirect to learn section

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -110,7 +110,7 @@
     },
     {
       "source": "/:locale/docs/inspector",
-      "destination": "/:locale/docs/guides/debugging-getting-started"
+      "destination": "/:locale/learn/getting-started/debugging"
     },
     {
       "source": "/:locale/contribute/:path*",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates the redirect for https://nodejs.org/en/docs/inspector to the new URL of https://nodejs.org/en/learn/getting-started/debugging following https://github.com/nodejs/nodejs.org/pull/6265.

This change is necessary to fix this failure of the [internet/test-inspector-help-page](https://github.com/nodejs/node/blob/main/test/internet/test-inspector-help-page.js) test in Node.js:

```
node:assert:399
    throw err;
    ^

AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(res.statusCode >= 200 && res.statusCode < 400)

    at ClientRequest.<anonymous> (/home/zsw/node/test/internet/test-inspector-help-page.js:18:5)
    at ClientRequest.<anonymous> (/home/zsw/node/test/common/index.js:461:15)
    at Object.onceWrapper (node:events:632:26)
    at ClientRequest.emit (node:events:517:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:700:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
    at TLSSocket.socketOnData (node:_http_client:541:22)
    at TLSSocket.emit (node:events:517:28)
    at addChunk (node:internal/streams/readable:368:12)
    at readableAddChunk (node:internal/streams/readable:341:9) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '=='
}
```

The test requires that the page at https://nodejs.org/en/docs/inspector (the URL is output by running the `node --inspect -e ""` command) exists.

## Validation

- Accessing https://nodejs.org/en/docs/inspector should now redirect to https://nodejs.org/en/learn/getting-started/debugging
- The [internet/test-inspector-help-page](https://github.com/nodejs/node/blob/main/test/internet/test-inspector-help-page.js) test case should also pass.

## Related Issues

- The URL was changed by https://github.com/nodejs/nodejs.org/pull/6265.
- From discussion in https://github.com/nodejs/nodejs.org/issues/5624, it was concluded that it was better to redirect the https://nodejs.org/en/docs/inspector URL instead of updating the output of `node --inspect -e ""`.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
