### PR TITLE
doc: update typescript docs

### DIFF
--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -1,7 +1,7 @@
 ---
 title: Running TypeScript Natively
 layout: learn
-authors: AugustinMauroy,khaosdoctor,jakebailey
+authors: AugustinMauroy, khaosdoctor, jakebailey
 ---
 
 > **⚠️WARNING⚠️:** All content in this article uses Node.js experimental features. Please make sure you are using a version of Node.js that supports the features mentioned in this article. And remember that experimental features can change in future versions of Node.js.

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -14,7 +14,7 @@ In the previous articles, we learned how to run TypeScript code using transpilat
 
 Since V22.6.0, Node.js has experimental support for some TypeScript syntax via "type stripping". You can write code that's valid TypeScript directly in Node.js without the need to transpile it first.
 
-The `--experimental-strip-types` flag tells Node.js to strip the type annotations from the TypeScript code before running it.
+The [`--experimental-strip-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-strip-types) flag tells Node.js to strip the type annotations from the TypeScript code before running it.
 
 ```bash
 node --experimental-strip-types example.ts
@@ -22,13 +22,13 @@ node --experimental-strip-types example.ts
 
 And that's it! You can now run TypeScript code directly in Node.js without the need to transpile it first, and use TypeScript to catch type-related errors.
 
-In V22.7.0 this experimental support was extended to transform TypeScript-only syntax, like `enum`s and `namespace`, with the addition of the `--experimental-transform-types` flag. Enabling `--experimental-transform-types` automatically implies that `--experimental-strip-types` is enabled, so there's no need to use both flags in the same command:
+In V22.7.0 this experimental support was extended to transform TypeScript-only syntax, like `enum`s and `namespace`, with the addition of the [`--experimental-transform-types`](https://nodejs.org/docs/latest-v23.x/api/cli.html#--experimental-transform-types) flag. Enabling `--experimental-transform-types` automatically implies that `--experimental-strip-types` is enabled, so there's no need to use both flags in the same command:
 
 ```bash
 node --experimental-transform-types another-example.ts
 ```
 
-From version V23 onwards, the `--experimental-strip-types` flag is enabled by default, enabling you to run any supported syntax, so running files like the one below with `node file.ts` is supported:
+From V23 onwards, the `--experimental-strip-types` flag is enabled by default (you can disable it via the [`--no-experimental-strip-types`](https://nodejs.org/docs/latest-v23.x/api/cli.html#--no-experimental-strip-types) flag), enabling you to run any supported syntax, so running files like the one below with `node file.ts` is supported:
 
 ```ts
 function foo(bar: number): string {
@@ -53,7 +53,7 @@ Future versions of Node.js will include support for TypeScript without the need 
 
 At the time of writing, the experimental support for TypeScript in Node.js has some limitations.
 
-You can get more information on the [API docs](https://nodejs.org/docs/latest/api/typescript.html#typescript-features).
+You can get more information on the [API docs](https://nodejs.org/docs/latest-v23.x/api/typescript.html#typescript-features).
 
 ### Configuration
 

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -1,9 +1,7 @@
 ---
 title: Running TypeScript Natively
 layout: learn
-authors: 
-  - AugustinMauroy
-  - khaosdoctor
+authors: AugustinMauroy,khaosdoctor
 ---
 
 > **⚠️WARNING⚠️:** All content in this article uses Node.js experimental features. Please make sure you are using a version of Node.js that supports the features mentioned in this article. And remember that experimental features can change in future versions of Node.js.
@@ -30,26 +28,24 @@ In V22.7.0 this experimental support was extended to transform TypeScript-only s
 node --experimental-transform-types another-example.ts
 ```
 
-From version V23 onwards, the `--experimental-strip-types` flag is enabled by default, enabling you to run any supported syntax, so running files like:
+From version V23 onwards, the `--experimental-strip-types` flag is enabled by default, enabling you to run any supported syntax, so running files like the one below with `node file.ts` is supported:
 
 ```ts
-function foo (bar: number): string {
-  return 'hello'
+function foo(bar: number): string {
+  return 'hello';
 }
 ```
 
-Using `node file.ts`, is supported, however, running any code that requires transformations, like:
+However, running any code that requires transformations, like the code below still needs the use of `--experimental-transform-types`:
 
 ```ts
 enum MyEnum {
   A,
-  B
+  B,
 }
 
-console.log(MyEnum.A)
+console.log(MyEnum.A);
 ```
-
-Still needs the use of `--experimental-transform-types`.
 
 Future versions of Node.js will include support for TypeScript without the need for a command line flag.
 
@@ -61,7 +57,7 @@ You can get more information on the [API docs](https://nodejs.org/docs/latest/ap
 
 ### Configuration
 
-Node.js will not support `tsconfig.json` by default. Thies means that, for a seamless experience while using TypeScript with Node, a base `tsconfig.json` configuration is required in order to match what Node achieves using Amaro (Node's TS loader). Such configuration can be found [here](https://nodejs.org/api/typescript.html#type-stripping) using TypeScript on version **5.7 or higher**.
+Node.js will not support `tsconfig.json` by default. This means that, for a seamless experience while using TypeScript with Node, a base `tsconfig.json` configuration is required in order to match what Node achieves using [Amaro](https://github.com/nodejs/amaro) (Node's TS loader). Such configuration can be found [here](https://nodejs.org/api/typescript.html#type-stripping) using TypeScript on version **5.7 or higher**.
 
 ## Important notes
 

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -57,7 +57,9 @@ You can get more information on the [API docs](https://nodejs.org/docs/latest/ap
 
 ### Configuration
 
-Node.js's TypeScript loader ([Amaro](https://github.com/nodejs/amaro)) does not check the `tsconfig.json` file when transforming TypeScript code. In order to configure TypeScript to recognize (and match) this behavior when type checking, we recommend setting the `compilerOptions` listed in [here](https://nodejs.org/api/typescript.html#type-stripping), as well as using TypeScript on version **5.7 or higher**.
+The Node.js TypeScript loader ([Amaro](https://github.com/nodejs/amaro)) does not need or use `tsconfig.json` to run TypeScript code.
+
+We recommend configuring your editor and `tsc` to reflect Node.js behavior by creating a `tsconfig.json` using the `compilerOptions` listed [here](https://nodejs.org/api/typescript.html#type-stripping), as well as using TypeScript version **5.7 or higher**.
 
 ## Important notes
 

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -1,7 +1,7 @@
 ---
 title: Running TypeScript Natively
 layout: learn
-authors: AugustinMauroy,khaosdoctor
+authors: AugustinMauroy,khaosdoctor,jakebailey
 ---
 
 > **⚠️WARNING⚠️:** All content in this article uses Node.js experimental features. Please make sure you are using a version of Node.js that supports the features mentioned in this article. And remember that experimental features can change in future versions of Node.js.
@@ -57,7 +57,7 @@ You can get more information on the [API docs](https://nodejs.org/docs/latest/ap
 
 ### Configuration
 
-Node.js will not support `tsconfig.json` by default. This means that, for a seamless experience while using TypeScript with Node, a base `tsconfig.json` configuration is required in order to match what Node achieves using [Amaro](https://github.com/nodejs/amaro) (Node's TS loader). Such configuration can be found [here](https://nodejs.org/api/typescript.html#type-stripping) using TypeScript on version **5.7 or higher**.
+Node.js's TypeScript loader ([Amaro](https://github.com/nodejs/amaro)) does not check the `tsconfig.json` file when transforming TypeScript code. In order to configure TypeScript to recognize (and match) this behavior when type checking, we recommend setting the `compilerOptions` listed in [here](https://nodejs.org/api/typescript.html#type-stripping), as well as using TypeScript on version **5.7 or higher**.
 
 ## Important notes
 

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -1,7 +1,7 @@
 ---
 title: Running TypeScript Natively
 layout: learn
-authors: AugustinMauroy, khaosdoctor, jakebailey
+authors: AugustinMauroy, khaosdoctor, jakebailey, robpalme
 ---
 
 > **⚠️WARNING⚠️:** All content in this article uses Node.js experimental features. Please make sure you are using a version of Node.js that supports the features mentioned in this article. And remember that experimental features can change in future versions of Node.js.

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -1,7 +1,9 @@
 ---
 title: Running TypeScript Natively
 layout: learn
-authors: AugustinMauroy
+authors: 
+  - AugustinMauroy
+  - khaosdoctor
 ---
 
 > **⚠️WARNING⚠️:** All content in this article uses Node.js experimental features. Please make sure you are using a version of Node.js that supports the features mentioned in this article. And remember that experimental features can change in future versions of Node.js.
@@ -22,11 +24,32 @@ node --experimental-strip-types example.ts
 
 And that's it! You can now run TypeScript code directly in Node.js without the need to transpile it first, and use TypeScript to catch type-related errors.
 
-In V22.7.0 this experimental support was extended to transform TypeScript-only syntax, like `enum`s and `namespace`, with the addition of the `--experimental-transform-types` flag.
+In V22.7.0 this experimental support was extended to transform TypeScript-only syntax, like `enum`s and `namespace`, with the addition of the `--experimental-transform-types` flag. Enabling `--experimental-transform-types` automatically implies that `--experimental-strip-types` is enabled, so there's no need to use both flags in the same command:
 
 ```bash
-node --experimental-strip-types --experimental-transform-types another-example.ts
+node --experimental-transform-types another-example.ts
 ```
+
+From version V23 onwards, the `--experimental-strip-types` flag is enabled by default, enabling you to run any supported syntax, so running files like:
+
+```ts
+function foo (bar: number): string {
+  return 'hello'
+}
+```
+
+Using `node file.ts`, is supported, however, running any code that requires transformations, like:
+
+```ts
+enum MyEnum {
+  A,
+  B
+}
+
+console.log(MyEnum.A)
+```
+
+Still needs the use of `--experimental-transform-types`.
 
 Future versions of Node.js will include support for TypeScript without the need for a command line flag.
 
@@ -35,6 +58,10 @@ Future versions of Node.js will include support for TypeScript without the need 
 At the time of writing, the experimental support for TypeScript in Node.js has some limitations.
 
 You can get more information on the [API docs](https://nodejs.org/docs/latest/api/typescript.html#typescript-features).
+
+### Configuration
+
+Node.js will not support `tsconfig.json` by default. Thies means that, for a seamless experience while using TypeScript with Node, a base `tsconfig.json` configuration is required in order to match what Node achieves using Amaro (Node's TS loader). Such configuration can be found [here](https://nodejs.org/api/typescript.html#type-stripping) using TypeScript on version **5.7 or higher**.
 
 ## Important notes
 


### PR DESCRIPTION
## Description

This PR extends and improves upon the original article about "How to run TS with Node". It fixes a small conceptual issue (using both flags), while adding the configuration section to point that the users will probably need to update their tsconfig and expands on new versions of node, especially on v23 which enables type stripping by default, but not type transformation.

Overall, it just adds more information on running TS by default.

## Validation

Documentation change, no code.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
