### PR TITLE
Fix: positioning of the toast notification (copy to clipboard)

### DIFF
--- a/layouts/Base.tsx
+++ b/layouts/Base.tsx
@@ -8,7 +8,7 @@ import { NotificationProvider } from '@/providers/notificationProvider';
 import styles from './layouts.module.css';
 
 const BaseLayout: FC<PropsWithChildren> = ({ children }) => (
-  <NotificationProvider viewportClassName="absolute bottom-0 right-0 list-none">
+  <NotificationProvider viewportClassName="fixed bottom-0 right-0 list-none">
     <NavigationStateProvider>
       <div className={styles.baseLayout}>{children}</div>
     </NavigationStateProvider>


### PR DESCRIPTION
## Description
The notification toast is positioned correctly at the bottom-right corner of the viewport, but when the page is scrollable, the toast remains in the same position on the screen and does not move down as expected when the page is scrolled.
ref:
https://nodejs.org/en/blog/announcements/v21-release-announce
https://nodejs.org/en/blog/announcements/v20-release-announce

## Expected behavior
The notification toast should stay at the bottom-right corner of the viewport regardless of scrolling. 

## Additional context
This issue seems to be caused by the absolute positioning of the toast container. The toast should be positioned using fixed positioning to ensure it stays in the correct place relative to the viewport when scrolling.



<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
