### PR TITLE
List WinGet as install method for Windows

### DIFF
--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
 import Select from '@/components/Common/Select';
+import WinGet from '@/components/Icons/Platform/WinGet';
 import Choco from '@/components/Icons/Platform/Choco';
 import Docker from '@/components/Icons/Platform/Docker';
 import FNM from '@/components/Icons/Platform/FNM';
@@ -31,7 +32,7 @@ const PlatformDropdown: FC = () => {
     }
 
     if (os === 'LINUX' || os === 'MAC') {
-      disabledItems.push('CHOCO');
+      disabledItems.push('WINGET', 'CHOCO');
     }
 
     const releaseSupportsHomebrew = supportedHomebrewVersions.includes(
@@ -68,6 +69,7 @@ const PlatformDropdown: FC = () => {
       values={formatDropdownItems({
         items: platformItems,
         icons: {
+          WINGET: <WinGet width={16} height={16} />,
           NVM: <NVM width={16} height={16} />,
           FNM: <FNM width={16} height={16} />,
           BREW: <Homebrew width={16} height={16} />,

--- a/apps/site/components/Icons/Platform/WinGet.tsx
+++ b/apps/site/components/Icons/Platform/WinGet.tsx
@@ -1,0 +1,21 @@
+import type { FC, SVGProps } from 'react';
+
+const WinGet: FC<SVGProps<SVGSVGElement>> = props => (
+  // TODO: Use real svg for WinGet: https://github.com/microsoft/winget-cli/issues/4691
+  // For now, the Windows logo is used as a placeholder
+  <svg
+  width="32"
+  height="32"
+  viewBox="0 0 32 32"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  {...props}
+>
+  <path fill="#FEBA08" d="M17 17h10v10H17z" />
+  <path fill="#05A6F0" d="M5 17h10v10H5z" />
+  <path fill="#80BC06" d="M17 5h10v10H17z" />
+  <path fill="#F25325" d="M5 5h10v10H5z" />
+</svg>
+);
+
+export default WinGet;

--- a/apps/site/i18n/locales/en.json
+++ b/apps/site/i18n/locales/en.json
@@ -310,6 +310,9 @@
         "homebrewIsNotNodejsPackageManager": "Homebrew is not a Node.js package manager.",
         "homebrewInstructions": "Follow official instructions at https://brew.sh/",
         "homebrewSupportsIntallingMajorNodejsVersion": "Homebrew only supports installing major Node.js versions and might not support the latest Node.js version from the {version} release line.",
+        "wingetIsNotNodejsPackageManager": "The Windows Package Manager is not a Node.js package manager.",
+        "wingetInstructions": "Follow official instructions at https://learn.microsoft.com/en-us/windows/package-manager/winget/install",
+        "wingetNotMaintainedByNodejs": "WinGet is not officially maintained by the Node.js project and might not support the {version} version of Node.js",
         "chocolateyIsNotNodejsPackageManager": "Chocolatey is not a Node.js package manager.",
         "chocolateyInstructions": "Follow official instructions at https://chocolatey.org/",
         "chocolateyNotMaintainedByNodejs": "Chocolatey is not officially maintained by the Node.js project and might not support the {version} version of Node.js"

--- a/apps/site/i18n/locales/en.json
+++ b/apps/site/i18n/locales/en.json
@@ -303,7 +303,7 @@
         "activateFNM": "activate fnm",
         "noteWithColon": "NOTE:",
         "dockerIsNotNodejsPackageManager": "Docker is not a Node.js package manager.",
-        "PleaseEndureAlreadyInstallOnSystem": "Please ensure it is already installed on your system.",
+        "PleaseEnsureAlreadyInstallOnSystem": "Please ensure it is already installed on your system.",
         "dockerInstructions": "Follow official instructions at https://docs.docker.com/desktop/",
         "dockerImagesLink": "Docker images are provided officially at https://github.com/nodejs/docker-node/",
         "pullsNodejsDockerImage": "pulls the Node.js Docker image",
@@ -312,7 +312,7 @@
         "homebrewSupportsIntallingMajorNodejsVersion": "Homebrew only supports installing major Node.js versions and might not support the latest Node.js version from the {version} release line.",
         "chocolateyIsNotNodejsPackageManager": "Chocolatey is not a Node.js package manager.",
         "chocolateyInstructions": "Follow official instructions at https://chocolatey.org/",
-        "chocolateyNotMaintanedByNodejs": "Chocolatey is not officially maintained by the Node.js project and might not support the {version} version of Node.js"
+        "chocolateyNotMaintainedByNodejs": "Chocolatey is not officially maintained by the Node.js project and might not support the {version} version of Node.js"
       }
     }
   }

--- a/apps/site/types/release.ts
+++ b/apps/site/types/release.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import type { NodeRelease } from '@/types/releases';
 import type { UserOS } from '@/types/userOS';
 
-export type PackageManager = 'NVM' | 'FNM' | 'BREW' | 'DOCKER' | 'CHOCO';
+export type PackageManager = 'NVM' | 'FNM' | 'BREW' | 'DOCKER' | 'WINGET' | 'CHOCO';
 
 export interface ReleaseState {
   os: UserOS;

--- a/apps/site/util/downloadUtils.ts
+++ b/apps/site/util/downloadUtils.ts
@@ -13,6 +13,7 @@ export enum PackageManagerLabel {
   NVM = 'nvm',
   FNM = 'fnm',
   BREW = 'Brew',
+  WINGET = 'WinGet',
   CHOCO = 'Chocolatey',
   DOCKER = 'Docker',
 }
@@ -37,6 +38,10 @@ export const operatingSystemItems = [
 ];
 
 export const platformItems = [
+  {
+    label: PackageManagerLabel.WINGET,
+    value: 'WINGET' as PackageManager,
+  },
   {
     label: PackageManagerLabel.NVM,
     value: 'NVM' as PackageManager,

--- a/apps/site/util/getNodeDownloadSnippet.ts
+++ b/apps/site/util/getNodeDownloadSnippet.ts
@@ -22,7 +22,7 @@ export const getNodeDownloadSnippet = (
     snippets.DOCKER = dedent`
       # ${t('layouts.download.codeBox.noteWithColon')}
       # ${t('layouts.download.codeBox.dockerIsNotNodejsPackageManager')}
-      # ${t('layouts.download.codeBox.PleaseEndureAlreadyInstallOnSystem')}
+      # ${t('layouts.download.codeBox.PleaseEnsureAlreadyInstallOnSystem')}
       # ${t('layouts.download.codeBox.dockerInstructions')}
       # ${t('layouts.download.codeBox.dockerImagesLink')}
 
@@ -69,7 +69,7 @@ export const getNodeDownloadSnippet = (
     snippets.BREW = dedent`
       # ${t('layouts.download.codeBox.noteWithColon')}
       # ${t('layouts.download.codeBox.homebrewIsNotNodejsPackageManager')}
-      # ${t('layouts.download.codeBox.PleaseEndureAlreadyInstallOnSystem')}
+      # ${t('layouts.download.codeBox.PleaseEnsureAlreadyInstallOnSystem')}
       # ${t('layouts.download.codeBox.homebrewInstructions')}
       # ${t('layouts.download.codeBox.homebrewSupportsIntallingMajorNodejsVersion', { version: release.major })}
 
@@ -100,9 +100,9 @@ export const getNodeDownloadSnippet = (
     snippets.CHOCO = dedent`
       # ${t('layouts.download.codeBox.noteWithColon')}
       # ${t('layouts.download.codeBox.chocolateyIsNotNodejsPackageManager')}
-      # ${t('layouts.download.codeBox.PleaseEndureAlreadyInstallOnSystem')}
+      # ${t('layouts.download.codeBox.PleaseEnsureAlreadyInstallOnSystem')}
       # ${t('layouts.download.codeBox.chocolateyInstructions')}
-      # ${t('layouts.download.codeBox.chocolateyNotMaintanedByNodejs', { version: release.versionWithPrefix })}
+      # ${t('layouts.download.codeBox.chocolateyNotMaintainedByNodejs', { version: release.versionWithPrefix })}
 
       # ${t('layouts.download.codeBox.downloadAndInstallNodejs')}
       choco install nodejs${release.isLts ? '-lts' : ''} --version="${release.version}"

--- a/apps/site/util/getNodeDownloadSnippet.ts
+++ b/apps/site/util/getNodeDownloadSnippet.ts
@@ -15,6 +15,7 @@ export const getNodeDownloadSnippet = (
     FNM: '',
     BREW: '',
     DOCKER: '',
+    WINGET: '',
     CHOCO: '',
   };
 
@@ -84,6 +85,22 @@ export const getNodeDownloadSnippet = (
   }
 
   if (os === 'WIN') {
+    snippets.WINGET = dedent`
+      # ${t('layouts.download.codeBox.noteWithColon')}
+      # ${t('layouts.download.codeBox.wingetIsNotNodejsPackageManager')}
+      # ${t('layouts.download.codeBox.PleaseEnsureAlreadyInstallOnSystem')}
+      # ${t('layouts.download.codeBox.wingetInstructions')}
+      # ${t('layouts.download.codeBox.wingetNotMaintainedByNodejs', { version: release.versionWithPrefix })}
+
+      # ${t('layouts.download.codeBox.downloadAndInstallNodejs')}
+      winget install -e --id OpenJS.NodeJS${release.isLts ? '.LTS' : ''} -v ${release.version}
+
+      # ${t('layouts.download.codeBox.verifiesRightNodejsVersion')}
+      node -v # ${t('layouts.download.codeBox.shouldPrint', { version: release.versionWithPrefix })}
+
+      # ${t('layouts.download.codeBox.verifiesRightNpmVersion')}
+      npm -v # ${t('layouts.download.codeBox.shouldPrint', { version: release.npm })}`;
+
     snippets.FNM = dedent`
       # ${t('layouts.download.codeBox.installsFnm')}
       winget install Schniz.fnm


### PR DESCRIPTION
## Description

This change adds `winget` to the list of ways to install Node.js on Windows.

## Validation

A new entry on https://nodejs.org/en/download/package-manager

## Related Issues

#4028 - regression
#3993

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.

*`npm install` fails on my Windows machine. Cannot run any test commands.*