### PR TITLE
fix: Return `locale` in `i18n.tsx`, also move default there

### DIFF
--- a/apps/site/app/[locale]/[[...path]]/page.tsx
+++ b/apps/site/app/[locale]/[[...path]]/page.tsx
@@ -71,9 +71,6 @@ const getPage: FC<DynamicParams> = async props => {
   const { path = [], locale = defaultLocale.code } = params;
 
   if (!availableLocaleCodes.includes(locale)) {
-    // Forces the current locale to be the Default Locale
-    setRequestLocale(defaultLocale.code);
-
     if (!allLocaleCodes.includes(locale)) {
       // when the locale is not listed in the locales, return NotFound
       return notFound();

--- a/apps/site/i18n.tsx
+++ b/apps/site/i18n.tsx
@@ -31,12 +31,18 @@ const loadLocaleDictionary = async (locale: string) => {
 
 // Provides `next-intl` configuration for RSC/SSR
 export default getRequestConfig(async ({ requestLocale }) => {
-  // Awaits for resolving the Request Locale
-  const locale = await requestLocale;
+  // This typically corresponds to the `[locale]` segment
+  let locale = await requestLocale;
+
+  // Ensure that the incoming locale is valid
+  if (!locale || !availableLocaleCodes.includes(locale)) {
+    locale = defaultLocale.code;
+  }
 
   return {
+    locale,
     // This is the dictionary of messages to be loaded
-    messages: await loadLocaleDictionary(locale ?? defaultLocale.code),
+    messages: await loadLocaleDictionary(locale),
     // We always define the App timezone as UTC
     timeZone: 'Etc/UTC',
   };


### PR DESCRIPTION
The `locale` should now also be returned from `getRequestConfig`, in order to be able to change an incoming locale to a default in case it's not supported. I saw you already had this mechanism in `page.tsx`, therefore I moved it there.