### PR TITLE
fix: ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,5 @@
     "stylelint-selector-bem-pattern": "4.0.0",
     "turbo": "1.13.2",
     "user-agent-data-types": "0.4.2"
-  },
-  "packageManager": "pnpm@8.6.3+sha1.30b2ad9776a393ccd1766239fd21e0c14a3c3acf"
+  }
 }


### PR DESCRIPTION
## Description

This key in json was introduce during a past pr. It's introduce by "old" turborepo version. Basically, if we were using node 22, it would call corepack, which would install pnpm _(What I understood from my experiments)_

## Validation

CI need to be green again

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
- **NA** I've covered new added functionality with unit tests if necessary.
