### PR TITLE
fix: breadcrumb overflow on mobile resolution

### DIFF
--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbItem/index.module.css
@@ -7,8 +7,8 @@
      text-sm
      font-medium;
 
-  &:last-child {
-    @apply w-full;
+  &:not(:last-child) {
+    @apply shrink-0;
   }
 
   a {

--- a/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
+++ b/apps/site/components/Common/Breadcrumbs/BreadcrumbRoot/index.module.css
@@ -1,6 +1,7 @@
 .list {
-  @apply flex
-    w-full
+  @apply xs:w-full
+    flex
+    w-screen
     gap-5
     px-6;
 }


### PR DESCRIPTION
## Description

The page names are too long in the breadcrumb of Learn pages, causing the page to overflow in mobile resolution.

With this PR, the last breadcrumb node, which is too long, is shown as much text as it can, and an ellipsis is added instead of an overflow

## Validation

The page width for the Learn and About pages should not overflow in the preview

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
