### PR TITLE
feat(meta): support nodejs v22

### DIFF
--- a/next.json.mjs
+++ b/next.json.mjs
@@ -1,9 +1,9 @@
 'use strict';
 
-import _authors from './authors.json' assert { type: 'json' };
-import _siteNavigation from './navigation.json' assert { type: 'json' };
-import _siteRedirects from './redirects.json' assert { type: 'json' };
-import _siteConfig from './site.json' assert { type: 'json' };
+import _authors from './authors.json' with { type: 'json' };
+import _siteNavigation from './navigation.json' with { type: 'json' };
+import _siteRedirects from './redirects.json' with { type: 'json' };
+import _siteConfig from './site.json' with { type: 'json' };
 
 /** @type {Record<string, import('./types').Author>} */
 export const authors = _authors;

--- a/next.locales.mjs
+++ b/next.locales.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import localeConfig from './i18n/config.json' assert { type: 'json' };
+import localeConfig from './i18n/config.json' with { type: 'json' };
 
 // As set of available and enabled locales for the website
 // This is used for allowing us to redirect the user to any


### PR DESCRIPTION
Follow up on #6732

This PR does the exact same as #6732, except it doesn't modify the `package.json` to officially allow support for Node.js v22, as Vercel doesn't support v22. 

This PR *allows* this to build on Node.js v22, but doesn't *recommend* building on that version.