### PR TITLE
fix: select should have scrollbar

### DIFF
--- a/components/Common/Select/__tests__/index.test.mjs
+++ b/components/Common/Select/__tests__/index.test.mjs
@@ -10,6 +10,12 @@ describe('Select', () => {
   const label = 'Option label';
   const onChange = jest.fn();
 
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+
   it('renders the label when provided', () => {
     const { getByLabelText } = render(
       <Select

--- a/components/Common/Select/index.tsx
+++ b/components/Common/Select/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
-import * as Primitive from '@radix-ui/react-select';
+import * as ScrollPrimitive from '@radix-ui/react-scroll-area';
+import * as SelectPrimitive from '@radix-ui/react-select';
 import classNames from 'classnames';
 import { useId, useMemo } from 'react';
 import type { FC } from 'react';
@@ -77,50 +78,58 @@ const Select: FC<SelectProps> = ({
         </label>
       )}
 
-      <Primitive.Root value={defaultValue} onValueChange={onChange}>
-        <Primitive.Trigger
+      <SelectPrimitive.Root value={defaultValue} onValueChange={onChange}>
+        <SelectPrimitive.Trigger
           className={styles.trigger}
           aria-label={label}
           id={id}
         >
-          <Primitive.Value placeholder={placeholder} />
+          <SelectPrimitive.Value placeholder={placeholder} />
           <ChevronDownIcon className={styles.icon} />
-        </Primitive.Trigger>
-        <Primitive.Portal>
-          <Primitive.Content
+        </SelectPrimitive.Trigger>
+
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Content
             position={inline ? 'popper' : 'item-aligned'}
             className={classNames(styles.dropdown, { [styles.inline]: inline })}
           >
-            <Primitive.Viewport>
-              {mappedValues.map(({ label, items }, key) => (
-                <Primitive.Group key={label?.toString() || key}>
-                  {label && (
-                    <Primitive.Label
-                      className={classNames(styles.item, styles.label)}
-                    >
-                      {label}
-                    </Primitive.Label>
-                  )}
+            <ScrollPrimitive.Root type="auto">
+              <SelectPrimitive.Viewport>
+                <ScrollPrimitive.Viewport>
+                  {mappedValues.map(({ label, items }, key) => (
+                    <SelectPrimitive.Group key={label?.toString() ?? key}>
+                      {label && (
+                        <SelectPrimitive.Label
+                          className={classNames(styles.item, styles.label)}
+                        >
+                          {label}
+                        </SelectPrimitive.Label>
+                      )}
 
-                  {items.map(({ value, label, iconImage, disabled }) => (
-                    <Primitive.Item
-                      key={value}
-                      value={value}
-                      disabled={disabled}
-                      className={classNames(styles.item, styles.text)}
-                    >
-                      <Primitive.ItemText>
-                        {iconImage}
-                        <span>{label}</span>
-                      </Primitive.ItemText>
-                    </Primitive.Item>
+                      {items.map(({ value, label, iconImage, disabled }) => (
+                        <SelectPrimitive.Item
+                          key={value}
+                          value={value}
+                          disabled={disabled}
+                          className={classNames(styles.item, styles.text)}
+                        >
+                          <SelectPrimitive.ItemText>
+                            {iconImage}
+                            <span>{label}</span>
+                          </SelectPrimitive.ItemText>
+                        </SelectPrimitive.Item>
+                      ))}
+                    </SelectPrimitive.Group>
                   ))}
-                </Primitive.Group>
-              ))}
-            </Primitive.Viewport>
-          </Primitive.Content>
-        </Primitive.Portal>
-      </Primitive.Root>
+                </ScrollPrimitive.Viewport>
+              </SelectPrimitive.Viewport>
+              <ScrollPrimitive.Scrollbar orientation="vertical">
+                <ScrollPrimitive.Thumb />
+              </ScrollPrimitive.Scrollbar>
+            </ScrollPrimitive.Root>
+          </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
     </span>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
@@ -4779,6 +4780,37 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This fixes an honest accessibility and UX issue, as our select components have no "scrollbars". This introduces Radix's ScrollArea which explicitly add scroll-areas and scroll bars when needed

## Validation

Scrollbars should appear when amount/quantity of items overflows on the max-height we proposed

