### PR TITLE
fix: learn page breadcrumbs where label !== path slug

### DIFF
--- a/components/withBreadcrumbs.tsx
+++ b/components/withBreadcrumbs.tsx
@@ -34,11 +34,13 @@ const WithBreadcrumbs: FC<WithBreadcrumbsProps> = ({ navKeys = [] }) => {
     return pathList.reduce((breadcrumbs, path, index) => {
       const nodeWithCurrentPath = currentNode.find(
         ([nodePath, entry]) =>
-          nodePath === path &&
+          // Checking link in cases where nodePath cannot = path. Like 'discoverJavaScriptTimers'
+          (nodePath === path || entry.link === pathname) &&
           // Skip checking child path if it is the last path since there is no more child item inside
           (index === pathList.length - 1 ||
             entry.items.some(
-              ([childPath]) => childPath === pathList[index + 1]
+              ([childPath, entry]) =>
+                childPath === pathList[index + 1] || entry.link === pathname
             ))
       );
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -49,8 +49,8 @@
             "asynchronousFlowControl": "Asynchronous flow control",
             "overviewOfBlockingVsNonBlocking": "Overview of Blocking vs Non-Blocking",
             "javascriptAsynchronousProgrammingAndCallbacks": "JavaScript Asynchronous Programming and Callbacks",
-            "discoverJavaScriptTimers": "Discover JavaScript Timers",
-            "theNodejsEventLoop": "The Node.js Event Loop",
+            "discoverJavascriptTimers": "Discover JavaScript Timers",
+            "eventLoopTimersAndNexttick": "The Node.js Event Loop",
             "theNodejsEventEmitter": "The Node.js Event Emitter",
             "understandingProcessnexttick": "Understanding process.nextTick()",
             "understandingSetimmediate": "Understanding setImmediate()",
@@ -66,7 +66,7 @@
             "readingFilesWithNodejs": "Reading files with Node.js",
             "writingFilesWithNodejs": "Writing files with Node.js",
             "workingWithFoldersInNodejs": "Working with folders in Node.js",
-            "howToWorkWithFileSystems": "How to work with Different Filesystems"
+            "workingWithDifferentFilesystems": "How to work with Different Filesystems"
           }
         },
         "commandLine": {

--- a/navigation.json
+++ b/navigation.json
@@ -201,13 +201,13 @@
               "link": "/learn/asynchronous-work/javascript-asynchronous-programming-and-callbacks",
               "label": "components.navigation.learn.asynchronousWork.links.javascriptAsynchronousProgrammingAndCallbacks"
             },
-            "discoverJavaScriptTimers": {
+            "discoverJavascriptTimers": {
               "link": "/learn/asynchronous-work/discover-javascript-timers",
-              "label": "components.navigation.learn.asynchronousWork.links.discoverJavaScriptTimers"
+              "label": "components.navigation.learn.asynchronousWork.links.discoverJavascriptTimers"
             },
-            "theNodejsEventLoop": {
+            "eventLoopTimersAndNexttick": {
               "link": "/learn/asynchronous-work/event-loop-timers-and-nexttick",
-              "label": "components.navigation.learn.asynchronousWork.links.theNodejsEventLoop"
+              "label": "components.navigation.learn.asynchronousWork.links.eventLoopTimersAndNexttick"
             },
             "theNodejsEventEmitter": {
               "link": "/learn/asynchronous-work/the-nodejs-event-emitter",
@@ -254,9 +254,9 @@
               "link": "/learn/manipulating-files/working-with-folders-in-nodejs",
               "label": "components.navigation.learn.manipulatingFiles.links.workingWithFoldersInNodejs"
             },
-            "howToWorkWithFileSystems": {
+            "workingWithDifferentFilesystems": {
               "link": "/learn/manipulating-files/working-with-different-filesystems",
-              "label": "components.navigation.learn.manipulatingFiles.links.howToWorkWithFileSystems"
+              "label": "components.navigation.learn.manipulatingFiles.links.workingWithDifferentFilesystems"
             }
           }
         },

--- a/util/__tests__/stringUtils.test.mjs
+++ b/util/__tests__/stringUtils.test.mjs
@@ -1,6 +1,7 @@
 import {
   getAcronymFromString,
   parseRichTextIntoPlainText,
+  dashToCamelCase,
 } from '@/util/stringUtils';
 
 describe('String utils', () => {
@@ -58,5 +59,17 @@ describe('String utils', () => {
     const richText = '   Line 1   \n   Line 2   \n   Line 3   ';
     const result = parseRichTextIntoPlainText(richText);
     expect(result).toBe('Line 1\nLine 2\nLine 3');
+  });
+
+  it('dashToCamelCase returns correct camelCase', () => {
+    expect(dashToCamelCase('foo-bar-baz')).toBe('fooBarBaz');
+  });
+
+  it('dashToCamelCase returns correct camelCase with capital first letter', () => {
+    expect(dashToCamelCase('Foo-bar')).toBe('fooBar');
+  });
+
+  it('dashToCamelCase returns correct camelCase with numbers', () => {
+    expect(dashToCamelCase('foo-123-bar')).toBe('foo123Bar');
   });
 });

--- a/util/stringUtils.ts
+++ b/util/stringUtils.ts
@@ -25,4 +25,6 @@ export const parseRichTextIntoPlainText = (richText: string) =>
 export const dashToCamelCase = (str: string) =>
   str
     .replace(/-([a-z])/g, (match, chr) => chr.toUpperCase())
+    // remove leftover - which don't match the above regex. Like 'es-2015'
+    .replace(/-/g, '')
     .replace(/^[A-Z]/, chr => chr.toLowerCase());


### PR DESCRIPTION
## Description

Uses link = pathname check as a fallback for finding breadcrumbs in the navigation tree where the label does not match the path.

Consider the article "event-loop-timers-and-nexttick" where the label is "The Nodejs Event loop". Breadcrumbs cannot be found in the navigation tree. Of course we can always change the article name to match the label but what about the article "discover-javascript-timers"? Why, there is no problem here! Except there is. The "s" in JavaScript is capitalized. (Shocking, I know. I learned this today). "JavaScript" cannot be written as "java-script" in dash-case. Is it javascript or a script written in Java?

Previously docs should have the same article name and label for the breadcrumbs to work. Now it is not necessary. Unless a deeply nested document structure is adopted. In which case we have to DFS the navigation tree.

These four articles faced this breadcrumb issue:
* https://nodejs.org/en/learn/getting-started/ecmascript-2015-es6-and-beyond
* https://nodejs.org/en/learn/asynchronous-work/discover-javascript-timers
* https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick
* https://nodejs.org/en/learn/manipulating-files/working-with-different-filesystems

## Validation

| Before | After |
|--------|--------|
| ![image](https://github.com/nodejs/nodejs.org/assets/91976421/70a485de-1881-4249-9969-ba973b4d33dc) | ![image](https://github.com/nodejs/nodejs.org/assets/91976421/91b849b3-13db-4718-9447-11098afa84fa) |

## Related Issues

Related to #6679 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
