### PR TITLE
feat: add support for Node.js v22

### DIFF
--- a/next.json.mjs
+++ b/next.json.mjs
@@ -1,9 +1,9 @@
 'use strict';
 
-import _authors from './authors.json' assert { type: 'json' };
-import _siteNavigation from './navigation.json' assert { type: 'json' };
-import _siteRedirects from './redirects.json' assert { type: 'json' };
-import _siteConfig from './site.json' assert { type: 'json' };
+import _authors from './authors.json' with { type: 'json' };
+import _siteNavigation from './navigation.json' with { type: 'json' };
+import _siteRedirects from './redirects.json' with { type: 'json' };
+import _siteConfig from './site.json' with { type: 'json' };
 
 /** @type {Record<string, import('./types').Author>} */
 export const authors = _authors;

--- a/next.locales.mjs
+++ b/next.locales.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import localeConfig from './i18n/config.json' assert { type: 'json' };
+import localeConfig from './i18n/config.json' with { type: 'json' };
 
 // As set of available and enabled locales for the website
 // This is used for allowing us to redirect the user to any

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "user-agent-data-types": "0.4.2"
       },
       "engines": {
-        "node": "v20"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "v20"
+    "node": ">=20"
   },
   "scripts": {
     "scripts:release-post": "cross-env NODE_NO_WARNINGS=1 node scripts/release-post/index.mjs",


### PR DESCRIPTION
## Description

This PR changes all instances of `import ... from ... assert { ... }` to `import ... from ... with { ... }`

## Validation

A reviewer should verify that the tests pass in both Node.js v22 and Node.js v20.

## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- **(N/A)** I've covered new added functionality with unit tests if necessary.
