### PR TITLE
Visually differentiate table of content heading levels

### DIFF
--- a/apps/site/components/Containers/MetaBar/__tests__/index.test.mjs
+++ b/apps/site/components/Containers/MetaBar/__tests__/index.test.mjs
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+
+import MetaBar from '..';
+
+describe('MetaBar', () => {
+  it('does not render h5s in the table of contents', () => {
+    const { queryByText, getByText } = render(
+      <MetaBar
+        items={{}}
+        headings={{
+          items: [
+            {
+              value: 'Heading Level 1',
+              depth: 1,
+              data: { id: 'heading-1' },
+            },
+            {
+              value: 'Heading Level 2',
+              depth: 2,
+              data: { id: 'heading-2' },
+            },
+            {
+              value: 'Heading Level 3',
+              depth: 3,
+              data: { id: 'heading-3' },
+            },
+            {
+              value: 'Heading Level 4',
+              depth: 4,
+              data: { id: 'heading-4' },
+            },
+            {
+              value: 'Heading Level 5',
+              depth: 5,
+              data: { id: 'heading-5' },
+            },
+            {
+              value: 'Heading Level 6',
+              depth: 6,
+              data: { id: 'heading-6' },
+            },
+          ],
+        }}
+      />
+    );
+
+    const h1Element = queryByText('Heading Level 1');
+    expect(h1Element).not.toBeInTheDocument();
+
+    getByText('Heading Level 2');
+    getByText('Heading Level 3');
+    getByText('Heading Level 4');
+
+    const h5Element = queryByText('Heading Level 5');
+    expect(h5Element).not.toBeInTheDocument();
+
+    const h6Element = queryByText('Heading Level 6');
+    expect(h6Element).not.toBeInTheDocument();
+  });
+});

--- a/apps/site/components/Containers/MetaBar/index.stories.tsx
+++ b/apps/site/components/Containers/MetaBar/index.stories.tsx
@@ -78,6 +78,21 @@ export const Default: Story = {
           depth: 3,
           data: { id: 'contact_and_future_updates' },
         },
+        {
+          value: 'Email',
+          depth: 4,
+          data: { id: 'email' },
+        },
+        {
+          value: 'Slack',
+          depth: 4,
+          data: { id: 'slack' },
+        },
+        {
+          value: '#node-website',
+          depth: 5, // h5s do not get shown
+          data: { id: 'node-website' },
+        },
       ],
     },
   },

--- a/apps/site/components/Containers/MetaBar/index.tsx
+++ b/apps/site/components/Containers/MetaBar/index.tsx
@@ -44,8 +44,13 @@ const MetaBar: FC<MetaBarProps> = ({ items, headings }) => {
             <dd>
               <ol>
                 {heading.map(head => (
-                  <li key={head.value}>
-                    <Link href={`#${head?.data?.id}`}>{head.value}</Link>
+                  <li
+                    key={head.value}
+                    className={
+                      head.depth === 3 ? 'pl-2' : head.depth === 4 ? 'pl-4' : ''
+                    }
+                  >
+                    <Link href={`#${head?.data?.id}`}> {head.value}</Link>
                   </li>
                 ))}
               </ol>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Previous attempts to fix this did not use `head.depth`. My quick looks at the code made it seem that this data was not available, but luckily it is! I should have known, because we constrain the headings we show already (omitting h1, h5, and h6). 

Finding this out was as quick as relaying it to contributors to fix - so I added a story and tests for visibility.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Here's a before (left) and after (right) from a recently published Learn article

![image](https://github.com/user-attachments/assets/785be5f5-8241-49c3-97c4-61ec831b6841)

Note the component wraps fine on smaller viewports

![image](https://github.com/user-attachments/assets/6251bfe1-ffc7-490b-aeeb-b0a11ca3a90c)


See the preview.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

fixes #7275 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
