### PR TITLE
fixed the text cutoff issue

### DIFF
--- a/apps/site/components/Common/Select/index.module.css
+++ b/apps/site/components/Common/Select/index.module.css
@@ -60,7 +60,7 @@
 
 .dropdown {
   @apply max-h-48
-    max-w-fit
+    max-w-xs
     overflow-hidden
     overflow-y-auto
     rounded-md

--- a/apps/site/components/Common/Select/index.module.css
+++ b/apps/site/components/Common/Select/index.module.css
@@ -60,7 +60,7 @@
 
 .dropdown {
   @apply max-h-48
-    max-w-xs
+    max-w-fit
     overflow-hidden
     overflow-y-auto
     rounded-md
@@ -96,7 +96,9 @@
   }
 
   .text > span > span {
-    @apply truncate;
+    @apply max-w-[250px]
+      truncate
+      text-wrap;
   }
 
   .label {

--- a/apps/site/components/Common/Select/index.module.css
+++ b/apps/site/components/Common/Select/index.module.css
@@ -96,7 +96,7 @@
   }
 
   .text > span > span {
-    @apply max-w-[250px]
+    @apply max-w-64
       truncate
       text-wrap;
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
added a fixed width of (250px) for wrap. 
the problem with putting the full width is that sometime it get overflow beyond like :
<img width="217" alt="image" src="https://github.com/user-attachments/assets/9cf612e9-1357-4559-a2ae-1854ed075497">
which is not a ideal case: so putting 250px maintain the previous width as well as gives a wrap around the long text
![Screenshot 2024-09-16 235624](https://github.com/user-attachments/assets/dbf61d36-f86f-4025-9d5d-df68bfc2493c)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #7035 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
