### PR TITLE
Add CSS structure for country-specific style overrides (#7326)

### DIFF
--- a/apps/site/styles/index.css
+++ b/apps/site/styles/index.css
@@ -12,3 +12,4 @@
 @import './base.css';
 @import './markdown.css';
 @import './effects.css';
+@import './locals.css';

--- a/apps/site/styles/locals.css
+++ b/apps/site/styles/locals.css
@@ -1,5 +1,3 @@
 html[lang='ko'] {
-  line-height: 1.8;
-  word-break: keep-all;
-  word-wrap: break-word;
+  @apply break-words break-keep leading-[1.8];
 }

--- a/apps/site/styles/locals.css
+++ b/apps/site/styles/locals.css
@@ -1,3 +1,10 @@
+/**
+ * To enhance readability for Korean users, line spacing is increased,
+ * line breaks in the middle of words are prevented, and long words are
+ * managed to avoid disrupting the layout.
+ */
 html[lang='ko'] {
-  @apply break-words break-keep leading-[1.8];
+  @apply break-words
+    break-keep
+    leading-7;
 }

--- a/apps/site/styles/locals.css
+++ b/apps/site/styles/locals.css
@@ -1,0 +1,5 @@
+html[lang='ko'] {
+  line-height: 1.8;
+  word-break: keep-all;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR introduces a CSS structure to support country-specific style overrides. The new structure allows defining localized styles efficiently while maintaining global consistency.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation
- Verified that global styles are unaffected by the changes in `locals.css`.  
- Tested that the styles (`line-height: 1.8`, `word-break: keep-all`, `word-wrap: break-word`) are correctly applied when the HTML `lang='ko'` attribute is present.  
- Visually compared the text layout before and after applying the Korean-specific styles to ensure proper implementation.  
- Ensured that styles for other languages (e.g., `lang='en'`) remain unchanged.

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Fixes #7326

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run format` to ensure the code follows the style guide.
- [X] I have run `npm run test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
