### PR TITLE
fix: Disable text selection for <Select> options

### DIFF
--- a/components/Common/Select/index.module.css
+++ b/components/Common/Select/index.module.css
@@ -72,7 +72,8 @@
     dark:bg-neutral-950;
 
   .item {
-    @apply truncate
+    @apply select-none
+      truncate
       px-2.5
       py-1.5
       text-sm


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

There's a strange behavior in Firefox when you try to pick a Node.js version from the select component on the Downloads page. Once you click on an option it also starts a text selection mode which you can see in the video below:


https://github.com/nodejs/nodejs.org/assets/920747/19aa60b4-8cc3-47a8-8ab1-771714c32dc4

This PR fixes it by disabling text selection for the options inside the `<Select>` component.


## Validation

https://github.com/nodejs/nodejs.org/assets/920747/96ec8522-f5d3-4cd1-a6ed-3b221dfe9b9c




## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
