### PR TITLE
fix: removed unnecessary md:top-60 in searchBoxModalPanel style

### DIFF
--- a/components/Common/Search/States/index.module.css
+++ b/components/Common/Search/States/index.module.css
@@ -17,7 +17,6 @@
     w-full
     bg-neutral-100
     dark:bg-neutral-950
-    md:top-60
     md:h-[450px]
     md:max-w-3xl
     md:rounded-xl


### PR DESCRIPTION
For details see #6427 
- There was unnecessary top element position 
- I removed it and test it the website in all screens it worked correctly