### PR TITLE
fix: open docs links in the same tab closes #6927

### DIFF
--- a/apps/site/components/Containers/NavBar/NavItem/index.tsx
+++ b/apps/site/components/Containers/NavBar/NavItem/index.tsx
@@ -31,9 +31,7 @@ const NavItem: FC<PropsWithChildren<NavItemProps>> = ({
   >
     <span className={styles.label}>{children}</span>
 
-    {((type === 'nav' && href.startsWith('http')) || target === '_blank') && (
-      <ArrowUpRightIcon className={styles.icon} />
-    )}
+    {target === '_blank' && <ArrowUpRightIcon className={styles.icon} />}
   </ActiveLink>
 );
 

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -17,7 +17,7 @@
       "label": "components.containers.navBar.links.blog"
     },
     "docs": {
-      "link": "/docs/latest/api/",
+      "link": "https://nodejs.org/docs/latest/api/",
       "label": "components.containers.navBar.links.docs"
     },
     "certification": {

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -17,9 +17,8 @@
       "label": "components.containers.navBar.links.blog"
     },
     "docs": {
-      "link": "https://nodejs.org/docs/latest/api/",
-      "label": "components.containers.navBar.links.docs",
-      "target": "_blank"
+      "link": "/docs/latest/api/",
+      "label": "components.containers.navBar.links.docs"
     },
     "certification": {
       "link": "https://openjsf.org/certification",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Open Docs link in the same tab

## Validation

Open the docs link in the header, should not have the icon and should open in the same tab.

Fixes https://github.com/nodejs/nodejs.org/issues/6927

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
