### PR TITLE
feat(copy): inline copy/paste for clipboard

### DIFF
--- a/components/Common/CodeBox/index.tsx
+++ b/components/Common/CodeBox/index.tsx
@@ -1,16 +1,13 @@
 'use client';
 
-import {
-  DocumentDuplicateIcon,
-  CodeBracketIcon,
-} from '@heroicons/react/24/outline';
+import { DocumentDuplicateIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import { useTranslations } from 'next-intl';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
-import { Fragment, isValidElement, useRef } from 'react';
+import { Fragment, isValidElement, useRef, useState } from 'react';
 
 import Button from '@/components/Common/Button';
-import { useCopyToClipboard, useNotification } from '@/hooks';
+import { useCopyToClipboard } from '@/hooks';
 
 import styles from './index.module.css';
 
@@ -78,23 +75,24 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
 }) => {
   const ref = useRef<HTMLPreElement>(null);
 
-  const notify = useNotification();
   const [, copyToClipboard] = useCopyToClipboard();
   const t = useTranslations();
+  const [copyContent, setCopyContent] = useState<string>(
+    t('components.common.codebox.copy')
+  );
+  const [copyTimeout, setCopyTimeout] = useState<NodeJS.Timeout>();
 
   const onCopy = async () => {
     if (ref.current?.textContent) {
       copyToClipboard(ref.current.textContent);
-
-      notify({
-        duration: 3000,
-        message: (
-          <div className={styles.notification}>
-            <CodeBracketIcon className={styles.icon} />
-            {t('components.common.codebox.copied')}
-          </div>
-        ),
-      });
+      setCopyContent(t('components.common.codebox.copied'));
+      clearTimeout(copyTimeout);
+      setCopyTimeout(
+        setTimeout(
+          () => setCopyContent(t('components.common.codebox.copy')),
+          3000
+        )
+      );
     }
   };
 
@@ -116,7 +114,7 @@ const CodeBox: FC<PropsWithChildren<CodeBoxProps>> = ({
           {showCopyButton && (
             <Button kind="neutral" className={styles.action} onClick={onCopy}>
               <DocumentDuplicateIcon className={styles.icon} />
-              {t('components.common.codebox.copy')}
+              {copyContent}
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Description

This PR changes the 'Copy to Clipboard' button's notification on copy to an inline text change.

## Validation

### Old
![image](https://github.com/nodejs/nodejs.org/assets/38299977/1852eef6-968d-4989-a4a0-d69a77ef618e)


### New
![image](https://github.com/nodejs/nodejs.org/assets/38299977/69ae7775-2cb4-4600-8cc5-730eaecdbe0a)

### Old


### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
