### PR TITLE
fix: Banner type

### DIFF
--- a/components/Downloads/ChangelogModal/index.module.css
+++ b/components/Downloads/ChangelogModal/index.module.css
@@ -21,6 +21,7 @@
       bg-white
       p-8
       focus:outline-none
+      dark:border-neutral-900
       dark:bg-neutral-950
       sm:my-20
       lg:max-w-[900px]

--- a/site.json
+++ b/site.json
@@ -31,7 +31,8 @@
       "startDate": "2024-03-28T13:45:00.000Z",
       "endDate": "2024-04-11T17:30:00.000Z",
       "text": "New security releases to be made available April 3rd, 2024",
-      "link": "https://nodejs.org/en/blog/vulnerability/april-2024-security-releases/"
+      "link": "https://nodejs.org/en/blog/vulnerability/april-2024-security-releases/",
+      "type": "warning"
     }
   },
   "websiteBadges": {


### PR DESCRIPTION
## Description

With this PR, the banner type from `default` was updated to `warning`. Security releases are important for end users and in my opinion good to consider this with a warning when they first come to the site, instead of showing it as a good thing with a green color in terms of UX.

Additionally, I have added a more compatible border color for the dark theme of the changelog modal 👀 

## Validation

The security update banner should appear as a warning in the preview.

<img width="600" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/c0d2458a-8edf-4056-9db9-63865d127b91">

<img width="600" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/d8697e19-5d0d-4c4b-b348-22d37f348fd1">

