### PR TITLE
docs(learn): Migrate the node.js event-loop, timers and process.nextTick() to the learn 

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -54,7 +54,8 @@
             "discoverJavaScriptTimers": "Discover JavaScript Timers",
             "understandingProcessnexttick": "Understanding process.nextTick()",
             "understandingSetimmediate": "Understanding setImmediate()",
-            "theNodejsEventEmitter": "The Node.js Event emitter"
+            "theNodejsEventEmitter": "The Node.js Event emitter",
+            "eventLoopTimersAndProcessnexttick": "Event Loop, Timers, and process.nextTick()"
           }
         },
         "manipulatingFiles": {

--- a/navigation.json
+++ b/navigation.json
@@ -165,6 +165,10 @@
             "theNodejsEventEmitter": {
               "link": "/learn/asynchronous-work/the-nodejs-event-emitter",
               "label": "components.navigation.learn.asynchronousWork.links.theNodejsEventEmitter"
+            },
+            "eventLoopTimersAndProcessnexttick": {
+              "link": "/learn/asynchronous-work/event-loop-timers-and-nexttick",
+              "label": "components.navigation.learn.asynchronousWork.links.eventLoopTimersAndProcessnexttick"
             }
           }
         },

--- a/pages/en/guides/index.md
+++ b/pages/en/guides/index.md
@@ -9,7 +9,6 @@ layout: docs.hbs
 
 ## Node.js core concepts
 
-- [The Node.js Event Loop, Timers, and `process.nextTick()`](/guides/event-loop-timers-and-nexttick/)
 - [Don't Block the Event Loop (or the Worker Pool)](/guides/dont-block-the-event-loop/)
 
 ## Module-related guides

--- a/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -449,7 +449,7 @@ Another example is extending an `EventEmitter` and emitting an
 event from within the constructor:
 
 ```js
-const EventEmitter = require('events');
+const EventEmitter = require('node:events');
 
 class MyEmitter extends EventEmitter {
   constructor() {
@@ -471,7 +471,7 @@ you can use `process.nextTick()` to set a callback to emit the event
 after the constructor has finished, which provides the expected results:
 
 ```js
-const EventEmitter = require('events');
+const EventEmitter = require('node:events');
 
 class MyEmitter extends EventEmitter {
   constructor() {

--- a/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -1,9 +1,9 @@
 ---
-title: The Node.js Event Loop, Timers, and process.nextTick()
-layout: docs.hbs
+title: Event Loop, Timers, and process.nextTick()
+layout: learn.hbs
 ---
 
-# The Node.js Event Loop, Timers, and `process.nextTick()`
+# Event Loop, Timers, and `process.nextTick()`
 
 ## What is the Event Loop?
 

--- a/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -106,7 +106,7 @@ threshold, then your script starts asynchronously reading a file which
 takes 95 ms:
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs');
 
 function someAsyncOperation(callback) {
   // Assume this takes 95ms to complete
@@ -257,7 +257,7 @@ callback is always executed first:
 
 ```js
 // timeout_vs_immediate.js
-const fs = require('fs');
+const fs = require('node:fs');
 
 fs.readFile(__filename, () => {
   setTimeout(() => {

--- a/redirects.json
+++ b/redirects.json
@@ -233,6 +233,10 @@
       "destination": "/:locale/learn/getting-started/security-best-practices"
     },
     {
+      "source": "/:locale/guides/event-loop-timers-and-nexttick/",
+      "destination": "/:locale/learn/asynchronous-work/event-loop-timers-and-nexttick"
+    },
+    {
       "source": "/:locale/get-involved",
       "destination": "/:locale/about/get-involved"
     },


### PR DESCRIPTION
## Description
This PR migrates the "The Node.js Event Loop , Timers , and  process.nextTick()" guide to the learn/asynchronous-work section

remove the section General and the link "The Node.js Event Loop , Timers , and  process.nextTick()"  from the guides section

create the redirect from the  "The Node.js Event Loop , Timers , and  process.nextTick()" guides link

## Validation 

![Screenshot from 2024-02-17 10-33-22](https://github.com/nodejs/nodejs.org/assets/118799941/672dcb82-d708-4ee0-aaee-9989ea22f629)

![Screenshot from 2024-02-17 10-33-59](https://github.com/nodejs/nodejs.org/assets/118799941/a058ec47-448b-457c-afe4-c621c8ab5862)



## Related Issues

Fixes #6224 

### Check List



Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
