### PR TITLE
fix(minor): Bash script on downloads page uses a command that is not installed on Mac

### DIFF
--- a/pages/en/download/package-manager.md
+++ b/pages/en/download/package-manager.md
@@ -156,7 +156,7 @@ Download the [macOS Installer](/#home-downloadhead) directly from the [nodejs.or
 _If you want to download the package with bash:_
 
 ```bash
-curl -O "https://nodejs.org/dist/latest/$(curl -s https://nodejs.org/dist/latest/ | grep "pkg" | cut -d'"' -f 2)" -o "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
+curl "https://nodejs.org/dist/latest/$(curl -s https://nodejs.org/dist/latest/ | grep "pkg" | cut -d'"' -f 2)" -o "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
 ```
 
 ### Alternatives

--- a/pages/en/download/package-manager.md
+++ b/pages/en/download/package-manager.md
@@ -156,7 +156,7 @@ Download the [macOS Installer](/#home-downloadhead) directly from the [nodejs.or
 _If you want to download the package with bash:_
 
 ```bash
-curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
+curl -O "https://nodejs.org/dist/latest/$(curl -s https://nodejs.org/dist/latest/ | grep "pkg" | cut -d'"' -f 2)" -o "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
 ```
 
 ### Alternatives


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I made this issue (#3758) about three years ago and then forgot about it. Not knowing how to fix it, I left the solution as a comment and hoped someone would figure it out. Today, I received two emails about comments reminding me about this minor issue. Now knowing a bit more about Git, I've decided that it's finally time to put this issue to rest.
So long...
(this description is longer than the fix lol)

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
The package was downloaded and successfully installed to /usr/local/bin. Running node -v confirmed that v21.6.2 was installed.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #3758

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- [X] I've covered new added functionality with unit tests if necessary.
