### PR TITLE
Fix: change the copy to clipboard behavior

### DIFF
--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -6,10 +6,10 @@ import {
 } from '@heroicons/react/24/outline';
 import { useTranslations } from 'next-intl';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
-import { Fragment, isValidElement, useRef } from 'react';
+import { Fragment, isValidElement, useRef, useState } from 'react';
 
 import Button from '@/components/Common/Button';
-import { useCopyToClipboard, useNotification } from '@/hooks';
+import { useCopyToClipboard } from '@/hooks';
 
 import styles from './index.module.css';
 
@@ -71,27 +71,27 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
   showCopyButton = true,
 }) => {
   const ref = useRef<HTMLPreElement>(null);
-
-  const notify = useNotification();
   const [, copyToClipboard] = useCopyToClipboard();
   const t = useTranslations();
-
+  const [copyButtonText, setCopyButtonText] = useState<string>(
+    t('components.common.codebox.copy')
+  );
+  const [icon, setIcon] = useState<ReactNode>(
+    <DocumentDuplicateIcon className={styles.icon} />
+  );
   const onCopy = async () => {
     if (ref.current?.textContent) {
       copyToClipboard(ref.current.textContent);
 
-      notify({
-        duration: 3000,
-        message: (
-          <div className={styles.notification}>
-            <CodeBracketIcon className={styles.icon} />
-            {t('components.common.codebox.copied')}
-          </div>
-        ),
-      });
+      setCopyButtonText(t('components.common.codebox.copied')); // Change button text to
+      setIcon(<CodeBracketIcon className={styles.icon} />); // Change icon
+      // Reset button text to "Copy" after 3 seconds
+      setTimeout(() => {
+        setCopyButtonText(t('components.common.codebox.copy'));
+        setIcon(<DocumentDuplicateIcon className={styles.icon} />);
+      }, 3000);
     }
   };
-
   return (
     <div className={styles.root}>
       <pre ref={ref} className={styles.content} tabIndex={0} dir="ltr">
@@ -104,8 +104,8 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
 
           {showCopyButton && (
             <Button kind="neutral" className={styles.action} onClick={onCopy}>
-              <DocumentDuplicateIcon className={styles.icon} />
-              {t('components.common.codebox.copy')}
+              {icon}
+              {copyButtonText}
             </Button>
           )}
         </div>


### PR DESCRIPTION
Fixes #6685 
## Description
the current behavior of the copy button doesn't seems to work in the smaller screen. and also it is not appealing for a notification style when we click on it.
- changes
- made state based transition for the button allowing a smooth interaction for both smaller screen and large one
## Validation
before click:
<img width="554" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/e00fe3cc-a259-421f-8720-5366e386f52c">

after click:
<img width="500" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/f3ae651c-c87c-46e1-a4b3-4ecc40fe5d44">

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
