### PR TITLE
fix: remove select item flex to enable truncation, add left spacing for items

### DIFF
--- a/components/Common/Select/index.module.css
+++ b/components/Common/Select/index.module.css
@@ -86,14 +86,24 @@
       dark:data-[highlighted]:bg-green-600;
   }
 
-  .text span {
-    @apply pl-4;
+  .text > span {
+    @apply flex
+      items-center
+      gap-2;
+  }
+
+  .text > span > span {
+    @apply truncate;
   }
 
   .label {
     @apply text-neutral-600
       dark:text-neutral-400;
   }
+}
+
+.dropdown:has(.label) .text > span > span {
+  @apply pl-3;
 }
 
 .inline {

--- a/components/Common/Select/index.module.css
+++ b/components/Common/Select/index.module.css
@@ -87,9 +87,7 @@
   }
 
   .text span {
-    @apply flex
-      items-center
-      gap-2;
+    @apply pl-4;
   }
 
   .label {

--- a/components/Common/Select/index.tsx
+++ b/components/Common/Select/index.tsx
@@ -111,7 +111,7 @@ const Select: FC<SelectProps> = ({
                     >
                       <Primitive.ItemText>
                         {iconImage}
-                        {label}
+                        <span>{label}</span>
                       </Primitive.ItemText>
                     </Primitive.Item>
                   ))}


### PR DESCRIPTION
Removes unneeded flex on select items which prevented truncation of long titles from working. Adds left padding to better visualize hierarchy of groups and clickable items inside.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes this issue: https://github.com/nodejs/nodejs.org/issues/6400#issue-2164933670
Currently, truncation in selects is not working because of flex set to the inner span of each select item. This removes this to fix the truncation issue and adds left padding to each item to further highlight the hierarchy.

On touch devices that don't support hover states it was hard to recognize groups and group items. This gives each item a 'pl-4` left padding to highlight these hierachies for all devies.

Before:
<img width="399" alt="image" src="https://github.com/nodejs/nodejs.org/assets/15133101/648376e4-96d6-4b7f-8353-32348fcd3f50">


After:
<img width="364" alt="image" src="https://github.com/nodejs/nodejs.org/assets/15133101/cd413ed0-563b-4d7d-b2c2-4417b0e0050f">

**This fix seems to be working fine. The downside of the left padding for items is, that this padding also exists when there aren't any groups used. This is the case on the Blog page.
Question is if this is relevant and improvement is needed to only add padding when groups are used.
Second question is if the previous set flex styles were intended to be used for anything down the road or are used on any page I am not aware of.**

Example of Blog page item padding without any groups used:
<img width="330" alt="image" src="https://github.com/nodejs/nodejs.org/assets/15133101/d2191b4a-f672-4658-86ca-07b608f78ba3">

## Validation

Tested the Learn page referenced in the Issue. Also tested About page select and Blog page select.

## Related Issues

Fixes #6400

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo lint` to ensure the code follows the style guide. And run `npx turbo lint:fix` to fix the style errors if necessary.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
