### PR TITLE
fix: layout shift on blogs due to i18n comps

### DIFF
--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -147,6 +147,7 @@
   @apply flex
     w-full
     justify-center
+    overflow-x-hidden
     bg-gradient-subtle
     dark:bg-gradient-subtle-dark
     xs:bg-none


### PR DESCRIPTION
<!--
A Layout shift caused by the i18n lang component on /blog route
-->



- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
