### PR TITLE
chore: Minor changes on download page

### DIFF
--- a/apps/site/app/[locale]/error.tsx
+++ b/apps/site/app/[locale]/error.tsx
@@ -11,7 +11,7 @@ const ErrorPage: FC<{ error: Error }> = () => {
   const t = useTranslations();
 
   return (
-    <GlowingBackdropLayout>
+    <GlowingBackdropLayout kind="default">
       500
       <h1 className="special -mt-4 text-center">
         {t('layouts.error.internalServerError.title')}

--- a/apps/site/app/[locale]/not-found.tsx
+++ b/apps/site/app/[locale]/not-found.tsx
@@ -12,7 +12,7 @@ const NotFoundPage: FC = () => {
   const t = useTranslations();
 
   return (
-    <GlowingBackdropLayout>
+    <GlowingBackdropLayout kind="default">
       404
       <h1 className="special -mt-4 text-center">
         {t('layouts.error.notFound.title')}

--- a/apps/site/components/Downloads/Release/BlogPostLink.tsx
+++ b/apps/site/components/Downloads/Release/BlogPostLink.tsx
@@ -3,16 +3,14 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import LinkWithArrow from '@/components/Downloads/Release/LinkWithArrow';
+import Link from '@/components/Link';
 import { ReleaseContext } from '@/providers/releaseProvider';
 
 const BlogPostLink: FC<PropsWithChildren> = ({ children }) => {
   const { release } = useContext(ReleaseContext);
   const version = release.versionWithPrefix;
 
-  return (
-    <LinkWithArrow href={`/blog/release/${version}`}>{children}</LinkWithArrow>
-  );
+  return <Link href={`/blog/release/${version}`}>{children}</Link>;
 };
 
 export default BlogPostLink;

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -64,7 +64,7 @@ const PlatformDropdown: FC = () => {
       placeholder={t('layouts.download.dropdown.unknown')}
       ariaLabel={t('layouts.download.dropdown.installMethod')}
       onChange={platform => platform && release.setPlatform(platform)}
-      className="min-w-20"
+      className="min-w-28"
       inline={true}
     />
   );

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -30,7 +30,7 @@ const PrebuiltDownloadButtons: FC = () => {
     : '';
 
   return (
-    <div className="my-4 flex flex-wrap gap-2">
+    <div className="my-4 flex flex-col flex-wrap gap-2 sm:flex-row">
       <Skeleton
         loading={os === 'LOADING' || platform === ''}
         hide={OS_NOT_SUPPORTING_INSTALLERS.includes(os)}

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -30,12 +30,16 @@ const PrebuiltDownloadButtons: FC = () => {
     : '';
 
   return (
-    <div className="my-4 flex gap-2">
+    <div className="my-4 flex flex-col flex-wrap gap-2 sm:flex-row">
       <Skeleton
         loading={os === 'LOADING' || platform === ''}
         hide={OS_NOT_SUPPORTING_INSTALLERS.includes(os)}
       >
-        <Button href={installerUrl} size="small" className="min-w-56">
+        <Button
+          href={installerUrl}
+          size="small"
+          className="w-full min-w-56 sm:w-auto"
+        >
           <CloudArrowDownIcon />
 
           {t('layouts.download.buttons.installer', {
@@ -46,7 +50,11 @@ const PrebuiltDownloadButtons: FC = () => {
       </Skeleton>
 
       <Skeleton loading={os === 'LOADING' || platform === ''}>
-        <Button href={binaryUrl} size="small" className="min-w-56">
+        <Button
+          href={binaryUrl}
+          size="small"
+          className="w-full min-w-56 sm:w-auto"
+        >
           <CloudArrowDownIcon />
 
           {t('layouts.download.buttons.binary', {

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -30,7 +30,7 @@ const PrebuiltDownloadButtons: FC = () => {
     : '';
 
   return (
-    <div className="my-4 flex flex-col flex-wrap gap-2 sm:flex-row">
+    <div className="my-4 flex flex-col gap-2 sm:flex-row">
       <Skeleton
         loading={os === 'LOADING' || platform === ''}
         hide={OS_NOT_SUPPORTING_INSTALLERS.includes(os)}

--- a/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -111,7 +111,7 @@ const ReleaseCodeBox: FC = () => {
       )}
 
       <Skeleton loading={renderSkeleton}>
-        <CodeBox language={displayName} className="min-h-[16rem]">
+        <CodeBox language={displayName} className="min-h-[16.5rem]">
           <code dangerouslySetInnerHTML={{ __html: parsedSnippets }} />
         </CodeBox>
       </Skeleton>

--- a/apps/site/layouts/GlowingBackdrop.tsx
+++ b/apps/site/layouts/GlowingBackdrop.tsx
@@ -11,10 +11,9 @@ type GlowingBackdropLayoutProps = PropsWithChildren<{
   kind?: 'home' | 'default';
 }>;
 
-const GlowingBackdropLayout: FC<GlowingBackdropLayoutProps> = ({
-  kind = 'home',
-  children,
-}) => (
+const GlowingBackdropLayout: FC<
+  PropsWithChildren<GlowingBackdropLayoutProps>
+> = ({ kind = 'home', children }) => (
   <>
     <WithNavBar />
     <div className={styles.centeredLayout}>

--- a/apps/site/layouts/GlowingBackdrop.tsx
+++ b/apps/site/layouts/GlowingBackdrop.tsx
@@ -8,7 +8,7 @@ import WithNavBar from '@/components/withNavBar';
 import styles from './layouts.module.css';
 
 type GlowingBackdropLayoutProps = PropsWithChildren<{
-  kind?: 'home';
+  kind?: 'home' | 'default';
 }>;
 
 const GlowingBackdropLayout: FC<GlowingBackdropLayoutProps> = ({


### PR DESCRIPTION
## Description

On small resolutions, download buttons have been changed to be full-width

The minimum width of the upload method causes shifting for cases where `ARM64` comes after the skeleton, the minimum width has been adjusted

For macOS and Linux, since the `CodeBox` height is higher after the skeleton, it causes a layout shift the minimum height adjusted

A different layout was used instead of the home layout for the Not Found page

Since the blog post is not an external link, the component used here has been changed

## Validation

The skeleton on the download page in the preview should not cause a layout shift. 

The layout on the Not Found page should also look correct

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
