### PR TITLE
fix: properly tag maintenance and flag versions correctly

### DIFF
--- a/components/Downloads/Release/VersionDropdown.tsx
+++ b/components/Downloads/Release/VersionDropdown.tsx
@@ -16,6 +16,10 @@ const getDropDownStatus = (version: string, status: string) => {
     return `${version} (Current)`;
   }
 
+  if (status === 'Maintenance') {
+    return `${version} (Maintenance)`;
+  }
+
   return version;
 };
 

--- a/components/withDownloadCategories.tsx
+++ b/components/withDownloadCategories.tsx
@@ -17,7 +17,7 @@ const WithDownloadCategories: FC<PropsWithChildren> = async ({ children }) => {
   const { page, category, subCategory } = getDownloadCategory(pathname);
 
   const initialRelease: Array<NodeReleaseStatus> = pathname.includes('current')
-    ? ['Current']
+    ? ['Current', 'Maintenance']
     : ['Active LTS', 'Maintenance LTS'];
 
   return (

--- a/next-data/generators/releaseData.mjs
+++ b/next-data/generators/releaseData.mjs
@@ -11,7 +11,7 @@ const getNodeReleaseStatus = (now, support) => {
   }
 
   if (maintenanceStart && now > new Date(maintenanceStart)) {
-    return 'Maintenance LTS';
+    return ltsStart ? 'Maintenance LTS' : 'Maintenance';
   }
 
   if (ltsStart && now > new Date(ltsStart)) {

--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -28,7 +28,7 @@ layout: home
         </>
       )}
     </WithNodeRelease>
-    <WithNodeRelease status={"Current"}>
+    <WithNodeRelease status={["Current", "Maintenance"]}>
       {({ release }) => (
         <small>
           Want new features sooner?

--- a/types/releases.ts
+++ b/types/releases.ts
@@ -1,5 +1,6 @@
 export type NodeReleaseStatus =
   | 'Maintenance LTS'
+  | 'Maintenance'
   | 'Active LTS'
   | 'Current'
   | 'End-of-life'


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes an issue of a maintenance version being flagged as "Maintenance LTS" and we not rendering correctly maintenance versions.

## Validation

On the preview branch, LTS version should again be marked as v20

## Related Issues

Closes https://github.com/nodejs/nodejs.org/issues/6584