### PR TITLE
refactor: Moving the version support button to the footer

### DIFF
--- a/apps/site/components/Common/ActiveLink/__tests__/index.test.mjs
+++ b/apps/site/components/Common/ActiveLink/__tests__/index.test.mjs
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react';
 
-import { VERSION_SUPPORT_SHORTCUT } from '@/next.constants.mjs';
-
 import ActiveLink from '..';
 
 // mock usePathname, but retain all the other imports
@@ -57,45 +55,6 @@ describe('ActiveLink', () => {
         activeClassName="active"
         allowSubPath={true}
         href={'/link/sub-link'}
-      >
-        Link
-      </ActiveLink>
-    );
-
-    expect(screen.findByText('Link')).resolves.toHaveAttribute('class', 'link');
-  });
-
-  it('sets active class when href is other than VERSION_SUPPORT_SHORTCUT', () => {
-    const { usePathname } = require('@/navigation.mjs');
-    usePathname.mockReturnValue('/link/sublink');
-
-    render(
-      <ActiveLink
-        className="link"
-        activeClassName="active"
-        allowSubPath={true}
-        href={'/link/sub-link'}
-      >
-        Link
-      </ActiveLink>
-    );
-
-    expect(screen.findByText('Link')).resolves.toHaveAttribute(
-      'class',
-      'link active'
-    );
-  });
-
-  it('does not set active class when href is VERSION_SUPPORT_SHORTCUT', () => {
-    const { usePathname } = require('@/navigation.mjs');
-    usePathname.mockReturnValue(VERSION_SUPPORT_SHORTCUT);
-
-    render(
-      <ActiveLink
-        className="link"
-        activeClassName="active"
-        allowSubPath={true}
-        href={VERSION_SUPPORT_SHORTCUT}
       >
         Link
       </ActiveLink>

--- a/apps/site/components/Common/ActiveLink/index.tsx
+++ b/apps/site/components/Common/ActiveLink/index.tsx
@@ -5,7 +5,6 @@ import type { ComponentProps, FC } from 'react';
 
 import Link from '@/components/Link';
 import { usePathname } from '@/navigation.mjs';
-import { VERSION_SUPPORT_SHORTCUT } from '@/next.constants.mjs';
 
 type ActiveLocalizedLinkProps = ComponentProps<typeof Link> & {
   activeClassName?: string;
@@ -27,9 +26,7 @@ const ActiveLink: FC<ActiveLocalizedLinkProps> = ({
       ? // When using allowSubPath we want only to check if
         // the current pathname starts with the utmost upper level
         // of an href (e.g. /docs/...)
-        pathname.startsWith(`/${href.toString().split('/')[1]}`) &&
-        // but not when this link is for the deep link shortcut to previous releases
-        href.toString() !== VERSION_SUPPORT_SHORTCUT
+        pathname.startsWith(`/${href.toString().split('/')[1]}`)
       : href.toString() === pathname,
   });
 

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -20,10 +20,6 @@
       "link": "https://nodejs.org/docs/latest/api/",
       "label": "components.containers.navBar.links.docs"
     },
-    "support": {
-      "link": "/about/previous-releases",
-      "label": "components.containers.navBar.links.support"
-    },
     "certification": {
       "link": "https://training.linuxfoundation.org/openjs/",
       "label": "components.containers.navBar.links.certification",
@@ -38,6 +34,10 @@
     {
       "link": "https://privacy-policy.openjsf.org/",
       "text": "components.containers.footer.links.privacyPolicy"
+    },
+    {
+      "link": "/about/previous-releases",
+      "text": "components.containers.footer.links.versionSupport"
     },
     {
       "link": "https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md",

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -178,8 +178,3 @@ export const GITHUB_API_KEY = process.env.NEXT_GITHUB_API_KEY || '';
  */
 export const ESP_SUPPORT_THRESHOLD_VERSION =
   process.env.ESP_SUPPORT_THRESHOLD_VERSION || '18.0.0';
-
-/**
- * This deep link into the app is repeated in the top nav, but we want to ignore it for active-link highlighting, since it will be covered by About
- */
-export const VERSION_SUPPORT_SHORTCUT = '/about/previous-releases';

--- a/packages/i18n/locales/en.json
+++ b/packages/i18n/locales/en.json
@@ -5,6 +5,7 @@
         "links": {
           "trademarkPolicy": "Trademark Policy",
           "privacyPolicy": "Privacy Policy",
+          "versionSupport": "Version Support",
           "codeOfConduct": "Code of Conduct",
           "security": "Security Policy"
         }
@@ -14,7 +15,6 @@
           "about": "About",
           "download": "Download",
           "docs": "Docs",
-          "support": "Version Support",
           "guides": "Guides",
           "learn": "Learn",
           "security": "Security",


### PR DESCRIPTION
## Description

With this PR, the `Version Support` button in the header was moved to the footer section where the policies and conducts are located

## Validation

The `Version Support` button should be visible and accessible in the preview

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
