### PR TITLE
fix: overflow issue on mobile GlowingBackdrop

### DIFF
--- a/components/Common/GlowingBackdrop/index.module.css
+++ b/components/Common/GlowingBackdrop/index.module.css
@@ -4,6 +4,7 @@
     top-0
     -z-10
     size-full
+    overflow-hidden
     opacity-50
     md:opacity-100;
 

--- a/components/Common/GlowingBackdrop/index.module.css
+++ b/components/Common/GlowingBackdrop/index.module.css
@@ -4,7 +4,6 @@
     top-0
     -z-10
     size-full
-    overflow-hidden
     opacity-50
     md:opacity-100;
 
@@ -25,7 +24,8 @@
     @apply absolute
       inset-0
       m-auto
-      h-[600px]
+      aspect-[1.67]
+      max-w-[1004px]
       object-cover
       text-neutral-300
       dark:text-neutral-900/75;


### PR DESCRIPTION
## Description

This PR aims to solve GlowingBackdrop overflow for the mobile resolution by limiting the container.

<img src="https://github.com/nodejs/nodejs.org/assets/14062599/285b0df2-19ab-40ac-8372-7b1dc32d5ae9" width="320" />

## Validation

A glowing backdrop in the preview should not be wider than the content

<img src="https://github.com/nodejs/nodejs.org/assets/14062599/6b1f7b4b-98bc-4c06-8e45-1f92696f19b7)" width="320" />

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
