### PR TITLE
chore: update incorrect code comments regarding dynamicParams

### DIFF
--- a/app/[locale]/feed/[feed]/route.ts
+++ b/app/[locale]/feed/[feed]/route.ts
@@ -29,7 +29,9 @@ export const GET = async (_: Request, { params }: StaticParams) => {
 export const generateStaticParams = async () =>
   siteConfig.rssFeeds.map(feed => ({ feed: feed.file, locale }));
 
-// Forces that only the paths from `generateStaticParams` are allowed, giving 404 on the contrary
+// In this case we want to catch-all possible requests. This is so that if a non defined feed is
+// requested we can manually return a 404 response for it instead of having Next.js handle it
+// and return our top level custom 404 html page instead
 // @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
 export const dynamicParams = true;
 

--- a/app/[locale]/next-data/og/route.tsx
+++ b/app/[locale]/next-data/og/route.tsx
@@ -64,7 +64,8 @@ export const generateStaticParams = async () => [
 // @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime
 export const runtime = VERCEL_ENV ? 'edge' : 'nodejs';
 
-// Enforces that only the paths from `generateStaticParams` are allowed, giving 404 on the contrary
+// In this case we want to catch-all possible requests. This ensures that we always generate and
+// serve the OpenGrapgh images independently on the locale
 // @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
 export const dynamicParams = true;
 


### PR DESCRIPTION
## Description

Very minor, this PR is simply updating a couple of code comments around `dynamicParams` which I am pretty sure are wrong and just [copy-pastas](https://github.com/search?q=repo%3Anodejs%2Fnodejs.org%20%22Forces%20that%20only%20the%20paths%20from%20%60generateStaticParams%60%20are%20allowed%2C%20giving%20404%20on%20the%20contrary%22&type=code) (and indeed they confused me at first)

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
