### PR TITLE
fix: zoom issue on smaller screens due to focus

### DIFF
--- a/next.dynamic.constants.mjs
+++ b/next.dynamic.constants.mjs
@@ -91,4 +91,5 @@ export const PAGE_VIEWPORT = {
   ],
   width: 'device-width',
   initialScale: 1,
+  maximumScale: 1,
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Clicking on the Navigation Panel on mobile zooms the website because of it having an input component in focus. This is unwanted behaviour. We can use the maximumScale property on meta viewport to prevent this.

## Validation

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#maximum-scale

## Related Issues

Fixes: #6416

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
