### PR TITLE
fix: bg on `LanguageDropDown`

### DIFF
--- a/components/Common/LanguageDropDown/index.module.css
+++ b/components/Common/LanguageDropDown/index.module.css
@@ -19,8 +19,10 @@
     rounded
     border
     border-neutral-200
+    bg-white
     shadow-lg
-    dark:border-neutral-900;
+    dark:border-neutral-900
+    dark:bg-neutral-950;
 
   > div {
     @apply max-h-80


### PR DESCRIPTION


## Description

This pr solve same issue that transparent bg for header/footer. So it's just add bg for `LanguageDropDown`


## Validation

**before:**

<img width="573" alt="Capture d’écran 2024-03-05 à 16 38 27" src="https://github.com/nodejs/nodejs.org/assets/97875033/7c87f069-953f-44d2-8e9e-44fe4bfcc71c">

**After:**

<img width="573" alt="Capture d’écran 2024-03-05 à 16 40 19" src="https://github.com/nodejs/nodejs.org/assets/97875033/67753335-cfbb-46f5-abdf-624fa4a064a0">


## Related Issues

No related Issues

### Check List


- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
- **NA** I've covered new added functionality with unit tests if necessary.
