### PR TITLE
fix: correct the execution order in esm

### DIFF
--- a/pages/en/learn/asynchronous-work/understanding-setimmediate.md
+++ b/pages/en/learn/asynchronous-work/understanding-setimmediate.md
@@ -51,3 +51,11 @@ start();
 ```
 
 This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which has just been added. In the end, the `baz()` in `macrotask queue` is called.
+
+The principle aforementioned holds true in CommonJS cases, but keep in mind in ES Modules, e.g. `mjs` files, the execution order will be different:
+
+```js
+// start bar foo zoo baz
+```
+
+This is because the ES Module being loaded is wrapped as an asynchronous operation, and thus the entire script is actually already in the `promises microtask queue`. So when the promise is immediately resolved, its callback is appended to the `microtask` queue. Node.js will attempt to clear the queue until moving to any other queue, and hence you will see it outputs `bar` first.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

As suggested, add an explanation on why mjs gives different execution order.

## Validation

<img width="768" alt="Screenshot 2024-05-16 at 1 00 29 pm" src="https://github.com/nodejs/nodejs.org/assets/28685065/ac708e4a-b08e-4ea9-9e6e-68cec247a795">



## Related Issues

Fixes:  https://github.com/nodejs/node/issues/52978

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
