### PR TITLE
fix: use openjsf.org Slack invite subdomain

### DIFF
--- a/navigation.json
+++ b/navigation.json
@@ -65,7 +65,7 @@
     },
     {
       "icon": "slack",
-      "link": "https://openjs-foundation.slack.com/join/shared_invite/zt-238w9sb83-Qk9NcsrEMomq94Y~3gW8EQ#/shared-invite/email",
+      "link": "https://slack-invite.openjsf.org/",
       "alt": "Slack"
     },
     {

--- a/navigation.json
+++ b/navigation.json
@@ -39,7 +39,7 @@
       "text": "components.containers.footer.links.codeOfConduct"
     },
     {
-      "link": "https://github.com/nodejs/node/blob/main/SECURITY.md",
+      "link": "https://github.com/nodejs/node/security/policy",
       "text": "components.containers.footer.links.security"
     },
     {

--- a/navigation.json
+++ b/navigation.json
@@ -39,7 +39,7 @@
       "text": "components.containers.footer.links.codeOfConduct"
     },
     {
-      "link": "https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security",
+      "link": "https://github.com/nodejs/node/blob/main/SECURITY.md",
       "text": "components.containers.footer.links.security"
     },
     {
@@ -120,7 +120,7 @@
           "label": "components.navigation.getInvolved.links.contribute"
         },
         "codeOfConduct": {
-          "link": "https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md",
+          "link": "https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md",
           "label": "components.navigation.getInvolved.links.codeOfConduct"
         }
       }


### PR DESCRIPTION
## Description

Replaces the hard-coded Slack invite that has either expired due to time or max usages with the OpenJSF-maintained subdomain that redirects to an active Slack invite for the workspace.

Also, consistently uses the branch name for GitHub links in the navigation data, rather than the HEAD commit. Also also, don't deep-link to the first heading in the Markdown content on said pages, as it seems to now result in the GitHub UI scrolling past said header.

## Validation

In an incognito window (to ensure you're not already signed into the OpenJSF Slack), confirm that the Slack icon in the footer now opens a valid invite to the workspace.

Other updated GitHub links in the navigation data still link to the intended files.

## Related Issues

Fixes #6498

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.