### PR TITLE
fix: code coverage comment

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -238,5 +238,5 @@ jobs:
         uses: MishaKav/jest-coverage-comment@434e6d2d37116d23d812809b61d499639842fa3b # v1.0.26
         with:
           title: 'Unit Test Coverage Report'
-          junitxml-path: ./junit.xml
+          junitxml-path: ./apps/site/junit.xml
           junitxml-title: Unit Test Report


### PR DESCRIPTION
## Description

On migration to monorepo we missed this line 

## Validation

It's should display the test coverage on comment

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
