### PR TITLE
Blog: update april-2 security release slug

### DIFF
--- a/pages/en/blog/vulnerability/april-2024-security-releases-2.md
+++ b/pages/en/blog/vulnerability/april-2024-security-releases-2.md
@@ -2,7 +2,7 @@
 date: 2024-04-04T03:00:00.000Z
 category: vulnerability
 title: Tuesday, April 9, 2024 Security Releases
-slug: april-2024-security-releases
+slug: april-2024-security-releases-2
 layout: blog-post
 author: The Node.js Project
 ---


### PR DESCRIPTION
It uses the same slug as another security release of April (https://nodejs.org/en/blog/vulnerability/april2-2024-security-releases). I'm changing to a more friendly slug