### PR TITLE
7342 edit this translation

### DIFF
--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFormatter, useTranslations } from 'next-intl';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
 import MetaBar from '@/components/Containers/MetaBar';
@@ -10,6 +10,8 @@ import WithAvatarGroup from '@/components/withAvatarGroup';
 import { useClientContext } from '@/hooks/react-client';
 import useMediaQuery from '@/hooks/react-client/useMediaQuery';
 import { DEFAULT_DATE_FORMAT } from '@/next.calendar.constants.mjs';
+import { TRANSLATION_URL } from '@/next.constants.mjs';
+import { defaultLocale } from '@/next.locales.mjs';
 import { getGitHubBlobUrl } from '@/util/gitHubUtils';
 
 const WithMetaBar: FC = () => {
@@ -23,6 +25,7 @@ const WithMetaBar: FC = () => {
     frontmatter.authors?.split(',').map(author => author.trim()) ?? [];
 
   const t = useTranslations();
+  const locale = useLocale();
 
   // Since we cannot show the same number of avatars in Mobile / Tablet
   // resolution as we do on desktop and there is overflow, we are adjusting
@@ -49,7 +52,13 @@ const WithMetaBar: FC = () => {
         'components.metabar.contribute': (
           <>
             <GitHub className="fill-neutral-700 dark:fill-neutral-100" />
-            <Link href={getGitHubBlobUrl(filename)}>
+            <Link
+              href={
+                locale === defaultLocale.code
+                  ? getGitHubBlobUrl(filename)
+                  : TRANSLATION_URL
+              }
+            >
               {t('components.metabar.contributeText')}
             </Link>
           </>

--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFormatter } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
 import MetaBar from '@/components/Containers/MetaBar';
@@ -21,6 +21,8 @@ const WithMetaBar: FC = () => {
 
   const usernames =
     frontmatter.authors?.split(',').map(author => author.trim()) ?? [];
+
+  const t = useTranslations();
 
   // Since we cannot show the same number of avatars in Mobile / Tablet
   // resolution as we do on desktop and there is overflow, we are adjusting
@@ -47,7 +49,9 @@ const WithMetaBar: FC = () => {
         'components.metabar.contribute': (
           <>
             <GitHub className="fill-neutral-700 dark:fill-neutral-100" />
-            <Link href={getGitHubBlobUrl(filename)}>Edit this page</Link>
+            <Link href={getGitHubBlobUrl(filename)}>
+              {t('components.metabar.contributeText')}
+            </Link>
           </>
         ),
       }}

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -187,3 +187,9 @@ export const ORAMA_CLOUD_API_KEY =
  * Note: This has no NEXT_PUBLIC prefix as it should not be exposed to the Browser.
  */
 export const GITHUB_API_KEY = process.env.NEXT_GITHUB_API_KEY || '';
+
+/**
+ * The resource we point people to when discussing internationalization efforts.
+ */
+export const TRANSLATION_URL =
+  'https://github.com/nodejs/nodejs.org/blob/main/TRANSLATION.md#how-to-translate';


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Usesthe (already, but unused) `edit this page` translation in the metabar, and conditionally sends the user to the appropriate resource

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Live

- en https://nodejs-org-git-7342-edit-this-translation-openjs.vercel.app/en/learn/getting-started/introduction-to-nodejs
- es https://nodejs-org-git-7342-edit-this-translation-openjs.vercel.app/es/learn/getting-started/introduction-to-nodejs


Rendering

![image](https://github.com/user-attachments/assets/0ace09fe-2c6c-4dfa-9191-45e3296d1da6)

- Within `en`  (default)locale: the url resolves as usual
- Within all other locales, the url resolves to https://github.com/nodejs/nodejs.org/blob/main/TRANSLATION.md#how-to-translate



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

closes #7342

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
