### PR TITLE
feat(accent color): use color of `navBar`

### DIFF
--- a/next.dynamic.constants.mjs
+++ b/next.dynamic.constants.mjs
@@ -52,6 +52,16 @@ export const PAGE_METADATA = {
   metadataBase: new URL(`${BASE_URL}${BASE_PATH}`),
   title: siteConfig.title,
   description: siteConfig.description,
+  themeColor: [
+    {
+      color: siteConfig.lightAccentColor,
+      media: '(prefers-color-scheme: light)',
+    },
+    {
+      color: siteConfig.darkAccentColor,
+      media: '(prefers-color-scheme: dark)',
+    },
+  ],
   robots: { index: true, follow: true },
   twitter: {
     card: siteConfig.twitter.card,

--- a/next.dynamic.constants.mjs
+++ b/next.dynamic.constants.mjs
@@ -52,16 +52,6 @@ export const PAGE_METADATA = {
   metadataBase: new URL(`${BASE_URL}${BASE_PATH}`),
   title: siteConfig.title,
   description: siteConfig.description,
-  themeColor: [
-    {
-      color: siteConfig.lightAccentColor,
-      media: '(prefers-color-scheme: light)',
-    },
-    {
-      color: siteConfig.darkAccentColor,
-      media: '(prefers-color-scheme: dark)',
-    },
-  ],
   robots: { index: true, follow: true },
   twitter: {
     card: siteConfig.twitter.card,
@@ -89,7 +79,16 @@ export const PAGE_METADATA = {
  * @return {import('next').Viewport}
  */
 export const PAGE_VIEWPORT = {
-  themeColor: siteConfig.accentColor,
+  themeColor: [
+    {
+      color: siteConfig.lightAccentColor,
+      media: '(prefers-color-scheme: light)',
+    },
+    {
+      color: siteConfig.darkAccentColor,
+      media: '(prefers-color-scheme: dark)',
+    },
+  ],
   width: 'device-width',
   initialScale: 1,
 };

--- a/site.json
+++ b/site.json
@@ -2,8 +2,8 @@
   "title": "Node.js",
   "description": "Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.",
   "favicon": "/static/images/favicons/favicon.png",
-  "lightAccentColor": "#C5E5B4",
-  "darkAccentColor": "#1A3F1D",
+  "lightAccentColor": "#FFFFFF",
+  "darkAccentColor": "#0D121C",
   "twitter": {
     "username": "@nodejs",
     "card": "summary",

--- a/site.json
+++ b/site.json
@@ -2,7 +2,8 @@
   "title": "Node.js",
   "description": "Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.",
   "favicon": "/static/images/favicons/favicon.png",
-  "accentColor": "#333",
+  "lightAccentColor": "#C5E5B4",
+  "darkAccentColor": "#1A3F1D",
   "twitter": {
     "username": "@nodejs",
     "card": "summary",

--- a/types/config.ts
+++ b/types/config.ts
@@ -29,7 +29,8 @@ export interface SiteConfig {
   description: string;
   featuredImage: string;
   favicon: string;
-  accentColor: string;
+  lightAccentColor: string;
+  darkAccentColor: string;
   og: OGConfig;
   twitter: TwitterConfig;
   rssFeeds: Array<RSSFeed>;


### PR DESCRIPTION
## Description

I noticed that on Safari, the header/tabs was gray-black because our accent color was `#333`, so I set it to the color of the `navbar` component because it matches perfectly. Question, should we use [`generateViewport`](https://nextjs.org/docs/app/api-reference/functions/generate-viewport) ?

### Before:


**Light**

<img width="1547" alt="Capture d’écran 2024-03-02 à 10 31 36" src="https://github.com/nodejs/nodejs.org/assets/97875033/4c5a8eae-54bd-4608-846c-7f3a64d61072">

**dark**

<img width="1547" alt="Capture d’écran 2024-03-02 à 11 50 20" src="https://github.com/nodejs/nodejs.org/assets/97875033/de6df842-9a9c-41b5-94f7-e80cf3a89ddc">

### After:

**Light**

<img width="1547" alt="Capture d’écran 2024-03-02 à 10 31 39" src="https://github.com/nodejs/nodejs.org/assets/97875033/061bb4af-1d62-464e-96bd-185f33edea31">

**dark**

<img width="1547" alt="Capture d’écran 2024-03-02 à 11 50 18" src="https://github.com/nodejs/nodejs.org/assets/97875033/b9d893b8-b1ba-48b5-be2d-e927e5e0ad1b">

## Related Issues

No Related Issues

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- [X] I've covered new added functionality with unit tests if necessary.
