### PR TITLE
build(script): use `dev` instead of `serve`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ for getting things done and landing your contribution.
 
    ```bash
    npm ci # installs this project's dependencies
-   npx turbo serve # starts a preview of your local changes
+   npx turbo dev # starts a development environment
    ```
 
 7. Perform your changes. In case you're unfamiliar with the structure of this repository, we recommend a read on the [Collaborator Guide](./COLLABORATOR_GUIDE.md)
@@ -118,14 +118,8 @@ for getting things done and landing your contribution.
     git push -u origin name-of-your-branch
     ```
 
-    > [!NOTE]\
-    > By default if you run the Website (either via `npm run serve` or `npm run build`) two files on the `public` folder will be generated.
-    >
-    > You don't need to reset/discard these files, as by default we use Git Hooks that simply ignore these files during commit.
-    > Note that these files are generated and should **not** be committed. (`public/node-release-data.json` and `public/blog-posts-data.json`)
-
-    > [!IMPORTANT]\
-    > Before committing and opening a Pull Request, please go first through our [Commit](#commit-guidelines) and [Pull Request](#pull-request-policy) guidelines outlined below.
+> [!IMPORTANT]\
+> Before committing and opening a Pull Request, please go first through our [Commit](#commit-guidelines) and [Pull Request](#pull-request-policy) guidelines outlined below.
 
 11. Create a Pull Request.
 
@@ -143,7 +137,7 @@ This repository contains several scripts and commands for performing numerous ta
 <details>
   <summary>Commands for Running & Building the Website</summary>
 
-- `npx turbo serve` runs Next.js's Local Development Server, listening by default on `http://localhost:3000/`.
+- `npx turbo dev` runs Next.js's Local Development Server, listening by default on `http://localhost:3000/`.
 - `npx turbo build` builds the Application on Production mode. The output is by default within `.next` folder.
   - This is used for the Node.js Vercel Deployments (Preview & Production)
 - `npx turbo deploy` builds the Application on Export Production Mode. The output is by default within `build` folder.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ```bash
 npm ci
-npx turbo serve
+npx turbo dev
 
 # listening at localhost:3000
 ```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "scripts:release-post": "cross-env NODE_NO_WARNINGS=1 node scripts/release-post/index.mjs",
     "dev": "cross-env NODE_NO_WARNINGS=1 next dev --turbo",
+    "serve": "npm run dev",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
     "start": "cross-env NODE_NO_WARNINGS=1 next start",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true npm run build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "scripts:release-post": "cross-env NODE_NO_WARNINGS=1 node scripts/release-post/index.mjs",
-    "serve": "cross-env NODE_NO_WARNINGS=1 next dev --turbo",
+    "dev": "cross-env NODE_NO_WARNINGS=1 next dev --turbo",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
     "start": "cross-env NODE_NO_WARNINGS=1 next start",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true npm run build",

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["NODE_ENV"],
   "pipeline": {
-    "serve": {
+    "dev": {
       "cache": false,
       "persistent": true,
       "env": [


### PR DESCRIPTION
## Description

I propose to change `serve` to `dev` because it's not serving the site. It's just create a dev environment.
Also on docs I had remove an obsolete mention.

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run format` to ensure the code follows the style guide.
- [X] I have run `npm run test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
- **NA** I've covered new added functionality with unit tests if necessary.
