### PR TITLE
fix(og): use the resolved page title

### DIFF
--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -218,7 +218,7 @@ const getDynamicRouter = async () => {
         path
       );
       pageMetadata.openGraph.images = [
-        `${currentLocale}/next-data/og?title=${data.title}&type=${data.category ?? 'announcement'}`,
+        `${currentLocale}/next-data/og?title=${pageMetadata.title}&type=${data.category ?? 'announcement'}`,
       ];
     });
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

OG image generation was using the `title` - but displaying `undefined` for some pages. This was because the previous logic was only taking account `title` from frontmatter in markdown pages. The new logic now directly mirrors the implementation of the `og:twitter` title

https://github.com/nodejs/nodejs.org/blob/main/next.dynamic.mjs#L221:

```js
    const { data } = matter(source);

    pageMetadata.title = data.title
      ? `${siteConfig.title} — ${data.title}`
      : siteConfig.title;

    pageMetadata.twitter.title = pageMetadata.title;
```

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
Before

![image](https://github.com/nodejs/nodejs.org/assets/298435/7fee2668-618e-4cfa-8771-6d4cc825f40b)


After

![image](https://github.com/nodejs/nodejs.org/assets/298435/5fce8862-f416-4ad5-8087-7137c21ccdf8)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #6483

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
