### PR TITLE
fix: Maximum scale and initial scale

### DIFF
--- a/next.dynamic.constants.mjs
+++ b/next.dynamic.constants.mjs
@@ -91,5 +91,5 @@ export const PAGE_VIEWPORT = {
   ],
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
+  maximumScale: 2,
 };


### PR DESCRIPTION
## Description

Since the `initial-scale` and `maximum-scale` are 1, our accessibility score drops to 94

![image](https://github.com/nodejs/nodejs.org/assets/14062599/780c43f5-041c-4099-a51e-792b30e06593)

https://dequeuniversity.com/rules/axe/4.8/meta-viewport

If we want to disable the scale/zoom at an input focus, we can consider disabling it before the input focus and then turning it on again. By default, this value should not remain the same

## Validation

We need to make sure that there is no Lighthouse error below in the Vercel preview;

<img width="528" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/fb4af232-6ff5-40ab-9a50-6f1ad3afc44a">

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
