### PR TITLE
feat(button): introduce `size` variant

### DIFF
--- a/apps/site/components/Common/Button/index.module.css
+++ b/apps/site/components/Common/Button/index.module.css
@@ -17,6 +17,12 @@
     @apply cursor-not-allowed;
   }
 
+  &.small {
+    @apply px-3
+      py-2
+      text-sm;
+  }
+
   &.neutral {
     @apply rounded
       bg-neutral-900

--- a/apps/site/components/Common/Button/index.stories.tsx
+++ b/apps/site/components/Common/Button/index.stories.tsx
@@ -11,6 +11,7 @@ export const Neutral: Story = {
     kind: 'neutral',
     children: 'Download Node (LTS)',
     disabled: false,
+    size: 'default',
   },
 };
 
@@ -19,6 +20,7 @@ export const Primary: Story = {
     kind: 'primary',
     children: 'Download Node (LTS)',
     disabled: false,
+    size: 'default',
   },
 };
 
@@ -27,6 +29,7 @@ export const Secondary: Story = {
     kind: 'secondary',
     children: 'Download Node (LTS)',
     disabled: false,
+    size: 'default',
   },
 };
 
@@ -35,6 +38,7 @@ export const Special: Story = {
     kind: 'special',
     children: 'Download Node (LTS)',
     disabled: false,
+    size: 'default',
   },
 };
 
@@ -48,7 +52,16 @@ export const WithIcon: Story = {
       </>
     ),
     disabled: false,
+    size: 'default',
   },
 };
 
-export default { component: Button } as Meta;
+export default {
+  component: Button,
+  argTypes: {
+    size: {
+      options: ['default', 'small'],
+      control: { type: 'radio' },
+    },
+  },
+} as Meta;

--- a/apps/site/components/Common/Button/index.tsx
+++ b/apps/site/components/Common/Button/index.tsx
@@ -14,11 +14,13 @@ import styles from './index.module.css';
 
 type ButtonProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   kind?: 'neutral' | 'primary' | 'secondary' | 'special';
+  size?: 'default' | 'small';
   disabled?: boolean;
 };
 
 const Button: FC<ButtonProps> = ({
   kind = 'primary',
+  size = 'default',
   disabled = false,
   href = undefined,
   children,
@@ -56,7 +58,12 @@ const Button: FC<ButtonProps> = ({
       role="button"
       href={disabled ? undefined : href}
       aria-disabled={disabled}
-      className={classNames(styles.button, styles[kind], className)}
+      className={classNames(
+        styles.button,
+        styles[kind],
+        styles[size],
+        className
+      )}
       tabIndex={disabled ? -1 : 0} // Ensure focusable if not disabled
       onClick={onClickHandler}
       onKeyDown={onKeyDownHandler}


### PR DESCRIPTION
## Description

Adding small variant to the button component. It's will be used in the future for the download page to have a button kind of less agressive.

## Validation

**Default**
<img width="603" alt="Capture d’écran 2024-12-22 à 11 59 31" src="https://github.com/user-attachments/assets/9e36e5b8-328d-4c46-9807-11be00f3ab80" />

**Small**
<img width="603" alt="Capture d’écran 2024-12-22 à 11 59 12" src="https://github.com/user-attachments/assets/b2c77e2d-376b-4319-865e-85e53429829c" />

## Related Issues

https://github.com/nodejs/nodejs.org/issues/7037#issuecomment-2558409941

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.