### PR TITLE
update hardcoded nvm version

### DIFF
--- a/apps/site/util/getNodeDownloadSnippet.ts
+++ b/apps/site/util/getNodeDownloadSnippet.ts
@@ -39,7 +39,7 @@ export const getNodeDownloadSnippet = (
   if (os === 'MAC' || os === 'LINUX') {
     snippets.NVM = dedent`
       # ${t('layouts.download.codeBox.installsNvm')}
-      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
       # ${t('layouts.download.codeBox.downloadAndInstallNodejsRestartTerminal')}
       nvm install ${release.major}


### PR DESCRIPTION
## Description

Updates to the latest nvm version.

This is a temporary workaround until #7296 is figured out.

## Validation

Go to the package manager download box. does the nvm URL say v0.40.1 instead of v0.40.0?

## Related Issues

#7296.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
