### PR TITLE
fix: Layout shift in download page / CodeBox

### DIFF
--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -4,6 +4,7 @@ import {
   DocumentDuplicateIcon,
   CodeBracketIcon,
 } from '@heroicons/react/24/outline';
+import classNames from 'classnames';
 import { useTranslations } from 'next-intl';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import { Fragment, isValidElement, useRef } from 'react';
@@ -63,12 +64,17 @@ const transformCode = (code: ReactNode, language: string): ReactNode => {
   );
 };
 
-type CodeBoxProps = { language: string; showCopyButton?: boolean };
+type CodeBoxProps = {
+  language: string;
+  showCopyButton?: boolean;
+  className?: string;
+};
 
 const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
   children,
   language,
   showCopyButton = true,
+  className,
 }) => {
   const ref = useRef<HTMLPreElement>(null);
 
@@ -94,7 +100,12 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
 
   return (
     <div className={styles.root}>
-      <pre ref={ref} className={styles.content} tabIndex={0} dir="ltr">
+      <pre
+        ref={ref}
+        className={classNames(styles.content, className)}
+        tabIndex={0}
+        dir="ltr"
+      >
         {transformCode(children, language)}
       </pre>
 

--- a/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -36,11 +36,9 @@ const ReleaseCodeBox: FC = () => {
 
   return (
     <div className="mb-2 mt-6 flex flex-col gap-2">
-      {code && (
-        <CodeBox language={codeLanguage}>
-          <code dangerouslySetInnerHTML={{ __html: code }} />
-        </CodeBox>
-      )}
+      <CodeBox language={codeLanguage} className="min-h-[15.5rem]">
+        <code dangerouslySetInnerHTML={{ __html: code }} />
+      </CodeBox>
 
       <span className="text-center text-xs text-neutral-800 dark:text-neutral-200">
         {t('layouts.download.codeBox.communityWarning')}


### PR DESCRIPTION
## Description

The content of the `CodeBox` on the download page causes a layout shift because it loads later. This PR aims to prevent the layout shift by giving this component a minimum height

## Validation

### Before

<img width="538" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/64c4b09e-1d83-40ca-8038-490013433ce3">

<img width="538" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/64ffcef2-5b70-4a6e-912e-af99c776762d">

### After

<img width="538" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/eb571da1-7813-40e8-a867-d71b7f9e37a9">

<img width="538" alt="image" src="https://github.com/nodejs/nodejs.org/assets/14062599/43c91c25-2d34-467c-a1bd-0f7d068e99e4">

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
