### PR TITLE
Blog: add cve to eol mention in last sec release

### DIFF
--- a/apps/site/pages/en/blog/vulnerability/january-2025-security-releases.md
+++ b/apps/site/pages/en/blog/vulnerability/january-2025-security-releases.md
@@ -13,7 +13,17 @@ Updates are now available for the 23.x, 22.x, 20.x, 18.x Node.js release lines f
 following issues.
 
 This security release includes the following dependency updates to address public vulnerabilities:
+
 - undici (v7.2.3, v6.21.1, v5.28.5) on v23.x, v22.x, v20.x, v18.x.
+
+Along with the security fixes, the Node.js team has also issued CVEs for
+End-of-Life (EOL) versions of Node.js.
+
+- Node.js v17.x or prior [CVE-2025-23087](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-23087)
+- Node.js v19.x [CVE-2025-23088](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-23088)
+- Node.js v21.x [CVE-2025-23089](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-23089)
+
+More information [in this blog post](https://nodejs.org/en/blog/vulnerability/upcoming-cve-for-eol-versions)
 
 ## Worker permission bypass via InternalWorker leak in diagnostics (CVE-2025-23083) - (high)
 


### PR DESCRIPTION
Following up: https://github.com/nodejs-private/nodejs.org-private/pull/426/

Forgot this in the original PR, I think my local branch wasn't up to date with the private one.