### PR TITLE
Fix aria label (RSS) is missing #6414

### DIFF
--- a/components/Blog/BlogHeader/index.tsx
+++ b/components/Blog/BlogHeader/index.tsx
@@ -23,7 +23,10 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
     <header className={styles.blogHeader}>
       <h1>
         {t('layouts.blog.title')}
-        <Link href={`/feed/${currentFile}`}>
+        <Link
+          href={`/feed/${currentFile}`}
+          aria-label={t('layouts.blog.blogHeader.RSS')}
+        >
           <RssIcon />
         </Link>
       </h1>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -254,6 +254,9 @@
         "weekly": "Weekly Updates",
         "wg": "Working Groups",
         "events": "Events"
+      },
+      "blogHeader": {
+        "RSS": "RSS feed"
       }
     },
     "error": {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

1. I have added aria-label for the RSS link.
2. I have also added the translation key for RSS link

