### PR TITLE
feat: Navigation state provider and hook

### DIFF
--- a/components/Common/ProgressionSidebar/index.tsx
+++ b/components/Common/ProgressionSidebar/index.tsx
@@ -1,9 +1,10 @@
 import { useTranslations } from 'next-intl';
 import type { ComponentProps, FC } from 'react';
+import { useRef } from 'react';
 
 import ProgressionSidebarGroup from '@/components/Common/ProgressionSidebar/ProgressionSidebarGroup';
 import WithRouterSelect from '@/components/withRouterSelect';
-import { useClientContext } from '@/hooks/react-server';
+import { useClientContext, useNavigationState } from '@/hooks';
 
 import styles from './index.module.css';
 
@@ -14,6 +15,9 @@ type ProgressionSidebarProps = {
 const ProgressionSidebar: FC<ProgressionSidebarProps> = ({ groups }) => {
   const t = useTranslations();
   const { pathname } = useClientContext();
+  const ref = useRef<HTMLElement>(null);
+
+  useNavigationState('progressionSidebar', ref);
 
   const selectItems = groups.map(({ items, groupName }) => ({
     label: groupName,
@@ -26,7 +30,7 @@ const ProgressionSidebar: FC<ProgressionSidebarProps> = ({ groups }) => {
     .find(item => pathname === item.value);
 
   return (
-    <nav className={styles.wrapper}>
+    <nav className={styles.wrapper} ref={ref}>
       <WithRouterSelect
         label={t('components.common.sidebar.title')}
         values={selectItems}

--- a/components/withProgressionSidebar.tsx
+++ b/components/withProgressionSidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { RichTranslationValues } from 'next-intl';
 import type { FC } from 'react';
 

--- a/hooks/react-client/index.ts
+++ b/hooks/react-client/index.ts
@@ -6,3 +6,4 @@ export { default as useClientContext } from './useClientContext';
 export { default as useKeyboardCommands } from './useKeyboardCommands';
 export { default as useClickOutside } from './useClickOutside';
 export { default as useBottomScrollListener } from './useBottomScrollListener';
+export { default as useNavigationState } from './useNavigationState';

--- a/hooks/react-client/useNavigationState.ts
+++ b/hooks/react-client/useNavigationState.ts
@@ -24,15 +24,15 @@ const useNavigationState = <T extends HTMLElement>(
 
   useEffect(() => {
     const element = ref.current;
-    if (navigationState[id] && navigationState[id].y !== element?.scrollTop) {
-      element?.scroll({ top: navigationState[id].y, behavior: 'instant' });
+    if (element) {
+      if (navigationState[id] && navigationState[id].y !== element.scrollTop) {
+        element.scroll({ top: navigationState[id].y, behavior: 'instant' });
+      }
+
+      element.addEventListener('scroll', handleScroll, { passive: true });
+
+      return () => element.removeEventListener('scroll', handleScroll);
     }
-
-    element?.addEventListener('scroll', handleScroll, { passive: true });
-
-    return () => {
-      element?.removeEventListener('scroll', handleScroll);
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/hooks/react-client/useNavigationState.ts
+++ b/hooks/react-client/useNavigationState.ts
@@ -33,6 +33,7 @@ const useNavigationState = <T extends HTMLElement>(
 
       return () => element.removeEventListener('scroll', handleScroll);
     }
+    // We need this effect to run only on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/hooks/react-client/useNavigationState.ts
+++ b/hooks/react-client/useNavigationState.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useContext, useEffect } from 'react';
+
+import { NavigationStateContext } from '@/providers/navigationStateProvider';
+import { debounce } from '@/util/debounce';
+
+const useNavigationState = <T extends HTMLElement>(
+  id: string,
+  ref: RefObject<T>,
+  debounceTime = 300
+) => {
+  const navigationState = useContext(NavigationStateContext);
+
+  const handleScroll = debounce(() => {
+    if (ref.current) {
+      navigationState[id] = {
+        x: ref.current.scrollLeft,
+        y: ref.current.scrollTop,
+      };
+    }
+  }, debounceTime);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (navigationState[id] && navigationState[id].y !== element?.scrollTop) {
+      element?.scroll({ top: navigationState[id].y, behavior: 'instant' });
+    }
+
+    element?.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      element?.removeEventListener('scroll', handleScroll);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useNavigationState;

--- a/layouts/Base.tsx
+++ b/layouts/Base.tsx
@@ -2,13 +2,16 @@
 
 import type { FC, PropsWithChildren } from 'react';
 
+import { NavigationStateProvider } from '@/providers/navigationStateProvider';
 import { NotificationProvider } from '@/providers/notificationProvider';
 
 import styles from './layouts.module.css';
 
 const BaseLayout: FC<PropsWithChildren> = ({ children }) => (
   <NotificationProvider viewportClassName="absolute bottom-0 right-0 list-none">
-    <div className={styles.baseLayout}>{children}</div>
+    <NavigationStateProvider>
+      <div className={styles.baseLayout}>{children}</div>
+    </NavigationStateProvider>
   </NotificationProvider>
 );
 

--- a/providers/navigationStateProvider.tsx
+++ b/providers/navigationStateProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { createContext, useRef } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+
+type NavigationStateContextType = Record<string, { x: number; y: number }>;
+
+export const NavigationStateContext = createContext<NavigationStateContextType>(
+  {}
+);
+
+export const NavigationStateProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const navigationState = useRef<NavigationStateContextType>({});
+
+  return (
+    <NavigationStateContext.Provider value={navigationState.current}>
+      {children}
+    </NavigationStateContext.Provider>
+  );
+};


### PR DESCRIPTION
## Description

Adds a Navigation State provider and hook to track scroll position and restore it on remount.

## Validation

![2024-05-0408-39-39-ezgif com-video-to-gif-converter](https://github.com/nodejs/nodejs.org/assets/91976421/cd73cf58-8ad1-4860-9d8d-ef030dbe5190)

## Related Issues

Temporary workaround for #6409
Get more info here - https://github.com/nodejs/nodejs.org/pull/6675#issuecomment-2093575403

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
