### PR TITLE
chore: remove vestigial commitizen references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ for getting things done and landing your contribution.
     ```bash
     cd ~/nodejs.org
     git add .
-    git commit #let commitizen handle the commit
+    git commit -m "describe your changes"
     git push -u origin name-of-your-branch
     ```
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@
   <a title="scorecard" href="https://securityscorecards.dev/viewer/?uri=github.com/nodejs/nodejs.org">
     <img src="https://api.securityscorecards.dev/projects/github.com/nodejs/nodejs.org/badge" alt="nodejs.org scorecard badge" />
   </a>
-  <a href="http://commitizen.github.io/cz-cli/" alt="Commitizen friendly">
-    <img src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg">
-  </a>
   <br />
   <br />
 </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@eslint/js": "~9.16.0",
         "@types/eslint__js": "8.42.3",
         "@types/node": "22.10.1",
-        "commitizen": "4.3.1",
         "cz-conventional-changelog": "3.3.0",
         "eslint": "~9.16.0",
         "eslint-plugin-import-x": "~4.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@eslint/js": "~9.16.0",
     "@types/eslint__js": "8.42.3",
     "@types/node": "22.10.1",
-    "commitizen": "4.3.1",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "~9.16.0",
     "eslint-plugin-import-x": "~4.4.3",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fully cleans up what was left after we forcibly removed commitzen within https://github.com/nodejs/nodejs.org/commit/0c3643f00cf7d5c1ba0327c56827f0b6f2953fa3

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

no changes expected

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

#6900 
#6844 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
