### PR TITLE
chore: Unify "node:" prefixes in code examples

### DIFF
--- a/pages/en/learn/manipulating-files/nodejs-file-stats.md
+++ b/pages/en/learn/manipulating-files/nodejs-file-stats.md
@@ -22,7 +22,7 @@ fs.stat('/Users/joe/test.txt', (err, stats) => {
 ```
 
 ```mjs
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 
 fs.stat('/Users/joe/test.txt', (err, stats) => {
   if (err) {
@@ -45,7 +45,7 @@ try {
 ```
 
 ```mjs
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 
 try {
   const stats = fs.statSync('/Users/joe/test.txt');

--- a/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
+++ b/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
@@ -21,7 +21,7 @@ fs.readFile('/Users/joe/test.txt', 'utf8', (err, data) => {
 ```
 
 ```mjs
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 
 fs.readFile('/Users/joe/test.txt', 'utf8', (err, data) => {
   if (err) {

--- a/pages/en/learn/manipulating-files/working-with-file-descriptors-in-nodejs.md
+++ b/pages/en/learn/manipulating-files/working-with-file-descriptors-in-nodejs.md
@@ -19,7 +19,7 @@ fs.open('/Users/joe/test.txt', 'r', (err, fd) => {
 ```
 
 ```mjs
-const fs = require('node:fs');
+import fs from 'node:fs';
 
 fs.open('/Users/joe/test.txt', 'r', (err, fd) => {
   // fd is our file descriptor

--- a/pages/en/learn/modules/backpressuring-in-streams.md
+++ b/pages/en/learn/modules/backpressuring-in-streams.md
@@ -600,7 +600,7 @@ myReadableStream.on('data', chunk => {
 ```
 
 ```mjs
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 // Create a custom Readable stream
 const myReadableStream = new Readable({


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I've noticed that a few code examples were a bit inconsistent when switching between CJS and MJS, this PR addresses it.

## Validation

Compare CJS and MJS code examples in the modified files.

## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
