### PR TITLE
fix(footer): update Privacy and Trademark Policy links

### DIFF
--- a/site.json
+++ b/site.json
@@ -38,11 +38,11 @@
   "websiteBadges": {},
   "footerLinks": [
     {
-      "link": "https://openjsf.org/wp-content/uploads/sites/84/2021/01/OpenJS-Foundation-Trademark-Policy-2021-01-12.docx.pdf",
+      "link": "https://trademark-policy.openjsf.org/",
       "text": "components.footer.links.trademarkPolicy"
     },
     {
-      "link": "https://openjsf.org/wp-content/uploads/sites/84/2021/04/OpenJS-Foundation-Privacy-Policy-2019-11-15.pdf",
+      "link": "https://privacy-policy.openjsf.org/",
       "text": "components.footer.links.privacyPolicy"
     },
     {


### PR DESCRIPTION
## Description

- update Privacy and Trademark Policy links

## Validation

- Went to the new beta Node.js website [https://beta-node-js-org.vercel.app/en](https://beta-node-js-org.vercel.app/en)
Clicked the "Trademark Policy" and "Privacy Policy" link in the footer

## Related Issues

Fixes #6401
Fixes #6402 

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
