### PR TITLE
chore: update dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
         patterns:
           - '@typescript-eslint/*'
           - 'eslint'
+          - 'typescript-eslint'
           - 'eslint-*'
           - 'stylelint'
           - 'stylelint-*'
@@ -43,10 +44,9 @@ updates:
       next-js:
         patterns:
           - 'next'
-          - 'turbo'
-          - 'next-mdx-remote'
-          - 'next-sitemap'
-          - 'next-themes'
+          - 'eslint-config-next'
+          - '@next/eslint-plugin-next'
+          - 'next-*'
           - '@vercel/*'
       mdx:
         patterns:
@@ -63,8 +63,12 @@ updates:
       tailwind:
         patterns:
           - '@savvywombat/tailwindcss-grid-areas'
+          - '@tailwindcss/container-queries'
           - 'prettier-plugin-tailwindcss'
           - 'tailwindcss'
+      orama:
+        patterns:
+          - '@orama/*'
     ignore:
       # Manually update major versions of @types/node with the version specified within .nvmrc
       - dependency-name: '@types/node'


### PR DESCRIPTION
## Description

Keep up to date Dependabot.

Also remove `turbo` on next group because turborepo isn't nextjs related

## Related Issues

Biran's comment https://github.com/nodejs/nodejs.org/pull/7081#issuecomment-2391445345

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
