### PR TITLE
feat(search): Enhance shortcut key transition for OS detection

### DIFF
--- a/components/Common/Search/index.module.css
+++ b/components/Common/Search/index.module.css
@@ -29,8 +29,8 @@
     absolute
     right-2
     ml-2
-    transition-opacity
-    duration-500
-    md:visible
-    [&>kbd]:font-ibm-plex-mono;
+    font-ibm-plex-mono
+    motion-safe:transition-opacity
+    motion-safe:duration-100
+    md:visible;
 }

--- a/components/Common/Search/index.module.css
+++ b/components/Common/Search/index.module.css
@@ -29,6 +29,8 @@
     absolute
     right-2
     ml-2
+    transition-opacity
+    duration-500
     md:visible
     [&>kbd]:font-ibm-plex-mono;
 }

--- a/components/Common/Search/index.tsx
+++ b/components/Common/Search/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import classNames from 'classnames';
 import { useTranslations } from 'next-intl';
 import { useState, type FC } from 'react';
 
@@ -31,6 +32,7 @@ export const SearchButton: FC = () => {
   const { os } = useDetectOS();
 
   const osCommandKey = os === 'MAC' ? '⌘' : 'Ctrl';
+  const isOSLoading = os === 'LOADING';
 
   return (
     <>
@@ -42,9 +44,14 @@ export const SearchButton: FC = () => {
         <MagnifyingGlassIcon className={styles.magnifyingGlassIcon} />
 
         {t('components.search.searchBox.placeholder')}
-        <span title={`${osCommandKey} K`} className={styles.shortcutIndicator}>
-          <kbd>{osCommandKey} K</kbd>
-        </span>
+        <kbd
+          title={`${osCommandKey} K`}
+          className={classNames(styles.shortcutIndicator, {
+            'opacity-0': isOSLoading,
+          })}
+        >
+          <abbr>{osCommandKey} K</abbr>
+        </kbd>
       </button>
 
       {isOpen ? <WithSearchBox onClose={closeSearchBox} /> : null}

--- a/hooks/react-client/useDetectOS.ts
+++ b/hooks/react-client/useDetectOS.ts
@@ -15,7 +15,7 @@ type UserOSState = {
 
 const useDetectOS = () => {
   const [userOSState, setUserOSState] = useState<UserOSState>({
-    os: 'OTHER',
+    os: 'LOADING',
     bitness: 86,
     architecture: 'ARM',
   });

--- a/types/userOS.ts
+++ b/types/userOS.ts
@@ -1,1 +1,1 @@
-export type UserOS = 'MAC' | 'WIN' | 'LINUX' | 'OTHER';
+export type UserOS = 'MAC' | 'WIN' | 'LINUX' | 'OTHER' | 'LOADING';

--- a/util/downloadUtils.ts
+++ b/util/downloadUtils.ts
@@ -91,6 +91,7 @@ export const bitnessItems = {
     },
   ],
   OTHER: [],
+  LOADING: [],
 };
 
 type formatDropdownItemsType = {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This pull request introduces a smoother transition for the shortcut key display within the search component. Previously, the shortcut key would abruptly change from "Ctrl K" to "Cmd K" (or vice versa) based on the operating system detection. This behavior caused a visual flash that was jarring to the user.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
Before:

https://github.com/nodejs/nodejs.org/assets/81780268/3dbf1ebd-46eb-4f44-a135-050d819a3507




After:


https://github.com/nodejs/nodejs.org/assets/81780268/f4de5878-21c2-4b8e-bc41-4151efc53824




## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
