### PR TITLE
Update event-loop-timers-and-nexttick.md

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -190,7 +190,7 @@ those timers' callbacks.
 
 ### check
 
-This phase allows a person to execute callbacks immediately after the
+This phase allows the event loop to execute callbacks immediately after the
 **poll** phase has completed. If the **poll** phase becomes idle and
 scripts have been queued with `setImmediate()`, the event loop may
 continue to the **check** phase rather than waiting.


### PR DESCRIPTION

Title:
Fix typo in event loop documentation: replace 'a person' with 'the event loop'

## Description

Replaced the phrase "a person" with "the event loop" in the event loop documentation to better describe the behavior of the system and improve clarity.

## Validation

I manually reviewed the change to ensure it accurately reflects the intended behavior described in the documentation. This change does not impact functionality and is purely a documentation fix.

## Related Issues

No specific issues linked to this PR.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.

