### PR TITLE
fix: Wrong bitness information

### DIFF
--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -25,13 +25,18 @@ const useDetectOS = () => {
       ([bitness, architecture]) => {
         const userAgent: string | undefined =
           (typeof navigator === 'object' && navigator.userAgent) || '';
-        const defaultBitness: number = 64; // Default bitness if unable to determine
+        const defaultBitness: number = 86; // Default bitness if unable to determine
         setUserOSState({
           os: detectOS(),
           bitness:
             bitness === '64' ||
             userAgent?.includes('WOW64') ||
-            userAgent?.includes('Win64')
+            userAgent?.includes('Win64') ||
+            userAgent?.includes('x86_64') ||
+            userAgent?.includes('x86-64') ||
+            userAgent?.includes('x64_64') ||
+            userAgent?.includes('x64;') ||
+            userAgent?.includes('AMD64')
               ? 64
               : defaultBitness,
           architecture: architecture ? architecture : '',

--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -25,7 +25,7 @@ const useDetectOS = () => {
       ([bitness, architecture]) => {
         const userAgent: string | undefined =
           (typeof navigator === 'object' && navigator.userAgent) || '';
-        const defaultBitness: number = 86; // Default bitness if unable to determine
+        const defaultBitness: number = 64; // Default bitness if unable to determine
         setUserOSState({
           os: detectOS(),
           bitness:

--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -25,18 +25,15 @@ const useDetectOS = () => {
       ([bitness, architecture]) => {
         const userAgent: string | undefined =
           (typeof navigator === 'object' && navigator.userAgent) || '';
-        const defaultBitness: number = 86; // Default bitness if unable to determine
+        // Default bitness if unable to determine
+        const defaultBitness: number = 86;
+        // Regex to detect 64-bit architecture in user agent
+        const bitnessRegex = /WOW64|Win64|x86_64|x86-64|x64_64|x64;|AMD64/;
+
         setUserOSState({
           os: detectOS(),
           bitness:
-            bitness === '64' ||
-            userAgent?.includes('WOW64') ||
-            userAgent?.includes('Win64') ||
-            userAgent?.includes('x86_64') ||
-            userAgent?.includes('x86-64') ||
-            userAgent?.includes('x64_64') ||
-            userAgent?.includes('x64;') ||
-            userAgent?.includes('AMD64')
+            bitness === '64' || bitnessRegex.test(userAgent)
               ? 64
               : defaultBitness,
           architecture: architecture ? architecture : '',

--- a/util/getNodeDownloadUrl.ts
+++ b/util/getNodeDownloadUrl.ts
@@ -15,37 +15,52 @@ export const getNodeDownloadUrl = (
 
   switch (os) {
     case 'MAC':
+      // Prepares a downloadable Node.js installer link for the x64, ARM64 platforms
       if (kind === 'installer') {
         return `${baseURL}/node-${versionWithPrefix}.pkg`;
       }
 
+      // Prepares a downloadable Node.js link for the ARM64 platform
       if (typeof bitness === 'string') {
         return `${baseURL}/node-${versionWithPrefix}-darwin-${bitness}.tar.gz`;
       }
 
-      return `${baseURL}/node-${versionWithPrefix}-darwin-x${bitness}.tar.gz`;
+      // Prepares a downloadable Node.js link for the x64 platform.
+      // Since the x86 platform is not officially supported, returns the x64
+      // link as the default value.
+      return `${baseURL}/node-${versionWithPrefix}-darwin-x64.tar.gz`;
     case 'WIN': {
       if (kind === 'installer') {
+        // Prepares a downloadable Node.js installer link for the ARM platforms
         if (typeof bitness === 'string') {
           return `${baseURL}/node-${versionWithPrefix}-${bitness}.msi`;
         }
 
+        // Prepares a downloadable Node.js installer link for the x64 and x86 platforms
         return `${baseURL}/node-${versionWithPrefix}-x${bitness}.msi`;
       }
 
+      // Prepares a downloadable Node.js link for the ARM64 platform
       if (typeof bitness === 'string') {
         return `${baseURL}/node-${versionWithPrefix}-win-${bitness}.zip`;
       }
 
+      // Prepares a downloadable Node.js link for the x64 and x86 platforms
       return `${baseURL}/node-${versionWithPrefix}-win-x${bitness}.zip`;
     }
     case 'LINUX':
+      // Prepares a downloadable Node.js link for the ARM platforms such as
+      // ARMv7 and ARMv8
       if (typeof bitness === 'string') {
         return `${baseURL}/node-${versionWithPrefix}-linux-${bitness}.tar.xz`;
       }
 
-      return `${baseURL}/node-${versionWithPrefix}-linux-x${bitness}.tar.xz`;
+      // Prepares a downloadable Node.js link for the x64 platform.
+      // Since the x86 platform is not officially supported, returns the x64
+      // link as the default value.
+      return `${baseURL}/node-${versionWithPrefix}-linux-x64.tar.xz`;
     default:
+      // Prepares a downloadable Node.js source code link
       return `${baseURL}/node-${versionWithPrefix}.tar.gz`;
   }
 };

--- a/util/getNodeDownloadUrl.ts
+++ b/util/getNodeDownloadUrl.ts
@@ -44,7 +44,7 @@ export const getNodeDownloadUrl = (
         return `${baseURL}/node-${versionWithPrefix}-linux-${bitness}.tar.xz`;
       }
 
-      return `${baseURL}/node-${versionWithPrefix}-linux-x64.tar.xz`;
+      return `${baseURL}/node-${versionWithPrefix}-linux-x${bitness}.tar.xz`;
     default:
       return `${baseURL}/node-${versionWithPrefix}.tar.gz`;
   }

--- a/util/getNodeDownloadUrl.ts
+++ b/util/getNodeDownloadUrl.ts
@@ -44,7 +44,7 @@ export const getNodeDownloadUrl = (
         return `${baseURL}/node-${versionWithPrefix}-linux-${bitness}.tar.xz`;
       }
 
-      return `${baseURL}/node-${versionWithPrefix}-linux-x${bitness}.tar.xz`;
+      return `${baseURL}/node-${versionWithPrefix}-linux-x64.tar.xz`;
     default:
       return `${baseURL}/node-${versionWithPrefix}.tar.gz`;
   }


### PR DESCRIPTION
## Description

If we cannot get the user's bitness information from the userAgent if `getHighEntropyValues` is not supported, the default is x86.

We act as if we are using the architecture, but since the x86 version is not officially distributed for Linux and Mac, users are directed to the wrong links.

This PR aims to create an alternative source to `getHighEntropyValues` by adding more to the conditions we check in `userAgent`.

Also, should we do something in the UI for versions that do not have an x86 version? (Maybe disabling the button?) cc @nodejs/nodejs-website 

## Validation

It would be better to test it on as many operating systems as possible in preview 👀 

## Related Issues

Fixes #6360

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
