### PR TITLE
CI: Orama cloud sync based on environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,9 +125,15 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
 
       - name: Sync Orama Cloud
+        # We only want to sync the Orama Cloud production indexes on `push` events.
+        # We also want to sync the Orama Cloud preview (deployment) indexes on `pull_request_target` events.
+        # We also want to ensure that the sync only happens on the `ubuntu-latest` runner to avoid duplicate syncs
+        # or Windows-based path issues.
         env:
-          ORAMA_INDEX_ID: ${{ secrets.ORAMA_INDEX_ID }}
-          ORAMA_SECRET_KEY: ${{ secrets.ORAMA_SECRET_KEY }}
-        if: github.ref == 'refs/heads/main'
+          ORAMA_INDEX_ID: ${{ github.event_name == 'push' && secrets.ORAMA_PRODUCTION_INDEX_ID || secrets.ORAMA_INDEX_ID }}
+          ORAMA_SECRET_KEY: ${{ github.event_name == 'push' && secrets.ORAMA_PRODUCTION_SECRET_KEY || secrets.ORAMA_SECRET_KEY }}
+        if: |
+          (matrix.os == 'ubuntu-latest') &&
+          ((github.event_name == 'push') || (github.event_name == 'pull_request_target'))
         run: |
           npm run sync-orama


### PR DESCRIPTION
## Description

In the previous PRs opened (#6814, #6806), we ensured that the Orama cloud sync script updates the preview environment on `push` and `pull_request_target` events.

With this PR, we aim to update the production indexes using this script on the `push` event instead of manually updating it and to update the preview environment on `pull_request_target` events.

Additionally, to prevent these scripts from running twice, we ensure they only run on `ubuntu-latest` runners. Since we are currently running it on `windows-latest` in the preview environment, the facets are currently not displayed correctly, likely due to differences in paths on Windows (You can check it in a sample preview build)

Before merging this development, the `ORAMA_PRODUCTION_INDEX_ID` and `ORAMA_PRODUCTION_SECRET_KEY` secrets need to be defined. I believe we should get support from @ovflowd or @bmuenzenmeyer for this 👀  I think we should first set these two values to point to the preview environment to ensure everything is working correctly, and then replace them with the production ones

Additionally, it would be helpful to ask the Orama team if indexing on every `pull_request_target` and `push` events would cause any issues on their side

## Related Issues

Related to #6719 
