### PR TITLE
Fix: nodejs.org/learn leads to 404

### DIFF
--- a/apps/site/redirects.json
+++ b/apps/site/redirects.json
@@ -265,6 +265,10 @@
       "destination": "/:locale/about/get-involved/:path*"
     },
     {
+      "source": "/learn",
+      "destination": "/en/learn"
+    },
+    {
       "source": "/:locale/learn",
       "destination": "/:locale/learn/getting-started/introduction-to-nodejs"
     },


### PR DESCRIPTION

## Description
Added the redirect path to the root of the Learn nav link

## Related Issues
Fixes #7000 nodejs.org/learn leads to 404

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
