### PR TITLE
fix: explain that example is not deterministic

### DIFF
--- a/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -42,7 +42,7 @@ process.nextTick(() => {
 });
 ```
 
-#### Output:
+#### Example output:
 
 ```bash
 Hello => number 1
@@ -50,3 +50,5 @@ Running at next tick => number 2
 Running before the timeout => number 3
 The timeout running last => number 4
 ```
+
+The exact output may differ from run to run.


### PR DESCRIPTION
The example of asynchronous code is not deterministic and can produce differ results from run to run. It is not a bug in the documentation.


cc @ovflowd 

https://github.com/nodejs/nodejs.org/pull/6606#issuecomment-2035260890