### PR TITLE
add changes to MetaBar index.modul.css

### DIFF
--- a/apps/site/components/Containers/MetaBar/index.module.css
+++ b/apps/site/components/Containers/MetaBar/index.module.css
@@ -23,7 +23,7 @@
   dt {
     @apply mb-2
       text-sm
-      font-medium
+      font-[700]
       text-neutral-800
       dark:text-neutral-200;
   }
@@ -40,7 +40,7 @@
     a {
       @apply max-xs:inline-block
         max-xs:py-1
-        font-semibold
+        font-[500]
         text-neutral-900
         underline
         dark:text-white;


### PR DESCRIPTION
# MetaBar modified

MetaBar index.module.css modifie
added different font-weight to the 'dd' and 'a' of the css file, to make difference between H2 & H3 at Metabar Table
## Validation
<img width="313" alt="Screenshot 2024-11-27 at 5 22 31 PM" src="https://github.com/user-attachments/assets/a1c68bc6-2dd8-45c6-9e22-a1817e836d32">

## Related Issues

https://github.com/nodejs/nodejs.org/issues/7275