### PR TITLE
fix:layout-shift caused by the radix dropdown menu.

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -4,6 +4,8 @@
 
 html,
 body {
+  scrollbar-gutter: stable;
+
   @apply size-full;
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -4,9 +4,8 @@
 
 html,
 body {
-  scrollbar-gutter: stable;
-
-  @apply size-full;
+  @apply size-full
+    [scrollbar-gutter:stable];
 }
 
 body {

--- a/styles/index.css
+++ b/styles/index.css
@@ -12,3 +12,7 @@
 @import './base.css';
 @import './markdown.css';
 @import './effects.css';
+
+html {
+  scrollbar-gutter: stable;
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -12,7 +12,3 @@
 @import './base.css';
 @import './markdown.css';
 @import './effects.css';
-
-html {
-  scrollbar-gutter: stable;
-}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
There are some layout shifts in the website which is caused by radix dropdown menu. By default radix drop-down add custom css properties to body tag which includes `overflow:hidden`  that literally caused the sudden layout shift when open the dropdown menu. To fix this there is a css property `scrollbar-gutter: stable` that will take care of this kind of scrollbar issue. Tailwind doesn't support this property by default right now, so I added this property by creating a html tag in index.css file. This property has a great browser support, so no need to worry about that. 


## Validation
**Before:**

https://github.com/nodejs/nodejs.org/assets/56039103/857abbfd-7133-47fa-a91e-77f0633a6c23




**After:**

https://github.com/nodejs/nodejs.org/assets/56039103/14d3baa0-6dec-432a-a1d4-f3a228aa7761



## Related Issues

No issue found. Directly made this PR.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [✅] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [✅ ] I have run `npx turbo format` to ensure the code follows the style guide.
- [✅] I have run `npx turbo test` to check if all tests are passing.
- [✅] I have run `npx turbo build` to check if the website builds without errors.
- [✅] I've covered new added functionality with unit tests if necessary.
