### PR TITLE
fix: use tabindex when href is not available

### DIFF
--- a/apps/site/components/Common/Button/index.tsx
+++ b/apps/site/components/Common/Button/index.tsx
@@ -24,6 +24,7 @@ const Button: FC<ButtonProps> = ({
     href={disabled ? undefined : href}
     aria-disabled={disabled}
     className={classNames(styles.button, styles[kind], className)}
+    tabIndex={!href ? 0 : undefined}
     {...props}
   >
     {children}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Since a button is being simulated in the bottom component, a tabindex is added to buttons that don't have an href so they can be selected with the keyboard

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
closes #7247
### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
