### PR TITLE
fix: numerous fixes regarding package manager page

### DIFF
--- a/components/Downloads/Release/OperatingSystemDropdown.tsx
+++ b/components/Downloads/Release/OperatingSystemDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
+
 import { useTranslations } from 'next-intl';
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect } from 'react';
 import type { FC } from 'react';
 
 import Select from '@/components/Common/Select';
@@ -22,7 +23,7 @@ const OperatingSystemDropdown: FC<OperatingSystemDropdownProps> = ({
   exclude = [],
 }) => {
   const { os: userOS } = useDetectOS();
-  const { platform, os, setOS } = useContext(ReleaseContext);
+  const { os, setOS } = useContext(ReleaseContext);
   const t = useTranslations();
 
   // we shouldn't react when "actions" change
@@ -33,43 +34,25 @@ const OperatingSystemDropdown: FC<OperatingSystemDropdownProps> = ({
   // disabled OSs, Platforms, based on specific criteria
   // this can be an optimisation for the future
   // to remove this logic from this component
-  const disabledItems = useMemo(() => {
-    const disabledItems = exclude;
-
-    if (platform === 'BREW') {
-      disabledItems.push('WIN');
-    }
-
-    if (platform === 'DOCKER') {
-      disabledItems.push('LINUX');
-    }
-
-    return disabledItems;
-  }, [exclude, platform]);
-
-  // @TODO: We should have a proper utility that gives
-  // disabled OSs, Platforms, based on specific criteria
-  // this can be an optimisation for the future
-  // to remove this logic from this component
   useEffect(() => {
-    const currentOSExcluded = disabledItems.includes(os);
+    const currentOSExcluded = exclude.includes(os);
 
     const nonExcludedOS = operatingSystemItems
       .map(({ value }) => value)
-      .find(os => !disabledItems.includes(os));
+      .find(os => !exclude.includes(os));
 
     if (currentOSExcluded && nonExcludedOS) {
       setOS(nonExcludedOS);
     }
     // we shouldn't react when "actions" change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [os, disabledItems]);
+  }, [os, exclude]);
 
   return (
     <Select
       values={formatDropdownItems({
         items: operatingSystemItems,
-        disabledItems,
+        disabledItems: exclude,
         icons: {
           WIN: <Microsoft width={16} height={16} />,
           MAC: <Apple width={16} height={16} />,

--- a/components/Downloads/Release/PlatformDropdown.tsx
+++ b/components/Downloads/Release/PlatformDropdown.tsx
@@ -29,11 +29,7 @@ const PlatformDropdown: FC = () => {
       disabledItems.push('BREW', 'NVM');
     }
 
-    if (os === 'LINUX') {
-      disabledItems.push('DOCKER', 'CHOCO');
-    }
-
-    if (os === 'MAC') {
+    if (os === 'LINUX' || os === 'MAC') {
       disabledItems.push('CHOCO');
     }
 

--- a/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -33,8 +33,9 @@ const ReleaseCodeBox: FC = () => {
   }, [release.versionWithPrefix, os, platform]);
 
   const codeLanguage = os === 'WIN' ? 'PowerShell' : 'Bash';
+
   return (
-    <div className="mb-2 mt-6 flex min-h-80 flex-col gap-2">
+    <div className="mb-2 mt-6 flex flex-col gap-2">
       {code && (
         <CodeBox language={codeLanguage}>
           <code dangerouslySetInnerHTML={{ __html: code }} />
@@ -42,6 +43,8 @@ const ReleaseCodeBox: FC = () => {
       )}
 
       <span className="text-center text-xs text-neutral-800 dark:text-neutral-200">
+        <b>{t('layouts.download.codeBox.managerInstalled')}</b>
+        <br />
         {t('layouts.download.codeBox.communityWarning')}
       </span>
     </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -284,6 +284,7 @@
         "platform": "Platform"
       },
       "codeBox": {
+        "managerInstalled": "Please ensure you have the right package manager installed before running a script.",
         "communityWarning": "Package managers and their installation scripts are not maintained by the Node.js project."
       }
     }

--- a/pages/en/download/package-manager/current.mdx
+++ b/pages/en/download/package-manager/current.mdx
@@ -5,7 +5,7 @@ subtitle: Download Node.js the way you want.
 ---
 
 <section>
-Install Node.js <Release.VersionDropdown /> on  <Release.OperatingSystemDropdown exclude={["AIX"]} /> using <Release.PlatformDropdown />
+Install Node.js <Release.VersionDropdown /> on <Release.OperatingSystemDropdown exclude={["AIX"]} /> using <Release.PlatformDropdown />
 
 <Release.ReleaseCodeBox />
 </section>

--- a/util/getNodeDownloadSnippet.ts
+++ b/util/getNodeDownloadSnippet.ts
@@ -51,7 +51,7 @@ export const getNodeDownloadSnippet = (release: NodeRelease, os: UserOS) => {
     case os === 'WIN':
       snippets.CHOCO = dedent`
       # download and install Node.js
-      choco install nodejs --version="${release.version}"
+      choco install nodejs${release.isLts ? '-lts' : ''} --version="${release.version}"
 
       # verifies the right Node.js version is in the environment
       node -v # should print \`${release.versionWithPrefix}\`

--- a/util/getNodeDownloadSnippet.ts
+++ b/util/getNodeDownloadSnippet.ts
@@ -12,42 +12,9 @@ export const getNodeDownloadSnippet = (release: NodeRelease, os: UserOS) => {
     CHOCO: '',
   };
 
-  if (os === 'LINUX' || os === 'MAC') {
-    snippets.NVM = dedent`
-      # installs NVM (Node Version Manager)
-      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-
-      # download and install Node.js
-      nvm install ${release.major}
-
-      # verifies the right Node.js version is in the environment
-      node -v # should print \`${release.versionWithPrefix}\`
-
-      # verifies the right NPM version is in the environment
-      npm -v # should print \`${release.npm}\``;
-
-    snippets.BREW = dedent`
-      # download and installs Homebrew (macOS/Linux Package Manager)
-      curl -o- https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
-
-      # download and install Node.js
-      brew install node@${release.major}
-
-      # verifies the right Node.js version is in the environment
-      node -v # should print \`${release.versionWithPrefix}\`
-
-      # verifies the right NPM version is in the environment
-      npm -v # should print \`${release.npm}\``;
-  }
-
-  if (os === 'MAC') {
-    snippets.DOCKER = dedent`
-      # installs Homebrew (macOS/Linux Package Manager)
-      curl -o- https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
-
-      # installs Docker Desktop
-      brew install docker --cask
-
+  switch (true) {
+    case os === 'WIN' || os === 'MAC' || os === 'LINUX':
+      snippets.DOCKER = dedent`
       # pulls the Node.js Docker image
       docker pull node:${release.major}-${release.major >= 4 ? 'alpine' : 'slim'}
 
@@ -56,15 +23,33 @@ export const getNodeDownloadSnippet = (release: NodeRelease, os: UserOS) => {
 
       # verifies the right NPM version is in the environment
       docker run node:${release.major}-${release.major >= 4 ? 'alpine' : 'slim'} npm -v # should print \`${release.npm}\``;
-  }
+    // eslint-disable-next-line no-fallthrough
+    case os === 'MAC' || os === 'LINUX':
+      snippets.NVM = dedent`
+        # installs NVM (Node Version Manager)
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 
-  if (os === 'WIN') {
-    snippets.CHOCO = dedent`
-      # installs Chocolatey (Windows Package Manager)
-      Set-ExecutionPolicy Bypass -Scope Process -Force;
-      [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-      iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
+        # download and install Node.js
+        nvm install ${release.major}
 
+        # verifies the right Node.js version is in the environment
+        node -v # should print \`${release.versionWithPrefix}\`
+
+        # verifies the right NPM version is in the environment
+        npm -v # should print \`${release.npm}\``;
+
+      snippets.BREW = dedent`
+        # download and install Node.js
+        brew install node@${release.major}
+
+        # verifies the right Node.js version is in the environment
+        node -v # should print \`${release.versionWithPrefix}\`
+
+        # verifies the right NPM version is in the environment
+        npm -v # should print \`${release.npm}\``;
+    // eslint-disable-next-line no-fallthrough
+    case os === 'WIN':
+      snippets.CHOCO = dedent`
       # download and install Node.js
       choco install nodejs --version="${release.version}"
 
@@ -73,24 +58,9 @@ export const getNodeDownloadSnippet = (release: NodeRelease, os: UserOS) => {
 
       # verifies the right NPM version is in the environment
       npm -v # should print \`${release.npm}\``;
-
-    snippets.DOCKER = dedent`
-      # installs Chocolatey (Windows Package Manager)
-      Set-ExecutionPolicy Bypass -Scope Process -Force;
-      [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-      iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'));
-
-      # installs Docker Desktop
-      choco install docker-desktop
-
-      # pulls the Node.js Docker image
-      docker pull node:${release.major}-${release.major >= 4 ? 'alpine' : 'slim'}
-
-      # verifies the right Node.js version is in the environment
-      docker run node:${release.major}-${release.major >= 4 ? 'alpine' : 'slim'} node -v # should print \`${release.versionWithPrefix}\`
-
-      # verifies the right NPM version is in the environment
-      docker run node:${release.major}-${release.major >= 4 ? 'alpine' : 'slim'} npm -v # should print \`${release.npm}\``;
+    // eslint-disable-next-line no-fallthrough
+    default:
+      break;
   }
 
   return snippets;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR does a few fixes/changes as discussed on previous issues and as pointed out:

- Remove the installation of the said package managers on the CodeBox snippets (except NVM, which is "universal" and specific to Node).js)
  - The reasoning is that folks will know how to install (and/or must have these package managers) preinstalled, such as Docker, Homebrew, and Chocolatey, as they are "OS" package managers, not Node.js package managers.
- Add Docker option for Linux since we removed Docker installation instructions
- Added warning that folks need to ensure that package managers are installed
- Fixed height of the CodeBox section
- Fixed bug that you couldn't switch between OSs (we were being too restrictive with one of the dropdowns)
- Fixed Choco LTS package

## Validation

- Ensure functionality on the Package Manager tab is working as expected

## Related Issues

Fixes https://github.com/nodejs/nodejs.org/issues/6637
Fixes https://github.com/nodejs/nodejs.org/issues/6479
