### PR TITLE
Update twisted link in docs

### DIFF
--- a/pages/en/about/index.mdx
+++ b/pages/en/about/index.mdx
@@ -82,4 +82,4 @@ over your cores.
 [`child_process.fork()`]: https://nodejs.org/api/child_process.html
 [`cluster`]: https://nodejs.org/api/cluster.html
 [event machine]: https://github.com/eventmachine/eventmachine
-[twisted]: https://twistedmatrix.com/trac/
+[twisted]: https://twisted.org/


### PR DESCRIPTION
The Twisted link used in the docs (https://twistedmatrix.com/trac) redirects to https://twisted.org. I just updated it to the final link.