### PR TITLE
fix: horizontal scrollbar appearing on small screen

### DIFF
--- a/components/Containers/Footer/index.module.css
+++ b/components/Containers/Footer/index.module.css
@@ -6,10 +6,10 @@
     border-t
     border-neutral-200
     bg-white
-    px-8
     py-4
     dark:border-neutral-900
     dark:bg-neutral-950
+    sm:px-8
     md:flex-row
     md:justify-between
     md:py-5;

--- a/components/Containers/MetaBar/index.module.css
+++ b/components/Containers/MetaBar/index.module.css
@@ -16,9 +16,8 @@
     xs:border-l-0
     xs:border-t
     xs:border-t-neutral-200
-    xs:dark:border-t-neutral-900;
-
-  overflow-wrap: anywhere;
+    xs:dark:border-t-neutral-900
+    [overflow-wrap:anywhere];
 
   dt {
     @apply mb-2

--- a/components/Containers/MetaBar/index.module.css
+++ b/components/Containers/MetaBar/index.module.css
@@ -8,6 +8,7 @@
     border-l-neutral-200
     px-4
     py-6
+    [overflow-wrap:anywhere]
     dark:border-l-neutral-900
     md:max-w-xs
     lg:px-6
@@ -16,8 +17,7 @@
     xs:border-l-0
     xs:border-t
     xs:border-t-neutral-200
-    xs:dark:border-t-neutral-900
-    [overflow-wrap:anywhere];
+    xs:dark:border-t-neutral-900;
 
   dt {
     @apply mb-2

--- a/components/Containers/MetaBar/index.module.css
+++ b/components/Containers/MetaBar/index.module.css
@@ -18,6 +18,8 @@
     xs:border-t-neutral-200
     xs:dark:border-t-neutral-900;
 
+  overflow-wrap: anywhere;
+
   dt {
     @apply mb-2
       text-sm

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -216,7 +216,6 @@
       @apply max-w-[660px]
         gap-4
         break-all;
-
     }
   }
 }

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -215,6 +215,8 @@
     main {
       @apply max-w-[660px]
         gap-4;
+
+      word-break: break-all;
     }
   }
 }

--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -214,9 +214,9 @@
 
     main {
       @apply max-w-[660px]
-        gap-4;
+        gap-4
+        break-all;
 
-      word-break: break-all;
     }
   }
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

On small screen (e.g: width 412px), on some security blog post page (e.g: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases), there is a horizontal scrollbar appearing because of the texts overflow in Table of Contents, and added padding in footer (we don't need this padding on small screens, as the "Trademark Policy", "Privacy Policy", etc. is centered). 

We can clearly see the horizontal (overflow-x) scrollbar on this screen:

![image](https://github.com/nodejs/nodejs.org/assets/25207499/bc0acf94-f628-437a-a14d-9fa85c5dbe0b)

## Validation

This PR fixes this issue by wrapping the texts:

![image](https://github.com/nodejs/nodejs.org/assets/25207499/91178724-ee2c-4b30-82e9-3888f511aed4)

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
