### PR TITLE
refactor: Default bitness on the download page

### DIFF
--- a/components/Downloads/Release/BitnessDropdown.tsx
+++ b/components/Downloads/Release/BitnessDropdown.tsx
@@ -79,11 +79,13 @@ const BitnessDropdown: FC = () => {
     if (currentBitnessExcluded && nonExcludedBitness) {
       // We set it as a Number for cases where it is 64 or 86 otherwise we are
       // setting it as a string (ARMv7, ARMv6, etc.)
-      if (Number.isNaN(Number(nonExcludedBitness)) === false) {
-        setBitness(Number(nonExcludedBitness));
-      } else {
-        setBitness(nonExcludedBitness);
-      }
+      const numericBitness = Number(nonExcludedBitness);
+
+      setBitness(
+        numericBitness.toString() === nonExcludedBitness
+          ? numericBitness
+          : nonExcludedBitness
+      );
     }
     // we shouldn't react when "actions" change
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

This PR contains the [review changes](https://github.com/nodejs/nodejs.org/pull/6614#discussion_r1557344906) suggested in #6614 

Apart from this, I will check if we can keep the bitness information as a string to use it without editing everywhere with different PR. We add x before bitness when string and repeat the type checks everywhere

(I'm open to suggestions to make this easier 😄)

## Validation

In the preview, download links should be correct

## Related Issues

Related to #6613 #6614 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npx turbo format` to ensure the code follows the style guide.
- [x] I have run `npx turbo test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
