### PR TITLE
Add Dutch locale in internationalization config

### DIFF
--- a/i18n/config.json
+++ b/i18n/config.json
@@ -188,5 +188,15 @@
     "hrefLang": "pl",
     "enabled": false,
     "default": false
+  },
+  {
+    "code": "nl",
+    "localName": "Nederlands",
+    "name": "Dutch",
+    "langDir": "ltr",
+    "dateFormat": "DD-MM-YYYY",
+    "hrefLang": "nl",
+    "enabled": false,
+    "default": false
   }
 ]


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I have added an entry for the Dutch locale in i18n/config.json, so that me and others can start translating the site into Dutch via Crowdin.


## Validation

Change is visible in the commit diff and also in i18n/config.json

## Related Issues


Adresses #6514 

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
