### PR TITLE
fix: Select component highlighted text color

### DIFF
--- a/apps/site/components/Common/Select/index.module.css
+++ b/apps/site/components/Common/Select/index.module.css
@@ -86,7 +86,8 @@
       data-[highlighted]:text-white
       data-[highlighted]:outline-none
       dark:text-neutral-200
-      dark:data-[highlighted]:bg-green-600;
+      dark:data-[highlighted]:bg-green-600
+      dark:data-[highlighted]:text-white;
   }
 
   .text > span {
@@ -132,7 +133,8 @@
       data-[highlighted]:text-neutral-900
       dark:text-white
       dark:data-[highlighted]:bg-neutral-900
-      dark:data-[disabled]:text-neutral-700;
+      dark:data-[disabled]:text-neutral-700
+      dark:data-[highlighted]:text-white;
   }
 
   &.dropdown {


### PR DESCRIPTION
## Description

With the update made in the PR https://github.com/nodejs/nodejs.org/pull/7179, the theme strategy was changed from `class` to `selector`.

This gives the styling given to the attribute more priority than the styling given to the class. With this PR, a highlighted text color for dark mode was added to the Select component

## Validation

In the preview build highlighted text should be visible

## Related Issues

fixes #7185

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
