### PR TITLE
"Backpressuring in Streams" doc: Update pipeline examples

### DIFF
--- a/apps/site/pages/en/learn/modules/backpressuring-in-streams.md
+++ b/apps/site/pages/en/learn/modules/backpressuring-in-streams.md
@@ -124,7 +124,7 @@ cleaning up and providing a callback when the pipeline is complete.
 Here is an example of using pipeline:
 
 ```cjs
-const { pipeline } = require('node:stream/promises');
+const { pipeline } = require('node:stream');
 const fs = require('node:fs');
 const zlib = require('node:zlib');
 
@@ -147,7 +147,7 @@ pipeline(
 ```
 
 ```mjs
-import { pipeline } from 'node:stream/promises';
+import { pipeline } from 'node:stream';
 import fs from 'node:fs';
 import zlib from 'node:zlib';
 

--- a/apps/site/pages/en/learn/modules/backpressuring-in-streams.md
+++ b/apps/site/pages/en/learn/modules/backpressuring-in-streams.md
@@ -169,15 +169,12 @@ pipeline(
 );
 ```
 
-You can also call [`promisify`][] on pipeline to use it with `async` / `await`:
+You can also use the [`stream/promises`][] module to use pipeline with `async` / `await`:
 
 ```cjs
-const stream = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 const fs = require('node:fs');
 const zlib = require('node:zlib');
-const util = require('node:util');
-
-const pipeline = util.promisify(stream.pipeline);
 
 async function run() {
   try {
@@ -194,12 +191,9 @@ async function run() {
 ```
 
 ```mjs
-import stream from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import fs from 'node:fs';
 import zlib from 'node:zlib';
-import util from 'node:util';
-
-const pipeline = util.promisify(stream.pipeline);
 
 async function run() {
   try {
@@ -749,4 +743,4 @@ Node.js.
 [piped]: https://nodejs.org/docs/latest/api/stream.html#stream_readable_pipe_destination_options
 [`pump`]: https://github.com/mafintosh/pump
 [`pipeline`]: https://nodejs.org/api/stream.html#stream_stream_pipeline_streams_callback
-[`promisify`]: https://nodejs.org/api/util.html#util_util_promisify_original
+[`stream/promises`]: https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In the "Backpressuring in Streams" documentation, update the `pipeline()` examples:
* **Callback** examples: Use the correct module (`stream`, not `stream/promises`).
* **Promise** examples: Use `stream/promises` instead of `promisify`.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

The updated page, when built locally (`npm run dev`) is http://localhost:3000/en/learn/modules/backpressuring-in-streams#the-problem-with-data-handling

Updated doc screenshots (click images to see full size):
|Section|CJS example|MJS example|
|---|---|---|
|callback|<img src="https://github.com/nodejs/nodejs.org/assets/1731388/c19222ef-cef8-4d1e-b2eb-2bb51713074c" width="320">|<img src="https://github.com/nodejs/nodejs.org/assets/1731388/f3b7177a-c383-4799-a102-98bd55ec7bc2" width="320">|
|promise|<img src="https://github.com/nodejs/nodejs.org/assets/1731388/b124284a-9b98-4e7c-95b2-847f271e030e" width="320">|<img src="https://github.com/nodejs/nodejs.org/assets/1731388/bcaf5156-19f4-40f4-a6e0-662dad23c4ec" width="320">|






## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
