### PR TITLE
Fix layout shift caused by redundant styles

### DIFF
--- a/apps/site/styles/base.css
+++ b/apps/site/styles/base.css
@@ -5,8 +5,7 @@
 
 html,
 body {
-  @apply size-full
-    [scrollbar-gutter:auto];
+  @apply h-full;
 }
 
 body {


### PR DESCRIPTION
## Description

Initially, @shoaibkh4n noticed that when opening and closing the drop-down list on the page https://nodejs.org/en/download layout-shift occurs and [suggested a solution](https://github.com/nodejs/nodejs.org/pull/6533) – add `scrollbar-gutter: stable;`. 

This really helped, but it led to an empty space on other pages equal to the size of the scrollbar (by the way, this happens only in SPA mode). @daklay noticed this and [suggested](https://github.com/nodejs/nodejs.org/pull/6663) setting `scrollbar-gutter: auto`, but this is unnecessary, since it is the default value.

In fact, Radix UI Dropdown Menu is already solving this problem, but it was prevented by the thoughtless assignment of such styles:

```css
html,
body {
  width: 100%;
}
```

There is a difference between `width: 100%` and `width: auto`. Therefore, you just need to delete these styles.

## Validation

After this changes no layout shift and empty spaces on other pages:

https://github.com/nodejs/nodejs.org/assets/6412192/686f2825-87e4-47e9-a586-a9df982abd61

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
