### PR TITLE
feat: migrated to shiki and fixed font-family

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -455,7 +455,7 @@ MDX is becoming the standard for parsing human-content on React/Next.js-based Ap
 
 #### Syntax Highlighting (Shiki) and Vercel
 
-Shiki is integrated on our workflow as a Reype Plugin, see the `next.mdx.shiki.mjs` file. We also use the `nord` theme for Shiki and a subset of the supported languages as defined on the `shiki.config.mjs` file.
+Shiki is integrated on our workflow as a Rehype Plugin, see the `next.mdx.shiki.mjs` file. We also use the `nord` theme for Shiki and a subset of the supported languages as defined on the `shiki.config.mjs` file.
 
 ### Vercel
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -80,7 +80,7 @@ The Website also uses several other Open Source libraries (not limited to) liste
 - [Tailwind][] is used as our CSS Framework and the Foundation of our Design System
 - [Hero Icons](https://heroicons.com/) is an SVG Icon Library used within our Codebase
 - [Radix UI][] is a collection of customizable UI components
-- [Shikiji][] is a Syntax Highlighter used for our Codeboxes
+- [Shiki][] is a Syntax Highlighter used for our Codeboxes
   - The syntax highlighting is done within the processing of the Markdown files with the MDX compiler as a Rehype plugin.
 - [MDX][] and Markdown are used for structuring the Content of the Website
 - [`next-intl`][] is the i18n Library adopted within the Website
@@ -453,11 +453,9 @@ MDX is becoming the standard for parsing human-content on React/Next.js-based Ap
 - `rehype-autolink-headings`: Allows us to add Anchor Links to Markdown Headings
 - `rehype-slug`: Allows us to add IDs to Markdown Headings
 
-#### Syntax Highlighting (Shikiji) and Vercel
+#### Syntax Highlighting (Shiki) and Vercel
 
-We use [Shikiji][] which is a refactor of the famous [Shiki](https://github.com/shikijs/shiki) syntax highlighter in ESM. We use it to support our native ESM-nature, and since Shiki is incompatible on serverless environments and Edge functions due of the need of Node's `fs`. Shikiji is definitely a nice port/rewrite of Shiki which supports our needs.
-
-Shikiji is integrated on our workflow as a Reype Plugin, see the `next.mdx.shiki.mjs` file. We also use the `nord` theme for Shikiji and a subset of the supported languages as defined on the `shiki.config.mjs` file.
+Shiki is integrated on our workflow as a Reype Plugin, see the `next.mdx.shiki.mjs` file. We also use the `nord` theme for Shiki and a subset of the supported languages as defined on the `shiki.config.mjs` file.
 
 ### Vercel
 
@@ -498,6 +496,6 @@ If you're unfamiliar or curious about something, we recommend opening a Discussi
 [MDX]: https://mdxjs.com/
 [PostCSS]: https://postcss.org/
 [React]: https://react.dev/
-[Shikiji]: https://github.com/antfu/shikiji
+[Shiki]: https://github.com/shikijs/shiki
 [Tailwind]: https://tailwindcss.com/
 [Radix UI]: https://www.radix-ui.com/

--- a/components/Common/CodeBox/index.module.css
+++ b/components/Common/CodeBox/index.module.css
@@ -42,6 +42,7 @@
             mr-4
             w-4.5
             text-right
+            font-ibm-plex-mono
             text-neutral-600
             [content:counter(line)]
             [counter-increment:line];

--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -34,7 +34,7 @@ const transformCode = (code: ReactNode): ReactNode => {
   const lines = content.split('\n');
 
   return (
-    <code>
+    <code style={{ fontFamily: 'monospace' }}>
       {lines.flatMap((line, lineIndex) => {
         const columns = line.split(' ');
 

--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -31,27 +31,33 @@ const transformCode = (code: ReactNode): ReactNode => {
     return code;
   }
 
+  // Note that since we use `.split` we will have an extra entry
+  // being an empty string, so we need to remove it
   const lines = content.split('\n');
 
   return (
     <code style={{ fontFamily: 'monospace' }}>
-      {lines.flatMap((line, lineIndex) => {
-        const columns = line.split(' ');
+      {lines
+        .flatMap((line, lineIndex) => {
+          const columns = line.split(' ');
 
-        return [
-          <span key={lineIndex} className="line">
-            {columns.map((column, columnIndex) => (
-              <Fragment key={columnIndex}>
-                <span>{column}</span>
-                {columnIndex < columns.length - 1 && <span> </span>}
-              </Fragment>
-            ))}
-          </span>,
-          // Add a break line so the text content is formatted correctly
-          // when copying to clipboard
-          '\n',
-        ];
-      })}
+          return [
+            <span key={lineIndex} className="line">
+              {columns.map((column, columnIndex) => (
+                <Fragment key={columnIndex}>
+                  <span>{column}</span>
+                  {columnIndex < columns.length - 1 && <span> </span>}
+                </Fragment>
+              ))}
+            </span>,
+            // Add a break line so the text content is formatted correctly
+            // when copying to clipboard
+            '\n',
+          ];
+        })
+        // Here we remove that empty line from before and
+        // the last flatMap entry which is an `\n`
+        .slice(0, -2)}
     </code>
   );
 };

--- a/next.mdx.shiki.mjs
+++ b/next.mdx.shiki.mjs
@@ -116,11 +116,11 @@ export default function rehypeShikiji() {
 
         // This removes all the original Code Elements and adds a new CodeTab Element
         // at the original start of the first Code Element
-        parent.children.splice(index, currentIndex, codeTabElement);
+        parent.children.splice(index, currentIndex - index, codeTabElement);
 
         // Prevent visiting the code block children and for the next N Elements
         // since all of them belong to this CodeTabs Element
-        return [SKIP, currentIndex];
+        return [SKIP];
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "remark-gfm": "~4.0.0",
         "remark-reading-time": "~2.0.1",
         "semver": "~7.5.4",
-        "shikiji": "~0.9.17",
+        "shiki": "~1.1.2",
         "tailwindcss": "^3.4.0",
         "turbo": "1.12.2",
         "typescript": "~5.3.2",
@@ -5448,6 +5448,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.1.2.tgz",
+      "integrity": "sha512-ERVzNQz88ZkDqUpWeC57Kp+Kmx5RjqeDBR1M8AGWGom4yrkITiTfXCGmjchlDSw12MhDTuPYR4HVFW8uT61RaQ=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -5588,15 +5593,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.6.12.tgz",
-      "integrity": "sha512-AJFrtBj0R11OFwwz+2j+ivRzttWXT6LesSGoLnxown24EV9uLQoHtGb7GOA2GyzY5wjUJS9gQBPGHXjvQEfLJA==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.6.15.tgz",
+      "integrity": "sha512-vfpfCywiasyP7vtbgLJhjssBEwUjZhBsRsubDAzumgOochPiKKPNwsSc5NU/4ZIGaC5zRO26kUaUqFIbJdTEUQ==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "7.6.12",
-        "@storybook/manager": "7.6.12",
-        "@storybook/node-logger": "7.6.12",
+        "@storybook/core-common": "7.6.15",
+        "@storybook/manager": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
         "@types/ejs": "^3.1.1",
         "@types/find-cache-dir": "^3.2.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
@@ -5613,6 +5618,136 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-common": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.6.15.tgz",
+      "integrity": "sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/types": "7.6.15",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.5.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/node-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.15.tgz",
+      "integrity": "sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
@@ -5710,23 +5845,23 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.6.12.tgz",
-      "integrity": "sha512-x4sG1oIVERxp+WnWUexVlgaJCFmML0kGi7a5qfx7z4vHMxCV/WG7g1q7mPS/kqStCGEiQdTciCqOEFqlMh9MLw==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.6.15.tgz",
+      "integrity": "sha512-2QRqCyVGDSkraHxX2JPYkkFccbu5Uo+JYFaFJo4vmMXzDurjWON+Ga2B8FCTd4A8P4C02Ca/79jgQoyBB3xoew==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@babel/types": "^7.23.0",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "7.6.12",
-        "@storybook/core-common": "7.6.12",
-        "@storybook/core-events": "7.6.12",
-        "@storybook/core-server": "7.6.12",
-        "@storybook/csf-tools": "7.6.12",
-        "@storybook/node-logger": "7.6.12",
-        "@storybook/telemetry": "7.6.12",
-        "@storybook/types": "7.6.12",
+        "@storybook/codemod": "7.6.15",
+        "@storybook/core-common": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/core-server": "7.6.15",
+        "@storybook/csf-tools": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/telemetry": "7.6.15",
+        "@storybook/types": "7.6.15",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -5763,6 +5898,120 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-common": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.6.15.tgz",
+      "integrity": "sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/types": "7.6.15",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.5.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/node-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.15.tgz",
+      "integrity": "sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@storybook/cli/node_modules/chalk": {
@@ -5819,18 +6068,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.6.12.tgz",
-      "integrity": "sha512-4EI4Ah1cvz6gFkXOS/LGf23oN8LO6ABGpWwPQoMHpIV3wUkFWBwrKFUe/UAQZGptnM0VZRYx4grS82Hluw4XJA==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.6.15.tgz",
+      "integrity": "sha512-NiEbTLCdacj6TMxC7G49IImXeMzkG8wpPr8Ayxm9HeG6q5UkiF5/DiZdqbJm2zaosOsOKWwvXg1t6Pq6Nivytg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@babel/types": "^7.23.0",
         "@storybook/csf": "^0.1.2",
-        "@storybook/csf-tools": "7.6.12",
-        "@storybook/node-logger": "7.6.12",
-        "@storybook/types": "7.6.12",
+        "@storybook/csf-tools": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/types": "7.6.15",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
         "globby": "^11.0.2",
@@ -5838,6 +6087,76 @@
         "lodash": "^4.17.21",
         "prettier": "^2.8.0",
         "recast": "^0.23.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/node-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.15.tgz",
+      "integrity": "sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6128,26 +6447,26 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.6.12.tgz",
-      "integrity": "sha512-tjWifKsDnIc8pvbjVyQrOHef70Gcp93Bg3WwuysB8PGk7lcX2RD9zv44HNIyjxdOLSSv66IGKrOldEBL3hab4w==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.6.15.tgz",
+      "integrity": "sha512-iIlxEAkrmKTSA3iGNqt/4QG7hf5suxBGYIB3DZAOfBo8EdZogMYaEmuCm5dbuaJr0mcVwlqwdhQiWb1VsR/NhA==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "7.6.12",
-        "@storybook/channels": "7.6.12",
-        "@storybook/core-common": "7.6.12",
-        "@storybook/core-events": "7.6.12",
+        "@storybook/builder-manager": "7.6.15",
+        "@storybook/channels": "7.6.15",
+        "@storybook/core-common": "7.6.15",
+        "@storybook/core-events": "7.6.15",
         "@storybook/csf": "^0.1.2",
-        "@storybook/csf-tools": "7.6.12",
+        "@storybook/csf-tools": "7.6.15",
         "@storybook/docs-mdx": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "7.6.12",
-        "@storybook/node-logger": "7.6.12",
-        "@storybook/preview-api": "7.6.12",
-        "@storybook/telemetry": "7.6.12",
-        "@storybook/types": "7.6.12",
+        "@storybook/manager": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/preview-api": "7.6.15",
+        "@storybook/telemetry": "7.6.15",
+        "@storybook/types": "7.6.15",
         "@types/detect-port": "^1.3.0",
         "@types/node": "^18.0.0",
         "@types/pretty-hrtime": "^1.0.0",
@@ -6180,10 +6499,141 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-common": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.6.15.tgz",
+      "integrity": "sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/types": "7.6.15",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.5.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/node-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.15.tgz",
+      "integrity": "sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/preview-api": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.15.tgz",
+      "integrity": "sha512-2KN9vlizF6sFlYsJEGnFqcQaJXs4TTdawC1VazVdtaMSHANDxxDu8F1cP+u7lpPH3DkNZUmTGQDBYfYY9xR0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "7.6.15",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-      "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -6241,9 +6691,9 @@
       }
     },
     "node_modules/@storybook/csf-tools": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.12.tgz",
-      "integrity": "sha512-MdhkYYxSW5I6Jpk34gTkAZsuj9sxe0xdyeUQpNa8CgJxG43F+ehZ6scW/IPjoSG9gCXBUJMekq26UrmbVfsLCQ==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.15.tgz",
+      "integrity": "sha512-8iKgg2cmbFTpVhRRJOqouhPcEh0c8ywabG4S8ICZvnJooSXUI9mD9p3tYCS7MYuSiHj0epa1Kkn9DtXJRo9o6g==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.23.0",
@@ -6251,10 +6701,70 @@
         "@babel/traverse": "^7.23.2",
         "@babel/types": "^7.23.0",
         "@storybook/csf": "^0.1.2",
-        "@storybook/types": "7.6.12",
+        "@storybook/types": "7.6.15",
         "fs-extra": "^11.1.0",
         "recast": "^0.23.1",
         "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6293,9 +6803,9 @@
       "dev": true
     },
     "node_modules/@storybook/manager": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.6.12.tgz",
-      "integrity": "sha512-WMWvswJHGiqJFJb98WQMQfZQhLuVtmci4y/VJGQ/Jnq1nJQs76BCtaeGiHcsYmRaAP1HMI4DbzuTSEgca146xw==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.6.15.tgz",
+      "integrity": "sha512-GGV2ElV5AOIApy/FSDzoSlLUbyd2VhQVD3TdNGRxNauYRjEO8ulXHw2tNbT6ludtpYpDTAILzI6zT/iag8hmPQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6678,14 +7188,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.6.12.tgz",
-      "integrity": "sha512-eBG3sLb9CZ05pyK2JXBvnaAsxDzbZH57VyhtphhuZmx0DqF/78qIoHs9ebRJpJWV0sL5rtT9vIq8QXpQhDHLWg==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.6.15.tgz",
+      "integrity": "sha512-klhKXLUS3OXozGEtMbbhKZLDfm+m3nNk2jvGwD6kkBenzFUzb0P2m8awxU7h1pBcKZKH/27U9t3KVzNFzWoWPw==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.6.12",
-        "@storybook/core-common": "7.6.12",
-        "@storybook/csf-tools": "7.6.12",
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-common": "7.6.15",
+        "@storybook/csf-tools": "7.6.15",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -6695,6 +7205,120 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/channels": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.15.tgz",
+      "integrity": "sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.15",
+        "@storybook/core-events": "7.6.15",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/client-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.15.tgz",
+      "integrity": "sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-common": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.6.15.tgz",
+      "integrity": "sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.15",
+        "@storybook/node-logger": "7.6.15",
+        "@storybook/types": "7.6.15",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.5.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-events": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.15.tgz",
+      "integrity": "sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/node-logger": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.15.tgz",
+      "integrity": "sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/types": {
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.15.tgz",
+      "integrity": "sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.15",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@storybook/telemetry/node_modules/chalk": {
@@ -20966,9 +21590,9 @@
       }
     },
     "node_modules/node-fetch-native": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.1.tgz",
-      "integrity": "sha512-bW9T/uJDPAJB2YNYEpWzE54U5O3MQidXsOyTfnbKYtTtFexRvGzb1waphBN4ZwP6EcIvYYEOwW0b72BpAqydTw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.2.tgz",
+      "integrity": "sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==",
       "dev": true
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -30551,18 +31175,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/shikiji": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
-      "integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
+    "node_modules/shiki": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.2.tgz",
+      "integrity": "sha512-qNzFwTv5uhEDNUIwp7wHjsrffVeLbmOgWnM5mZZhoiz7G2qAUvqVfUzuWfieD45/YAKipzCtdV9SndacKtABow==",
       "dependencies": {
-        "shikiji-core": "0.9.19"
+        "@shikijs/core": "1.1.2"
       }
-    },
-    "node_modules/shikiji-core": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
-      "integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -30767,9 +31386,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
     },
     "node_modules/sprintf-js": {
@@ -30851,12 +31470,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "7.6.12",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.6.12.tgz",
-      "integrity": "sha512-zcH9CwIsE8N4PX3he5vaJ3mTTWGxu7cxJ/ag9oja/k3N5/IvQjRyIU1TLkRVb28BB8gaLyorpnc4C4aLVGy4WQ==",
+      "version": "7.6.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.6.15.tgz",
+      "integrity": "sha512-Ybezq9JRk5CBhzjgzZ/oT7mnU45UwhyVSGKW+PUKZGGUG9VH2hCrTEES9f/zEF82kj/5COVPyqR/5vlXuuS39A==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "7.6.12"
+        "@storybook/cli": "7.6.15"
       },
       "bin": {
         "sb": "index.js",
@@ -32710,9 +33329,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
-      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
+      "integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==",
       "dev": true
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "remark-gfm": "~4.0.0",
     "remark-reading-time": "~2.0.1",
     "semver": "~7.5.4",
-    "shikiji": "~0.9.17",
+    "shiki": "~1.1.2",
     "tailwindcss": "^3.4.0",
     "turbo": "1.12.2",
     "typescript": "~5.3.2",

--- a/pages/en/guides/event-loop-timers-and-nexttick.md
+++ b/pages/en/guides/event-loop-timers-and-nexttick.md
@@ -242,7 +242,7 @@ setImmediate(() => {
 });
 ```
 
-```
+```bash
 $ node timeout_vs_immediate.js
 timeout
 immediate
@@ -269,7 +269,7 @@ fs.readFile(__filename, () => {
 });
 ```
 
-```
+```bash
 $ node timeout_vs_immediate.js
 immediate
 timeout

--- a/shiki.config.mjs
+++ b/shiki.config.mjs
@@ -1,20 +1,15 @@
 'use strict';
 
-/**
- * READ: This file allows us to configure a subset of languages that we want to support on the Node.js Website
- * we use `shikiji` which is an ESM-only rewrite of Shiki
- */
+import diffLanguage from 'shiki/langs/diff.mjs';
+import dockerLanguage from 'shiki/langs/docker.mjs';
+import javaScriptLanguage from 'shiki/langs/javascript.mjs';
+import jsonLanguage from 'shiki/langs/json.mjs';
+import shellScriptLanguage from 'shiki/langs/shellscript.mjs';
+import shellSessionLanguage from 'shiki/langs/shellsession.mjs';
+import typeScriptLanguage from 'shiki/langs/typescript.mjs';
+import shikiNordTheme from 'shiki/themes/nord.mjs';
 
-import diffLanguage from 'shikiji/langs/diff.mjs';
-import dockerLanguage from 'shikiji/langs/docker.mjs';
-import javaScriptLanguage from 'shikiji/langs/javascript.mjs';
-import jsonLanguage from 'shikiji/langs/json.mjs';
-import shellScriptLanguage from 'shikiji/langs/shellscript.mjs';
-import shellSessionLanguage from 'shikiji/langs/shellsession.mjs';
-import typeScriptLanguage from 'shikiji/langs/typescript.mjs';
-import shikiNordTheme from 'shikiji/themes/nord.mjs';
-
-/** @type {Array<import('shikiji').LanguageRegistration>} */
+/** @type {Array<import('shiki').LanguageRegistration>} */
 export const LANGUAGES = [
   {
     ...javaScriptLanguage[0],

--- a/util/getHighlighter.ts
+++ b/util/getHighlighter.ts
@@ -1,5 +1,5 @@
-import { getHighlighterCore } from 'shikiji/core';
-import { getWasmInlined } from 'shikiji/wasm';
+import { getHighlighterCore } from 'shiki/core';
+import getWasm from 'shiki/wasm';
 
 import { LANGUAGES, DEFAULT_THEME } from '@/shiki.config.mjs';
 
@@ -7,7 +7,7 @@ import { LANGUAGES, DEFAULT_THEME } from '@/shiki.config.mjs';
 const memoizedShikiji = await getHighlighterCore({
   themes: [DEFAULT_THEME],
   langs: LANGUAGES,
-  loadWasm: getWasmInlined,
+  loadWasm: getWasm,
 });
 
 export const highlightToHtml = (code: string, language: string) =>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR migrates us back to Shiki as Shikiji (the ESM-rewrite) got ported back to Shiki itself.
This PR also fixes that CodeBoxes without any specific language to highlight (default plain text) should not use th IBM-Plex font as it breaks plain text.

## Validation

Syntax Highlighting and Codeboxes should still work as usual

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes https://github.com/nodejs/nodejs.org/issues/6337