### PR TITLE
Fix: missing Promise in tsdoc of 2 functions

### DIFF
--- a/next.dynamic.mjs
+++ b/next.dynamic.mjs
@@ -79,7 +79,7 @@ const getDynamicRouter = async () => {
    * This method returns a list of all routes that exist for a given locale
    *
    * @param {string} locale
-   * @returns {Array<string>}
+   * @returns {Promise<Array<string>>}
    */
   const getRoutesByLanguage = async (locale = defaultLocale.code) => {
     const shouldIgnoreStaticRoute = pathname =>
@@ -187,7 +187,7 @@ const getDynamicRouter = async () => {
    *
    * @param {string} locale
    * @param {string} path
-   * @returns {import('next').Metadata}
+   * @returns {Promise<import('next').Metadata>}
    */
   const _getPageMetadata = async (locale = defaultLocale.code, path = '') => {
     const pageMetadata = { ...PAGE_METADATA };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Added missing Promise to tsdoc of getRoutesByLanguage and _getPageMetadata
The missing Promise keyword causes tsserver to output `'await' has no effect on the type of this expression`

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npx turbo format` to ensure the code follows the style guide.
- [ ] I have run `npx turbo test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
