### PR TITLE
fix: legacy - use Buffer.from() instead of btoa()

### DIFF
--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -112,8 +112,12 @@ layout: home
 
     ```js displayName="Work with Threads"
     // threads.mjs
-    import { Worker, isMainThread,
-      workerData, parentPort } from 'node:worker_threads';
+    import { 
+      Worker,
+      isMainThread,
+      workerData,
+      parentPort 
+    } from 'node:worker_threads';
 
     if (isMainThread) {
       const data = 'some data';
@@ -121,7 +125,9 @@ layout: home
       worker.on('message', msg => console.log('Reply from Thread:', msg));
     } else {
       const source = workerData;
-      parentPort.postMessage(btoa(source.toUpperCase()));
+      parentPort.postMessage(
+        Buffer.from(source.toUpperCase()).toString("base64")
+      );
     }
 
     // run with `node threads.mjs`


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Fix homepage example for "Work with Threads":
`btoa("")` is a legacy function, `Buffer.from("").toString("base64")` should be used instead.

![image](https://github.com/nodejs/nodejs.org/assets/71079641/15f92fec-5223-46be-b044-a478afc4d7fc)

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
