### PR TITLE
NODE_ENV is not part of Node.js core and an antipattern

### DIFF
--- a/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
+++ b/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
@@ -74,5 +74,5 @@ if (['production', 'staging'].includes(process.env.NODE_ENV)) {
 }
 ```
 
-While this might look harmless, it makes the production and staging environments different, thus making reliable testing impossible. For example a test and thus a functionality of your product could pass when `NODE_ENV` is set to development but fail when setting `NODE_ENV` to `production`.
+While this might look harmless, it makes the production and staging environments different, thus making reliable testing impossible. For example a test and thus a functionality of your product could pass when `NODE_ENV` is set to `development` but fail when setting `NODE_ENV` to `production`.
 Therefore, setting `NODE_ENV` to anything but `production` is considered an _antipattern_.

--- a/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
+++ b/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
@@ -1,15 +1,23 @@
 ---
 title: Node.js, the difference between development and production
 layout: learn
-authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, RenanTKN
+authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, RenanTKN, mcollina
 ---
 
 # Node.js, the difference between development and production
 
-You can have different configurations for production and development environments.
+__There is no difference between development and production in Node.js__, i.e., there are no specific settings you need to apply to make Node.js work in a production configuration.
+However, a few libraries in the npm registry recognize using the `NODE_ENV` variable and default it to a `development` setting.
+Always run your Node.js with the `NODE_ENV=production` set.
 
-Node.js assumes it's always running in a development environment.
-You can signal Node.js that you are running in production by setting the `NODE_ENV=production` environment variable.
+A popular way of configuring your application is by using the [twelve factor methodology](https://12factor.net/).
+
+## NODE_ENV in Express
+
+In the wildly popular [express](https://expressjs.com/) framework, setting the `NODE_ENV` to `production` generally ensures that:
+
+- logging is kept to a minimum, essential level
+- more caching levels take place to optimize performance
 
 This is usually done by executing the command
 
@@ -25,16 +33,32 @@ You can also apply the environment variable by prepending it to your application
 NODE_ENV=production node app.js
 ```
 
-This environment variable is a convention that is widely used in external libraries as well.
+For example, in an Express app, you can use this to set different error handlers per environment:
 
-Setting the environment to `production` generally ensures that
+```js
+if (process.env.NODE_ENV === 'development') {
+  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
+}
 
-- logging is kept to a minimum, essential level
-- more caching levels take place to optimize performance
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.errorHandler());
+}
+```
 
 For example [Pug](https://pugjs.org), the templating library used by [Express](https://expressjs.com), compiles in debug mode if `NODE_ENV` is not set to `production`. Express views are compiled in every request in development mode, while in production they are cached. There are many more examples.
 
-You can use conditional statements to execute code in different environments:
+__This environment variable is a convention widely used in external libraries, but not within Node.js itself__.
+
+## Why is NODE_ENV considered an antipattern?
+
+An environment is a digital platform or a system where engineers can build, test, _deploy_, and manage software products. Conventionally, there are four stages or types of environments where our application is run:
+
+* Development
+* Testing
+* Staging
+* Production
+
+The fundamental problem of `NODE_ENV` stems from developers combining optimizations and software behavior with the environment their software is running on. The result is code like the following:
 
 ```js
 if (process.env.NODE_ENV === 'development') {
@@ -50,14 +74,5 @@ if (['production', 'staging'].includes(process.env.NODE_ENV)) {
 }
 ```
 
-For example, in an Express app, you can use this to set different error handlers per environment:
-
-```js
-if (process.env.NODE_ENV === 'development') {
-  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-}
-
-if (process.env.NODE_ENV === 'production') {
-  app.use(express.errorHandler());
-}
-```
+While this might look harmless, it makes the production and stanging environments different, making testing impossible.
+Therefore, setting `NODE_ENV` to anything but `production` is considered an _antipattern_.

--- a/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
+++ b/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
@@ -74,5 +74,5 @@ if (['production', 'staging'].includes(process.env.NODE_ENV)) {
 }
 ```
 
-While this might look harmless, it makes the production and stanging environments different, making testing impossible.
+While this might look harmless, it makes the production and staging environments different, thus making reliable testing impossible. For example a test and thus a functionality of your product could pass when `NODE_ENV` is set to development but fail when setting `NODE_ENV` to `production`.
 Therefore, setting `NODE_ENV` to anything but `production` is considered an _antipattern_.

--- a/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
+++ b/apps/site/pages/en/learn/getting-started/nodejs-the-difference-between-development-and-production.md
@@ -6,7 +6,7 @@ authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, RenanTKN, mc
 
 # Node.js, the difference between development and production
 
-__There is no difference between development and production in Node.js__, i.e., there are no specific settings you need to apply to make Node.js work in a production configuration.
+**There is no difference between development and production in Node.js**, i.e., there are no specific settings you need to apply to make Node.js work in a production configuration.
 However, a few libraries in the npm registry recognize using the `NODE_ENV` variable and default it to a `development` setting.
 Always run your Node.js with the `NODE_ENV=production` set.
 
@@ -47,16 +47,16 @@ if (process.env.NODE_ENV === 'production') {
 
 For example [Pug](https://pugjs.org), the templating library used by [Express](https://expressjs.com), compiles in debug mode if `NODE_ENV` is not set to `production`. Express views are compiled in every request in development mode, while in production they are cached. There are many more examples.
 
-__This environment variable is a convention widely used in external libraries, but not within Node.js itself__.
+**This environment variable is a convention widely used in external libraries, but not within Node.js itself**.
 
 ## Why is NODE_ENV considered an antipattern?
 
 An environment is a digital platform or a system where engineers can build, test, _deploy_, and manage software products. Conventionally, there are four stages or types of environments where our application is run:
 
-* Development
-* Testing
-* Staging
-* Production
+- Development
+- Testing
+- Staging
+- Production
 
 The fundamental problem of `NODE_ENV` stems from developers combining optimizations and software behavior with the environment their software is running on. The result is code like the following:
 


### PR DESCRIPTION
Setting NODE_ENV to anything but production is an antipattern should be avoided.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
