### PR TITLE
chore(download): remove references to corepack

### DIFF
--- a/pages/en/download/current.mdx
+++ b/pages/en/download/current.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/index.mdx
+++ b/pages/en/download/index.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/package-manager/current.mdx
+++ b/pages/en/download/package-manager/current.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/package-manager/index.mdx
+++ b/pages/en/download/package-manager/index.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/prebuilt-binaries/current.mdx
+++ b/pages/en/download/prebuilt-binaries/current.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/prebuilt-binaries/index.mdx
+++ b/pages/en/download/prebuilt-binaries/index.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/source-code/current.mdx
+++ b/pages/en/download/source-code/current.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/source-code/index.mdx
+++ b/pages/en/download/source-code/index.mdx
@@ -11,7 +11,7 @@ subtitle: Download Node.js the way you want.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 


### PR DESCRIPTION
## Description

There are multiple ongoing discussions at the moment around the future of corepack, with that in mind I believe it would be more prudent to wait for it to be stable before highlighting it on the downloads page.

## Validation

Copy text only.

## Related Issues

- https://github.com/nodejs/node/pull/51886
- https://github.com/nodejs/node/issues/51931
- https://github.com/nodejs/node/issues/50963

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
