### PR TITLE
fix: make the `searchButton` width dynamic to fit the content

### DIFF
--- a/apps/site/components/Common/Search/index.module.css
+++ b/apps/site/components/Common/Search/index.module.css
@@ -1,6 +1,5 @@
 .searchButton {
   @apply flex
-    w-52
     gap-2
     rounded-md
     bg-neutral-200

--- a/apps/site/components/Common/Search/index.module.css
+++ b/apps/site/components/Common/Search/index.module.css
@@ -1,5 +1,8 @@
 .searchButton {
   @apply flex
+    grow
+    basis-80
+    items-center
     gap-2
     rounded-md
     bg-neutral-200
@@ -8,6 +11,7 @@
     text-neutral-800
     hover:bg-neutral-300
     hover:text-neutral-900
+    sm:mr-auto
     dark:bg-neutral-900
     dark:text-neutral-600
     dark:hover:bg-neutral-800

--- a/apps/site/components/Containers/NavBar/NavItem/index.module.css
+++ b/apps/site/components/Containers/NavBar/NavItem/index.module.css
@@ -7,9 +7,9 @@
     py-2;
 
   .label {
-    @apply text-sm
+    @apply text-base
       font-medium
-      leading-5;
+      lg:text-sm;
   }
 
   .icon {

--- a/apps/site/components/Containers/NavBar/index.module.css
+++ b/apps/site/components/Containers/NavBar/index.module.css
@@ -47,6 +47,8 @@
   @apply hidden
     flex-1
     flex-col
+    justify-between
+    gap-4
     lg:flex
     lg:flex-row
     lg:items-center;
@@ -55,12 +57,13 @@
 .navItems {
   @apply flex
     flex-col
-    gap-1
+    gap-0
     border-b
     border-neutral-200
     p-4
     lg:flex-1
     lg:flex-row
+    lg:gap-1
     lg:border-0
     lg:p-0
     dark:border-neutral-900;
@@ -68,11 +71,16 @@
 
 .actionsWrapper {
   @apply flex
+    flex-row
+    flex-wrap
     items-center
+    justify-between
     gap-2
     border-b
     border-neutral-200
     p-4
+    sm:flex-nowrap
+    lg:basis-96
     lg:border-0
     lg:p-0
     dark:border-neutral-900;


### PR DESCRIPTION
closes #6903
closes #6841

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In this pull request, I am solving the problem I figured out and reported on #6903 (now closed) and #6841 issue. It's a simple solution with a great visual impact on the issue, and finally, the solution works correctly on all idioms of the website.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

| Before | Now |
| ----------- | ----------- |
| ![Screenshot 2024-07-05 at 05-58-14](https://github.com/nodejs/nodejs.org/assets/31008635/ce3f6859-9e7f-4eed-adc7-2bff041f86bc) | ![Screenshot 2024-07-05 at 05-58-37](https://github.com/nodejs/nodejs.org/assets/31008635/01c82f9f-9675-47be-a1b8-0424be28d1cf) |


## Related Issues

- https://github.com/nodejs/nodejs.org/issues/6903
- https://github.com/nodejs/nodejs.org/issues/6841

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
