### PR TITLE
fix: RSS alternate link tag does not expose release/vuln feeds

### DIFF
--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -212,6 +212,21 @@ const getDynamicRouter = async () => {
       path
     );
 
+    const match = path.match(/blog\/(release|vulnerability)/);
+
+    if (match) {
+      const category = match[1];
+      const currentFile = siteConfig.rssFeeds.find(
+        item => item.category === category
+      )?.file;
+      // Dynamically construct the XML path for blog/release and blog/vulnerability
+      pageMetadata.alternates.types['application/rss+xml'] =
+        `${baseUrlAndPath}/en/feed/${currentFile}`;
+    } else {
+      pageMetadata.alternates.types['application/rss+xml'] =
+        `${BASE_URL}${BASE_PATH}/en/feed/blog.xml`;
+    }
+
     availableLocaleCodes.forEach(currentLocale => {
       pageMetadata.alternates.languages[currentLocale] = getUrlForPathname(
         currentLocale,

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -224,7 +224,7 @@ const getDynamicRouter = async () => {
         `${baseUrlAndPath}/en/feed/${currentFile}`;
     } else {
       pageMetadata.alternates.types['application/rss+xml'] =
-        `${BASE_URL}${BASE_PATH}/en/feed/blog.xml`;
+        `${baseUrlAndPath}/en/feed/blog.xml`;
     }
 
     availableLocaleCodes.forEach(currentLocale => {

--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -212,19 +212,23 @@ const getDynamicRouter = async () => {
       path
     );
 
-    const match = path.match(/blog\/(release|vulnerability)/);
-
-    if (match) {
-      const category = match[1];
+    const blogMatch = path.match(/^blog\/(release|vulnerability)(\/|$)/);
+    if (blogMatch) {
+      const category = blogMatch[1];
       const currentFile = siteConfig.rssFeeds.find(
         item => item.category === category
       )?.file;
-      // Dynamically construct the XML path for blog/release and blog/vulnerability
-      pageMetadata.alternates.types['application/rss+xml'] =
-        `${baseUrlAndPath}/en/feed/${currentFile}`;
+      // Use getUrlForPathname to dynamically construct the XML path for blog/release and blog/vulnerability
+      pageMetadata.alternates.types['application/rss+xml'] = getUrlForPathname(
+        locale,
+        `feed/${currentFile}`
+      );
     } else {
-      pageMetadata.alternates.types['application/rss+xml'] =
-        `${baseUrlAndPath}/en/feed/blog.xml`;
+      // Use getUrlForPathname for the default blog XML feed path
+      pageMetadata.alternates.types['application/rss+xml'] = getUrlForPathname(
+        locale,
+        'feed/blog.xml'
+      );
     }
 
     availableLocaleCodes.forEach(currentLocale => {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR addresses an issue where the RSS alternate link tags in the website's head were incorrectly pointing to the general blog feed (blog.xml) for both release and vulnerability pages. Instead, these pages should specifically reference their respective RSS feeds (releases.xml and vulnerabilities.xml). However for all other pages, the general blog RSS feed (blog.xml) is used as it is being done already (current behaviour)

## Validation

![image](https://github.com/nodejs/nodejs.org/assets/24819103/2aecfdc6-0535-4990-87b5-b478de025d50)
![image](https://github.com/nodejs/nodejs.org/assets/24819103/71684a7c-4714-47da-8401-62fcf4d7ba78)

## Related Issues

closes #6559

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
