### PR TITLE
doc: update examples

### DIFF
--- a/pages/en/new-design/index.mdx
+++ b/pages/en/new-design/index.mdx
@@ -65,7 +65,7 @@ layout: home.hbs
     });
 
     test('that throws as 1 is not equal 2', () => {
-      // throws an exception because 1!=2
+      // throws an exception because 1 ≠ 2
       assert.strictEqual(1, 2);
     });
     ```
@@ -99,13 +99,13 @@ layout: home.hbs
     ```
 
     ```js displayName="Work with Threads"
-    import { Worker, isMainThread } from 'node:worker_threads';
-    import { workerData, parentPort } from 'node:worker_threads';
+    import { Worker, isMainThread,
+      workerData, parentPort } from ’node:worker_threads’;
 
     if (isMainThread) {
       const data = 'some data';
       const worker = new Worker(import.meta.filename, { workerData: data });
-      worker.on('message', m => console.log('Reply from Thread:', m));
+      worker.on('message', msg => console.log(‘Reply from Thread:’, msg));
     } else {
       const source = workerData;
       parentPort.postMessage(btoa(source.toUpperCase()));

--- a/pages/en/new-design/index.mdx
+++ b/pages/en/new-design/index.mdx
@@ -65,7 +65,7 @@ layout: home.hbs
     });
 
     test('that throws as 1 is not equal 2', () => {
-      // throws an exception because 1 ≠ 2
+      // throws an exception because 1 != 2
       assert.strictEqual(1, 2);
     });
     ```
@@ -100,12 +100,12 @@ layout: home.hbs
 
     ```js displayName="Work with Threads"
     import { Worker, isMainThread,
-      workerData, parentPort } from ’node:worker_threads’;
+      workerData, parentPort } from 'node:worker_threads';
 
     if (isMainThread) {
       const data = 'some data';
       const worker = new Worker(import.meta.filename, { workerData: data });
-      worker.on('message', msg => console.log(‘Reply from Thread:’, msg));
+      worker.on('message', msg => console.log('Reply from Thread:', msg));
     } else {
       const source = workerData;
       parentPort.postMessage(btoa(source.toUpperCase()));


### PR DESCRIPTION
Some minor tweaks for readability of the code examples. In the threads one, it felt odd that we were importing from `node:worker_threads` twice; is that just to have the same number of lines of code as the other examples?

I also find single-character variable names harder to follow than named ones.