### PR TITLE
fix(action): correct lint path, clean up warnings, fix lints

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-# Node.js
-node_modules
-
-# Next.js & Vercel Directories
-.turbo

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run `npx lint:md --fix`
         # This runs a specific version of ESLint with only the Translation Pages Globbing
         # This avoid that unrelated changes get linted/modified within this PR
-        run: npx eslint "apps/site/pages/**/*.md?(x)" --fix --cache --cache-strategy=metadata --cache-file=apps/site/.eslintmdcache
+        run: npx eslint "apps/site/pages/**/*.md?(x)" --fix --cache --cache-strategy=metadata --cache-file=apps/site/.eslintmdcache --config=apps/site/eslint.config.js
 
       - name: Run `npx prettier --write`
         # This runs a specific version of Prettier with only the Translation Pages Globbing

--- a/apps/site/eslint.config.js
+++ b/apps/site/eslint.config.js
@@ -22,6 +22,7 @@ const compatConfig = compat.config({
 export default tseslint.config(
   {
     ignores: [
+      'node_modules',
       '.next',
       '.swc',
       '.turbo',

--- a/apps/site/eslint.config.js
+++ b/apps/site/eslint.config.js
@@ -88,6 +88,7 @@ export default tseslint.config(
     rules: {
       'no-irregular-whitespace': 'off',
       '@next/next/no-img-element': 'off',
+      '@next/next/no-html-link-for-pages': ['error', 'apps/site/pages/'],
 
       // https://github.com/typescript-eslint/typescript-eslint/issues/9860
       '@typescript-eslint/consistent-type-imports': 'off',

--- a/packages/i18n/eslint.config.js
+++ b/packages/i18n/eslint.config.js
@@ -6,6 +6,8 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   {
     ignores: [
+      'node_modules',
+      '.turbo',
       'build',
       'coverage',
       'global.d.ts',


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

https://github.com/nodejs/nodejs.org/actions/runs/10850360175/job/30111620392 failed due to incorrect eslint configuration/invocation

## Validation

```
npx eslint "apps/site/pages/**/*.md?(x)" --fix --cache --cache-strategy=metadata --cache-file=apps/site/.eslintmdcache --config=apps/site/eslint.config.js
```

⬆️ succeeds now 

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

A cleaned up and rebased https://github.com/nodejs/nodejs.org/pull/7040 should succeed

## Related Issues

supports #7040 cleanly

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
