### PR TITLE
refactor(searchbox): Remove unnecessary useEffect hook

### DIFF
--- a/components/Common/Search/States/WithSearchBox.tsx
+++ b/components/Common/Search/States/WithSearchBox.tsx
@@ -79,15 +79,6 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
     return reset;
   }, []);
 
-  useEffect(
-    () => {
-      search(searchTerm);
-    },
-    // we don't need to care about memoization of search function
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [searchTerm, selectedFacet]
-  );
-
   useKeyboardCommands(cmd => {
     if (searchError || !searchResults || searchResults.count <= 0) {
       return;
@@ -135,7 +126,10 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
     router.push(`/search?q=${searchTerm}&section=${selectedFacetName}`);
   };
 
-  const changeFacet = (idx: string) => setSelectedFacet(Number(idx));
+  const changeFacet = (idx: string) => {
+    setSelectedFacet(Number(idx));
+    search(searchTerm);
+  };
 
   const filterBySection = () => {
     if (selectedFacet === 0) {
@@ -188,7 +182,10 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
                 role="combobox"
                 type="search"
                 className={styles.searchBoxInput}
-                onChange={event => setSearchTerm(event.target.value)}
+                onChange={event => {
+                  setSearchTerm(event.target.value);
+                  search(event.target.value);
+                }}
                 value={searchTerm}
               />
             </form>

--- a/components/Common/Search/States/WithSearchBox.tsx
+++ b/components/Common/Search/States/WithSearchBox.tsx
@@ -39,7 +39,7 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchBoxRef = useRef<HTMLDivElement>(null);
 
-  const search = (term: string) => {
+  const search = (term: string, section: number) => {
     oramaSearch({
       term,
       ...DEFAULT_ORAMA_QUERY_PARAMS,
@@ -51,7 +51,7 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
         'path',
         'siteSection',
       ],
-      ...filterBySection(),
+      ...filterBySection(section),
     })
       .then(setSearchResults)
       .catch(setSearchError);
@@ -128,15 +128,15 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
 
   const changeFacet = (idx: string) => {
     setSelectedFacet(Number(idx));
-    search(searchTerm);
+    search(searchTerm, Number(idx));
   };
 
-  const filterBySection = () => {
-    if (selectedFacet === 0) {
+  const filterBySection = (section: number) => {
+    if (section === 0) {
       return {};
     }
 
-    return { where: { siteSection: { eq: selectedFacetName } } };
+    return { where: { siteSection: { eq: Object.keys(facets)[section] } } };
   };
 
   const facets: Facets = {
@@ -184,7 +184,7 @@ export const WithSearchBox: FC<SearchBoxProps> = ({ onClose }) => {
                 className={styles.searchBoxInput}
                 onChange={event => {
                   setSearchTerm(event.target.value);
-                  search(event.target.value);
+                  search(event.target.value, selectedFacet);
                 }}
                 value={searchTerm}
               />


### PR DESCRIPTION
## Description

![image](https://github.com/nodejs/nodejs.org/assets/72620481/1d52e605-d8fc-4a42-a0d3-3b5fb3f4eed7)


Removes this unnecessary useEffect in the withSearchBox component.This useEffect can be removed because we have only 2 event handlers where this search function should be called(which is not a lot).

Also,
![image](https://github.com/nodejs/nodejs.org/assets/72620481/939048bb-9a98-4b4d-b429-2145303800c2)
This effect properly calls the search api with `''` as the search term and sets the initial search results so we dont need the above effect(the one that I removed) to run on mount with the empty search term and for subsequent changes in the search term and facet we can call the search function in the event handlers as explained above.

## Related Issues
Please refer #6717 to know more.


### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
