### PR TITLE
refactor(downloadreleasestable): added module version back to the releases table

### DIFF
--- a/apps/site/components/Downloads/DownloadReleasesTable.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable.tsx
@@ -18,6 +18,7 @@ const DownloadReleasesTable: FC = async () => {
       <thead>
         <tr>
           <th>Node.js Version</th>
+          <th>Module Version</th>
           <th>Codename</th>
           <th>Release Date</th>
           <th colSpan={2}>npm</th>
@@ -27,6 +28,7 @@ const DownloadReleasesTable: FC = async () => {
         {releaseData.map(release => (
           <tr key={release.major}>
             <td data-label="Version">v{release.version}</td>
+            <td data-label="Modules">v{release.modules}</td>
             <td data-label="LTS">{release.codename || '-'}</td>
             <td data-label="Date">
               <time>{release.releaseDate}</time>


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Re-added the node module version to the previous releases table.
## Validation

A new column exists after the node version column

## Related Issues

#6188 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
