### PR TITLE
chore: use `toUpperCase` in `detectOS`

### DIFF
--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -6,7 +6,6 @@ export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
   return osMatch ? (osMatch[1].toUpperCase() as UserOS) : 'OTHER';
 };
 
-
 // Since `navigator.appVersion` is deprecated, we use the `userAgent``
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion
 export const detectOS = (): UserOS => detectOsInUserAgent(navigator?.userAgent);

--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -1,21 +1,16 @@
 import type { UserOS } from '@/types/userOS';
 
 export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
-  const osMatch = userAgent?.match(/(Win|Mac|Linux)/);
-  switch (osMatch && osMatch[1]) {
-    case 'Win':
-      return 'WIN';
-    case 'Mac':
-      return 'MAC';
-    case 'Linux':
-      return 'LINUX';
-    case 'AIX':
-      return 'AIX';
-    default:
-      return 'OTHER';
-  }
+  const osMatch = userAgent?.match(/(Win|Mac|Linux|AIX)/);
+  const osMap: Record<string, UserOS> = {
+    Win: 'WIN',
+    Mac: 'MAC',
+    Linux: 'LINUX',
+    AIX: 'AIX',
+  };
+  return osMap[osMatch?.[1] ?? ''] || 'OTHER';
 };
 
-// Since `navigator.appVersion` is deprecated, we use the `userAgent``
+// Since navigator.appVersion is deprecated, we use the userAgent
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion
 export const detectOS = (): UserOS => detectOsInUserAgent(navigator?.userAgent);

--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -1,15 +1,11 @@
 import type { UserOS } from '@/types/userOS';
 
 export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
+  // Match OS names and convert to uppercase directly if there's a match
   const osMatch = userAgent?.match(/(Win|Mac|Linux|AIX)/);
-  const osMap: Record<string, UserOS> = {
-    Win: 'WIN',
-    Mac: 'MAC',
-    Linux: 'LINUX',
-    AIX: 'AIX',
-  };
-  return osMap[osMatch?.[1] ?? ''] || 'OTHER';
+  return osMatch ? (osMatch[1].toUpperCase() as UserOS) : 'OTHER';
 };
+
 
 // Since `navigator.appVersion` is deprecated, we use the `userAgent``
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion

--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -11,6 +11,6 @@ export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
   return osMap[osMatch?.[1] ?? ''] || 'OTHER';
 };
 
-// Since navigator.appVersion is deprecated, we use the userAgent
+// Since `navigator.appVersion` is deprecated, we use the `userAgent``
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion
 export const detectOS = (): UserOS => detectOsInUserAgent(navigator?.userAgent);


### PR DESCRIPTION
Instead of using the switch statement, we use a faster way with an object. Hope it's not useless tho.