### PR TITLE
fix: download button pointing to an incorrect binary on Windows arm64

### DIFF
--- a/apps/site/components/Downloads/DownloadButton/index.tsx
+++ b/apps/site/components/Downloads/DownloadButton/index.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Common/Button';
 import { useDetectOS } from '@/hooks';
 import type { NodeRelease } from '@/types';
 import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
+import { getUserBitnessByArchitecture } from '@/util/getUserBitnessByArchitecture';
 
 import styles from './index.module.css';
 
@@ -17,7 +18,8 @@ const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
   release: { versionWithPrefix },
   children,
 }) => {
-  const { os, bitness } = useDetectOS();
+  const { os, bitness: userBitness, architecture: userArchitecture } = useDetectOS();
+  const bitness = getUserBitnessByArchitecture(userArchitecture, userBitness);
   const downloadLink = getNodeDownloadUrl(versionWithPrefix, os, bitness);
 
   return (

--- a/apps/site/components/Downloads/DownloadButton/index.tsx
+++ b/apps/site/components/Downloads/DownloadButton/index.tsx
@@ -18,7 +18,11 @@ const DownloadButton: FC<PropsWithChildren<DownloadButtonProps>> = ({
   release: { versionWithPrefix },
   children,
 }) => {
-  const { os, bitness: userBitness, architecture: userArchitecture } = useDetectOS();
+  const {
+    os,
+    bitness: userBitness,
+    architecture: userArchitecture,
+  } = useDetectOS();
   const bitness = getUserBitnessByArchitecture(userArchitecture, userBitness);
   const downloadLink = getNodeDownloadUrl(versionWithPrefix, os, bitness);
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR changes the way `DownloadButton` calculates `bitness` which gets passed to `getNodeDownloadUrl`. 

Previously, this value was passed directly from `useDetectOS()`, leading to the issue mentioned in the original issue.

After this change, `bitness` is calculated similarly to how it's done in `BitnessDropdown`, so: by passing `architecture` and `bitness` to `getUserBitnessByArchitecture`:

https://github.com/nodejs/nodejs.org/blob/c5345f551ea545cf9d04017204b17f3099940ada/apps/site/components/Downloads/Release/BitnessDropdown.tsx#L16-L29

## Validation

See #7239 for reproduction steps.

I've validated the fix by navigating to [Vercel preview](https://nodejs-org-git-fork-wojtekmaj-patch-1-openjs.vercel.app/en) (linked by a bot below) and verifying the binary link (see bottom left corner):

![image](https://github.com/user-attachments/assets/4b592f7e-92df-4a67-b1ab-3285f5e39925)

## Related Issues

Closes #7239 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
