### PR TITLE
CI: fix coverage summary path

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -224,3 +224,4 @@ jobs:
           title: 'Unit Test Coverage Report'
           junitxml-path: ./apps/site/junit.xml
           junitxml-title: Unit Test Report
+          coverage-summary-path: ./apps/site/coverage/coverage-summary.json


### PR DESCRIPTION
## Description

Unit test coverage report does not appear in the current CI test outputs;

<img width="520" alt="image" src="https://github.com/user-attachments/assets/d67a9618-f8e0-47d5-911c-4ca39ee183f0">

When I checked [MishaKav/jest-coverage-comment](https://github.com/MishaKav/jest-coverage-comment/tree/434e6d2d37116d23d812809b61d499639842fa3b/), the `coverage-summary-path` is set as default(`./coverage/coverage-summary.json`), and it seems that our coverage path has actually started to mismatch with the multi-package workspace we have just migrated to

This PR aims to bring back the `Unit Test Coverage Report` section

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
