### PR TITLE
fix: compatibility engine should run even on initial state

### DIFF
--- a/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
+++ b/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
@@ -30,9 +30,9 @@ const OperatingSystemDropdown: FC<OperatingSystemDropdownProps> = () => {
   // We parse the compatibility of the dropdown items
   const parsedOperatingSystems = useMemo(
     () => parseCompat(OPERATING_SYSTEMS, release),
-    // We only want to react on the change of the OS, Bitness, and Version
+    // We only want to react on the change of the Install Method
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [release.os, release.platform, release.version]
+    [release.installMethod]
   );
 
   return (

--- a/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
+++ b/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
@@ -32,7 +32,7 @@ const OperatingSystemDropdown: FC<OperatingSystemDropdownProps> = () => {
     () => parseCompat(OPERATING_SYSTEMS, release),
     // We only want to react on the change of the Install Method
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [release.installMethod]
+    [release.installMethod, release.os]
   );
 
   return (

--- a/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
@@ -30,7 +30,7 @@ const PackageManagerDropdown: FC = () => {
       ),
     // We only want to react on the change of the Version
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [release.version]
+    [release.version, release.packageManager]
   );
 
   return (

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -40,7 +40,7 @@ const PlatformDropdown: FC = () => {
         : [],
     // We only want to react on the change of the OS, Platform, and Version
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [release.os, release.platform, release.version]
+    [release.os, release.version]
   );
 
   // We set the Platform to the next available Architecture when the current

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -30,7 +30,7 @@ const PrebuiltDownloadButtons: FC = () => {
     : '';
 
   return (
-    <div className="my-4 flex gap-2">
+    <div className="my-4 flex flex-wrap gap-2">
       <Skeleton
         loading={os === 'LOADING' || platform === ''}
         hide={OS_NOT_SUPPORTING_INSTALLERS.includes(os)}

--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -42,9 +42,9 @@ export enum PackageManagerLabel {
 }
 
 type DownloadCompatibility = {
-  os: Array<UserOS>;
-  installMethod: Array<Types.InstallationMethod>;
-  platform: Array<UserPlatform>;
+  os: Array<UserOS | 'LOADING'>;
+  installMethod: Array<Types.InstallationMethod | ''>;
+  platform: Array<UserPlatform | ''>;
   semver: Array<string>;
   releases: Array<NodeReleaseStatus>;
 };
@@ -97,15 +97,13 @@ export const parseCompat = <
 ): Array<T> => {
   const satisfiesSemver = (semver: string) => satisfies(version, semver);
 
-  const supportsOS = (i: T['compatibility']) =>
-    i.os?.includes(os as UserOS) ?? true;
+  const supportsOS = (i: T['compatibility']) => i.os?.includes(os) ?? true;
 
   const supportsInstallMethod = (i: T['compatibility']) =>
-    i.installMethod?.includes(installMethod as Types.InstallationMethod) ??
-    true;
+    i.installMethod?.includes(installMethod) ?? true;
 
   const supportsPlatform = (i: T['compatibility']) =>
-    i.platform?.includes(platform as UserPlatform) ?? true;
+    i.platform?.includes(platform) ?? true;
 
   const supportsVersion = (i: T['compatibility']) =>
     i.semver?.some(satisfiesSemver) ?? true;
@@ -146,7 +144,7 @@ export const OPERATING_SYSTEMS: Array<DownloadDropdownItem<UserOS>> = [
   {
     label: OperatingSystemLabel.AIX,
     value: 'AIX',
-    compatibility: { installMethod: ['' as Types.InstallationMethod] },
+    compatibility: { installMethod: [''] },
     iconImage: <OSIcons.AIX width={16} height={16} />,
   },
 ];

--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -146,7 +146,7 @@ export const OPERATING_SYSTEMS: Array<DownloadDropdownItem<UserOS>> = [
   {
     label: OperatingSystemLabel.AIX,
     value: 'AIX',
-    compatibility: { installMethod: [] },
+    compatibility: { installMethod: ['' as Types.InstallationMethod] },
     iconImage: <OSIcons.AIX width={16} height={16} />,
   },
 ];

--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -98,13 +98,14 @@ export const parseCompat = <
   const satisfiesSemver = (semver: string) => satisfies(version, semver);
 
   const supportsOS = (i: T['compatibility']) =>
-    os === 'LOADING' || (i.os?.includes(os) ?? true);
+    i.os?.includes(os as UserOS) ?? true;
 
   const supportsInstallMethod = (i: T['compatibility']) =>
-    (installMethod === '' || i.installMethod?.includes(installMethod)) ?? true;
+    i.installMethod?.includes(installMethod as Types.InstallationMethod) ??
+    true;
 
   const supportsPlatform = (i: T['compatibility']) =>
-    platform === '' || (i.platform?.includes(platform) ?? true);
+    i.platform?.includes(platform as UserPlatform) ?? true;
 
   const supportsVersion = (i: T['compatibility']) =>
     i.semver?.some(satisfiesSemver) ?? true;


### PR DESCRIPTION
This PR prevents the compatibility engine to simply say it is compatible when on a loading state.