### PR TITLE
fix: change NVM to nvm

### DIFF
--- a/util/downloadUtils.ts
+++ b/util/downloadUtils.ts
@@ -31,7 +31,7 @@ export const operatingSystemItems = [
 
 export const platformItems = [
   {
-    label: 'NVM',
+    label: 'nvm',
     value: 'NVM' as PackageManager,
   },
   {

--- a/util/getNodeDownloadSnippet.ts
+++ b/util/getNodeDownloadSnippet.ts
@@ -27,7 +27,7 @@ export const getNodeDownloadSnippet = (release: NodeRelease, os: UserOS) => {
 
   if (os === 'MAC' || os === 'LINUX') {
     snippets.NVM = dedent`
-      # installs NVM (Node Version Manager)
+      # installs nvm (Node Version Manager)
       curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 
       # download and install Node.js


### PR DESCRIPTION
## Description

I believe `nvm` is always lowercase as seen in their readme 

https://github.com/nvm-sh/nvm/blob/master/README.md

## Validation

Visit https://nodejs-org-git-fork-styfle-patch-1-openjs.vercel.app/en/download/package-manager and note the dropdown.

## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
