### PR TITLE
feat: default transition (for colors) to `0.3s`

### DIFF
--- a/components/Common/LanguageDropDown/index.module.css
+++ b/components/Common/LanguageDropDown/index.module.css
@@ -10,8 +10,6 @@
     @apply bg-neutral-100
       dark:bg-neutral-900;
   }
-
-  transition: none !important;
 }
 
 .dropDownContent {
@@ -30,6 +28,8 @@
     @apply max-h-80
       w-48 overflow-y-auto;
   }
+
+  transition: none !important;
 }
 
 .dropDownItem {

--- a/components/Common/LanguageDropDown/index.module.css
+++ b/components/Common/LanguageDropDown/index.module.css
@@ -28,8 +28,6 @@
     @apply max-h-80
       w-48 overflow-y-auto;
   }
-
-  transition: none !important;
 }
 
 .dropDownItem {

--- a/components/Common/LanguageDropDown/index.module.css
+++ b/components/Common/LanguageDropDown/index.module.css
@@ -10,6 +10,8 @@
     @apply bg-neutral-100
       dark:bg-neutral-900;
   }
+
+  transition: none !important;
 }
 
 .dropDownContent {

--- a/styles/base.css
+++ b/styles/base.css
@@ -1,6 +1,6 @@
 * {
-  @apply subpixel-antialiased;
-  transition: all 0.3s;
+  @apply subpixel-antialiased
+    transition-colors;
 }
 
 html,

--- a/styles/base.css
+++ b/styles/base.css
@@ -1,5 +1,6 @@
 * {
   @apply subpixel-antialiased;
+  transition: all 0.3s;
 }
 
 html,


### PR DESCRIPTION
## Description

This PR sets the default `transition` to `0.3s`

## Validation

To validate whether a transition exists, hover over some elements, and verify a `0.3s` fade from their properties.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
	> **Note:** `SyntaxError: Unexpected identifier 'assert'`, might be a local Node.js issue
- [x] I have run `npx turbo build` to check if the website builds without errors.
	> **Note:** `SyntaxError: Unexpected identifier 'assert'`, might be a local Node.js issue
- [x] I've covered new added functionality with unit tests if necessary.
