### PR TITLE
feat: Add PowerShell support to Shiki

### DIFF
--- a/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -25,17 +25,19 @@ const ReleaseCodeBox: FC = () => {
     // but usually we should recommend users to download "major" versions
     // since our Downlooad Buttons get the latest minor of a major, it does make sense
     // to request installation of a major via a package manager
+    const codeLanguage = os === 'WIN' ? 'powershell' : 'bash';
     memoizedShiki
-      .then(shiki => highlightToHtml(shiki)(updatedCode, 'bash'))
+      .then(shiki => highlightToHtml(shiki)(updatedCode, codeLanguage))
       .then(setCode);
     // Only react when the specific release number changed
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [release.versionWithPrefix, os, platform]);
 
+  const codeLanguage = os === 'WIN' ? 'PowerShell' : 'Bash';
   return (
     <div className="mb-2 mt-6 flex min-h-80 flex-col gap-2">
       {code && (
-        <CodeBox language="Bash">
+        <CodeBox language={codeLanguage}>
           <code dangerouslySetInnerHTML={{ __html: code }} />
         </CodeBox>
       )}

--- a/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -25,9 +25,8 @@ const ReleaseCodeBox: FC = () => {
     // but usually we should recommend users to download "major" versions
     // since our Downlooad Buttons get the latest minor of a major, it does make sense
     // to request installation of a major via a package manager
-    const codeLanguage = os === 'WIN' ? 'powershell' : 'bash';
     memoizedShiki
-      .then(shiki => highlightToHtml(shiki)(updatedCode, codeLanguage))
+      .then(shiki => highlightToHtml(shiki)(updatedCode, 'bash'))
       .then(setCode);
     // Only react when the specific release number changed
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/shiki.config.mjs
+++ b/shiki.config.mjs
@@ -4,6 +4,7 @@ import diffLanguage from 'shiki/langs/diff.mjs';
 import dockerLanguage from 'shiki/langs/docker.mjs';
 import javaScriptLanguage from 'shiki/langs/javascript.mjs';
 import jsonLanguage from 'shiki/langs/json.mjs';
+import powershellLanguage from 'shiki/langs/powershell.mjs';
 import shellScriptLanguage from 'shiki/langs/shellscript.mjs';
 import shellSessionLanguage from 'shiki/langs/shellsession.mjs';
 import typeScriptLanguage from 'shiki/langs/typescript.mjs';
@@ -33,6 +34,12 @@ export const LANGUAGES = [
     scopeName: 'source.shell',
     aliases: ['bash', 'sh', 'shell', 'zsh'],
     displayName: 'Bash',
+  },
+  {
+    ...powershellLanguage[0],
+    scopeName: 'source.powershell',
+    aliases: ['ps', 'ps1'],
+    displayName: 'PowerShell',
   },
   {
     ...shellSessionLanguage[0],


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR addresses issue #6511 by integrating PowerShell (ps1) syntax highlighting support into the Shiki configuration used on the 'Install on Windows using Package Manager' page. It ensures that when Windows is selected from the dropdown, the codebox correctly highlights PowerShell scripts. This enhancement improves readability for PowerShell users


## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
### Before:
![image](https://github.com/nodejs/nodejs.org/assets/24819103/3cb1b5c9-f64c-4a5c-bf3c-82ddda7bffa0)

### After:
![image](https://github.com/nodejs/nodejs.org/assets/24819103/bf1d8b3a-3a44-4d19-94aa-f06fd0aa7adb)


## Related Issues

closes #6511 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
