### PR TITLE
fix: update Project governance page to match reality

### DIFF
--- a/pages/en/about/governance.md
+++ b/pages/en/about/governance.md
@@ -26,7 +26,8 @@ A guide for Collaborators is maintained at [collaborator-guide.md][].
 
 The project is governed by the [Technical Steering Committee (TSC)][]
 which is responsible for high-level guidance of the project. TSC is a
-subset of active Collaborators and is nominated by existing TSC members.
+subset of active Collaborators and who are nominated by other existing TSC
+members.
 
 [consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [readme.md]: https://github.com/nodejs/node/blob/main/README.md#current-project-team-members

--- a/pages/en/about/governance.md
+++ b/pages/en/about/governance.md
@@ -12,11 +12,11 @@ The Node.js project follows a [Consensus Seeking][] decision making model.
 ## Collaborators
 
 The [nodejs/node][] core GitHub repository is maintained by the Collaborators
-who are added by the Technical Steering Committee ([TSC][]) on an ongoing basis.
+who are nominated by other existing Collaborators on an ongoing basis.
 
 Individuals making significant and valuable contributions are made Collaborators
-and given commit-access to the project. These individuals are identified by the
-TSC and their nomination is discussed with the existing Collaborators.
+and given commit-access to the project. These individuals are identified by other
+Collaborators and their nomination is discussed with the existing Collaborators.
 
 For the current list of Collaborators, see the project's [README.md][].
 
@@ -25,7 +25,8 @@ A guide for Collaborators is maintained at [collaborator-guide.md][].
 ## Technical Steering Committee
 
 The project is governed by the [Technical Steering Committee (TSC)][]
-which is responsible for high-level guidance of the project.
+which is responsible for high-level guidance of the project. TSC is a
+subset of active Collaborators and is nominated by existing TSC members.
 
 [consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [readme.md]: https://github.com/nodejs/node/blob/main/README.md#current-project-team-members

--- a/pages/en/about/governance.md
+++ b/pages/en/about/governance.md
@@ -26,7 +26,7 @@ A guide for Collaborators is maintained at [collaborator-guide.md][].
 
 The project is governed by the [Technical Steering Committee (TSC)][]
 which is responsible for high-level guidance of the project. TSC is a
-subset of active Collaborators and who are nominated by other existing TSC
+subset of active Collaborators who are nominated by other existing TSC
 members.
 
 [consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
I noticed that the governance page (source is https://github.com/nodejs/nodejs.org/blob/main/pages/en/about/governance.md) appears to be out of sync and probably is copied from an older document that used incorrect descriptions. At least it does not match what we say in https://github.com/nodejs/node/blob/main/GOVERNANCE.md now and I remember we made sure that it was clear it's collaborators who nominate collaborators (which is also what we do in practice).

Here is my attempt at clarifying the text.

cc @nodejs/tsc

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
