### PR TITLE
Fix/link to next intl is missing in collaborator guide

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -83,7 +83,7 @@ The Website also uses several other Open Source libraries (not limited to) liste
 - [Shiki][] is a Syntax Highlighter used for our Codeboxes
   - The syntax highlighting is done within the processing of the Markdown files with the MDX compiler as a Rehype plugin.
 - [MDX][] and Markdown are used for structuring the Content of the Website
-- [`next-intl`][] is the i18n Library adopted within the Website
+- [`next-intl`](https://www.npmjs.com/package/next-intl) is the i18n Library adopted within the Website
   - It provides an excellent integration with Next.js, But it also supports standalone support for i18n if it eventually migrates from Next.js to something else.
   - Supports React Server Components and Next.js Middlewares
 - [`next-sitemap`](https://www.npmjs.com/package/next-sitemap) is used for Sitemap and `robots.txt` Generation

--- a/components/Blog/BlogHeader/index.tsx
+++ b/components/Blog/BlogHeader/index.tsx
@@ -18,12 +18,13 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
   const currentFile =
     siteConfig.rssFeeds.find(item => item.category === category)?.file ??
     'blog.xml';
+  const ariaLabel = t('layouts.blog.blogHeader.RSS');
 
   return (
     <header className={styles.blogHeader}>
       <h1>
         {t('layouts.blog.title')}
-        <Link href={`/feed/${currentFile}`}>
+        <Link href={`/feed/${currentFile}`} aria-label={ariaLabel}>
           <RssIcon />
         </Link>
       </h1>

--- a/components/Blog/BlogHeader/index.tsx
+++ b/components/Blog/BlogHeader/index.tsx
@@ -18,13 +18,15 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
   const currentFile =
     siteConfig.rssFeeds.find(item => item.category === category)?.file ??
     'blog.xml';
-  const ariaLabel = t('layouts.blog.blogHeader.RSS');
 
   return (
     <header className={styles.blogHeader}>
       <h1>
         {t('layouts.blog.title')}
-        <Link href={`/feed/${currentFile}`} aria-label={ariaLabel}>
+        <Link
+          href={`/feed/${currentFile}`}
+          aria-label={t('layouts.blog.blogHeader.RSS')}
+        >
           <RssIcon />
         </Link>
       </h1>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -254,6 +254,9 @@
         "weekly": "Weekly Updates",
         "wg": "Working Groups",
         "events": "Events"
+      },
+      "blogHeader": {
+        "RSS": "RSS feed"
       }
     },
     "error": {


### PR DESCRIPTION
For more details see #6424 
- I added the missing link for the next-intl libary