### PR TITLE
fix the inconsistency in Development start command between Contributing Guide and README 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ for getting things done and landing your contribution.
 
    ```bash
    npm ci # installs this project's dependencies
-   npx turbo dev  # starts a development environment
+   npm run dev  # starts a development environment
    ```
 
 7. Perform your changes. In case you're unfamiliar with the structure of this repository, we recommend a read on the [Collaborator Guide](./COLLABORATOR_GUIDE.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ for getting things done and landing your contribution.
 
    ```bash
    npm ci # installs this project's dependencies
-   npm run dev  # starts a development environment
+   npm run dev # starts a development environment
    ```
 
 7. Perform your changes. In case you're unfamiliar with the structure of this repository, we recommend a read on the [Collaborator Guide](./COLLABORATOR_GUIDE.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ for getting things done and landing your contribution.
 
    ```bash
    npm ci # installs this project's dependencies
-   npm run dev # starts a development environment
+   npx turbo dev  # starts a development environment
    ```
 
 7. Perform your changes. In case you're unfamiliar with the structure of this repository, we recommend a read on the [Collaborator Guide](./COLLABORATOR_GUIDE.md)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ```bash
 npm ci
-npx turbo dev
+npm run dev
 
 # listening at localhost:3000
 ```


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The inconsistency between the Contributing Guide and the README regarding the development start command appears to be a result of the project's migration to Turborepo. To ensure clarity and consistency for contributors, it would be beneficial to align the documentation across all project files.

<!-- Write a brief description of the changes introduced by this PR -->


## Related Issues
Fixes #7219 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
