### PR TITLE
fix: added ellipsis for long content in breadcrumb

### DIFF
--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
@@ -1,10 +1,15 @@
 .item {
   @apply flex
-    max-w-96
-    items-center
-    gap-5
-    text-sm
-    font-medium;
+     max-w-fit
+     items-center
+     gap-5
+     truncate
+     text-sm
+     font-medium;
+
+  &:last-child {
+    @apply w-full;
+  }
 
   a {
     @apply flex-shrink
@@ -24,6 +29,7 @@
 
   .separator {
     @apply size-4
+      max-w-fit
       flex-shrink-0
       flex-grow
       text-neutral-600

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
@@ -3,7 +3,6 @@
     max-w-96
     items-center
     gap-5
-    truncate
     text-sm
     font-medium;
 

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
@@ -1,7 +1,9 @@
 .item {
   @apply flex
+    max-w-96
     items-center
     gap-5
+    truncate
     text-sm
     font-medium;
 

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
@@ -1,6 +1,6 @@
 .link {
   @apply w-full 
-  truncate;
+    truncate;
 
   &.active {
     @apply rounded

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
@@ -1,4 +1,6 @@
 .link {
+  @apply w-full truncate;
+
   &.active {
     @apply rounded
       bg-green-600

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
@@ -1,5 +1,6 @@
 .link {
-  @apply w-full truncate;
+  @apply w-full 
+  truncate;
 
   &.active {
     @apply rounded

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbLink/index.module.css
@@ -1,5 +1,5 @@
 .link {
-  @apply w-full 
+  @apply max-w-fit 
     truncate;
 
   &.active {

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
@@ -1,7 +1,6 @@
 .list {
   @apply flex
     w-full
-    items-center
     gap-5
     pl-2;
 }

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
@@ -1,5 +1,7 @@
 .list {
   @apply flex
+    w-full
     items-center
-    gap-5;
+    gap-5
+    pl-2;
 }

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
@@ -2,5 +2,5 @@
   @apply flex
     w-full
     gap-5
-    pl-2;
+    px-2;
 }

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
@@ -2,5 +2,5 @@
   @apply flex
     w-full
     gap-5
-    px-2;
+    px-6;
 }

--- a/apps/site/components/Common/Breadcrumbs/index.tsx
+++ b/apps/site/components/Common/Breadcrumbs/index.tsx
@@ -29,13 +29,6 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
   const lengthOffset = maxLength - totalLength;
   const isOverflow = lengthOffset < 0;
 
-  const formatLabelWithWordCount = (label: string, maxWords: number) => {
-    const words = label.split(' ');
-    if (words.length > maxWords) {
-      return <>{words.slice(0, maxWords).join(' ')} ...</>;
-    }
-    return label;
-  };
   const items = useMemo(
     () =>
       links.map((link, index, items) => {
@@ -45,8 +38,6 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
           // We add 1 here to take into account of the truncated breadcrumb.
           position <= Math.abs(lengthOffset) + 1 && isOverflow && !isLastItem;
 
-        const labelString = link.label.toString();
-        const formattedLabel = formatLabelWithWordCount(labelString, 6);
         return (
           <BreadcrumbItem
             key={link.label.toString()}
@@ -55,7 +46,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
             position={position + +!hideHome}
           >
             <BreadcrumbLink href={link.href} active={isLastItem}>
-              <div className=" text-center">{formattedLabel}</div>
+              {link.label}
             </BreadcrumbLink>
           </BreadcrumbItem>
         );

--- a/apps/site/components/Common/Breadcrumbs/index.tsx
+++ b/apps/site/components/Common/Breadcrumbs/index.tsx
@@ -18,6 +18,7 @@ type BreadcrumbsProps = {
   maxLength?: number;
   hideHome?: boolean;
 };
+// Convert link.label to string and get its length
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({
   links = [],
@@ -28,6 +29,13 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
   const lengthOffset = maxLength - totalLength;
   const isOverflow = lengthOffset < 0;
 
+  const formatLabelWithWordCount = (label: string, maxWords: number) => {
+    const words = label.split(' ');
+    if (words.length > maxWords) {
+      return <>{words.slice(0, maxWords).join(' ')} ...</>;
+    }
+    return label;
+  };
   const items = useMemo(
     () =>
       links.map((link, index, items) => {
@@ -37,6 +45,8 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
           // We add 1 here to take into account of the truncated breadcrumb.
           position <= Math.abs(lengthOffset) + 1 && isOverflow && !isLastItem;
 
+        const labelString = link.label.toString();
+        const formattedLabel = formatLabelWithWordCount(labelString, 6);
         return (
           <BreadcrumbItem
             key={link.label.toString()}
@@ -45,7 +55,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
             position={position + +!hideHome}
           >
             <BreadcrumbLink href={link.href} active={isLastItem}>
-              {link.label}
+              <div className=" text-center">{formattedLabel}</div>
             </BreadcrumbLink>
           </BreadcrumbItem>
         );

--- a/apps/site/components/Common/Breadcrumbs/index.tsx
+++ b/apps/site/components/Common/Breadcrumbs/index.tsx
@@ -18,7 +18,6 @@ type BreadcrumbsProps = {
   maxLength?: number;
   hideHome?: boolean;
 };
-// Convert link.label to string and get its length
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({
   links = [],


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

added ellipsis for the long content in the breadcrumb to improve the layout shifting and in some case, breaking of the breadcrumb into next line.

## Validation
before:
<img width="652" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/871323bc-0985-48af-92bb-d7f73efef52e">

after:
<img width="641" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/75df5705-b141-4e43-bb96-8ef388528762">

### Other Changes
- Layout is shifted toward the left.

## Related Issues
Fixes #6754 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
