### PR TITLE
Introduce notify-on-force-push workflow

### DIFF
--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Notify on Push
+permissions:
+  contents: read
+
+jobs:
+  notify_on_push:
+    name: Notify on Force Push on `main`
+    if: github.repository == 'nodejs/nodejs.org' && github.event.forced
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990 # 2.3.2
+        env:
+          SLACK_COLOR: '#DE512A'
+          SLACK_ICON: https://github.com/nodejs.png?size=48
+          SLACK_TITLE: ${{ github.actor }} force-pushed to ${{ github.ref }}
+          SLACK_MESSAGE: |
+            A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.repository }}@${{ github.ref_name }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
+
+            Before: <https://github.com/${{ github.repository }}/commit/${{ github.event.before }}|${{ github.event.before }}>
+            After: <https://github.com/${{ github.repository }}/commit/${{ github.event.after }}|${{ github.event.after }}>
+          SLACK_USERNAME: nodejs-bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adopting the[ workflow from nodejs/node](https://github.com/nodejs/node/blob/main/.github/workflows/notify-on-push.yml) - https://github.com/rtCamp/action-slack-notify - which will be useful as we add more users with `write` access to the repo as part of CODEOWNERS work, AND it introduces accountability for existing users.

Should anyone be able to force push at all? I think the answer remains yes, but I want more visibility to it.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Post-merge, force pushes will send a Slack message to #nodejs-website

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
