### PR TITLE
fix: Change link to point to npm release notes

### DIFF
--- a/components/Downloads/Release/NpmLink.tsx
+++ b/components/Downloads/Release/NpmLink.tsx
@@ -10,7 +10,9 @@ const NpmLink: FC = () => {
   const { release } = useContext(ReleaseContext);
 
   return (
-    <LinkWithArrow href={`https://github.com/npm/cli/releases/tag/v${release.npm}`}>
+    <LinkWithArrow
+      href={`https://github.com/npm/cli/releases/tag/v${release.npm}`}
+    >
       npm ({release.npm})
     </LinkWithArrow>
   );

--- a/components/Downloads/Release/NpmLink.tsx
+++ b/components/Downloads/Release/NpmLink.tsx
@@ -10,7 +10,7 @@ const NpmLink: FC = () => {
   const { release } = useContext(ReleaseContext);
 
   return (
-    <LinkWithArrow href={`https://www.npmjs.com/package/npm/v/${release.npm}`}>
+    <LinkWithArrow href={`https://github.com/npm/cli/releases/tag/v${release.npm}`}>
       npm ({release.npm})
     </LinkWithArrow>
   );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Previously, this link was pointing to the npm registry which looks nearly the same for every release.

This PR changes the link to point to the release notes for the given version of npm.

## Validation

Click on "Node.js includes npm (10.2.4)" here:

<img width="931" alt="image" src="https://github.com/nodejs/nodejs.org/assets/229881/0a7005de-1143-4db0-aa7d-8af617db9951">


## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
