### PR TITLE
January Security Release

### DIFF
--- a/apps/site/pages/en/blog/release/v18.20.6.md
+++ b/apps/site/pages/en/blog/release/v18.20.6.md
@@ -1,0 +1,103 @@
+---
+date: '2025-01-21T17:05:27.542Z'
+category: release
+title: Node v18.20.6 (LTS)
+layout: blog-post
+author: Rafael Gonzaga
+---
+
+## 2025-01-21, Version 18.20.6 'Hydrogen' (LTS), @RafaelGSS
+
+This is a security release.
+
+### Notable Changes
+
+- CVE-2025-23085 - src: fix HTTP2 mem leak on premature close and ERR_PROTO (Medium)
+- CVE-2025-23084 - path: fix path traversal in normalize() on Windows (Medium)
+
+Dependency update:
+
+- CVE-2025-22150 - Use of Insufficiently Random Values in undici fetch() (Medium)
+
+### Commits
+
+- \[[`c03ad5ed63`](https://github.com/nodejs/node/commit/c03ad5ed63)] - **build**: use rclone instead of aws CLI (Michaël Zasso) [#55617](https://github.com/nodejs/node/pull/55617)
+- \[[`8232463294`](https://github.com/nodejs/node/commit/8232463294)] - **build, tools**: drop leading `/` from `r2dir` (Richard Lau) [#53951](https://github.com/nodejs/node/pull/53951)
+- \[[`b26bcd3394`](https://github.com/nodejs/node/commit/b26bcd3394)] - **build, tools**: copy release assets to staging R2 bucket once built (flakey5) [#51394](https://github.com/nodejs/node/pull/51394)
+- \[[`56df127b7b`](https://github.com/nodejs/node/commit/56df127b7b)] - **build,tools**: simplify upload of shasum signatures (Michaël Zasso) [#53892](https://github.com/nodejs/node/pull/53892)
+- \[[`a63e9372ed`](https://github.com/nodejs/node/commit/a63e9372ed)] - **(CVE-2025-22150)** **deps**: update undici to v5.28.5 (Matteo Collina) [nodejs-private/node-private#657](https://github.com/nodejs-private/node-private/pull/657)
+- \[[`da2d177f91`](https://github.com/nodejs/node/commit/da2d177f91)] - **(CVE-2025-23084)** **path**: fix path traversal in normalize() on Windows (Tobias Nießen) [nodejs-private/node-private#555](https://github.com/nodejs-private/node-private/pull/555)
+- \[[`6cc8d58e6f`](https://github.com/nodejs/node/commit/6cc8d58e6f)] - **(CVE-2025-23085)** **src**: fix HTTP2 mem leak on premature close and ERR_PROTO (RafaelGSS) [nodejs-private/node-private#650](https://github.com/nodejs-private/node-private/pull/650)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v18.20.6/node-v18.20.6-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v18.20.6/node-v18.20.6-x64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v18.20.6/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v18.20.6/win-x64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v18.20.6/node-v18.20.6.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v18.20.6/node-v18.20.6-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v18.20.6/node-v18.20.6.tar.gz \
+Other release files: https://nodejs.org/dist/v18.20.6/ \
+Documentation: https://nodejs.org/docs/v18.20.6/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+25f9f8b8275186b632a9e0ff7f22bba85eebe3aeb7c4ed84822529ba917d2a04  node-v18.20.6-aix-ppc64.tar.gz
+7105fb1ac42968010020db61edcc0ea0a366b37d792405d2959668e45b612753  node-v18.20.6-darwin-arm64.tar.gz
+cc797a76aee995ebef16a446a445886287dab82d2e496a2ea58197e1065a88d4  node-v18.20.6-darwin-arm64.tar.xz
+25a4040000e9838af28d0d168301c70d07dcc61294089dde5f5d9044dafda1e5  node-v18.20.6-darwin-x64.tar.gz
+5f079ab410b3278e05cb367b4d2f4638bb93cdd19c8224f3da1068ef19e1f5ab  node-v18.20.6-darwin-x64.tar.xz
+8f7f8f23d5f3265d09a556ba9aed207792ab90307140d04e55096dea7d63ac6e  node-v18.20.6-headers.tar.gz
+68a846f73547b4074469eccc758a6700237d0e615e77766931cad6c40f1f111f  node-v18.20.6-headers.tar.xz
+9580a8c3bb3e8014e15c6940595c45e831f5a878dec78f086824a8adf91a327f  node-v18.20.6-linux-arm64.tar.gz
+169d317cc39ba5513c9588f7aded1bdff7f807b82c4dacb40ca03fd427d288b0  node-v18.20.6-linux-arm64.tar.xz
+d55580014639304a9fc0567a5e5b772d8a19d6c02c40f3fd4006216f97c759c2  node-v18.20.6-linux-armv7l.tar.gz
+7375b789338f01d4496e8febc16234cf3672efa57a16ca7bfc17d07ce034d9ac  node-v18.20.6-linux-armv7l.tar.xz
+afa669b8c424f0f0d33ef461764194d126a1e5a07bad432252cfbefb7f9a52d0  node-v18.20.6-linux-ppc64le.tar.gz
+3f431b1beb67141a43fea19b778e534357798bb20b4129de6360edae88a107bc  node-v18.20.6-linux-ppc64le.tar.xz
+bb65d62cd88f45c91b60da975563ad1bffefce9337ba6e85997fb42496c19fd0  node-v18.20.6-linux-s390x.tar.gz
+d58c4e6107b58b27b493c7a111b16b6f393e5af7ab69584b0548581fdca0a449  node-v18.20.6-linux-s390x.tar.xz
+bff0672c5117e6f0809c456d9194630b5886442ddf298b2292529959c45b92c0  node-v18.20.6-linux-x64.tar.gz
+abf47264a9a13b2233743ce8a966945388a1a10a56f841310a6d4dd12e18ca9a  node-v18.20.6-linux-x64.tar.xz
+58e2e5a7cfe2a2d780a5246a114c644459dae8d71d4c2eabbe5b7ae91e21e5df  node-v18.20.6.pkg
+e7ddfeabea3d1f7cc622cc9861d2fb0955b9e60940dbbedbed6f2f821ab3e4c7  node-v18.20.6.tar.gz
+c669b48b632fa6797d4f5fa7bbd2b476ec961120957864402226cc9fd8ebbc0e  node-v18.20.6.tar.xz
+6f289a5054bfec7a0a03d7feb09a58fd5661749dedfdb71bb1c3bfb854990faf  node-v18.20.6-win-x64.7z
+611a152838d67e05ddde02fbf5abc7f40bccd80a7e68fdaeae8745f729acff59  node-v18.20.6-win-x64.zip
+064c34005f30f89f86fbbafb90b4da02587f785d17c899026832f221637d1736  node-v18.20.6-win-x86.7z
+cde3c32739d7f4e8c405819c66ca2e5c9462e43a31633f4185d4865bd60d4027  node-v18.20.6-win-x86.zip
+df2828bfbbc5da31e70e840da365289c2578c9bfdca5d6b502e87e6675efba5a  node-v18.20.6-x64.msi
+1942cff39580a9f15cb28418a391a5779d81b3384f2a8766cc4ec2d63c45f61f  node-v18.20.6-x86.msi
+a64403d47ef2121e60eac8643f85fb3a682b7ffcc3b6ffe3fcacf10101cb7fbf  win-x64/node.exe
+abfd50aed29f44e39725388fc60210b4a716b4fd759ebb9124ae01c30ccf81f9  win-x64/node.lib
+5c99323f91d14803d5b9aff6474cc5d43bbb317589fc1ab099e3a4f31fcadd1f  win-x64/node_pdb.7z
+52c63d593b3eeb9c6c27cd843111e613584749a2106ca4177dc057b2b906cd42  win-x64/node_pdb.zip
+c3e2439a460ae24386694f03cae8b4105c2013aae6ae7cb1d5acef2a599346f3  win-x86/node.exe
+3442ac0d3ad2c5e840f0f2ae84a1c7abe1736a315d83a161b843c5c31a986f83  win-x86/node.lib
+1639c9101390cd0a0d2d516b6c8dfe091bd3d14f0d12195fee22ca3e82d8d510  win-x86/node_pdb.7z
+af1e5136a75422ed6df75dae6dd419eb5a179e05c6f5b9aa1b42ea6fb8ea496e  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQGzBAEBCAAdFiEEiQwI24V5Fi/uDfnbi+q0389VXvQFAmeP0PoACgkQi+q0389V
+XvQ3ugv/Qi7vH20YIkuxRGiMu2QtfSta4zxh3KT9Vty/j8uHLqEBF+VLFzK8wpkB
+uBMkVgnsj8YrmuF5QSlIGZqhmzDpO4qiN9f+je7CZCIH7+y5t507mML/SRDaDUb4
+njzBfHNoTGpIUqFc8L0bxCcuTTytLK5hbyiz4C7ISIYO3dtlqB3KBF70/cSNVYDw
+uZSxZ2pOdA569XP/DVEbCIyP1zw3oxmjBP+2vgStnsJ8zBGI4aYVQkowtRmj5n3K
+3dS3QtvdVySH+RJatNvf6trEk3DMAelQcJpHq9yRu+dXl0MFdCmWnXugnPFT9d/v
+5f/AlKbMeXJPIhIrCZX9SuaHw7kQ31wklSsbyKZkXzgD1p9pf4jcwNUWTIvnzl+S
+2k+YVNAFM7YeOxpsbgGebD8wp1KQkf8kIyVUFMhBJvCkaZmKEIQStNZtPfpyyWFS
+It9EMDBPCP6oUDit+ZVHS3wncqW0nOsgguqZ5zl6k4BH7B/i8oIo+g8FAthar+J9
+a0OF6HP9
+=/PCS
+-----END PGP SIGNATURE-----
+```

--- a/apps/site/pages/en/blog/release/v20.18.2.md
+++ b/apps/site/pages/en/blog/release/v20.18.2.md
@@ -1,0 +1,110 @@
+---
+date: '2025-01-21T17:05:40.198Z'
+category: release
+title: Node v20.18.2 (LTS)
+layout: blog-post
+author: Rafael Gonzaga
+---
+
+## 2025-01-21, Version 20.18.2 'Iron' (LTS), @RafaelGSS
+
+This is a security release.
+
+### Notable Changes
+
+- CVE-2025-23083 - throw on InternalWorker use when permission model is enabled (High)
+- CVE-2025-23085 - src: fix HTTP2 mem leak on premature close and ERR_PROTO (Medium)
+- CVE-2025-23084 - path: fix path traversal in normalize() on Windows (Medium)
+
+Dependency update:
+
+- CVE-2025-22150 - Use of Insufficiently Random Values in undici fetch() (Medium)
+
+### Commits
+
+- \[[`df8b9f2c3e`](https://github.com/nodejs/node/commit/df8b9f2c3e)] - **(CVE-2025-22150)** **deps**: update undici to v6.21.1 (Matteo Collina) [nodejs-private/node-private#663](https://github.com/nodejs-private/node-private/pull/663)
+- \[[`42d5821873`](https://github.com/nodejs/node/commit/42d5821873)] - **(CVE-2025-23084)** **path**: fix path traversal in normalize() on Windows (Tobias Nießen) [nodejs-private/node-private#555](https://github.com/nodejs-private/node-private/pull/555)
+- \[[`8187a4b9bb`](https://github.com/nodejs/node/commit/8187a4b9bb)] - **src**: fix HTTP2 mem leak on premature close and ERR_PROTO (RafaelGSS)
+- \[[`389f239a28`](https://github.com/nodejs/node/commit/389f239a28)] - **(CVE-2025-23083)** **src,loader,permission**: throw on InternalWorker use (RafaelGSS) [nodejs-private/node-private#652](https://github.com/nodejs-private/node-private/pull/652)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v20.18.2/node-v20.18.2-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v20.18.2/node-v20.18.2-x64.msi \
+Windows ARM 64-bit Installer: https://nodejs.org/dist/v20.18.2/node-v20.18.2-arm64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v20.18.2/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v20.18.2/win-x64/node.exe \
+Windows ARM 64-bit Binary: https://nodejs.org/dist/v20.18.2/win-arm64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v20.18.2/node-v20.18.2.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v20.18.2/node-v20.18.2-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v20.18.2/node-v20.18.2.tar.gz \
+Other release files: https://nodejs.org/dist/v20.18.2/ \
+Documentation: https://nodejs.org/docs/v20.18.2/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+efcddeb91b189b02706d1a75a67b4a111253ec8f64cc30cc3dc4649744abd52b  node-v20.18.2-aix-ppc64.tar.gz
+40c5a72564b8667342bec84aab50d2af1503af2b274f1a7a09d2d929461988b6  node-v20.18.2-arm64.msi
+fa76d5b5340f14070ebaa88ef8faa28c1e9271502725e830cb52f0cf5b6493de  node-v20.18.2-darwin-arm64.tar.gz
+32dc17147054df9cdf96d03103f4661b4cb0bb9b4ca4b70e34fe632f1bab189c  node-v20.18.2-darwin-arm64.tar.xz
+00a16bb0a82a2ad5d00d66b466ae1afa678482283747c27e9bce96668f334744  node-v20.18.2-darwin-x64.tar.gz
+184c9b8e246a3fd139caf2456510dc99ec548ad2e5203fbc5fc56ba48104e8eb  node-v20.18.2-darwin-x64.tar.xz
+d74c718976adc308991fb8784f0b3f82845436bf8f04d2c982ab5cab5115289f  node-v20.18.2-headers.tar.gz
+05819d72dcc0aa788baab1066e18ede5f1ab6730a1925cd6b15c131b55fd4272  node-v20.18.2-headers.tar.xz
+319789e8a055ff80793a05e633c8c5c9226050144a09da3747225b4ec56a2a99  node-v20.18.2-linux-arm64.tar.gz
+5c1437aa16e7e6a2e0687a42c4d3f0a8f8a2039cda8880cb3be8cd983aeefb44  node-v20.18.2-linux-arm64.tar.xz
+65397a4a63960bda94718099698d2961623e9ef400f60f4c3a71add2268bccfb  node-v20.18.2-linux-armv7l.tar.gz
+63d4df56fb2e34a5077345f78941094204d2223ce03b8ebc9c1500e6e2aae68d  node-v20.18.2-linux-armv7l.tar.xz
+9b2f0fd3b02d8b59bde3e2a251e4df501e755c99cfc4886b0bdf85fa4d0bc538  node-v20.18.2-linux-ppc64le.tar.gz
+828a2635261ca225cd4a8a4b1a914003cdc7b30656c2e9092ac7aab02ac361db  node-v20.18.2-linux-ppc64le.tar.xz
+7e52e03823feaa2483a7cbcf85767790776f87a2c7112d87600c3d9d3b1ae6e9  node-v20.18.2-linux-s390x.tar.gz
+bcf3680e111f1d24e403db3d5600315266ae1f8d9d1f69f39c61dbf8d8c9036e  node-v20.18.2-linux-s390x.tar.xz
+eb5b031bdd728871c3b9a82655dbfa533bc262c0b6da1d09a86842430cef07d4  node-v20.18.2-linux-x64.tar.gz
+4e50f727ae09bdafecf2322c72faf7cd82bf3b8851a16b8bb63974e0d8d6eceb  node-v20.18.2-linux-x64.tar.xz
+87d10db681bca2a39fcadcc908d5e5b2c7effa16370c4ca555373b85e25275b1  node-v20.18.2.pkg
+cf3ef49fafbfee3cdcd936a0d6031341b73bfa6b26a484ea0a4936c26d24b829  node-v20.18.2.tar.gz
+69bf81b70f3a95ae0763459f02860c282d7e3a47567c8afaf126cc778176a882  node-v20.18.2.tar.xz
+d28d21e000ebed8b6131201b727d1998d4dbc4dbdb6e5ad07679552e4c75fa4d  node-v20.18.2-win-arm64.7z
+b89d196a2d9dc3dac87c268aac9a983fa2fd1881c14884bc848312783ccf7d2f  node-v20.18.2-win-arm64.zip
+06e72c0f78cc1bf1819eb0a0a37001d2917f19ad46a149c2f923c901f599ba52  node-v20.18.2-win-x64.7z
+ed790b94570518a7dce67b62485e16bc4bffecee4ec3b6df35ed220ae91117a5  node-v20.18.2-win-x64.zip
+fa561ebff3f52667228f9fcd9e67ce22a86e5c28c8e3782e01a95c90b6ed114d  node-v20.18.2-win-x86.7z
+25f00a77843accc098561a35ce3ed923357f0127b8e5db594cb62188e3290b88  node-v20.18.2-win-x86.zip
+f3ad2d799e1645281d22d71b447f3899e569da87fea78bef9571b0c2b53288d6  node-v20.18.2-x64.msi
+783c4041ceb69226184a1b26177b5d9dc85e502d0f124c64d2b2c6f8ab12e5d5  node-v20.18.2-x86.msi
+83e7ad1b8c4d4d9c5e06849c3e8f3a5948a5eb6aa34c5bd973ba700e0386f42c  win-arm64/node.exe
+58795bcd44e8023ff443dedabf7f9af928732a51befc5324082aafe56e0f5eb0  win-arm64/node.lib
+83fdda5fb5869c18f5d5d3dc4d0479f6bdad16f0888c95b8008f03654593afdd  win-arm64/node_pdb.7z
+4049c1e7c2fc82c4d43c9d8567e7d20f20c0d360c281fcb924ce9cd4b9ce8dc3  win-arm64/node_pdb.zip
+8487a277e92282904dfe0f860dbd5d229543e97a858a223fbe9c9b8670bbe170  win-x64/node.exe
+5a16801c62c34c8056744ac339950c970b2b76f39b2d02afef4112ff51b74f1a  win-x64/node.lib
+6ff19d51a762405717f7dff33811ba6371334de95946efbccf6f8dd786ec93e8  win-x64/node_pdb.7z
+07ef9641b5a339de2f43f698dc3b1aeb321e851645b199cbeb0f378674263bf1  win-x64/node_pdb.zip
+ab4b6beaaa170cfed83a2c9c71d8d5032ac514a5ebd7a5aa0553731267964f5e  win-x86/node.exe
+fcc6ab34ebd4ad3a44de12376c3822c2ebc41febaa1ed4c4221ddc239f79f61c  win-x86/node.lib
+ab74677f28b517eee9f745930541d02a870ae2d3f29a5ac91fe630813a1cd987  win-x86/node_pdb.7z
+6080ab7b513194510c8938c276b7fd4379eb0ed69cfa09dbb21da8a4eeddd75f  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQGzBAEBCAAdFiEEiQwI24V5Fi/uDfnbi+q0389VXvQFAmeP0VcACgkQi+q0389V
+XvSVVAv9Gqyi4i2K2vHIKo7Pe/ZQB4BLg5nmzDtd6SNqtcSgTM+oR3u1vOeFdeTL
+tXpIFaqUh0uYTYBpE4aJWajwXPnKWYu+uJO8Z1PtfUitM9PiZT5w2Ko69QPxIt7K
+4BmRxFhCVAH87R2SKiXWWzhDBQDQKboQFBtVG4G16HfOXp9leKSxUTKQ8B0fU+4L
+qbiCk9EvaBAmEJdrzT8Od/GjMdcBFXzllNRlROVu5hhAv6+HHlMuxR3RgaN5wml+
+zFFQeQk+lY1YZeA0DpslwB5raCrsLehkEywlXsJHF3wmRKOhsrFaQlTDLtzZuyoN
+BY6LQqkmY5hJGiCOeiXSCNHAXUpqmOLvUJQgXSW0jaEh41o66yXk7MGthUegYo5o
+AekiwYEZE50K4QLE9xdIFjQ5GeSp0iK81wxGgPLjVS0DBe0sw+sDWMep+yisHmhP
+Ttf0cY501JvjbdaBB40ug5LFpABuKQJgzmbTmrU8Edf+apbJa35OZRt2bNg7xoYs
+SzUkh4yR
+=eALp
+-----END PGP SIGNATURE-----
+```

--- a/apps/site/pages/en/blog/release/v22.13.1.md
+++ b/apps/site/pages/en/blog/release/v22.13.1.md
@@ -1,0 +1,110 @@
+---
+date: '2025-01-21T17:05:48.839Z'
+category: release
+title: Node v22.13.1 (LTS)
+layout: blog-post
+author: Rafael Gonzaga
+---
+
+## 2025-01-21, Version 22.13.1 'Jod' (LTS), @RafaelGSS
+
+This is a security release.
+
+### Notable Changes
+
+- CVE-2025-23083 - src,loader,permission: throw on InternalWorker use when permission model is enabled (High)
+- CVE-2025-23085 - src: fix HTTP2 mem leak on premature close and ERR_PROTO (Medium)
+- CVE-2025-23084 - path: fix path traversal in normalize() on Windows (Medium)
+
+Dependency update:
+
+- CVE-2025-22150 - Use of Insufficiently Random Values in undici fetch() (Medium)
+
+### Commits
+
+- \[[`520da342e0`](https://github.com/nodejs/node/commit/520da342e0)] - **(CVE-2025-22150)** **deps**: update undici to v6.21.1 (Matteo Collina) [nodejs-private/node-private#662](https://github.com/nodejs-private/node-private/pull/662)
+- \[[`99f217369f`](https://github.com/nodejs/node/commit/99f217369f)] - **(CVE-2025-23084)** **path**: fix path traversal in normalize() on Windows (Tobias Nießen) [nodejs-private/node-private#555](https://github.com/nodejs-private/node-private/pull/555)
+- \[[`984f735e35`](https://github.com/nodejs/node/commit/984f735e35)] - **(CVE-2025-23085)** **src**: fix HTTP2 mem leak on premature close and ERR_PROTO (RafaelGSS) [nodejs-private/node-private#650](https://github.com/nodejs-private/node-private/pull/650)
+- \[[`2446870618`](https://github.com/nodejs/node/commit/2446870618)] - **(CVE-2025-23083)** **src,loader,permission**: throw on InternalWorker use (RafaelGSS) [nodejs-private/node-private#651](https://github.com/nodejs-private/node-private/pull/651)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v22.13.1/node-v22.13.1-x86.msi \
+Windows 64-bit Installer: https://nodejs.org/dist/v22.13.1/node-v22.13.1-x64.msi \
+Windows ARM 64-bit Installer: https://nodejs.org/dist/v22.13.1/node-v22.13.1-arm64.msi \
+Windows 32-bit Binary: https://nodejs.org/dist/v22.13.1/win-x86/node.exe \
+Windows 64-bit Binary: https://nodejs.org/dist/v22.13.1/win-x64/node.exe \
+Windows ARM 64-bit Binary: https://nodejs.org/dist/v22.13.1/win-arm64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v22.13.1/node-v22.13.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v22.13.1/node-v22.13.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v22.13.1/node-v22.13.1.tar.gz \
+Other release files: https://nodejs.org/dist/v22.13.1/ \
+Documentation: https://nodejs.org/docs/v22.13.1/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  node-v22.13.1-aix-ppc64.tar.gz
+be127be1d98cad94c56f46245d0f2de89934d300028694456861a6d5ac558bf3  node-v22.13.1-arm64.msi
+97483ff4361d239a56d038c6335767a56a291e78c10f07446f463f05d9d19b89  node-v22.13.1-darwin-arm64.tar.gz
+9c169a9369f6c667a4de6b14c7492065adbae0fa830ef4c666bea2c53ac7b576  node-v22.13.1-darwin-arm64.tar.xz
+6fdcc8412d434664238b0651ebd5ad55d15a08598ff42dcb6d9cf1d434a6c4be  node-v22.13.1-darwin-x64.tar.gz
+cbc49a2f179ec51f3a7d49f91b05e16db2ea8ea4ca586e1e370d19661becf0eb  node-v22.13.1-darwin-x64.tar.xz
+f9cde9ace585c3979f1b4ee247914f35fae6e7b7eabc6a40961f89ad39e78964  node-v22.13.1-headers.tar.gz
+2722236564df6d33b1d953f23e21bf5247b62b38ea9000b47c655ee3a9a440e7  node-v22.13.1-headers.tar.xz
+911d9c07af38c82be22cd0a3db613aabc578ba940b35380aeedadd6d48070bc1  node-v22.13.1-linux-arm64.tar.gz
+0a237c413ccbab920640438bf6e1a32edb19845bdc21f0e1cd5b91545ce1c126  node-v22.13.1-linux-arm64.tar.xz
+82be9fa5e74ee29d7342d38306dbee19d3e2239b5b753870c04fd03768916a7e  node-v22.13.1-linux-armv7l.tar.gz
+f2be8dca2a7a518f6d187aa4b18abbeeafd71096a6d95f73f4d8bc0f8d2394ea  node-v22.13.1-linux-armv7l.tar.xz
+e4d34550d791cc809cfbfe8d0e3082634796add404169484b0849fbae0714576  node-v22.13.1-linux-ppc64le.tar.gz
+377a7a1ea66f39251e1657f419e9404d526fcca9910620d0ecf0a870c6308f6b  node-v22.13.1-linux-ppc64le.tar.xz
+56375cf2c827a425d708bd0322fd635b6f2038e272468395f4e160e1ea4ae91e  node-v22.13.1-linux-s390x.tar.gz
+22da01dbcead3ef7e69de6c1310a1c5c485039631f731a6ff0c35530cf5c811b  node-v22.13.1-linux-s390x.tar.xz
+666148b9fe0c7e1301cc1b029e33a45e9e4a893f68d2d2bb1cc88a931a88a004  node-v22.13.1-linux-x64.tar.gz
+0d2a5af33c7deab5555c8309cd3f373446fe1526c1b95833935ab3f019733b3b  node-v22.13.1-linux-x64.tar.xz
+620a7b4008aa0406678987ce2dd22458a38bae163fe7c69fd243f1204725e6c2  node-v22.13.1.pkg
+e7d5b1e84e7f3c3cebda81e2b138469eef41ba4ecf16a87fd15fc3f7afa3f701  node-v22.13.1.tar.gz
+cfce282119390f7e0c2220410924428e90dadcb2df1744c0c4a0e7baae387cc2  node-v22.13.1.tar.xz
+b2c537f24a725d7e6058d23b1b89bbf31e6c7299b51ac31e9c25dc3c6a61e2d9  node-v22.13.1-win-arm64.7z
+db6d3d28e1b34acdbd9db7bac5ec37980e07e48a6a2edcd3747d605fc8a5468e  node-v22.13.1-win-arm64.zip
+d495abe2ae53962065fad979814259735fd90a4e03c6b94ccd3e32bc933aeda5  node-v22.13.1-win-x64.7z
+398a61e250a5584a62a5959e2f69f5d597fc83f1a5ebe3ed8fff29ba39d55f14  node-v22.13.1-win-x64.zip
+3c87ddd4aac7f980ed11caf97942bd87a647ce61d644ca08321508836b3d1899  node-v22.13.1-win-x86.7z
+504ed03c8596dfeabddfcd0736f987be93e3330a5c690306dedacef8880b592c  node-v22.13.1-win-x86.zip
+821566022dc3b262ac2f76598ee4f46003a6edafe5dadb84e5fbc7daaa1a78c7  node-v22.13.1-x64.msi
+79c36ea6aa2ede10b416bdae55b568ab31798ede2697440b266312bba95ef580  node-v22.13.1-x86.msi
+afb7dcd60c7557843e5c2777205564950544297ba0588faa2aae573ccb735767  win-arm64/node.exe
+988eb8c60a5ade17e652dbdb60d56d3c6ad5e599a99ce04932b8c4c86583cdaf  win-arm64/node.lib
+b19efd6f54283a2c01027f0e74e54563d06495b87efe08d111e1a176afd14d02  win-arm64/node_pdb.7z
+0bb490f44fc575dd570326fae9f0a5fca1187bfc342f57a50084ef86aa2e6679  win-arm64/node_pdb.zip
+8f6945c55a51c893691534e7163372e4cedb62c8ad80a2a975df3f14a19fba16  win-x64/node.exe
+65e45757c026c93a170743a811ef1b921ae12d6d9dd62d258bbbca0626687626  win-x64/node.lib
+2ad1af26e2f78247473e1e05f78fff3be7401f47c327f45602c84dce5d552cc0  win-x64/node_pdb.7z
+31099d09933aad429c36071503cd200eb66c41529524ac159873f97d9f097c83  win-x64/node_pdb.zip
+0b7071f0a7d90d4e1567d94a37c5d94441a3ca71a4eaa9596bc06e992c06e9c8  win-x86/node.exe
+79bae10059e833ce7fa4de05e5601034461327e2e7cb75c2144b87d4ab5ac547  win-x86/node.lib
+c3fb150e58d16dadd95c24c8a0a4c020a18b3c852b63e36df39587a301512ca4  win-x86/node_pdb.7z
+97890935271fe117a745584ca710f0fcd38bbf24b8c920800411df87a3e22dc3  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQGzBAEBCAAdFiEEiQwI24V5Fi/uDfnbi+q0389VXvQFAmeP0bUACgkQi+q0389V
+XvTMfgv+JrSbhYgsQcE3md4lAbKnFvK6iitjeefWXednZAHU3IRauZQyfwW0FZfM
+2k9VPHR2AhqgDbvaFWE5hfAV4tQ244U/RojS5K8irEm80Eryp1RWLJ92D4DtNFDH
+p4hH1FRuOW5Rd+TzfuADPv/eNfFn6h9u/N+zcOHYVk6PeActzte+GKV56aiooYzg
+LKDH9sMTjV792qJmEcesNnQ5D5y23gSUiEVC8p1GYyQBhingD3tzrIoc0wRUZ8LB
+36GUn/v5EikD78ts3Jiq96NW+KcstqGSFLu7P57Opkgd/a5+lqYPcn6XB2vzTV0S
+HAC07OQzNnafUoXipUqnbg/Z4PXsi+LayPzoaUKp+sQLIEY+CNvTCygI5poYIEp/
++yuHkF/tYGhYh+47jMJsh/dpcm/ak71ia0hE2Qj9oY92y3gTln7VdcbZdkmTEOVa
+0TI7QhPeN4FACCBxsaWVTosW4tJw972h2mqieahJqLyrUEMbWBo/R5LuU1NXGlJf
+nZrtP89S
+=vTe7
+-----END PGP SIGNATURE-----
+```

--- a/apps/site/pages/en/blog/release/v23.6.1.md
+++ b/apps/site/pages/en/blog/release/v23.6.1.md
@@ -1,0 +1,101 @@
+---
+date: '2025-01-21T17:06:07.900Z'
+category: release
+title: Node v23.6.1 (Current)
+layout: blog-post
+author: Rafael Gonzaga
+---
+
+## 2025-01-21, Version 23.6.1 (Current), @RafaelGSS
+
+This is a security release.
+
+### Notable Changes
+
+- CVE-2025-23083 - src,loader,permission: throw on InternalWorker use when permission model is enabled (High)
+- CVE-2025-23085 - src: fix HTTP2 mem leak on premature close and ERR_PROTO (Medium)
+- CVE-2025-23084 - path: fix path traversal in normalize() on Windows (Medium)
+
+Dependency update:
+
+- CVE-2025-22150 - Use of Insufficiently Random Values in undici fetch() (Medium)
+
+### Commits
+
+- \[[`f2ad4d3af8`](https://github.com/nodejs/node/commit/f2ad4d3af8)] - **(CVE-2025-22150)** **deps**: update undici to v6.21.1 (Matteo Collina) [nodejs-private/node-private#654](https://github.com/nodejs-private/node-private/pull/654)
+- \[[`0afc6f9600`](https://github.com/nodejs/node/commit/0afc6f9600)] - **(CVE-2025-23084)** **path**: fix path traversal in normalize() on Windows (RafaelGSS) [nodejs-private/node-private#555](https://github.com/nodejs-private/node-private/pull/555)
+- \[[`3c7686163e`](https://github.com/nodejs/node/commit/3c7686163e)] - **(CVE-2025-23085)** **src**: fix HTTP2 mem leak on premature close and ERR_PROTO (RafaelGSS) [nodejs-private/node-private#650](https://github.com/nodejs-private/node-private/pull/650)
+- \[[`51938f023a`](https://github.com/nodejs/node/commit/51938f023a)] - **(CVE-2025-23083)** **src,loader,permission**: throw on InternalWorker use (RafaelGSS) [nodejs-private/node-private#629](https://github.com/nodejs-private/node-private/pull/629)
+
+Windows 64-bit Installer: https://nodejs.org/dist/v23.6.1/node-v23.6.1-x64.msi \
+Windows ARM 64-bit Installer: https://nodejs.org/dist/v23.6.1/node-v23.6.1-arm64.msi \
+Windows 64-bit Binary: https://nodejs.org/dist/v23.6.1/win-x64/node.exe \
+Windows ARM 64-bit Binary: https://nodejs.org/dist/v23.6.1/win-arm64/node.exe \
+macOS 64-bit Installer: https://nodejs.org/dist/v23.6.1/node-v23.6.1.pkg \
+macOS Apple Silicon 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-darwin-arm64.tar.gz \
+macOS Intel 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-darwin-x64.tar.gz \
+Linux 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-linux-x64.tar.xz \
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-linux-ppc64le.tar.xz \
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-linux-s390x.tar.xz \
+AIX 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-aix-ppc64.tar.gz \
+ARMv7 32-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-linux-armv7l.tar.xz \
+ARMv8 64-bit Binary: https://nodejs.org/dist/v23.6.1/node-v23.6.1-linux-arm64.tar.xz \
+Source Code: https://nodejs.org/dist/v23.6.1/node-v23.6.1.tar.gz \
+Other release files: https://nodejs.org/dist/v23.6.1/ \
+Documentation: https://nodejs.org/docs/v23.6.1/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+1a05b4193005a912b99674ee1198808ed3b38850224928a8966e298a33b50471  node-v23.6.1-aix-ppc64.tar.gz
+a3b0bf4eaffe7af44c88a901bdeeedace5f03bfee25d56cbf393a4574ad8e36e  node-v23.6.1-arm64.msi
+b87c90f1efff3f2f49070ce4714a11228a43331bb590b06fc7bcb36e530b2ea0  node-v23.6.1-darwin-arm64.tar.gz
+631742b69fd30235b89847fb9f36216e003f1efe8f013919fd30109ebeac565e  node-v23.6.1-darwin-arm64.tar.xz
+bcdc29188f2d8d7a129b88a6c19830ac91e53e64c3744b18f412dce533f67ef7  node-v23.6.1-darwin-x64.tar.gz
+a011faa573727a959c9f916672f7bf4114d118c9adb6a593ef331167c273e5b5  node-v23.6.1-darwin-x64.tar.xz
+113ef099f137331e2bc34c886f206827948c8312de563449f2366947a7f39d6c  node-v23.6.1-headers.tar.gz
+11e295df3f37dcc663a7c2c9473b94b3674c0c847b32e150cf9f3f7308b13cea  node-v23.6.1-headers.tar.xz
+8b221bb5ef173e9b6fecf4fc4a31696a775bbfe07ea45f8c7bdf88d7b9c9460f  node-v23.6.1-linux-arm64.tar.gz
+e9a709ea4142c0c269d7e670e37e65cf549bf69d62342907cd15a49ba7da1748  node-v23.6.1-linux-arm64.tar.xz
+3bdb2e31de44038f166531edb2f3d99278b6c36576392c4939762029efa53439  node-v23.6.1-linux-armv7l.tar.gz
+892a1285c5245a869eda0b0d6e5428b563d33a705d44de1d1d07f44d78c7b344  node-v23.6.1-linux-armv7l.tar.xz
+c3db627673540e4c1ffd6f2f112e5dd8e6d89eaeba4fbdfdaa90e071c11d58b1  node-v23.6.1-linux-ppc64le.tar.gz
+ec825715a1a48e359cffdd299e98d28b5cef27c4e7acfadb3440e9ab4b75fa42  node-v23.6.1-linux-ppc64le.tar.xz
+68e8c2d68a749616ae82605ae85871a3e281c6ae0b68d5cb4ffa68320c949104  node-v23.6.1-linux-s390x.tar.gz
+6d3c768b8ee3a648387a79e0ad2b43fc3e736f96eac924cff7e9aae01dc1f9c9  node-v23.6.1-linux-s390x.tar.xz
+0aaa37396638ae6e71af66927dcc41414327051d5a8030d3057db1ceb7719854  node-v23.6.1-linux-x64.tar.gz
+9387c4bf8f175e81cb2f004f3f4b2cd96abfb708df3755142e878effe035fcc5  node-v23.6.1-linux-x64.tar.xz
+ae1746cea80934d7ba3d0a9a10e492822cbc23dc80945339090c39e2715b8b2d  node-v23.6.1.pkg
+35c0f7957085083071fcf01c7eaea953fba98f17afc4d7c189e3ef56925b453c  node-v23.6.1.tar.gz
+fefa49dede8733018ada4e30f885808cc4e22167b8ae3233c6d6a23737aff76f  node-v23.6.1.tar.xz
+eb52ed2507285f3f6ad19553b28e0a6425f00ee7190e2cc6dc68709201e30403  node-v23.6.1-win-arm64.7z
+74599c4c9c61f666497b2a501c92b463566681587beba69da5368b9ecfdeaac5  node-v23.6.1-win-arm64.zip
+597e75859698e7062481a6da92e3c54108099f57c45e9b391d64a0afa642e06e  node-v23.6.1-win-x64.7z
+9be8fe4eb81c6108ffca066590c160d9b6c94080c24b4dfa119eb4e3ae187aa8  node-v23.6.1-win-x64.zip
+61ae8aee959557eda5056d07cd8ec58cab47cff631dcf18465b1dd31191f4752  node-v23.6.1-x64.msi
+48b260b200236fe3960d81e39cf130012c8a877868ffdf2eba6a78afef44a0de  win-arm64/node.exe
+46a85ee5432885387948e02ced2499975b34cc2080ea3ed4e99b6c7323d38d74  win-arm64/node.lib
+d1471a48b2852173a87f8aa9644394986b8d924a087c939dd31e03a0be4d87f0  win-arm64/node_pdb.7z
+7183292cab61ea6b6aa7f885a217b7b921f9f1d06fac4d475ec60386315988fb  win-arm64/node_pdb.zip
+0cb029d3c8a66969e7c06ee01b7db1298b9300ef79f54b95505e532b24058536  win-x64/node.exe
+4a54d5aeab30bb14dbad9260f6430c81f1e1afb430c68c40f6e5fec7ce288e2e  win-x64/node.lib
+98aa064c688818d7c15d32341163e046a007ae9b9ed4a660fb99a6f01ac3b9ba  win-x64/node_pdb.7z
+1bda974a08110f08e5b11bb04277da2728e27756cf94c154cfcce72fd6a3dcc6  win-x64/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQGzBAEBCAAdFiEEiQwI24V5Fi/uDfnbi+q0389VXvQFAmeP0ocACgkQi+q0389V
+XvQgMgwAjohyA6mtco8lX/0oKW3+T5q4EWct2IVaF27qkFxkB5fN7YsHAKqeuBUK
+zSAb/9ga9XJZgwv2zDl/NQJwzgvFZL1sSxViY6p8DqGGFev5Ueeoaapplnrg2C/k
+KPggMCoZmBuJv2uYKVRVkrDxUfGB3K38P9wBc8k3LceSiehgS85IR4z2t4dn0a0q
+RtkgZ2wtOD4KWPEIPpw8pFPdOemuB0eD4l0mG6vsWS+Rj/hSccIoRwMZ54GIbXF+
+xMRL0X9eA01Izlqw8awNS9KKULni8T3C+4jMOc4BoY8QBXVrF+bgEnNnw/h967SI
+iyYV2aIJQG9jTlhnfBkSFyNB0PM1KtqIPsKmLGD1SZqKoBFEyE74F2aB0P/IOnt6
+OeKf5Rc1/IZ4BbMj626gMkvubClSdtHR/qmKri5AerQGDnczOV+k4ROhj/MhdwgS
+A0er3cpzVbtB716+7d9rIOe8CrbXJY5y6eJMtvxyBwqvD5d9I1oplKYqPISjkjK5
+HPq8a1pt
+=MTqA
+-----END PGP SIGNATURE-----
+```

--- a/apps/site/pages/en/blog/vulnerability/january-2025-security-releases.md
+++ b/apps/site/pages/en/blog/vulnerability/january-2025-security-releases.md
@@ -1,11 +1,64 @@
 ---
-date: 2025-01-14T03:00:00.000Z
+date: 2025-01-21T03:00:00.000Z
 category: vulnerability
 title: Tuesday, January 21, 2025 Security Releases
 slug: january-2025-security-releases
 layout: blog-post
 author: The Node.js Project
 ---
+
+## Security releases available
+
+Updates are now available for the 23.x, 22.x, 20.x, 18.x Node.js release lines for the
+following issues.
+
+This security release includes the following dependency updates to address public vulnerabilities:
+- undici (v7.2.3, v6.21.1, v5.28.5) on v23.x, v22.x, v20.x, v18.x.
+
+## Worker permission bypass via InternalWorker leak in diagnostics (CVE-2025-23083) - (high)
+
+With the aid of the diagnostics_channel utility, an event can be hooked into whenever a worker thread is created. This is not limited only to workers but also exposes internal workers, where an instance of them can be fetched, and its constructor can be grabbed and reinstated for malicious usage.
+
+This vulnerability affects Permission Model users (--permission) on Node.js v20, v22, and v23.
+
+Impact:
+
+- This vulnerability affects all users in active release lines: 20.x, 22.x, 23.x
+
+Thank you, to leodog896 for reporting this vulnerability and thank you RafaelGSS for fixing it.
+
+## Path traversal by drive name in Windows environment (CVE-2025-23084) - (medium)
+
+A vulnerability has been identified in Node.js, specifically affecting the handling of drive names in the Windows environment. Certain Node.js functions do not treat drive names as special on Windows. As a result, although Node.js assumes a relative path, it actually refers to the root directory.
+
+On Windows, a path that does not start with the file separator is treated as relative to the current directory.
+
+This vulnerability affects Windows users of `path.join` API.
+
+Impact:
+
+- This vulnerability affects all users in active release lines: 18.x, 20.x, 22.x, 23.x
+
+Thank you, to taise for reporting this vulnerability and thank you tniessen for fixing it.
+
+## GOAWAY HTTP/2 frames cause memory leak outside heap (CVE-2025-23085) - (medium)
+
+A memory leak could occur when a remote peer abruptly closes the socket without sending a GOAWAY notification. Additionally, if an invalid header was detected by nghttp2, causing the connection to be terminated by the peer, the same leak was triggered. This flaw could lead to increased memory consumption and potential denial of service under certain conditions.
+
+This vulnerability affects HTTP/2 Server users on Node.js v18.x, v20.x, v22.x and v23.x.
+
+Impact:
+
+- This vulnerability affects all users in active release lines: 18.x, 20.x, 22.x, 23.x
+
+Thank you, to newtmitch for reporting this vulnerability and thank you RafaelGSS for fixing it.
+
+## Downloads and release details
+
+- [Node.js v18.20.6](/blog/release/v18.20.6/)
+- [Node.js v20.18.2](/blog/release/v20.18.2/)
+- [Node.js v22.13.1](/blog/release/v22.13.1/)
+- [Node.js v23.6.1](/blog/release/v23.6.1/)
 
 # Summary
 

--- a/apps/site/site.json
+++ b/apps/site/site.json
@@ -28,9 +28,9 @@
   ],
   "websiteBanners": {
     "index": {
-      "startDate": "2025-01-14T03:00:00.000Z",
-      "endDate": "2025-01-21T03:00:00.000Z",
-      "text": "New security releases to be made available Tuesday, January 21, 2025",
+      "startDate": "2025-01-21T03:00:00.000Z",
+      "endDate": "2025-01-28T03:00:00.000Z",
+      "text": "January Security Release is available",
       "link": "https://nodejs.org/en/blog/vulnerability/january-2025-security-releases",
       "type": "warning"
     }


### PR DESCRIPTION
Refs: https://github.com/nodejs-private/security-release/pull/41

cc: @nodejs/tsc 