### PR TITLE
chore: Clean up homepage code examples (tweak comments + no wrapping)

### DIFF
--- a/components/Common/CodeBox/index.module.css
+++ b/components/Common/CodeBox/index.module.css
@@ -11,6 +11,7 @@
 
     & > code {
       @apply grid
+        overflow-x-auto
         bg-transparent
         p-0
         font-ibm-plex-mono
@@ -24,11 +25,6 @@
         @apply relative
           min-w-0
           pl-8;
-
-        & > span {
-          @apply whitespace-break-spaces
-            break-words;
-        }
 
         &:not(:empty:last-child)::before {
           @apply inline-block

--- a/components/Common/Tabs/index.module.css
+++ b/components/Common/Tabs/index.module.css
@@ -1,33 +1,39 @@
-.tabsList {
-  @apply flex
-    gap-2
-    font-open-sans;
+.tabsRoot {
+  @apply max-w-full;
 
-  .tabsTrigger {
-    @apply border-b-2
-      border-b-transparent
-      px-1
-      pb-[11px]
-      text-sm
-      font-semibold
-      text-neutral-800
-      dark:text-neutral-200;
+  .tabsList {
+    @apply flex
+      gap-2
+      overflow-x-auto
+      font-open-sans;
 
-    &[data-state='active'] {
-      @apply border-b-green-600
-        text-green-600
-        dark:border-b-green-400
-        dark:text-green-400;
+    .tabsTrigger {
+      @apply whitespace-nowrap
+        border-b-2
+        border-b-transparent
+        px-1
+        pb-[11px]
+        text-sm
+        font-semibold
+        text-neutral-800
+        dark:text-neutral-200;
+
+      &[data-state='active'] {
+        @apply border-b-green-600
+          text-green-600
+          dark:border-b-green-400
+          dark:text-green-400;
+      }
     }
-  }
 
-  .addons {
-    @apply ml-auto
-      border-b-2
-      border-b-transparent
-      px-1
-      pb-[11px]
-      text-sm
-      font-semibold;
+    .addons {
+      @apply ml-auto
+        border-b-2
+        border-b-transparent
+        px-1
+        pb-[11px]
+        text-sm
+        font-semibold;
+    }
   }
 }

--- a/components/Common/Tabs/index.tsx
+++ b/components/Common/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs';
+import classNames from 'classnames';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
 import styles from './index.module.css';
@@ -18,7 +19,7 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
 }) => (
   <TabsPrimitive.Root
     {...props}
-    className={[styles.tabsRoot, props.className].filter(Boolean).join(' ')}
+    className={classNames(styles.tabsRoot, props.className)}
   >
     <TabsPrimitive.List className={styles.tabsList}>
       {tabs.map(tab => (

--- a/components/Common/Tabs/index.tsx
+++ b/components/Common/Tabs/index.tsx
@@ -16,7 +16,10 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
   children,
   ...props
 }) => (
-  <TabsPrimitive.Root {...props}>
+  <TabsPrimitive.Root
+    {...props}
+    className={[styles.tabsRoot, props.className].filter(Boolean).join(' ')}
+  >
     <TabsPrimitive.List className={styles.tabsList}>
       {tabs.map(tab => (
         <TabsPrimitive.Trigger

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -116,6 +116,7 @@
 
     &:nth-of-type(2) {
       @apply flex
+          min-w-0
           max-w-md
           flex-[1_1]
           flex-col
@@ -125,7 +126,7 @@
           lg:max-w-3xl;
 
       > div {
-        @apply w-fit;
+        @apply w-fit max-w-full;
       }
 
       > p {

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -61,6 +61,7 @@
 .centeredLayout {
   @apply flex
     w-full
+    min-w-0
     items-center
     justify-center
     px-4
@@ -117,7 +118,7 @@
     &:nth-of-type(2) {
       @apply flex
           min-w-0
-          max-w-md
+          max-w-full
           flex-[1_1]
           flex-col
           items-center
@@ -126,7 +127,9 @@
           lg:max-w-3xl;
 
       > div {
-        @apply w-fit max-w-full;
+        @apply w-fit
+          max-w-md
+          md:max-w-full;
       }
 
       > p {

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -127,7 +127,7 @@
           lg:max-w-3xl;
 
       > div {
-        @apply w-fit
+        @apply w-full
           max-w-md
           md:max-w-full;
       }

--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -43,7 +43,7 @@ layout: home
 <section>
   <div>
     ```js displayName="Create an HTTP Server"
-    // make a file `server.mjs` and run with `node server.mjs`
+    // server.mjs
     import { createServer } from 'node:http';
 
     const server = createServer((req, res) => {
@@ -55,10 +55,12 @@ layout: home
     server.listen(3000, '127.0.0.1', () => {
       console.log('Listening on 127.0.0.1:3000');
     });
+
+    // run with `node server.mjs`
     ```
 
     ```js displayName="Write Tests"
-    // make a file `tests.mjs` and run with `node tests.mjs`
+    // tests.mjs
     import assert from 'node:assert';
     import test from 'node:test';
 
@@ -70,10 +72,12 @@ layout: home
       // throws an exception because 1 != 2
       assert.strictEqual(1, 2);
     });
+
+    // run with `node tests.mjs`
     ```
 
     ```js displayName="Read and Hash a File"
-    // make a file `crypto.mjs` and run with `node crypto.mjs`
+    // crypto.mjs
     import { createHash } from 'node:crypto';
     import { readFile } from 'node:fs/promises';
 
@@ -85,10 +89,12 @@ layout: home
     hasher.end();
 
     const fileHash = hasher.read();
+
+    // run with `node crypto.mjs`
     ```
 
     ```js displayName="Read Streams"
-    // make a file `streams.mjs` and run with `node streams.mjs`
+    // streams.mjs
     import { pipeline } from 'node:stream';
     import { createReadStream, createWriteStream } from 'node:fs';
     import { createGzip } from 'node:zlib';
@@ -100,10 +106,12 @@ layout: home
       createGzip(),
       createWriteStream('package.json.gz')
     );
+
+    // run with `node streams.mjs`
     ```
 
     ```js displayName="Work with Threads"
-    // make a file `threads.mjs` and run with `node threads.mjs`
+    // threads.mjs
     import { Worker, isMainThread,
       workerData, parentPort } from 'node:worker_threads';
 
@@ -115,6 +123,8 @@ layout: home
       const source = workerData;
       parentPort.postMessage(btoa(source.toUpperCase()));
     }
+
+    // run with `node threads.mjs`
     ```
 
   </div>


### PR DESCRIPTION
## Description

Ensures that tabs + code don't allow for whitespace wrapping outside of what is in the source, preferring to overflow with scrolling within their container. I should note that I tried my best to resolve some responsiveness issues that this introduces (hence setting some max/min widths to stop grid/flex overflowing -- that being said, it looks like there are general responsiveness issues on these pages beyond this change (especially around tablet breakpoints).

Also, cleans up the comments in the examples to better follow what I think the user flow would be for trying them out, as I'd noted in https://github.com/nodejs/nodejs.org/pull/6457#pullrequestreview-1920590229

## Validation

On mobile + desktop, the code examples on the homepage behave as one would expect them to. On mobile, you can scroll the tabs + code to see more, rather than it wrapping.

## Related Issues

Fixes #6388

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
