### PR TITLE
fix: Unoptimized SVG images

### DIFF
--- a/apps/site/components/MDX/Image/index.tsx
+++ b/apps/site/components/MDX/Image/index.tsx
@@ -2,7 +2,9 @@ import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import type { FC } from 'react';
 
-const MDXImage: FC<ImageProps> = ({ width, height, alt, ...props }) => {
+import { isSvgImage } from '@/util/imageUtils';
+
+const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
   if (!width || !height) {
     // Since `width` and `height` are not provided in the Markdown image format,
     // we provide the height and width automatically.
@@ -10,6 +12,8 @@ const MDXImage: FC<ImageProps> = ({ width, height, alt, ...props }) => {
     return (
       <Image
         {...props}
+        src={src}
+        unoptimized={isSvgImage(src.toString())}
         alt={alt}
         width={0}
         height={0}
@@ -19,7 +23,16 @@ const MDXImage: FC<ImageProps> = ({ width, height, alt, ...props }) => {
     );
   }
 
-  return <Image {...props} alt={alt} width={width} height={height} />;
+  return (
+    <Image
+      {...props}
+      alt={alt}
+      width={width}
+      height={height}
+      src={src}
+      unoptimized={isSvgImage(src.toString())}
+    />
+  );
 };
 
 export default MDXImage;

--- a/apps/site/components/MDX/Image/index.tsx
+++ b/apps/site/components/MDX/Image/index.tsx
@@ -5,6 +5,8 @@ import type { FC } from 'react';
 import { isSvgImage } from '@/util/imageUtils';
 
 const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
+  const isUnoptimizedImage = isSvgImage(src.toString());
+
   if (!width || !height) {
     // Since `width` and `height` are not provided in the Markdown image format,
     // we provide the height and width automatically.
@@ -13,7 +15,7 @@ const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
       <Image
         {...props}
         src={src}
-        unoptimized={isSvgImage(src.toString())}
+        unoptimized={isUnoptimizedImage}
         alt={alt}
         width={0}
         height={0}
@@ -30,7 +32,7 @@ const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
       width={width}
       height={height}
       src={src}
-      unoptimized={isSvgImage(src.toString())}
+      unoptimized={isUnoptimizedImage}
     />
   );
 };

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -23,8 +23,6 @@ const nextConfig = {
   images: {
     // We disable image optimisation during static export builds
     unoptimized: ENABLE_STATIC_EXPORT,
-    // We allow SVGs to be used as images
-    dangerouslyAllowSVG: true,
     // We add it to the remote pattern for the static images we use from GitHub
     remotePatterns: [
       {

--- a/apps/site/util/__tests__/imageUtils.test.mjs
+++ b/apps/site/util/__tests__/imageUtils.test.mjs
@@ -1,0 +1,43 @@
+import { isSvgImage } from '@/util/imageUtils';
+
+describe('isSvgImage', () => {
+  const testCases = [
+    {
+      description: 'should return true for a valid .svg URL',
+      input: 'https://nodejs.org/image.svg',
+      expected: true,
+    },
+    {
+      description: 'should return true for a URL with query params',
+      input: 'https://nodejs.org/image.svg?query=param',
+      expected: true,
+    },
+    {
+      description: 'should return false for a URL without a .svg extension',
+      input: 'https://nodejs.org/image',
+      expected: false,
+    },
+    {
+      description:
+        'should return false for a URL containing ".svg" but not ending with it',
+      input: 'https://nodejs.org/image.svg.png',
+      expected: false,
+    },
+    {
+      description: 'should return false for an empty string',
+      input: '',
+      expected: false,
+    },
+    {
+      description: 'should return false for a non-URL string',
+      input: 'not-a-url',
+      expected: false,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, () => {
+      expect(isSvgImage(input)).toBe(expected);
+    });
+  });
+});

--- a/apps/site/util/imageUtils.ts
+++ b/apps/site/util/imageUtils.ts
@@ -12,9 +12,5 @@ export const isSvgImage = (src: string): boolean => {
   const [image] = src.split('?');
 
   // Check if the base path (before any query parameters) ends with '.svg'
-  if (image.endsWith('.svg')) {
-    return true;
-  }
-
-  return false;
+  return image.endsWith('.svg')
 };

--- a/apps/site/util/imageUtils.ts
+++ b/apps/site/util/imageUtils.ts
@@ -12,5 +12,5 @@ export const isSvgImage = (src: string): boolean => {
   const [image] = src.split('?');
 
   // Check if the base path (before any query parameters) ends with '.svg'
-  return image.endsWith('.svg')
+  return image.endsWith('.svg');
 };

--- a/apps/site/util/imageUtils.ts
+++ b/apps/site/util/imageUtils.ts
@@ -1,4 +1,7 @@
 /**
+ * This is a temporary workaround that can be removed once Next.js is upgraded.
+ * See https://github.com/vercel/next.js/pull/72970
+ *
  * Checks if the given source string points to an SVG image.
  *
  * This function examines the base part of the provided string (ignoring query parameters)

--- a/apps/site/util/imageUtils.ts
+++ b/apps/site/util/imageUtils.ts
@@ -1,13 +1,20 @@
-export const isSvgImage = (src: string) => {
-  let isSvg = false;
+/**
+ * Checks if the given source string points to an SVG image.
+ *
+ * This function examines the base part of the provided string (ignoring query parameters)
+ * to determine if it ends with the `.svg` extension.
+ *
+ * @param src - The URL or string representing the source of the image.
+ * @returns `true` if the source points to an SVG image, otherwise `false`.
+ */
+export const isSvgImage = (src: string): boolean => {
+  // Split the source string at the '?' character to separate the main path from query parameters
+  const [image] = src.split('?');
 
-  if (src.includes('.svg')) {
-    const image = new URL(src);
-
-    if (image.pathname.endsWith('.svg')) {
-      isSvg = true;
-    }
+  // Check if the base path (before any query parameters) ends with '.svg'
+  if (image.endsWith('.svg')) {
+    return true;
   }
 
-  return isSvg;
+  return false;
 };

--- a/apps/site/util/imageUtils.ts
+++ b/apps/site/util/imageUtils.ts
@@ -1,0 +1,13 @@
+export const isSvgImage = (src: string) => {
+  let isSvg = false;
+
+  if (src.includes('.svg')) {
+    const image = new URL(src);
+
+    if (image.pathname.endsWith('.svg')) {
+      isSvg = true;
+    }
+  }
+
+  return isSvg;
+};


### PR DESCRIPTION
## Description

With this PR, as discussed in https://github.com/nodejs/nodejs.org/pull/6454#discussion_r1848782388, instead of serving all images with `dangerouslyAllowSVG`, we now serve images with the `.svg` extension as unoptimized

## Validation

The images in the preview build should load without any problems

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
