### PR TITLE
fix: 404 on the 'package managers' link on home page

### DIFF
--- a/apps/site/next.mdx.use.client.mjs
+++ b/apps/site/next.mdx.use.client.mjs
@@ -20,6 +20,8 @@ export const clientMdxComponents = {
   Button: Button,
   // Links with External Arrow
   LinkWithArrow: LinkWithArrow,
+  // Regular links (without arrow)
+  Link: Link,
 };
 
 /**

--- a/apps/site/pages/en/index.mdx
+++ b/apps/site/pages/en/index.mdx
@@ -23,7 +23,7 @@ layout: home
           <small>
             Downloads Node.js <b>{release.versionWithPrefix}</b>
             <sup title="Downloads a Node.js installer for your current platform">1</sup> with long-term support.
-            Node.js can also be installed via <a href="/download/package-manager">package managers</a>.
+            Node.js can also be installed via <Link href="/download/package-manager">package managers</Link>.
           </small>
         </>
       )}

--- a/apps/site/pages/es/index.mdx
+++ b/apps/site/pages/es/index.mdx
@@ -21,7 +21,7 @@ Node.js® es un entorno de ejecución de JavaScript multiplataforma, de código 
         <small>
           Descarga Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> con soporte a largo plazo.
-          Node.js también puede ser instalado a través de <a href="/download/package-manager">gestores de paquetes</a>.
+          Node.js también puede ser instalado a través de <Link href="/download/package-manager">gestores de paquetes</Link>.
         </small>
       </>
     )}

--- a/apps/site/pages/fa/index.mdx
+++ b/apps/site/pages/fa/index.mdx
@@ -23,7 +23,7 @@ Node.js یک محیط اجرای جاوااسکریپت متن‌باز، رای
         <small>
           دانلود Node.js <b>{release.versionWithPrefix}</b>
           <sup title="دانلود نصب‌کننده Node.js برای پلتفرم فعلی شما">1</sup> با پشتیبانی بلندمدت.
-          Node.js همچنین از طریق <a href="/download/package-manager">package managers</a> نیز قابل نصب است.
+          Node.js همچنین از طریق <Link href="/download/package-manager">package managers</Link> نیز قابل نصب است.
         </small>
       </>
     )}

--- a/apps/site/pages/fr/index.mdx
+++ b/apps/site/pages/fr/index.mdx
@@ -22,7 +22,7 @@ qui permet aux développeurs de créer des serveurs, des applications web, des o
         <small>
           Télécharger Node.js  <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> avec un support à long terme.
-            Node.js peut également être installé via <a href="/download/package-manager">gestionnaires de paquets</a>.
+            Node.js peut également être installé via <Link href="/download/package-manager">gestionnaires de paquets</Link>.
         </small>
       </>
     )}

--- a/apps/site/pages/id/index.mdx
+++ b/apps/site/pages/id/index.mdx
@@ -21,7 +21,7 @@ Node.js® adalah lingkungan runtime JavaScript gratis dan sumber terbuka yang li
         <small>
           Unduhan Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> dengan dukungan jangka panjang (LTS).
-          Node.js juga dapat diinstal melalui <a href="/download/package-manager">manajer paket</a>.
+          Node.js juga dapat diinstal melalui <Link href="/download/package-manager">manajer paket</Link>.
         </small>
       </>
     )}

--- a/apps/site/pages/ja/index.mdx
+++ b/apps/site/pages/ja/index.mdx
@@ -21,7 +21,7 @@ Node.js®は自由かつオープンソースでクロスプラットフォー�
         <small>
           長期サポート版Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup>をダウンロードする。
-          <a href="/download/package-manager">パッケージマネージャー</a>を利用したインストール方法もあります。
+          <Link href="/download/package-manager">パッケージマネージャー</Link>を利用したインストール方法もあります。
         </small>
       </>
     )}

--- a/apps/site/pages/ko/index.mdx
+++ b/apps/site/pages/ko/index.mdx
@@ -21,7 +21,7 @@ Node.js®는 무료, 오픈소스, 크로스플랫폼 JavaSript 런타임 환경
         <small>
           Node.js 다운로드  <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> LTS.
-          Node.js는 <a href="/download/package-manager">package managers</a>를 통해서도 다운로드 할 수 있습니다..
+          Node.js는 <Link href="/download/package-manager">package managers</Link>를 통해서도 다운로드 할 수 있습니다..
         </small>
       </>
     )}

--- a/apps/site/pages/pt/index.mdx
+++ b/apps/site/pages/pt/index.mdx
@@ -21,7 +21,7 @@ Node.js® é uma ambiente de execução de JavaScript disponível para várias p
         <small>
           Descarregar a Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Descarregar um instalador da Node.js para a nossa plataforma atual">1</sup> com o suporte de longo prazo.
-          A Node.js também pode ser instalada através dos <a href="/download/package-manager">gestores de pacotes</a>.
+          A Node.js também pode ser instalada através dos <Link href="/download/package-manager">gestores de pacotes</Link>.
         </small>
       </>
     )}

--- a/apps/site/pages/tr/index.mdx
+++ b/apps/site/pages/tr/index.mdx
@@ -21,7 +21,7 @@ Node.js®, ücretsiz, açık kaynaklı, çapraz platform JavaScript çalıştır
         <small>
           Node.js'i indir <b>{release.versionWithPrefix}</b>
           <sup title="Mevcut platformunuz için bir Node.js yükleyicisi indirir">1</sup> uzun vadeli destek ile indirin.
-          Node.js ayrıca <a href="/download/package-manager">paket yöneticileri</a> aracılığıyla da kurulabilir.
+          Node.js ayrıca <Link href="/download/package-manager">paket yöneticileri</Link> aracılığıyla da kurulabilir.
         </small>
       </>
     )}

--- a/apps/site/pages/uk/index.mdx
+++ b/apps/site/pages/uk/index.mdx
@@ -21,7 +21,7 @@ Node.js® — це безплатне, кросплатформне середо
         <small>
           Завантажує Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> із довгостроковою підтримкою.
-          Node.js також можна встановити через <a href="/download/package-manager">менеджери пакетів</a>.
+          Node.js також можна встановити через <Link href="/download/package-manager">менеджери пакетів</Link>.
         </small>
       </>
     )}

--- a/apps/site/pages/zh-cn/index.mdx
+++ b/apps/site/pages/zh-cn/index.mdx
@@ -21,7 +21,7 @@ Node.js® 是一个免费、开源、跨平台的 JavaScript 运行时环境，�
         <small>
           下载 Node.js <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup> 长期支持版本。
-          Node.js 也可以通过 <a href="/download/package-manager">软件包管理器</a> 进行安装。
+          Node.js 也可以通过 <Link href="/download/package-manager">软件包管理器</Link> 进行安装。
         </small>
       </>
     )}

--- a/apps/site/pages/zh-tw/index.mdx
+++ b/apps/site/pages/zh-tw/index.mdx
@@ -21,7 +21,7 @@ Node.js® 是一款免費的跨平台開源 JavaScript 執行環境，供開發�
         <small>
           下載享有長期支援功能的 Node.js  <b>{release.versionWithPrefix}</b>
           <sup title="Downloads a Node.js installer for your current platform">1</sup>。
-          Node.js 也可以透過 <a href="/download/package-manager">套件管理器</a> 安裝。
+          Node.js 也可以透過 <Link href="/download/package-manager">套件管理器</Link> 安裝。
         </small>
       </>
     )}

--- a/apps/site/redirects.json
+++ b/apps/site/redirects.json
@@ -285,6 +285,10 @@
       "destination": "/:locale/download/package-manager"
     },
     {
+      "source": "/download/package-manager",
+      "destination": "/en/download/package-manager"
+    },
+    {
       "source": "/:locale/download/current",
       "destination": "/:locale/download/package-manager/current"
     },


### PR DESCRIPTION
## Description

[Nodejs.org](https://nodejs.org/) currently has a 404 link, when clicking on [_package managers_](https://nodejs.org/download/package-manager) (in all languages). [AFAICT](https://web.archive.org/web/20230314191504/https://nodejs.org/download/package-manager/), this link has been broken for about a year and a half.

This PR fixes the issue, by using the `Link` component, which already has the correct behavior - adding the locale at the beginning of the `href` path. The issue is fixed for all languages, linking to the correct download page, and I've added a redirect, so stored / cached URLs will also start working.

![nodejs-1](https://github.com/user-attachments/assets/e23a0d44-c79c-4a66-ab79-8180de1b2793)
![nodejs-2](https://github.com/user-attachments/assets/e00a0b14-9892-4bf9-84a4-035b58cd9df5)

## Validation

Tested locally, with `npx turbo dev` and it fixes the issue locally. The new links with locale at the beginning are added and the redirect also works. I don't have the config for the nginx reverse proxy used in production, in Vercel, so I cannot verify this part, but I assume it will just work.

## Related Issues

Somewhat similar to #7001

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
