### PR TITLE
fix: missing links from release

### DIFF
--- a/apps/site/pages/en/blog/release/v20.17.0.md
+++ b/apps/site/pages/en/blog/release/v20.17.0.md
@@ -1,5 +1,5 @@
 ---
-date: '2024-08-21T17:16:02.534Z'
+date: '2024-08-21T17:40:21.142Z'
 category: release
 title: Node v20.17.0 (LTS)
 layout: blog-post
@@ -235,7 +235,7 @@ Windows 32-bit Installer: https://nodejs.org/dist/v20.17.0/node-v20.17.0-x86.msi
 Windows 64-bit Installer: https://nodejs.org/dist/v20.17.0/node-v20.17.0-x64.msi \
 Windows ARM 64-bit Installer: https://nodejs.org/dist/v20.17.0/node-v20.17.0-arm64.msi \
 Windows 32-bit Binary: https://nodejs.org/dist/v20.17.0/win-x86/node.exe \
-Windows 64-bit Binary: _Coming soon_ \
+Windows 64-bit Binary: https://nodejs.org/dist/v20.17.0/win-x64/node.exe \
 Windows ARM 64-bit Binary: https://nodejs.org/dist/v20.17.0/win-arm64/node.exe \
 macOS 64-bit Installer: https://nodejs.org/dist/v20.17.0/node-v20.17.0.pkg \
 macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-darwin-arm64.tar.gz \
@@ -245,8 +245,8 @@ Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux
 Linux s390x 64-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-s390x.tar.xz \
 AIX 64-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-aix-ppc64.tar.gz \
 ARMv7 32-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-armv7l.tar.xz \
-ARMv8 64-bit Binary: _Coming soon_ \
-Source Code: _Coming soon_ \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v20.17.0/node-v20.17.0-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v20.17.0/node-v20.17.0.tar.gz \
 Other release files: https://nodejs.org/dist/v20.17.0/ \
 Documentation: https://nodejs.org/docs/v20.17.0/api/
 


### PR DESCRIPTION
@nodejs/nodejs-website fixing some missing links and the https://nodejs.org/en/blog/release/v20.17.0 is not going up