### PR TITLE
Refactor/fix: attempt at making notificationProvider only render on client efficiently

### DIFF
--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -28,12 +28,12 @@ export const NotificationProvider: FC<PropsWithChildren<NotificationProps>> = ({
   children,
 }) => {
   const [notification, dispatch] = useState<NotificationContextType>(null);
-
   useEffect(() => {
-    const timeout = setTimeout(() => dispatch(null), notification?.duration);
-
-    return () => clearTimeout(timeout);
-  }, [notification]);
+    if (notification && typeof window !== 'undefined') {
+      const timeout = setTimeout(() => dispatch(null), notification?.duration);
+      return () => clearTimeout(timeout);
+    }
+  }, [notification?.duration]);
 
   return (
     <NotificationContext.Provider value={notification}>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Making sure this componenet Effect is only running on client by checking if notification && typeof window !== 'undefined', this is more of a hacky solution i'm open to request of changes and more guidance
## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #6629 
### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [X] I have run `npx turbo test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
