### PR TITLE
fix: Redirect old debug guide URL to new URL

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -113,6 +113,10 @@
       "destination": "/:locale/learn/getting-started/debugging"
     },
     {
+      "source": "/:locale/docs/guides/debugging-getting-started",
+      "destination": "/:locale/learn/getting-started/debugging"
+    },
+    {
       "source": "/:locale/contribute/:path*",
       "destination": "/:locale/get-involved"
     },


### PR DESCRIPTION


<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add a redirect from the old URL https://nodejs.org/en/docs/guides/debugging-getting-started to the new URL at https://nodejs.org/en/learn/getting-started/debugging. 

[A GitHub search shows the old URL being widely referenced](https://github.com/search?q=https%3A%2F%2Fnodejs.org%2Fen%2Fdocs%2Fguides%2Fdebugging-getting-started&type=code).

## Validation

https://nodejs.org/en/docs/guides/debugging-getting-started/ should redirect to the new location and NOT show a 404 error page.
<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Refs: https://github.com/nodejs/nodejs.org/issues/6219
Refs: https://github.com/nodejs/nodejs.org/pull/6265
Refs: https://github.com/nodejs/nodejs.org/pull/6288
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
