### PR TITLE
doc: fix the fnm docs for a functional instruction guide

### DIFF
--- a/apps/site/i18n/locales/en.json
+++ b/apps/site/i18n/locales/en.json
@@ -300,6 +300,7 @@
         "shouldPrint": "should print `{version}`",
         "installsFnm": "installs fnm (Fast Node Manager)",
         "downloadAndInstallNodejs": "download and install Node.js",
+        "activateFNM": "activate fnm",
         "noteWithColon": "NOTE:",
         "dockerIsNotNodejsPackageManager": "Docker is not a Node.js package manager.",
         "PleaseEndureAlreadyInstallOnSystem": "Please ensure it is already installed on your system.",

--- a/apps/site/util/getNodeDownloadSnippet.ts
+++ b/apps/site/util/getNodeDownloadSnippet.ts
@@ -54,6 +54,9 @@ export const getNodeDownloadSnippet = (
       # ${t('layouts.download.codeBox.installsFnm')}
       curl -fsSL https://fnm.vercel.app/install | bash
 
+      # ${t('layouts.download.codeBox.activateFNM')}
+      source ~/.bashrc
+
       # ${t('layouts.download.codeBox.downloadAndInstallNodejs')}
       fnm use --install-if-missing ${release.major}
 


### PR DESCRIPTION
Before the change: when the commands were copy&paste (followed to the letter) they wouldn't work and users wouldn't have a functional node or npm binary

After the change: correct the instructions so that the fnm library is first sourced from the bash shell to activate it into the path which allows to use fnm as an executable and run node and npm binaries too.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
