### PR TITLE
chore: bump @storybook/addon-webpack5-compiler-swc from 1.0.5 to 2.0.0

### DIFF
--- a/apps/site/.storybook/main.ts
+++ b/apps/site/.storybook/main.ts
@@ -11,7 +11,19 @@ const config: StorybookConfig = {
   typescript: { reactDocgen: false, check: false },
   core: { disableTelemetry: true, disableWhatsNewNotifications: true },
   framework: '@storybook/react-webpack5',
-  swc: () => ({ jsc: { transform: { react: { runtime: 'automatic' } } } }),
+  swc: () => ({
+    jsc: {
+      parser: {
+        syntax: 'typescript',
+        tsx: true,
+      },
+      transform: {
+        react: {
+          runtime: 'automatic',
+        },
+      },
+    },
+  }),
   addons: [
     '@storybook/addon-webpack5-compiler-swc',
     '@storybook/addon-controls',

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -83,7 +83,7 @@
     "@storybook/addon-styling-webpack": "^1.0.1",
     "@storybook/addon-themes": "^8.4.6",
     "@storybook/addon-viewport": "^8.4.6",
-    "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
+    "@storybook/addon-webpack5-compiler-swc": "^2.0.0",
     "@storybook/react-webpack5": "^8.4.6",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "@storybook/addon-styling-webpack": "^1.0.1",
         "@storybook/addon-themes": "^8.4.6",
         "@storybook/addon-viewport": "^8.4.6",
-        "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
+        "@storybook/addon-webpack5-compiler-swc": "^2.0.0",
         "@storybook/react-webpack5": "^8.4.6",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.1.0",
@@ -4930,11 +4930,10 @@
       }
     },
     "node_modules/@storybook/addon-webpack5-compiler-swc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-webpack5-compiler-swc/-/addon-webpack5-compiler-swc-1.0.5.tgz",
-      "integrity": "sha512-1NlM3noit2vA22OyWb8Ma2lhcEKCS1Snv2kr+EkaVABUqNDfVc9AD/GgYQhF7F/2CoF5N2JU7uzXDzFHd5TzZg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-webpack5-compiler-swc/-/addon-webpack5-compiler-swc-2.0.0.tgz",
+      "integrity": "sha512-8lL6vzXMgBFYQ89TFNPG4KjQ1WcRjKOubCTsnv0lRWC6KbF1ipyMFiEDpHOxxHbKhfk2kvQKZVqt8KLNV5zwcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.7.3",
         "swc-loader": "^0.2.3"


### PR DESCRIPTION
## Description

Bump @storybook/addon-webpack5-compiler-swc from 1.0.5 to 2.0.0. This was a breaking change as "_deep merging the user's settings with the SWC default options no longer happens_". 

This PR therefore updates the SWC configuration for TypeScript support.

## Validation

Storybook should build and serve successfully.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
