### PR TITLE
chore: add general portuguese to locale

### DIFF
--- a/i18n/config.json
+++ b/i18n/config.json
@@ -120,6 +120,16 @@
     "default": false
   },
   {
+    "code": "pt",
+    "localName": "Português",
+    "name": "Português",
+    "langDir": "ltr",
+    "dateFormat": "MM.DD.YYYY",
+    "hrefLang": "pt",
+    "enabled": false,
+    "default": false
+  },
+  {
     "code": "ro",
     "localName": "Română",
     "name": "Romanian",


### PR DESCRIPTION
## Description

In this pull request, I am adding the support for general Portuguese that is a Portuguese to serve more broad speakers beyond Brazilian as we have more than 8 countries in the world that speak officially Portuguese.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
