### PR TITLE
Update crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -35,6 +35,7 @@ files:
   - source: /apps/site/snippets/en/**/*.bash
     translation: /apps/site/snippets/%two_letters_code%/**/%original_file_name%
     content_segmentation: 0
+    type: txt
     languages_mapping:
       two_letters_code:
         es-ES: es


### PR DESCRIPTION
## Description

A small change to the configuration file related to Crowdin-GitHub connector to ensure that all files are processed as plain text file. I noticed that one file (docker.bash) was detected as Play Framework file - it won't allow to make comments translatable within the file

## Validation

The change was tested locally, it works well. Note that you probably need to delete `docker.bash` from Crowdin project to re-apply new type)

## Related Issues

No issues

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
