### PR TITLE
infra: add `@oramacloud/*` to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,7 @@ updates:
       orama:
         patterns:
           - '@orama/*'
+          - '@oramacloud/*'
     ignore:
       # Manually update major versions of @types/node with the version specified within .nvmrc
       - dependency-name: '@types/node'


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Add `@oramacloud/*` to the dependabot config, as we use deps from both `@orama/` and `@oramacloud/`

## Validation

**N/A**

### Check List

**N/A**
