### PR TITLE
fix: Bitness type in dropdown

### DIFF
--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -64,21 +64,27 @@ const BitnessDropdown: FC = () => {
   // this can be an optimisation for the future
   // to remove this logic from this component
   useEffect(() => {
-    const mappedBittnessesValues = bitnessItems[os].map(({ value }) => value);
+    const mappedBitnessValues = bitnessItems[os].map(({ value }) => value);
 
-    const currentBittnessExcluded =
+    const currentBitnessExcluded =
       // Different OSs support different Bitnessess, hence we should also check
       // if besides the current bitness not being supported for a given release version
       // we also should check if it is not supported by the OS
       disabledItems.includes(String(bitness)) ||
-      !mappedBittnessesValues.includes(String(bitness));
+      !mappedBitnessValues.includes(String(bitness));
 
-    const nonExcludedBitness = mappedBittnessesValues.find(
-      bittness => !disabledItems.includes(bittness)
+    const nonExcludedBitness = mappedBitnessValues.find(
+      bitness => !disabledItems.includes(bitness)
     );
 
-    if (currentBittnessExcluded && nonExcludedBitness) {
-      setBitness(nonExcludedBitness);
+    if (currentBitnessExcluded && nonExcludedBitness) {
+      // We set it as a Number for cases where it is 64 or 86 otherwise we are
+      // setting it as a string (ARMv7, ARMv6, etc.)
+      if (Number.isNaN(Number(nonExcludedBitness)) === false) {
+        setBitness(Number(nonExcludedBitness));
+      } else {
+        setBitness(nonExcludedBitness);
+      }
     }
     // we shouldn't react when "actions" change
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

When the default bitness information was excluded and non-excluded bitness existed, we were assigning bitness information as a string by default. With this PR, it was possible to assign numbers such as 86 ,64 or strings such as "arm64" or "armv7l" depending on the type of bitness selected.

With this PR, we aim to create the correct link even when the default bitness is disabled from the `getNodeDownloadUrl` method. I will check if we can prepare test cases to check these links 👀 

## Validation

In the preview, download links should be correct

## Related Issues

Fixes #6613

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
