### PR TITLE
hotfix: attempt to fix vercel region (access fetch during initial build)

### DIFF
--- a/apps/site/next-data/blogData.ts
+++ b/apps/site/next-data/blogData.ts
@@ -3,15 +3,20 @@ import {
   IS_DEV_ENV,
   NEXT_DATA_URL,
   VERCEL_ENV,
+  VERCEL_REGION,
 } from '@/next.constants.mjs';
 import type { BlogPostsRSC } from '@/types';
 
 const getBlogData = (cat: string, page?: number): Promise<BlogPostsRSC> => {
+  const IS_NOT_VERCEL_RUNTIME_ENV =
+    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
+    (!IS_DEV_ENV && !VERCEL_ENV);
+
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
-  if (ENABLE_STATIC_EXPORT || (VERCEL_ENV !== 'production' && !IS_DEV_ENV)) {
+  if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
     return import('@/next-data/providers/blogData').then(
       ({ provideBlogPosts, providePaginatedBlogPosts }) =>
         page ? providePaginatedBlogPosts(cat, page) : provideBlogPosts(cat)

--- a/apps/site/next-data/downloadSnippets.ts
+++ b/apps/site/next-data/downloadSnippets.ts
@@ -3,6 +3,7 @@ import {
   IS_DEV_ENV,
   NEXT_DATA_URL,
   VERCEL_ENV,
+  VERCEL_REGION,
 } from '@/next.constants.mjs';
 import { availableLocaleCodes } from '@/next.locales.mjs';
 import type { DownloadSnippet } from '@/types';
@@ -14,11 +15,15 @@ const getDownloadSnippets = (lang: string): Promise<Array<DownloadSnippet>> => {
     return Promise.resolve([]);
   }
 
+  const IS_NOT_VERCEL_RUNTIME_ENV =
+    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
+    (!IS_DEV_ENV && !VERCEL_ENV);
+
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
-  if (ENABLE_STATIC_EXPORT || (VERCEL_ENV !== 'production' && !IS_DEV_ENV)) {
+  if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
     return import('@/next-data/providers/downloadSnippets').then(
       ({ default: provideDownloadSnippets }) => provideDownloadSnippets(lang)!
     );

--- a/apps/site/next-data/releaseData.ts
+++ b/apps/site/next-data/releaseData.ts
@@ -3,15 +3,20 @@ import {
   IS_DEV_ENV,
   NEXT_DATA_URL,
   VERCEL_ENV,
+  VERCEL_REGION,
 } from '@/next.constants.mjs';
 import type { NodeRelease } from '@/types';
 
 const getReleaseData = (): Promise<Array<NodeRelease>> => {
+  const IS_NOT_VERCEL_RUNTIME_ENV =
+    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
+    (!IS_DEV_ENV && !VERCEL_ENV);
+
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
-  if (ENABLE_STATIC_EXPORT || (VERCEL_ENV !== 'production' && !IS_DEV_ENV)) {
+  if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
     return import('@/next-data/providers/releaseData').then(
       ({ default: provideReleaseData }) => provideReleaseData()
     );

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
This PR aims to server as a hot-fix for PROD builds (during build-time the fetch to self-consume is of course not available, but during Vercel runtime it should be available)