### PR TITLE
fix: Content visibility in dropdown

### DIFF
--- a/components/Common/Select/index.module.css
+++ b/components/Common/Select/index.module.css
@@ -60,7 +60,7 @@
 
 .dropdown {
   @apply max-h-48
-    max-w-xs
+    max-w-full
     overflow-hidden
     overflow-y-auto
     rounded-md


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The current dropdown menu on the About page in mobile view has a visibility issue. Some of the content is being cut off and is not scrollable horizontally, resulting in an incomplete user experience.
ref: https://nodejs.org/en/learn/getting-started/introduction-to-nodejs

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
before:
<img width="490" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/abc97980-cb8d-4a90-9f46-810718376b2f">
after:
<img width="479" alt="image" src="https://github.com/nodejs/nodejs.org/assets/122612557/f9351969-2587-4a89-9615-59c256259f80">



### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
