### PR TITLE
fix breadcrumbs to the top of learn page

### DIFF
--- a/layouts/Learn.tsx
+++ b/layouts/Learn.tsx
@@ -15,14 +15,13 @@ const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
       <WithProgressionSidebar navKey="learn" />
 
       <main>
+        <WithBreadcrumbs />
         {children}
 
         <WithSidebarCrossLinks navKey="learn" />
       </main>
 
       <WithMetaBar />
-
-      <WithBreadcrumbs />
     </ArticleLayout>
   </>
 );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->
Fixes #6651 

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I have relocated the breadcrumbs to the top section.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
