### PR TITLE
download: restore preamble in download snippets

### DIFF
--- a/apps/site/snippets/en/download/brew.bash
+++ b/apps/site/snippets/en/download/brew.bash
@@ -1,3 +1,9 @@
+# NOTE:
+# Homebrew is not a Node.js package manager.
+# Please ensure it is already installed on your system.
+# Follow official instructions at https://brew.sh/
+# Homebrew only supports installing major Node.js versions and might not support the latest Node.js version from the 22 release line.
+
 # download and install Node.js
 brew install node@${props.release.major}
 

--- a/apps/site/snippets/en/download/choco.bash
+++ b/apps/site/snippets/en/download/choco.bash
@@ -1,3 +1,9 @@
+# NOTE:
+# Chocolatey is not a Node.js package manager.
+# Please ensure it is already installed on your system.
+# Follow official instructions at https://chocolatey.org/
+# Chocolatey is not officially maintained by the Node.js project and might not support the v22.12.0 version of Node.js
+
 # download and install Node.js
 choco install nodejs-lts --version="${props.release.major}"
 

--- a/apps/site/snippets/en/download/docker.bash
+++ b/apps/site/snippets/en/download/docker.bash
@@ -1,3 +1,9 @@
+# NOTE:
+# Docker is not a Node.js package manager.
+# Please ensure it is already installed on your system.
+# Follow official instructions at https://docs.docker.com/desktop/
+# Docker images are provided officially at https://github.com/nodejs/docker-node/
+
 # pulls the Node.js Docker image
 docker pull node:${props.release.major}-${props.release.major >= 4 ? 'alpine' : 'slim'}
 

--- a/apps/site/snippets/en/download/fnm.bash
+++ b/apps/site/snippets/en/download/fnm.bash
@@ -1,5 +1,11 @@
+# installs fnm (Fast Node Manager)
+curl -fsSL https://fnm.vercel.app/install | bash
+
+# activate fnm
+source ~/.bashrc
+
 # download and install Node.js
-fnm install ${props.release.major}
+fnm use --install-if-missing ${props.release.major}
 
 # verifies the right Node.js version is in the environment
 node -v # should print "${props.release.versionWithPrefix}"

--- a/apps/site/snippets/en/download/nvm.bash
+++ b/apps/site/snippets/en/download/nvm.bash
@@ -1,3 +1,6 @@
+# installs nvm (Node Version Manager)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
 # download and install Node.js (you may need to restart the terminal)
 nvm install ${props.release.major}
 


### PR DESCRIPTION
See https://nodejs-hj4exhlax-openjs.vercel.app/en/download/package-manager (preview from #7323) for the previous version

See https://github.com/nodejs/nodejs.org/pull/7351#issuecomment-2563161476 for removal context

## Description

Restores package manager setup instructions, as they were prior to #7351.

## Validation

this PR's preview will confirm that.

## Related Issues

See above.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.