### PR TITLE
feat: Make MD headers clickable

### DIFF
--- a/next.mdx.mjs
+++ b/next.mdx.mjs
@@ -19,7 +19,9 @@ export const NEXT_REHYPE_PLUGINS = [
   // Automatically add anchor links to headings (H1, ...)
   [
     rehypeAutolinkHeadings,
-    { properties: { ariaHidden: true, tabIndex: -1, class: 'anchor' } },
+    {
+      behavior: 'wrap',
+    },
   ],
   // Transforms sequential code elements into code tabs and
   // adds our syntax highlighter (Shikiji) to Codeboxes

--- a/next.mdx.mjs
+++ b/next.mdx.mjs
@@ -17,12 +17,7 @@ export const NEXT_REHYPE_PLUGINS = [
   // Generates `id` attributes for headings (H1, ...)
   rehypeSlug,
   // Automatically add anchor links to headings (H1, ...)
-  [
-    rehypeAutolinkHeadings,
-    {
-      behavior: 'wrap',
-    },
-  ],
+  [rehypeAutolinkHeadings, { behavior: 'wrap' }],
   // Transforms sequential code elements into code tabs and
   // adds our syntax highlighter (Shikiji) to Codeboxes
   rehypeShikiji,

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -41,7 +41,8 @@ main {
   h5,
   h6 {
     &[id] a {
-      @apply text-neutral-900 dark:text-white;
+      @apply text-neutral-900
+        dark:text-white;
     }
   }
 

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -39,6 +39,17 @@ main {
   h3,
   h4,
   h5,
+  h6 {
+    &[id] a {
+      @apply text-neutral-900 dark:text-white;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
   h6,
   strong {
     @apply font-semibold


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Currently, the MD pipeline is configured to add links to all Markdown headings, the issue is that the link is currently invisible:

![Screenshot 2024-03-24 at 15 55 07](https://github.com/nodejs/nodejs.org/assets/920747/0a472922-fc98-4fba-b550-e289e3f5f117)

This PR changes the config to make whole headings clickable, and adds a bit of styling to make sure these links have correct colors.

## Validation


https://github.com/nodejs/nodejs.org/assets/920747/0bc28641-7842-4e35-9f98-99e46a9ecaff



## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
