### PR TITLE
fix: Changelog trigger and minor visual bugs

### DIFF
--- a/components/Common/Badge/index.module.css
+++ b/components/Common/Badge/index.module.css
@@ -20,6 +20,7 @@
       border
       px-2.5
       py-0.5
+      text-center
       text-white;
   }
 

--- a/components/Downloads/ChangelogModal/index.module.css
+++ b/components/Downloads/ChangelogModal/index.module.css
@@ -89,5 +89,10 @@
     pre {
       @apply overflow-auto;
     }
+
+    code,
+    a {
+      @apply break-words;
+    }
   }
 }

--- a/components/Downloads/Release/ChangelogLink.tsx
+++ b/components/Downloads/Release/ChangelogLink.tsx
@@ -10,9 +10,14 @@ const ChangelogLink: FC<PropsWithChildren> = ({ children }) => {
   const { modalOpen, setModalOpen } = useContext(ReleaseContext);
 
   return (
-    <button onClick={() => setModalOpen(!modalOpen)}>
-      <LinkWithArrow className="cursor-pointer">{children}</LinkWithArrow>
-    </button>
+    <LinkWithArrow asChild>
+      <button
+        className="anchor cursor-pointer"
+        onClick={() => setModalOpen(!modalOpen)}
+      >
+        {children}
+      </button>
+    </LinkWithArrow>
   );
 };
 

--- a/components/Downloads/Release/LinkWithArrow.tsx
+++ b/components/Downloads/Release/LinkWithArrow.tsx
@@ -1,16 +1,29 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
-import type { ComponentProps, FC } from 'react';
+import type { SlotProps } from '@radix-ui/react-slot';
+import { Slot } from '@radix-ui/react-slot';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
 import Link from '@/components/Link';
 
-const LinkWithArrow: FC<ComponentProps<typeof Link>> = ({
+type LinkWithArrowProps =
+  | ({ asChild?: false } & ComponentProps<typeof Link>)
+  | ({ asChild: true } & SlotProps);
+
+const LinkWithArrow: FC<PropsWithChildren<LinkWithArrowProps>> = ({
   children,
+  asChild = false,
   ...props
-}) => (
-  <Link {...props}>
-    {children}
-    <ArrowUpRightIcon className="ml-1 inline w-3 fill-neutral-600 dark:fill-white" />
-  </Link>
-);
+}) => {
+  const Comp = asChild ? Slot : Link;
+
+  return (
+    <Comp {...props}>
+      <>
+        {children}
+        <ArrowUpRightIcon className="ml-1 inline w-3 fill-neutral-600 dark:fill-white" />
+      </>
+    </Comp>
+  );
+};
 
 export default LinkWithArrow;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@savvywombat/tailwindcss-grid-areas": "~4.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@savvywombat/tailwindcss-grid-areas": "~4.0.0",

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -75,10 +75,11 @@ main {
       dark:text-white;
   }
 
-  a {
+  a,
+  .anchor {
     @apply text-green-600
       dark:text-green-400
-      xs:underline;
+      xs:font-semibold;
 
     &:hover {
       @apply text-green-900
@@ -86,7 +87,7 @@ main {
     }
 
     &[role='button'] {
-      @apply xs:no-underline;
+      @apply xs:font-regular;
     }
 
     &:has(code) {


### PR DESCRIPTION
## Description

This PR aims to solve some minor visual problems on mobile and the SEO problem in the change log trigger.

- The `anchor` element in the changelog trigger has been removed, and `@radix-ui/react-slot` has been added, which we can use in such cases.
- Fixed the overflow issue in the changelog modal
- Underline styling in headings in mobile resolution has been removed
- The semibold font arrangement was made instead of the underlined links we added for accessibility in mobile design. IMO we do not lose anything in accessibility and the content looks more focused.

## Validation

### Badge Component

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/db5fe9e7-299a-49f6-8f0f-b6ffc925a88f">

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/fb14ac75-17f2-40da-baf8-53e646c40b11">

### Headings

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/9a084f1a-7f01-4478-875c-52324bc22fcf">

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/fbb614b7-0f7f-4443-90ad-4faced0b0c8c">

### Changelog modal

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/c7349a77-0ae8-4fcd-a41d-14a3c6c37c91">

<img width="376" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/825d30f8-6bef-4f78-b8b7-49537e8175ae">

In Preview we need to make sure everything is working correctly on mobile/desktop and our SEO scores are improving

## Related Issues

Fixes #6566

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
