### PR TITLE
chore: updated chromatic action cli version

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -225,7 +225,7 @@ jobs:
             startsWith(github.event.pull_request.head.ref, 'dependabot/') == false &&
             github.event.pull_request.head.ref != 'chore/crowdin')
         # sha reference has no stable git tag reference or URL. see https://github.com/chromaui/chromatic-cli/issues/797
-        uses: chromaui/action@807600692d28833b717c155e15ed20905cdc865c
+        uses: chromaui/action@5f6574e351eb055223ae8ea9e1a734d1d695ea9c
         with:
           buildScriptName: storybook:build
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
This PR simply updates the hashed version of the Chromatic CLI.

**Note:** This change will only reflect once merged as changes to the Workflows will only take affect once merged.