### PR TITLE
fix(rtl): add static dir to CodeBox

### DIFF
--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -94,7 +94,7 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
 
   return (
     <div className={styles.root}>
-      <pre ref={ref} className={styles.content} tabIndex={0}>
+      <pre ref={ref} className={styles.content} tabIndex={0} dir="ltr">
         {transformCode(children, language)}
       </pre>
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In RTL languages, the code box should remain LTR because the written code has an LTR direction. In this project, when using `CodeTabs`, there is no issue as `radix-ui/react-tabs` applies the LTR direction. However, when using `CodeBox` in an RTL language, it encounters a problem as shown in the image below.

## Validation

![Screenshot_2024-04-23_14_57_33](https://github.com/nodejs/nodejs.org/assets/17986464/77584e89-b029-4ef6-ad21-80a6f714172f)

Became the:
![Screenshot_2024-04-23_14_58_12](https://github.com/nodejs/nodejs.org/assets/17986464/5bf157d8-38a9-474f-aac6-f7457f182d8c)

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
