### PR TITLE
fix: invalid property name "stop-color"

### DIFF
--- a/apps/site/components/Icons/Social/Mastodon.tsx
+++ b/apps/site/components/Icons/Social/Mastodon.tsx
@@ -26,8 +26,8 @@ const Mastodon: FC<SVGProps<SVGSVGElement>> = props => (
         y2="79"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stop-color="#6364FF" />
-        <stop offset="1" stop-color="#563ACC" />
+        <stop stopColor="#6364FF" />
+        <stop offset="1" stopColor="#563ACC" />
       </linearGradient>
     </defs>
   </svg>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes error thrown at startup because of an invalid property used in the `Mastodon` component.

## Validation

Tested locally on Chrome

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
