### PR TITLE
fix: Search box button accessibility

### DIFF
--- a/components/Common/Search/index.module.css
+++ b/components/Common/Search/index.module.css
@@ -8,7 +8,7 @@
     pr-4
     text-left
     text-sm
-    text-neutral-700
+    text-neutral-800
     hover:bg-neutral-300
     hover:text-neutral-900
     dark:bg-neutral-900
@@ -28,8 +28,10 @@
   @apply invisible
     absolute
     right-2
-    ml-2
-    font-ibm-plex-mono
+    px-1
+    font-["Inter",var(--font-ibm-plex-mono)]
+    text-xs
+    leading-5
     motion-safe:transition-opacity
     motion-safe:duration-100
     md:visible;

--- a/components/Common/Search/index.module.css
+++ b/components/Common/Search/index.module.css
@@ -1,12 +1,10 @@
 .searchButton {
-  @apply relative
+  @apply flex
     w-52
+    gap-2
     rounded-md
     bg-neutral-200
-    py-2
-    pl-9
-    pr-4
-    text-left
+    p-2
     text-sm
     text-neutral-800
     hover:bg-neutral-300
@@ -18,20 +16,19 @@
 }
 
 .magnifyingGlassIcon {
-  @apply absolute
-    left-2
-    top-[8px]
-    size-5;
+  @apply size-5;
 }
 
 .shortcutIndicator {
   @apply invisible
-    absolute
-    right-2
+    flex
+    flex-1
+    items-center
+    justify-end
+    self-center
     px-1
     font-ibm-plex-mono
     text-xs
-    leading-5
     motion-safe:transition-opacity
     motion-safe:duration-100
     md:visible;

--- a/components/Common/Search/index.module.css
+++ b/components/Common/Search/index.module.css
@@ -29,7 +29,7 @@
     absolute
     right-2
     px-1
-    font-["Inter",var(--font-ibm-plex-mono)]
+    font-ibm-plex-mono
     text-xs
     leading-5
     motion-safe:transition-opacity

--- a/components/Common/Search/index.tsx
+++ b/components/Common/Search/index.tsx
@@ -40,6 +40,7 @@ export const SearchButton: FC = () => {
         type="button"
         onClick={openSearchBox}
         className={styles.searchButton}
+        aria-label={t('components.search.searchBox.placeholder')}
       >
         <MagnifyingGlassIcon className={styles.magnifyingGlassIcon} />
 


### PR DESCRIPTION
## Description

The contrast ratio of the background and text in the search box button does not meet the minimum contrast requirements (`4.5:1`). With this PR was updated to meet the minimum contrast ratio

https://dequeuniversity.com/rules/axe/4.8/color-contrast

## Validation

Old `3.69` / New `5.48`

<img width="313" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/9fbe2886-ecf0-4882-802f-e807f7a8b95c">

<img width="313" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/51ed29d4-6d61-4d57-8546-addf0d430e0d">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
