### PR TITLE
style: make sidebars sticky

### DIFF
--- a/apps/site/components/Containers/MetaBar/index.module.css
+++ b/apps/site/components/Containers/MetaBar/index.module.css
@@ -1,5 +1,9 @@
 .wrapper {
-  @apply flex
+  @apply sticky
+    top-0
+    flex
+    h-max
+    min-h-screen
     w-full
     flex-col
     items-start

--- a/apps/site/components/Containers/MetaBar/index.module.css
+++ b/apps/site/components/Containers/MetaBar/index.module.css
@@ -1,9 +1,5 @@
 .wrapper {
-  @apply sticky
-    top-0
-    flex
-    h-max
-    min-h-screen
+  @apply flex
     w-full
     flex-col
     items-start
@@ -13,6 +9,10 @@
     px-4
     py-6
     [overflow-wrap:anywhere]
+    lg:sticky
+    lg:top-0
+    lg:h-max
+    lg:min-h-screen
     lg:px-6
     dark:border-neutral-900;
 

--- a/apps/site/components/Containers/Sidebar/index.module.css
+++ b/apps/site/components/Containers/Sidebar/index.module.css
@@ -1,5 +1,9 @@
 .wrapper {
-  @apply flex
+  @apply sticky
+    top-0
+    flex
+    h-max
+    min-h-screen
     w-full
     flex-col
     items-start

--- a/apps/site/components/Containers/Sidebar/index.module.css
+++ b/apps/site/components/Containers/Sidebar/index.module.css
@@ -1,9 +1,5 @@
 .wrapper {
-  @apply sticky
-    top-0
-    flex
-    h-max
-    min-h-screen
+  @apply flex
     w-full
     flex-col
     items-start

--- a/apps/site/layouts/layouts.module.css
+++ b/apps/site/layouts/layouts.module.css
@@ -18,7 +18,7 @@
     sm:grid
     sm:grid-cols-[theme(spacing.52)_1fr]
     sm:grid-rows-[1fr]
-    sm:overflow-hidden
+    sm:overflow-visible
     md:grid-cols-[theme(spacing.64)_1fr]
     lg:grid-cols-[theme(spacing.52)_1fr_theme(spacing.52)]
     xl:grid-cols-[theme(spacing.80)_1fr_theme(spacing.80)];


### PR DESCRIPTION
## Description

Make sidebars "sticky" to the browser top, making it accessible when scrolled partially or entirely down the page

## Validation

When scrolling down the page, sidebars should remain visible:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/2437b3c8-186a-4fd8-bbc0-4f80227b29fb">

On mobile, layout should be unaffected:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/b42c453e-2e3e-4b14-83c7-f8a78301fb13">


## Related Issues

Addresses #7122 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
