### PR TITLE
fix: redirect to default locale page when locale is not supported

### DIFF
--- a/app/[locale]/[[...path]]/page.tsx
+++ b/app/[locale]/[[...path]]/page.tsx
@@ -1,5 +1,5 @@
 import { setContext, setTags } from '@sentry/nextjs';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import type { FC } from 'react';
 
@@ -9,7 +9,11 @@ import WithLayout from '@/components/withLayout';
 import { ENABLE_STATIC_EXPORT, VERCEL_REVALIDATE } from '@/next.constants.mjs';
 import { PAGE_VIEWPORT, DYNAMIC_ROUTES } from '@/next.dynamic.constants.mjs';
 import { dynamicRouter } from '@/next.dynamic.mjs';
-import { availableLocaleCodes, defaultLocale } from '@/next.locales.mjs';
+import {
+  allLocaleCodes,
+  availableLocaleCodes,
+  defaultLocale,
+} from '@/next.locales.mjs';
 import { MatterProvider } from '@/providers/matterProvider';
 
 type DynamicStaticPaths = { path: Array<string>; locale: string };
@@ -67,7 +71,14 @@ const getPage: FC<DynamicParams> = async ({ params }) => {
     // Forces the current locale to be the Default Locale
     unstable_setRequestLocale(defaultLocale.code);
 
-    return notFound();
+    if (!allLocaleCodes.includes(locale)) {
+      // when the locale is not listed in the locales, return NotFound
+      return notFound();
+    }
+
+    // Redirect to the default locale path
+    const pathname = dynamicRouter.getPathname(path);
+    return redirect(`/${defaultLocale.code}/${pathname}`);
   }
 
   // Configures the current Locale to be the given Locale of the Request

--- a/next.locales.mjs
+++ b/next.locales.mjs
@@ -20,7 +20,11 @@ const availableLocalesMap = Object.fromEntries(
   localeConfig.map(locale => [locale.code, locale])
 );
 
+// Creates all supported locales
+const allLocaleCodes = localeConfig.map(locale => locale.code);
+
 export {
+  allLocaleCodes,
   availableLocales,
   availableLocaleCodes,
   availableLocalesMap,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

https://nodejs.org/ja/ pages are 404. this issue link reported about the problem.
https://github.com/nodejs/nodejs.org/issues/6501

When some locales are not supported in this page, this patch redirects the url to default locale `/en` url.

## Validation

- launch local dev environment
- go to https://localhost:3000/ja
- see the url from /ja to /en

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Related to [#6501](https://github.com/nodejs/nodejs.org/issues/6501)

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
