### PR TITLE
fix: footer missing on learn & about layout

### DIFF
--- a/apps/site/layouts/About.tsx
+++ b/apps/site/layouts/About.tsx
@@ -1,6 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 
 import WithBreadcrumbs from '@/components/withBreadcrumbs';
+import WithFooter from '@/components/withFooter';
 import WithMetaBar from '@/components/withMetaBar';
 import WithNavBar from '@/components/withNavBar';
 import WithSidebar from '@/components/withSidebar';
@@ -21,6 +22,8 @@ const AboutLayout: FC<PropsWithChildren> = ({ children }) => (
 
       <WithBreadcrumbs navKeys={['about', 'getInvolved']} />
     </ArticleLayout>
+
+    <WithFooter />
   </>
 );
 

--- a/apps/site/layouts/Learn.tsx
+++ b/apps/site/layouts/Learn.tsx
@@ -1,6 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 
 import WithBreadcrumbs from '@/components/withBreadcrumbs';
+import WithFooter from '@/components/withFooter';
 import WithMetaBar from '@/components/withMetaBar';
 import WithNavBar from '@/components/withNavBar';
 import WithProgressionSidebar from '@/components/withProgressionSidebar';
@@ -26,6 +27,8 @@ const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
 
       <WithBreadcrumbs navKeys={['learn']} />
     </ArticleLayout>
+
+    <WithFooter />
   </>
 );
 

--- a/apps/site/layouts/layouts.module.css
+++ b/apps/site/layouts/layouts.module.css
@@ -1,6 +1,8 @@
 .baseLayout {
   @apply grid
-    size-full
+    h-max
+    min-h-full
+    w-full
     grid-cols-[1fr]
     grid-rows-[auto_1fr_auto];
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Added a footer to the Learn and About layouts, ensuring it appears as the natural last item in the scrolled content.

## Related Issues
closes https://github.com/nodejs/nodejs.org/issues/6829

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
