### PR TITLE
content/chore(learn): give visibility to the status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ These are maintained in different repositories and we urge users to open **issue
 
 [Translation Guidelines][]
 
+[Status Page](https://status.nodejs.org/) of the Node.js web infrastructure.
+
 ## Thanks
 
 - Thanks to all contributors and collaborators that make this project possible.

--- a/apps/site/pages/en/about/get-involved/contribute.md
+++ b/apps/site/pages/en/about/get-involved/contribute.md
@@ -24,7 +24,7 @@ When reporting an issue we also need as much information about your environment 
 The Node.js project is currently managed across a number of separate GitHub repositories, each with their own separate issues database. If possible, please direct any issues you are reporting to the appropriate repository but don't worry if things happen to get put in the wrong place, the community of contributors will be more than happy to help get you pointed in the right direction.
 
 - To report issues specific to Node.js, please use [nodejs/node](https://github.com/nodejs/node)
-- To report issues specific to this website, please use [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org/issues)
+- To report issues specific to this website, please use [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org/issues). Please check if issues have already been reported before creating a new one. Also you have the [status page](https://status.nodejs.org) to check the status of the website.
 
 ## Code contributions
 

--- a/apps/site/pages/en/about/get-involved/contribute.md
+++ b/apps/site/pages/en/about/get-involved/contribute.md
@@ -24,7 +24,7 @@ When reporting an issue we also need as much information about your environment 
 The Node.js project is currently managed across a number of separate GitHub repositories, each with their own separate issues database. If possible, please direct any issues you are reporting to the appropriate repository but don't worry if things happen to get put in the wrong place, the community of contributors will be more than happy to help get you pointed in the right direction.
 
 - To report issues specific to Node.js, please use [nodejs/node](https://github.com/nodejs/node)
-- To report issues specific to this website, please use [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org/issues). Please check if issues have already been reported before creating a new one. Also you have the [status page](https://status.nodejs.org) to check the status of the website.
+- To report issues specific to this website, please use [nodejs/nodejs.org](https://github.com/nodejs/nodejs.org/issues). Please check if issues have already been reported before creating a new one. The [status page](https://status.nodejs.org) also reports any large-scale disruptions to the site and downloads.
 
 ## Code contributions
 


### PR DESCRIPTION
## Description

Add status page on about and on the readme

## Related Issues

Potential solution for #7050

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
