### PR TITLE
chore: remove corepack mention

### DIFF
--- a/pages/en/download/current.mdx
+++ b/pages/en/download/current.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of Node.js for <Release.Operating
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/index.mdx
+++ b/pages/en/download/index.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of Node.js for <Release.Operating
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/package-manager/current.mdx
+++ b/pages/en/download/package-manager/current.mdx
@@ -11,7 +11,7 @@ Install Node.js <Release.VersionDropdown /> on  <Release.OperatingSystemDropdown
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/package-manager/index.mdx
+++ b/pages/en/download/package-manager/index.mdx
@@ -11,7 +11,7 @@ Install Node.js <Release.VersionDropdown /> on <Release.OperatingSystemDropdown 
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/prebuilt-binaries/current.mdx
+++ b/pages/en/download/prebuilt-binaries/current.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of Node.js for <Release.Operating
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/prebuilt-binaries/index.mdx
+++ b/pages/en/download/prebuilt-binaries/index.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of Node.js for <Release.Operating
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/source-code/current.mdx
+++ b/pages/en/download/source-code/current.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of the Node.js source code.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 

--- a/pages/en/download/source-code/index.mdx
+++ b/pages/en/download/source-code/index.mdx
@@ -11,7 +11,7 @@ I want the <Release.VersionDropdown /> version of the Node.js source code.
 </section>
 
 <section>
-Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />) and corepack.
+Node.js includes <LinkWithArrow href="https://npmjs.com">npm</LinkWithArrow> (<Release.NpmVersion />).
 
 Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
 


### PR DESCRIPTION
This PR removes the Corepack mention for the time being, as we have no easy way of calculating which version actually bundles Corepack nor which version of Corepack is bundled. + The TSC is still discussing the future of Corepack.

cc @nodejs/tsc 