### PR TITLE
fix: Improved understanding of setImmediate and setTimeout output

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -30,34 +30,34 @@ Use `nextTick()` when you want to make sure that in the next event loop iteratio
 console.log('Hello => number 1');
 
 setImmediate(() => {
-  console.log('Running before the timeout => number 3');
+  console.log('Running setImmediate in the check phase => number 3');
 });
 
 setTimeout(() => {
-  console.log('The timeout running last => number 4');
+  console.log('Running setTimeout in the timers phase => number 4');
 }, 0);
 
 process.nextTick(() => {
-  console.log('Running at next tick => number 2');
+  console.log('Running process.nextTick in the nextTick queue => number 2');
 });
 ```
 
 #### Example output:
 
-```bash
+```text
 Hello => number 1
-Running at next tick => number 2
-Running before the timeout => number 3
-The timeout running last => number 4
+Running process.nextTick in the nextTick queue => number 2
+Running setImmediate in the check phase => number 3
+Running setTimeout in the timers phase => number 4
 ```
 
 The output aforementioned holds true in ES Modules, e.g. mjs files, but keep in mind in CommonJS case, the output may be different:
 
-```bash
+```text
 Hello => number 1
-Running at next tick => number 2
-The timeout running last => number 4
-Running before the timeout => number 3
+Running process.nextTick in the nextTick queue => number 2
+Running setTimeout in the timers phase => number 4
+Running setImmediate in the check phase => number 3
 ```
 
-This is because the execution order of setImmediate and setTimeout is undeterministic in CommonJs.
+This is because the execution order of `setImmediate` and `setTimeout` is undeterministic in CommonJS.

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -51,4 +51,13 @@ Running before the timeout => number 3
 The timeout running last => number 4
 ```
 
-The exact output may differ from run to run.
+The output aforementioned holds true in ES Modules, e.g. mjs files, but keep in mind in CommonJS case, the output may be different:
+
+```bash
+Hello => number 1
+Running at next tick => number 2
+The timeout running last => number 4
+Running before the timeout => number 3
+```
+
+This is because the execution order of setImmediate and setTimeout is undeterministic in CommonJs.


### PR DESCRIPTION
## Description

In the understanding-processnexttick.md file we have code example output for setImmediate and setTimeout. While that output holds true for ES modules case and have indeterministic behaviour in CommonJS case. I mentioned it to improve the understanding, incase a person tries to run the code and get confused.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->


### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [] I've covered new added functionality with unit tests if necessary. - Not required
