### PR TITLE
fix: correct same level side navigation on breadcrumbs

### DIFF
--- a/components/withBreadcrumbs.tsx
+++ b/components/withBreadcrumbs.tsx
@@ -35,6 +35,7 @@ const WithBreadcrumbs: FC<WithBreadcrumbsProps> = ({ navKeys = [] }) => {
       const nodeWithCurrentPath = currentNode.find(
         ([nodePath, entry]) =>
           nodePath === path &&
+          // Skip checking child path if it is the last path since there is no more child item inside
           (index === pathList.length - 1 ||
             entry.items.some(
               ([childPath]) => childPath === pathList[index + 1]

--- a/components/withBreadcrumbs.tsx
+++ b/components/withBreadcrumbs.tsx
@@ -8,22 +8,19 @@ import { useClientContext, useMediaQuery, useSiteNavigation } from '@/hooks';
 import type { NavigationKeys } from '@/types';
 import { dashToCamelCase } from '@/util/stringUtils';
 
-const WithBreadcrumbs: FC = () => {
-  const { navigationItems, getSideNavigation } = useSiteNavigation();
+type WithBreadcrumbsProps = {
+  navKeys?: Array<NavigationKeys>;
+};
+
+const WithBreadcrumbs: FC<WithBreadcrumbsProps> = ({ navKeys = [] }) => {
+  const { getSideNavigation } = useSiteNavigation();
   const { pathname } = useClientContext();
   const isMobileScreen = useMediaQuery('(max-width: 639px)');
 
   const maxLength = isMobileScreen ? 2 : 4;
 
   const getBreadrumbs = () => {
-    const [navigationKey] =
-      navigationItems.find(([, item]) => pathname.includes(item.link)) || [];
-
-    if (navigationKey === undefined) {
-      return [];
-    }
-
-    const navigationTree = getSideNavigation([navigationKey as NavigationKeys]);
+    const navigationTree = getSideNavigation(navKeys);
 
     const pathList = pathname
       .split('/')
@@ -34,9 +31,14 @@ const WithBreadcrumbs: FC = () => {
 
     // Reduce the pathList to a breadcrumbs array by finding each path in the current navigation layer,
     // updating the currentNode to the found node's items(next layer) for the next iteration.
-    return pathList.reduce((breadcrumbs, path) => {
+    return pathList.reduce((breadcrumbs, path, index) => {
       const nodeWithCurrentPath = currentNode.find(
-        ([nodePath]) => nodePath === path
+        ([nodePath, entry]) =>
+          nodePath === path &&
+          (index === pathList.length - 1 ||
+            entry.items.some(
+              ([childPath]) => childPath === pathList[index + 1]
+            ))
       );
 
       if (nodeWithCurrentPath) {

--- a/layouts/About.tsx
+++ b/layouts/About.tsx
@@ -17,7 +17,7 @@ const AboutLayout: FC<PropsWithChildren> = ({ children }) => (
 
       <WithMetaBar />
 
-      <WithBreadcrumbs />
+      <WithBreadcrumbs navKeys={['about', 'getInvolved']} />
     </ArticleLayout>
   </>
 );

--- a/layouts/Learn.tsx
+++ b/layouts/Learn.tsx
@@ -22,7 +22,7 @@ const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
 
       <WithMetaBar />
 
-      <WithBreadcrumbs />
+      <WithBreadcrumbs navKeys={['learn']} />
     </ArticleLayout>
   </>
 );

--- a/navigation.json
+++ b/navigation.json
@@ -92,11 +92,11 @@
           "link": "/about/governance",
           "label": "components.navigation.about.links.governance"
         },
-        "releases": {
+        "previousReleases": {
           "link": "/about/previous-releases",
           "label": "components.navigation.about.links.releases"
         },
-        "security": {
+        "securityReporting": {
           "link": "/about/security-reporting",
           "label": "components.navigation.about.links.security"
         }
@@ -113,7 +113,7 @@
           "link": "/about/get-involved/collab-summit",
           "label": "components.navigation.getInvolved.links.collabSummit"
         },
-        "upcomingEvents": {
+        "events": {
           "link": "/about/get-involved/events",
           "label": "components.navigation.getInvolved.links.upcomingEvents"
         },


### PR DESCRIPTION
## Description

- Update side bar navigation key name to match with route path in `navigation.json`
- Add target side bar nav keys to HOC `withBreadcrumbs.tsx` to get directly sidebar navigation data for `About.tsx` and `Learn.tsx` page. 
- Update logic on matching route path in function `getBreadrumbs` of HOC `withBreadcrumbs.tsx`.

## Validation

- Open page path `/en/about/`, go through all items in side bar navigation to see it shows correct breadcrumbs data.

![6679](https://github.com/nodejs/nodejs.org/assets/89153099/81ffa4b6-4195-473b-a88f-1d5e5a94dc15)

## Related Issues

Fixes #6679

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
