### PR TITLE
fix: improve readability by avoiding breaking words

### DIFF
--- a/layouts/layouts.module.css
+++ b/layouts/layouts.module.css
@@ -215,7 +215,7 @@
     main {
       @apply max-w-[660px]
         gap-4
-        break-all;
+        break-normal;
     }
   }
 }


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Currently `break-all` strategy is used for word breaking. This harms readability, since words can break into two lines. See attached image for example from v22 release announcement post.

![break-all](https://github.com/nodejs/nodejs.org/assets/650675/f8b24b4e-5499-43b6-bd0c-21baa6e2261f)

## Validation

Works according to screenshot

![image](https://github.com/nodejs/nodejs.org/assets/650675/21c7eedd-39d5-4b95-aa6d-2b3f98264ff4)

## Related Issues

No

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
