### PR TITLE
chore: Update dependabot lint group to include @eslint/* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
           - 'eslint'
           - 'typescript-eslint'
           - 'eslint-*'
+          - '@eslint/*'
           - 'stylelint'
           - 'stylelint-*'
         exclude-patterns:


### PR DESCRIPTION
## Description

@eslint/* packages will now be in the lint group so they can all be bumped together.

## Related Issues

https://github.com/nodejs/nodejs.org/pull/7173


### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.

