### PR TITLE
Update tsx example

### DIFF
--- a/pages/en/learn/getting-started/nodejs-with-typescript.md
+++ b/pages/en/learn/getting-started/nodejs-with-typescript.md
@@ -148,20 +148,26 @@ Then you can run your TypeScript code like this:
 npx ts-node example.ts
 ```
 
-### Running TypeScript Code with a Node.js Loader
+### Running TypeScript Code with `tsx`
 
-Since Node.js v19.0.0, you can use a [custom loader](https://nodejs.org/api/cli.html#--importmodule). Download a loader such as `ts-node` or `tsx` or `nodejs-loaders`
+You can use [tsx](https://tsx.is/) to run TypeScript code directly in Node.js without the need to compile it first. But it's not typechecking your code. So we recommend to type check your code first with `tsc` and then run it with `tsx` before shipping it.
 
-First you need to install the loader:
+To use `tsx`, you need to install it first:
 
 ```bash
-npm i -D ts-node
+npm i -D tsx
 ```
 
 Then you can run your TypeScript code like this:
 
 ```bash
-node --loader=ts-node/esm example.ts
+npx tsx example.ts
+```
+
+If you want to use `tsx` via `node`, you can register `tsx` via `--import`:
+
+```bash
+node --import=tsx example.ts
 ```
 
 ## TypeScript in the Node.js world


### PR DESCRIPTION
## Description

This updates the `tsx` example to remove the mention of `--loader`, which is an [undocumented](https://nodejs.org/api/cli.html#--experimental-loadermodule) experimental flag that was created by accident and [will likely go away in the future, as the warning states](https://github.com/nodejs/node/issues/51196#issue-2045156881) when you use it. The stable, documented, recommended approach is to use `--import` instead. See https://github.com/nodejs/node/issues/51196#issuecomment-2089130867.

`ts-node` doesn’t (directly) support `--import`, so I’m leaving its example as just `npx ts-node`; there are [multiple](https://github.com/TypeStrong/ts-node/issues/2072) [open issues on their repo asking them to update](https://github.com/TypeStrong/ts-node/issues/1909#issuecomment-2089155346). I updated the `tsx` example to be more user-focused and to use `tsx` as the example of registering module hooks via `--import`.

## Validation

https://nodejs-org-git-fork-geoffreybooth-remove-loader-openjs.vercel.app/en/learn/getting-started/nodejs-with-typescript#running-typescript-code-with-tsx

<img width="771" alt="image" src="https://github.com/nodejs/nodejs.org/assets/456802/5e54b670-f479-4e00-9edb-52c62c7c1dff">

## Related Issues

Resolves https://github.com/nodejs/node/issues/51196

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you’ve followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I’ve covered new added functionality with unit tests if necessary.
