### PR TITLE
fix: input debounce

### DIFF
--- a/components/Common/Search/States/WithSearchBox.tsx
+++ b/components/Common/Search/States/WithSearchBox.tsx
@@ -71,7 +71,9 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
   }, []);
 
   useEffect(
-    () => debounce(() => search(searchTerm), 1000),
+    () => {
+      debounce(() => search(searchTerm), 1000)();
+    },
     // we don't need to care about memoization of search function
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [searchTerm, selectedFacet]
@@ -100,7 +102,12 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
   };
 
   const facets: Facets = {
-    all: searchResults?.count ?? 0,
+    all: searchResults?.facets
+      ? Object.values(searchResults?.facets.siteSection.values).reduce(
+          (a, b) => a + b,
+          0
+        )
+      : 0,
     ...(searchResults?.facets?.siteSection?.values ?? {}),
   };
 

--- a/util/debounce.ts
+++ b/util/debounce.ts
@@ -1,16 +1,16 @@
 type DebounceFunction<T = unknown> = (...args: Array<T>) => void;
 
-export const debounce = <T extends DebounceFunction>(
-  func: T,
-  delay: number
-): ((...args: Parameters<T>) => void) => {
-  let timeoutId: NodeJS.Timeout;
+let timeoutId: NodeJS.Timeout;
 
-  return (...args: Parameters<T>) => {
+export const debounce =
+  <T extends DebounceFunction>(
+    func: T,
+    delay: number
+  ): ((...args: Parameters<T>) => void) =>
+  (...args: Parameters<T>) => {
     clearTimeout(timeoutId);
 
     timeoutId = setTimeout(() => {
       func(...args);
     }, delay);
   };
-};


### PR DESCRIPTION
## Description

With this PR, the debounce method we use in the search box has been ensured to work as expected. The request should be triggered when the user has not made any input for 1000ms. The debounce method has been removed from `useEffect`'s return to fix the previous state(irrelevant results) issue. When the facet is selected, the total is always correct with the reducer, since the API gives the selected one instead of the total number.

## Validation

You can check it by searching in the preview.

Example screenshots;

Before:
<img width="600" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/56f875ce-afe0-434a-aeaa-0683503fac67">

After:
<img width="600" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/261fa7b1-c506-4c58-ba94-f1056fe1dd83">

### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
