### PR TITLE
feat(download): don't directly download

### DIFF
--- a/components/Downloads/DownloadButton/index.tsx
+++ b/components/Downloads/DownloadButton/index.tsx
@@ -11,20 +11,22 @@ import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
 
 import styles from './index.module.css';
 
-type DownloadButtonProps = { release: NodeRelease };
+type DownloadButtonProps = { release?: NodeRelease; downloadLink?: string };
 
 const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
-  release: { versionWithPrefix },
+  release: { versionWithPrefix = '' } = {},
+  downloadLink,
   children,
 }) => {
   const { os, bitness } = useDetectOS();
-  const downloadLink = getNodeDownloadUrl(versionWithPrefix, os, bitness);
+  const downloadHref =
+    downloadLink || getNodeDownloadUrl(versionWithPrefix, os, bitness);
 
   return (
     <>
       <Button
         kind="special"
-        href={downloadLink}
+        href={downloadHref}
         className={classNames(styles.downloadButton, styles.special)}
       >
         {children}
@@ -34,7 +36,7 @@ const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
 
       <Button
         kind="primary"
-        href={downloadLink}
+        href={downloadHref}
         className={classNames(styles.downloadButton, styles.primary)}
       >
         {children}

--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -16,27 +16,7 @@ layout: home
   </div>
 
   <div>
-    <WithNodeRelease status={['LTS']}>
-      {({ release }) => (
-        <>
-          <DownloadButton release={release}>Download Node.js (LTS)</DownloadButton>
-          <small>
-            Downloads Node.js <b>{release.versionWithPrefix}</b>
-            <sup title="Downloads a Node.js installer for your current platform">1</sup> with long-term support.
-            Node.js can also be installed via <a href="/download/package-manager">package managers</a>.
-          </small>
-        </>
-      )}
-    </WithNodeRelease>
-    <WithNodeRelease status={['Current']}>
-      {({ release }) => (
-        <small>
-          Want new features sooner?
-          Get <b>Node.js <DownloadLink release={release}>{release.versionWithPrefix}</DownloadLink></b>
-          <sup title="Downloads a Node.js installer for your current platform">1</sup> instead.
-        </small>
-      )}
-    </WithNodeRelease>
+    <DownloadButton downloadLink={'/download/prebuilt-binaries'}>Download Node.js</DownloadButton>
   </div>
 </section>
 


### PR DESCRIPTION
## Description

This PR modifies the download button on the front page to link to the download page, rather than directly downloading the binaries directly. I feel that a direct download of the binaries will catch the user off-guard, as when I press the download button, I am expected to be taken to a download page, rather than to have the download directly occur.

Personally, I am **strongly** against directly downloaded from that button, I find it unclear that that is a download button (Yes, I know it says 'download', but I assumed it would go to the download page)

---

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [-] I've covered new added functionality with unit tests if necessary.
