### PR TITLE
content: synchronize contribute page with GOVERNANCE.md

### DIFF
--- a/apps/site/pages/en/about/get-involved/contribute.md
+++ b/apps/site/pages/en/about/get-involved/contribute.md
@@ -28,20 +28,26 @@ The Node.js project is currently managed across a number of separate GitHub repo
 
 ## Code contributions
 
-If you'd like to fix bugs or add a new feature to Node.js, please make sure you consult the [Node.js Contribution Guidelines](https://github.com/nodejs/node/blob/main/CONTRIBUTING.md/#pull-requests). The review process by existing collaborators for all contributions to the project is explained there as well.
+If you'd like to fix bugs or add a new feature to Node.js, please make sure you consult the [Node.js Contribution Guidelines](https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md). The review process by existing collaborators for all contributions to the project is explained there as well.
 
 If you are wondering how to start, you can check [Node Todo](https://www.nodetodo.org/) which may guide you towards your first contribution.
 
 ## Becoming a collaborator
 
-By becoming a collaborator, contributors can have even more impact on the project. They can help other contributors by reviewing their contributions, triage issues and take an even bigger part in shaping the project's future. Individuals identified by the TSC as making significant and valuable contributions across any Node.js repository may be made Collaborators and given commit access to the project. Activities taken into consideration include (but are not limited to) the quality of:
+By becoming a collaborator, contributors can have even more impact on the project. They can help other contributors by reviewing their contributions, triaging issues and taking an even bigger part in shaping the project's future.
 
-- code commits and pull requests
-- documentation commits and pull requests
-- comments on issues and pull requests
-- contributions to the Node.js website
-- assistance provided to end users and novice contributors
-- participation in working groups
-- other participation in the wider Node.js community
+Existing collaborators may identify and nominate individuals who make significant and valuable contributions across any Node.js repository to be a new collaborator and give them commit access to the project. Activities taken into consideration include (but are not limited to) the quality of:
 
-If individuals making valuable contributions do not believe they have been considered for commit access, they may [log an issue](https://github.com/nodejs/TSC/issues) or [contact a TSC member](https://github.com/nodejs/node#tsc-technical-steering-committee) directly.
+- Commits in the [nodejs/node][] repository.
+- Pull requests and issues opened in the [nodejs/node][] repository.
+- Comments on pull requests and issues in the [nodejs/node][] repository
+- Reviews on pull requests in the [nodejs/node][] repository
+- Help provided to end-users and novice contributors
+- Pull requests and issues opened throughout the Node.js organization
+- Comments on pull requests and issues throughout the Node.js organization
+- Participation in other projects, teams, and working groups of the Node.js organization
+- Other participation in the wider Node.js community
+
+Collaborators might overlook someone with valuable contributions. In that case, the contributor may open an issue or contact a collaborator to request a nomination.
+
+[nodejs/node]: https://github.com/nodejs/node


### PR DESCRIPTION
Some of the content on the contribute page on the website has been out of date. Synchronize it with
https://github.com/nodejs/node/blob/main/GOVERNANCE.md.

In addition, the pull request guide now lives in https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md so update the link as well.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
