### PR TITLE
chore: reduce Searchbox button layout shift

### DIFF
--- a/apps/site/components/Common/Search/utils.ts
+++ b/apps/site/components/Common/Search/utils.ts
@@ -2,6 +2,9 @@ import tailwindConfig from '@/tailwind.config';
 
 const colors = tailwindConfig.theme.colors;
 export const themeConfig = {
+  typography: {
+    '--font-primary': 'var(--font-open-sans)',
+  },
   colors: {
     light: {
       '--text-color-primary': colors.neutral[900],

--- a/apps/site/components/Common/Skeleton/index.tsx
+++ b/apps/site/components/Common/Skeleton/index.tsx
@@ -3,10 +3,11 @@ import { isValidElement } from 'react';
 
 import styles from './index.module.css';
 
-type SkeletonProps = { hide?: boolean; loading?: boolean };
+type SkeletonProps = { hide?: boolean; loading?: boolean; className?: string };
 
 const Skeleton: FC<PropsWithChildren<SkeletonProps>> = ({
   children,
+  className,
   hide = false,
   loading = true,
 }) => {
@@ -26,7 +27,7 @@ const Skeleton: FC<PropsWithChildren<SkeletonProps>> = ({
     <span
       tabIndex={-1}
       aria-hidden="true"
-      className={styles.skeleton}
+      className={`${styles.skeleton} ${className}`}
       data-inline-skeleton={isValidElement(children) ? undefined : true}
     >
       {children}

--- a/apps/site/components/Common/Skeleton/index.tsx
+++ b/apps/site/components/Common/Skeleton/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { FC, PropsWithChildren } from 'react';
 import { isValidElement } from 'react';
 
@@ -27,7 +28,7 @@ const Skeleton: FC<PropsWithChildren<SkeletonProps>> = ({
     <span
       tabIndex={-1}
       aria-hidden="true"
-      className={`${styles.skeleton} ${className}`}
+      className={classNames(styles.skeleton, className)}
       data-inline-skeleton={isValidElement(children) ? undefined : true}
     >
       {children}

--- a/apps/site/components/Containers/NavBar/index.module.css
+++ b/apps/site/components/Containers/NavBar/index.module.css
@@ -86,8 +86,15 @@
     dark:border-neutral-900;
 }
 
-.searchButtonSkeleton {
-  @apply flex-grow;
+span.searchButtonSkeleton {
+  @apply my-px
+    mr-2
+    flex-grow
+    rounded-xl;
+
+  &:empty {
+    @apply h-10;
+  }
 }
 
 .ghIconWrapper {

--- a/apps/site/components/Containers/NavBar/index.module.css
+++ b/apps/site/components/Containers/NavBar/index.module.css
@@ -12,6 +12,11 @@
     dark:bg-neutral-950;
 }
 
+.searchWrapper {
+  @apply flex
+    flex-grow;
+}
+
 .nodeIconAndMobileItemsToggler {
   @apply flex
     h-16

--- a/apps/site/components/Containers/NavBar/index.module.css
+++ b/apps/site/components/Containers/NavBar/index.module.css
@@ -12,11 +12,6 @@
     dark:bg-neutral-950;
 }
 
-.searchWrapper {
-  @apply flex
-    flex-grow;
-}
-
 .nodeIconAndMobileItemsToggler {
   @apply flex
     h-16
@@ -89,6 +84,10 @@
     lg:border-0
     lg:p-0
     dark:border-neutral-900;
+}
+
+.searchButtonSkeleton {
+  @apply flex-grow;
 }
 
 .ghIconWrapper {

--- a/apps/site/components/Containers/NavBar/index.tsx
+++ b/apps/site/components/Containers/NavBar/index.tsx
@@ -71,7 +71,9 @@ const NavBar: FC<NavbarProps> = ({
         </div>
 
         <div className={style.actionsWrapper}>
-          <SearchButton />
+          <div className={style.searchWrapper}>
+            <SearchButton />
+          </div>
 
           <ThemeToggle onClick={onThemeTogglerClick} />
 

--- a/apps/site/components/Containers/NavBar/index.tsx
+++ b/apps/site/components/Containers/NavBar/index.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import type { FC, ComponentProps, HTMLAttributeAnchorTarget } from 'react';
 
 import LanguageDropdown from '@/components/Common/LanguageDropDown';
+import Skeleton from '@/components/Common/Skeleton';
 import ThemeToggle from '@/components/Common/ThemeToggle';
 import NavItem from '@/components/Containers/NavBar/NavItem';
 import GitHub from '@/components/Icons/Social/GitHub';
@@ -19,6 +20,7 @@ import style from './index.module.css';
 
 const SearchButton = dynamic(() => import('@/components/Common/Search'), {
   ssr: false,
+  loading: () => <Skeleton className={style.searchButtonSkeleton} loading />,
 });
 
 const navInteractionIcons = {
@@ -71,9 +73,7 @@ const NavBar: FC<NavbarProps> = ({
         </div>
 
         <div className={style.actionsWrapper}>
-          <div className={style.searchWrapper}>
-            <SearchButton />
-          </div>
+          <SearchButton />
 
           <ThemeToggle onClick={onThemeTogglerClick} />
 

--- a/apps/site/components/Containers/NavBar/index.tsx
+++ b/apps/site/components/Containers/NavBar/index.tsx
@@ -20,7 +20,9 @@ import style from './index.module.css';
 
 const SearchButton = dynamic(() => import('@/components/Common/Search'), {
   ssr: false,
-  loading: () => <Skeleton className={style.searchButtonSkeleton} loading />,
+  loading: () => (
+    <Skeleton className={style.searchButtonSkeleton} loading={true} />
+  ),
 });
 
 const navInteractionIcons = {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This is a small tweak to prevent the Cumulative Layout Shift caused by the lazily loaded Search Button Component. The ‘final’ solution would be to support SSR in orana-ui-components, which we are actively working on, but still no ETA.  

## Validation

Compared to the old behavior, where the items on the right-hand side of the navbar would shift positions, now the items remain fixed. The only change is that the SearchBox is displayed in place of the previously empty space

## Related Issues

No issues were created for it

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run format` to ensure the code follows the style guide.
- [X] I have run `npm run test` to check if all tests are passing.
- [X] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
