### PR TITLE
Fix(test): TypeError in useBottomScrollListener Test Due to Incorrect act Import

### DIFF
--- a/hooks/react-client/__tests__/useBottomScrollListener.test.mjs
+++ b/hooks/react-client/__tests__/useBottomScrollListener.test.mjs
@@ -1,5 +1,4 @@
-import { fireEvent, renderHook } from '@testing-library/react';
-import { act } from 'react';
+import { fireEvent, renderHook, act } from '@testing-library/react';
 
 import useBottomScrollListener from '@/hooks/react-client/useBottomScrollListener';
 


### PR DESCRIPTION
## Description
as mentioned in https://github.com/nodejs/nodejs.org/pull/6728#issuecomment-2122111441
We encountered an issue with the useBottomScrollListener tests where a TypeError is thrown, indicating that act is not a function. This error prevents the tests from running correctly.

Error Message
The specific error message is:
<img width="948" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/973a7d26-94f3-4d67-9a0f-4a6821a06153">

This error occurs in the following test cases within hooks/react-client/__tests__/useBottomScrollListener.test.mjs:
the cause of it was importing the act function from react instead of @testing-library/react. The act function from react is not compatible with the testing setup provided by React Testing Library, leading to the observed TypeError.

## validation
## Before:
<img width="487" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/a6393d59-c11f-4773-8044-7b19327d3cea">

## after:
<img width="446" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/b77a1d3d-267e-4010-8d38-70f98bcbeb56">

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
