### PR TITLE
fix: Read locale from params in layout

### DIFF
--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -14,13 +14,9 @@ import '@/styles/index.css';
 
 const fontClasses = classNames(IBM_PLEX_MONO.variable, OPEN_SANS.variable);
 
-const RootLayout: FC<
-  PropsWithChildren<{
-    params: Promise<{
-      locale: string;
-    }>;
-  }>
-> = async ({ children, params }) => {
+type RotLayoutProps = PropsWithChildren<{ params: { locale: string } }>;
+
+const RootLayout: FC<RotLayoutProps> = async ({ children, params }) => {
   const { locale } = await params;
 
   const { langDir, hrefLang } = availableLocalesMap[locale] || defaultLocale;

--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -1,7 +1,6 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import classNames from 'classnames';
-import { getLocale } from 'next-intl/server';
 import type { FC, PropsWithChildren } from 'react';
 
 import BaseLayout from '@/layouts/Base';
@@ -15,8 +14,17 @@ import '@/styles/index.css';
 
 const fontClasses = classNames(IBM_PLEX_MONO.variable, OPEN_SANS.variable);
 
-const RootLayout: FC<PropsWithChildren> = async ({ children }) => {
-  const locale = await getLocale();
+type Props = {
+  params: Promise<{
+    locale: string;
+  }>;
+};
+
+const RootLayout: FC<PropsWithChildren<Props>> = async ({
+  children,
+  params,
+}) => {
+  const locale = (await params).locale;
 
   const { langDir, hrefLang } = availableLocalesMap[locale] || defaultLocale;
 

--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -14,17 +14,14 @@ import '@/styles/index.css';
 
 const fontClasses = classNames(IBM_PLEX_MONO.variable, OPEN_SANS.variable);
 
-type Props = {
-  params: Promise<{
-    locale: string;
-  }>;
-};
-
-const RootLayout: FC<PropsWithChildren<Props>> = async ({
-  children,
-  params,
-}) => {
-  const locale = (await params).locale;
+const RootLayout: FC<
+  PropsWithChildren<{
+    params: Promise<{
+      locale: string;
+    }>;
+  }>
+> = async ({ children, params }) => {
+  const { locale } = await params;
 
   const { langDir, hrefLang } = availableLocalesMap[locale] || defaultLocale;
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

`getLocale` can only be called once `setRequestLocale` was called ([ref](https://next-intl-docs.vercel.app/docs/getting-started/app-router/with-i18n-routing#add-setrequestlocale-to-all-relevant-layouts-and-pages)). Alternatively, we can avoid this entirely by just reading `locale` from `await params`.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

`npm run build && npm run start` locally. Also `npm run dev` works.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://github.com/nodejs/nodejs.org/pull/7155

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
