### PR TITLE
meta(codeowners): add typescript to learn section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,4 +22,6 @@ crowdin.yml @nodejs/web-infra
 apps/site/redirects.json @nodejs/web-infra
 apps/site/site.json @nodejs/web-infra
 
+# Specific content
 apps/site/pages/en/learn/getting-started/security-best-practices.md @nodejs/security-wg
+apps/site/pages/en/learn/typescript @nodejs/typescript


### PR DESCRIPTION
## Description

Adding typescript team to code owners. In goal to have someone to review the content and maintain it.
Also it's was discussed on meeting there are any objections.

## Validation

`CODEOWNERS` should be valid

## Related Issues

Related to #7292 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
