### PR TITLE
fix: added digit regex

### DIFF
--- a/util/__tests__/stringUtils.test.mjs
+++ b/util/__tests__/stringUtils.test.mjs
@@ -1,6 +1,7 @@
 import {
   getAcronymFromString,
   parseRichTextIntoPlainText,
+  dashToCamelCase,
 } from '@/util/stringUtils';
 
 describe('String utils', () => {
@@ -58,5 +59,23 @@ describe('String utils', () => {
     const richText = '   Line 1   \n   Line 2   \n   Line 3   ';
     const result = parseRichTextIntoPlainText(richText);
     expect(result).toBe('Line 1\nLine 2\nLine 3');
+  });
+
+  it('should convert dash-separated strings to camelCase', () => {
+    expect(dashToCamelCase('hello-world')).toBe('helloWorld');
+    expect(dashToCamelCase('my-name-is')).toBe('myNameIs');
+    expect(dashToCamelCase('dash-to-camel-case')).toBe('dashToCamelCase');
+  });
+
+  it('should handle strings without dashes', () => {
+    expect(dashToCamelCase('hello')).toBe('hello');
+    expect(dashToCamelCase('world')).toBe('world');
+  });
+
+  it('should handle numbers in the string', () => {
+    expect(dashToCamelCase('my-name-is-007')).toBe('myNameIs007');
+    expect(dashToCamelCase('123-abc')).toBe('123Abc');
+    expect(dashToCamelCase('test-1-2-3')).toBe('test123');
+    expect(dashToCamelCase('test-123-abc')).toBe('test123Abc');
   });
 });

--- a/util/stringUtils.ts
+++ b/util/stringUtils.ts
@@ -24,5 +24,5 @@ export const parseRichTextIntoPlainText = (richText: string) =>
 
 export const dashToCamelCase = (str: string) =>
   str
-    .replace(/-([a-z])/g, (match, chr) => chr.toUpperCase())
+    .replace(/-([a-z0-9])/g, (match, chr) => chr.toUpperCase())
     .replace(/^[A-Z]/, chr => chr.toLowerCase());


### PR DESCRIPTION
- additional small changes for breadcrumb
the url of the ECMAScript in learn page contain digit after the dash ("https://nodejs.org/en/learn/getting-started/ecmascript-2015-es6-and-beyond") which is not handle resulting in below behavior

the current behavior:
<img width="955" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/9bec176a-a2c1-44a6-a904-0563fa61dcc1">

after adding digit regex:
<img width="932" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/be94b514-c1f8-4f06-88bd-5ea0cf707b3d">

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
