### PR TITLE
feat: Mark external links in the sidebar

### DIFF
--- a/components/Containers/Sidebar/SidebarItem/index.module.css
+++ b/components/Containers/Sidebar/SidebarItem/index.module.css
@@ -6,10 +6,22 @@
     dark:text-neutral-200;
 
   a {
+    @apply inline-flex
+      items-center
+      gap-2
+      p-2;
+  }
+
+  .label {
     @apply w-full
-      p-2
       text-sm
       font-regular;
+  }
+
+  .icon {
+    @apply size-3
+      text-neutral-500
+      dark:text-neutral-200;
   }
 }
 

--- a/components/Containers/Sidebar/SidebarItem/index.tsx
+++ b/components/Containers/Sidebar/SidebarItem/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
 import ActiveLink from '@/components/Common/ActiveLink';
@@ -13,7 +14,9 @@ type SidebarItemProps = {
 const SidebarItem: FC<SidebarItemProps> = ({ label, link }) => (
   <li className={styles.sideBarItem}>
     <ActiveLink href={link} activeClassName={styles.active}>
-      {label}
+      <span className={styles.label}>{label}</span>
+
+      {link.startsWith('http') && <ArrowUpRightIcon className={styles.icon} />}
     </ActiveLink>
   </li>
 );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

A small change to mark external links in the sidebar with the arrow icon, similar to the top bar navigation.

## Validation

https://nodejs-org-git-fork-damianstasik-mark-external-li-1a8b15-openjs.vercel.app/en/about

![Screenshot 2024-03-24 at 13 37 42](https://github.com/nodejs/nodejs.org/assets/920747/e73e534a-18bf-46b2-88aa-458b8fdb52a7)

## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
