### PR TITLE
Update h1 so that it is visible

### DIFF
--- a/styles/effects.css
+++ b/styles/effects.css
@@ -4,6 +4,7 @@ h1.special {
     text-4xl
     leading-[3rem]
     -tracking-[0.045rem]
+    text-transparent
     dark:bg-gradient-subtle-white
     md:text-5xl
     md:leading-[4rem]

--- a/styles/effects.css
+++ b/styles/effects.css
@@ -4,7 +4,6 @@ h1.special {
     text-4xl
     leading-[3rem]
     -tracking-[0.045rem]
-    [-webkit-text-fill-color:transparent]
     dark:bg-gradient-subtle-white
     md:text-5xl
     md:leading-[4rem]

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -91,7 +91,7 @@ export default {
         900: '#411526',
       },
       white: '#FFFFFF',
-      transparent: 'transparent',
+      transparent: 'RGBA(255, 255, 255, 0)',
       shadow: '#101828',
     },
     fontSize: {


### PR DESCRIPTION
## Description

Removed web-text-fill-color:transparent.

## Validation

Select the title text, and click outside the browser so that it looses focus.

**Before**
![imagen](https://github.com/nodejs/nodejs.org/assets/13491373/d078b2f9-dde2-4e77-b8a2-4a9e80b0e685)

**After**
![imagen](https://github.com/nodejs/nodejs.org/assets/13491373/263fe590-d3a5-456e-a6b4-6e7e019e450c)

## Related Issues
Fixes #6585 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
