### PR TITLE
fix: proper release status

### DIFF
--- a/app/[locale]/next-data/api-data/route.ts
+++ b/app/[locale]/next-data/api-data/route.ts
@@ -16,8 +16,8 @@ const getPathnameForApiFile = (name: string, version: string) =>
 export const GET = async () => {
   const releases = provideReleaseData();
 
-  const { versionWithPrefix } = releases.find(release =>
-    ['Active LTS', 'Maintenance LTS'].includes(release.status)
+  const { versionWithPrefix } = releases.find(
+    release => release.status === 'LTS'
   )!;
 
   const gitHubApiResponse = await fetch(getGitHubApiDocsUrl(versionWithPrefix));

--- a/components/Downloads/DownloadButton/index.stories.tsx
+++ b/components/Downloads/DownloadButton/index.stories.tsx
@@ -12,7 +12,7 @@ export const Default: Story = {
       ltsStart: '2023-10-24',
       maintenanceStart: '2024-10-22',
       endOfLife: '2026-04-30',
-      status: 'Active LTS',
+      status: 'LTS',
       major: 20,
       version: '20.11.0',
       versionWithPrefix: 'v20.11.0',

--- a/components/Downloads/Release/PlatformDropdown.tsx
+++ b/components/Downloads/Release/PlatformDropdown.tsx
@@ -13,7 +13,7 @@ import { ReleaseContext } from '@/providers/releaseProvider';
 import type { PackageManager } from '@/types/release';
 import { formatDropdownItems, platformItems } from '@/util/downloadUtils';
 
-const supportedHomebrewVersions = ['Active LTS', 'Maintenance LTS', 'Current'];
+const supportedHomebrewVersions = ['LTS', 'Current'];
 
 const PlatformDropdown: FC = () => {
   const { release, os, platform, setPlatform } = useContext(ReleaseContext);

--- a/components/Downloads/Release/VersionDropdown.tsx
+++ b/components/Downloads/Release/VersionDropdown.tsx
@@ -8,16 +8,12 @@ import Select from '@/components/Common/Select';
 import { ReleaseContext } from '@/providers/releaseProvider';
 
 const getDropDownStatus = (version: string, status: string) => {
-  if (status === 'Active LTS') {
+  if (status === 'LTS') {
     return `${version} (LTS)`;
   }
 
   if (status === 'Current') {
     return `${version} (Current)`;
-  }
-
-  if (status === 'Maintenance') {
-    return `${version} (Maintenance)`;
   }
 
   return version;

--- a/components/withDownloadCategories.tsx
+++ b/components/withDownloadCategories.tsx
@@ -16,9 +16,9 @@ const WithDownloadCategories: FC<PropsWithChildren> = async ({ children }) => {
   const { pathname } = useClientContext();
   const { page, category, subCategory } = getDownloadCategory(pathname);
 
-  const initialRelease: Array<NodeReleaseStatus> = pathname.includes('current')
-    ? ['Current', 'Maintenance']
-    : ['Active LTS', 'Maintenance LTS'];
+  const initialRelease: NodeReleaseStatus = pathname.includes('current')
+    ? 'Current'
+    : 'LTS';
 
   return (
     <LinkTabs

--- a/next-data/generators/__tests__/releaseData.test.mjs
+++ b/next-data/generators/__tests__/releaseData.test.mjs
@@ -48,6 +48,6 @@ describe('generateReleaseData', () => {
     expect(release.v8).toBe('8.0.276.20');
     expect(release.releaseDate).toBe('2021-04-20');
     expect(release.modules).toBe('83');
-    expect(release.status).toBe('Maintenance LTS');
+    expect(release.status).toBe('LTS');
   });
 });

--- a/next-data/generators/releaseData.mjs
+++ b/next-data/generators/releaseData.mjs
@@ -4,18 +4,14 @@ import nodevu from '@nodevu/core';
 
 // Gets the appropriate release status for each major release
 const getNodeReleaseStatus = (now, support) => {
-  const { endOfLife, maintenanceStart, ltsStart, currentStart } = support;
+  const { endOfLife, ltsStart, currentStart } = support;
 
-  if (endOfLife && now > new Date(endOfLife)) {
+  if (endOfLife && now >= new Date(endOfLife)) {
     return 'End-of-life';
   }
 
-  if (maintenanceStart && now > new Date(maintenanceStart)) {
-    return ltsStart ? 'Maintenance LTS' : 'Maintenance';
-  }
-
-  if (ltsStart && now > new Date(ltsStart)) {
-    return 'Active LTS';
+  if (ltsStart && now >= new Date(ltsStart)) {
+    return 'LTS';
   }
 
   if (currentStart && now >= new Date(currentStart)) {
@@ -58,7 +54,7 @@ const generateReleaseData = () => {
           version: latestVersion.semver.raw,
           versionWithPrefix: `v${latestVersion.semver.raw}`,
           codename: major.support.codename || '',
-          isLts: status === 'Active LTS' || status === 'Maintenance LTS',
+          isLts: status === 'LTS',
           npm: latestVersion.dependencies.npm || '',
           v8: latestVersion.dependencies.v8 || '',
           releaseDate: latestVersion.releaseDate || '',

--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -16,7 +16,7 @@ layout: home
   </div>
 
   <div>
-    <WithNodeRelease status={['Active LTS', 'Maintenance LTS']}>
+    <WithNodeRelease status={['LTS']}>
       {({ release }) => (
         <>
           <DownloadButton release={release}>Download Node.js (LTS)</DownloadButton>
@@ -28,7 +28,7 @@ layout: home
         </>
       )}
     </WithNodeRelease>
-    <WithNodeRelease status={["Current", "Maintenance"]}>
+    <WithNodeRelease status={['Current']}>
       {({ release }) => (
         <small>
           Want new features sooner?

--- a/types/releases.ts
+++ b/types/releases.ts
@@ -1,10 +1,4 @@
-export type NodeReleaseStatus =
-  | 'Maintenance LTS'
-  | 'Maintenance'
-  | 'Active LTS'
-  | 'Current'
-  | 'End-of-life'
-  | 'Pending';
+export type NodeReleaseStatus = 'LTS' | 'Current' | 'End-of-life' | 'Pending';
 
 export interface NodeReleaseSource {
   major: number;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

As per recommendation of the Node.js releasers, we should simplify our status stamping and ignore "Maintenance" statuses and only consider EOL statuses.

## Validation

LTS and Current versions should still render properly and all the logic should be working as expected

## Related Issues

Fixes https://github.com/nodejs/nodejs.org/issues/6584
