### PR TITLE
fix: select arm64 by default

### DIFF
--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -25,6 +25,8 @@ const BitnessDropdown: FC = () => {
 
   useEffect(() => {
     setBitness(getUserBitnessByArchitecture(userArchitecture, userBitness));
+    // we shouldn't update the effect on setter state change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userArchitecture, userBitness]);
 
   // @TODO: We should have a proper utility that gives

--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -23,14 +23,6 @@ const BitnessDropdown: FC = () => {
   // we also reset the bitness when the OS changes, because different OSs have
   // different bitnesses available
 
-  // useEffect(() => {
-  //   if (userArchitecture == 'arm' && userBitness == 64) {
-  //     setBitness('arm64');
-  //   } else {
-  //     setBitness(userBitness);
-  //   }
-  // }, [setBitness, userBitness, userArchitecture]);
-
   useEffect(() => {
     setBitness(getUserBitnessByArchitecture(userArchitecture, userBitness));
   }, [userArchitecture, userBitness]);

--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -14,13 +14,21 @@ const parseNumericBitness = (bitness: string) =>
   /^\d+$/.test(bitness) ? Number(bitness) : bitness;
 
 const BitnessDropdown: FC = () => {
-  const { bitness: userBitness } = useDetectOS();
+  const { bitness: userBitness, architecture: userArchitecture } =
+    useDetectOS();
   const { bitness, os, release, setBitness } = useContext(ReleaseContext);
   const t = useTranslations();
 
   // we also reset the bitness when the OS changes, because different OSs have
   // different bitnesses available
-  useEffect(() => setBitness(userBitness), [setBitness, userBitness]);
+
+  useEffect(() => {
+    if (userArchitecture == 'arm' && userBitness == 64) {
+      setBitness('arm64');
+    } else {
+      setBitness(userBitness);
+    }
+  }, [setBitness, userBitness, userArchitecture]);
 
   // @TODO: We should have a proper utility that gives
   // disabled OSs, Platforms, based on specific criteria

--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -9,6 +9,7 @@ import Select from '@/components/Common/Select';
 import { useDetectOS } from '@/hooks/react-client';
 import { ReleaseContext } from '@/providers/releaseProvider';
 import { bitnessItems, formatDropdownItems } from '@/util/downloadUtils';
+import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture';
 
 const parseNumericBitness = (bitness: string) =>
   /^\d+$/.test(bitness) ? Number(bitness) : bitness;
@@ -22,13 +23,17 @@ const BitnessDropdown: FC = () => {
   // we also reset the bitness when the OS changes, because different OSs have
   // different bitnesses available
 
+  // useEffect(() => {
+  //   if (userArchitecture == 'arm' && userBitness == 64) {
+  //     setBitness('arm64');
+  //   } else {
+  //     setBitness(userBitness);
+  //   }
+  // }, [setBitness, userBitness, userArchitecture]);
+
   useEffect(() => {
-    if (userArchitecture == 'arm' && userBitness == 64) {
-      setBitness('arm64');
-    } else {
-      setBitness(userBitness);
-    }
-  }, [setBitness, userBitness, userArchitecture]);
+    setBitness(getUserBitnessByArchitecture(userArchitecture, userBitness));
+  }, [userArchitecture, userBitness]);
 
   // @TODO: We should have a proper utility that gives
   // disabled OSs, Platforms, based on specific criteria

--- a/hooks/react-client/__tests__/useDetectOS.test.mjs
+++ b/hooks/react-client/__tests__/useDetectOS.test.mjs
@@ -35,6 +35,7 @@ describe('useDetectOS', () => {
       expect(result.current).toStrictEqual({
         os: 'WIN',
         bitness: 64,
+        architecture: '',
       });
     });
   });
@@ -53,6 +54,7 @@ describe('useDetectOS', () => {
       expect(result.current).toStrictEqual({
         os: 'WIN',
         bitness: 64,
+        architecture: '',
       });
     });
   });
@@ -71,6 +73,7 @@ describe('useDetectOS', () => {
       expect(result.current).toStrictEqual({
         os: 'MAC',
         bitness: 86,
+        architecture: '',
       });
     });
   });

--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -4,33 +4,39 @@ import { useEffect, useState } from 'react';
 
 import type { UserOS } from '@/types/userOS';
 import { detectOS } from '@/util/detectOS';
+import { getArchitecture } from '@/util/getArchitecture';
 import { getBitness } from '@/util/getBitness';
 
 type UserOSState = {
   os: UserOS;
   bitness: number;
+  architecture: string;
 };
 
 const useDetectOS = () => {
   const [userOSState, setUserOSState] = useState<UserOSState>({
     os: 'OTHER',
     bitness: 86,
+    architecture: 'ARM',
   });
 
   useEffect(() => {
-    getBitness().then(bitness => {
-      const userAgent = navigator?.userAgent;
-
-      setUserOSState({
-        os: detectOS(),
-        bitness:
-          bitness === '64' ||
-          userAgent?.includes('WOW64') ||
-          userAgent?.includes('Win64')
-            ? 64
-            : 86,
-      });
-    });
+    Promise.all([getBitness(), getArchitecture()]).then(
+      ([bitness, architecture]) => {
+        const userAgent: string | undefined = navigator?.userAgent;
+        const defaultBitness: number = 86; // Default bitness if unable to determine
+        setUserOSState({
+          os: detectOS(),
+          bitness:
+            bitness === '64' ||
+            userAgent?.includes('WOW64') ||
+            userAgent?.includes('Win64')
+              ? 64
+              : defaultBitness,
+          architecture: architecture ? architecture : '',
+        });
+      }
+    );
   }, []);
 
   return userOSState;

--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -23,7 +23,8 @@ const useDetectOS = () => {
   useEffect(() => {
     Promise.all([getBitness(), getArchitecture()]).then(
       ([bitness, architecture]) => {
-        const userAgent: string | undefined = navigator?.userAgent;
+        const userAgent: string | undefined =
+          (typeof navigator === 'object' && navigator.userAgent) || '';
         const defaultBitness: number = 86; // Default bitness if unable to determine
         setUserOSState({
           os: detectOS(),

--- a/util/__tests__/getUserBitnessByArchitecture.test.mjs
+++ b/util/__tests__/getUserBitnessByArchitecture.test.mjs
@@ -1,4 +1,4 @@
-import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture'; // Replace 'yourFile' with the correct path to your file containing getUserBitnessByArchitecture function
+import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture'; 
 
 describe('getUserBitnessByArchitecture', () => {
   it('should return "arm64" for arm architecture and 64-bit', () => {

--- a/util/__tests__/getUserBitnessByArchitecture.test.mjs
+++ b/util/__tests__/getUserBitnessByArchitecture.test.mjs
@@ -1,4 +1,4 @@
-import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture'; 
+import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture';
 
 describe('getUserBitnessByArchitecture', () => {
   it('should return "arm64" for arm architecture and 64-bit', () => {

--- a/util/__tests__/getUserBitnessByArchitecture.test.mjs
+++ b/util/__tests__/getUserBitnessByArchitecture.test.mjs
@@ -1,0 +1,13 @@
+import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture'; // Replace 'yourFile' with the correct path to your file containing getUserBitnessByArchitecture function
+
+describe('getUserBitnessByArchitecture', () => {
+  it('should return "arm64" for arm architecture and 64-bit', () => {
+    const result = getUserBitnessByArchitecture('arm', 64);
+    expect(result).toBe('arm64');
+  });
+
+  it('should return the user bitness for other architectures', () => {
+    const result = getUserBitnessByArchitecture('x86', 32);
+    expect(result).toBe(32);
+  });
+});

--- a/util/getArchitecture.ts
+++ b/util/getArchitecture.ts
@@ -1,0 +1,19 @@
+/// <reference types="user-agent-data-types" />
+
+export const getArchitecture = async () => {
+  // This is necessary to detect Windows 11 on Edge.
+  // [MDN](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
+  // [MSFT](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11)
+  if (typeof navigator?.userAgentData?.getHighEntropyValues === 'function') {
+    const entropyValues = navigator.userAgentData.getHighEntropyValues([
+      'architecture',
+    ]);
+
+    // Apparently in some cases this is not a Promise, we can Promisify it.
+    return Promise.resolve(entropyValues)
+      .then(({ architecture }) => architecture)
+      .catch(() => undefined);
+  }
+
+  return undefined;
+};

--- a/util/getUserBitnessByArchitecture.ts
+++ b/util/getUserBitnessByArchitecture.ts
@@ -1,0 +1,10 @@
+export const getUserBitnessByArchitecture = (
+  userArchitecture: string,
+  userBitness: number
+) => {
+  if (userArchitecture == 'arm' && userBitness == 64) {
+    return 'arm64';
+  } else {
+    return userBitness;
+  }
+};

--- a/util/getUserBitnessByArchitecture.ts
+++ b/util/getUserBitnessByArchitecture.ts
@@ -4,7 +4,7 @@ export const getUserBitnessByArchitecture = (
 ) => {
   if (userArchitecture === 'arm' && userBitness === 64) {
     return 'arm64';
-  } else {
-    return userBitness;
   }
+
+  return userBitness;
 };

--- a/util/getUserBitnessByArchitecture.ts
+++ b/util/getUserBitnessByArchitecture.ts
@@ -2,7 +2,7 @@ export const getUserBitnessByArchitecture = (
   userArchitecture: string,
   userBitness: number
 ) => {
-  if (userArchitecture == 'arm' && userBitness == 64) {
+  if (userArchitecture === 'arm' && userBitness === 64) {
     return 'arm64';
   } else {
     return userBitness;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Selected ARM64 by default in the dropdown if user is visiting from M1 

<!-- Write a brief description of the changes introduced by this PR -->

1) Added "getArchitecture" utility and embed it on our util that detects the UserOS.
2) Checked if architecture is ARM if visiting from M1

## Validation

<img width="1439" alt="nodejs" src="https://github.com/nodejs/nodejs.org/assets/45811662/d553d819-c847-4a64-a9a6-bdf6fb0b1964">


<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
Fixes #6364 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->


<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

