### PR TITLE
fix: add link to `nodejs.org/download/release`

### DIFF
--- a/apps/site/pages/en/download/prebuilt-binaries/index.mdx
+++ b/apps/site/pages/en/download/prebuilt-binaries/index.mdx
@@ -13,12 +13,12 @@ I want the <Release.VersionDropdown /> version of Node.js for <Release.Operating
 <section>
 Node.js includes <Release.NpmLink />.
 
-Read the changelog for <Release.ChangelogLink>this version</Release.ChangelogLink>
+Read the changelog for <Release.ChangelogLink>this version</Release.ChangelogLink>.
 
-Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>
+Read the blog post for <Release.BlogPostLink>this version</Release.BlogPostLink>.
 
-Learn how to <Release.VerifyingBinariesLink>verify signed SHASUMS</Release.VerifyingBinariesLink>
+Learn how to <Release.VerifyingBinariesLink>verify signed SHASUMS</Release.VerifyingBinariesLink>.
 
-Check out <LinkWithArrow href="https://nodejs.org/download/nightly/">Nightly</LinkWithArrow> prebuilt binaries or <LinkWithArrow href="https://unofficial-builds.nodejs.org/download/">Unofficial Builds</LinkWithArrow> for other platforms
+Check out <LinkWithArrow href="https://nodejs.org/download/nightly/">Nightly</LinkWithArrow> prebuilt binaries, all <LinkWithArrow href="https://nodejs.org/download/release/">Release</LinkWithArrow> prebuilt binaries, or <LinkWithArrow href="https://unofficial-builds.nodejs.org/download/">Unofficial Builds</LinkWithArrow> for other platforms.
 
 </section>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I was looking for that link (which was present on the old website), so I figured I might as well add it back.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
Who's got time for that, am I right?

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
