### PR TITLE
fix: codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,12 +6,12 @@
 .husky @nodejs/web-infra
 
 # Framework
-./app/site/next.config.mjs @nodejs/web-infra
-./app/site/next.dynamic.mjs @nodejs/web-infra
+app/site/next.config.mjs @nodejs/web-infra
+app/site/next.dynamic.mjs @nodejs/web-infra
 
 # Node.js Release Blog Posts
-./app/site/pages/en/blog/release @nodejs/releasers
-./app/site/pages/en/blog/announcements @nodejs/releasers
+app/site/pages/en/blog/release @nodejs/releasers
+app/site/pages/en/blog/announcements @nodejs/releasers
 
 # Package Ecosystem
 package.json @nodejs/nodejs-website
@@ -19,5 +19,5 @@ turbo.json @nodejs/nodejs-website @nodejs/web-infra
 
 # Web Infrastructure
 crowdin.yml @nodejs/web-infra
-./app/site/redirects.json @nodejs/web-infra
-./app/site/site.json @nodejs/web-infra
+app/site/redirects.json @nodejs/web-infra
+app/site/site.json @nodejs/web-infra

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,12 +6,12 @@
 .husky @nodejs/web-infra
 
 # Framework
-next.config.mjs @nodejs/web-infra
-next.dynamic.mjs @nodejs/web-infra
+./app/site/next.config.mjs @nodejs/web-infra
+./app/site/next.dynamic.mjs @nodejs/web-infra
 
 # Node.js Release Blog Posts
-/pages/en/blog/release @nodejs/releasers
-/pages/en/blog/announcements @nodejs/releasers
+./app/site/pages/en/blog/release @nodejs/releasers
+./app/site/pages/en/blog/announcements @nodejs/releasers
 
 # Package Ecosystem
 package.json @nodejs/nodejs-website
@@ -19,5 +19,5 @@ turbo.json @nodejs/nodejs-website @nodejs/web-infra
 
 # Web Infrastructure
 crowdin.yml @nodejs/web-infra
-redirects.json @nodejs/web-infra
-site.json @nodejs/web-infra
+./app/site/redirects.json @nodejs/web-infra
+./app/site/site.json @nodejs/web-infra


### PR DESCRIPTION
## Description

During migration to monorepo `codeowner` wasn't updated.

## Validation

it's should represent the correct owning.
It's should be correct code owner

## Related Issues

No Related Issues

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
