### PR TITLE
fix: correct headings levels for Previous Releases page

### DIFF
--- a/pages/en/about/previous-releases.mdx
+++ b/pages/en/about/previous-releases.mdx
@@ -10,12 +10,12 @@ After six months, odd-numbered releases (9, 11, etc.) become unsupported, and ev
 _LTS_ release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
 Production applications should only use _Active LTS_ or _Maintenance LTS_ releases.
 
-### Release Schedule
+## Release Schedule
 
 ![Releases](https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true)
 
 Full details regarding Node.js release schedule are available [on GitHub](https://github.com/nodejs/release#release-schedule).
 
-### Looking for latest release of a version branch?
+## Looking for latest release of a version branch?
 
 <DownloadReleasesTable />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
As mentioned in https://github.com/nodejs/nodejs.org/pull/6676#issuecomment-2084837883


On the "Previous Releases" page, the headings levels were wrong: h1 -> h3.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
The headings levels should now be correct: h1 -> h2.

![image](https://github.com/nodejs/nodejs.org/assets/25207499/1084cfc0-6f17-40ef-9255-f6927f01f848)

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
