### PR TITLE
docs: #7416 - Removes winget from documentation because of unreliability

### DIFF
--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -364,17 +364,6 @@ Download the [Windows Installer](/#home-downloadhead) directly from the [nodejs.
 
 ### Alternatives
 
-Using **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-After running one of the two commands above, it may be necessary to restart the
-terminal emulator before the `node` CLI command becomes available.
-
 Using **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/es/download/package-manager/all.md
+++ b/apps/site/pages/es/download/package-manager/all.md
@@ -359,16 +359,6 @@ Descarga el [Instalador de Windows](/#home-downloadhead) directamente desde la w
 
 ### Alternativas
 
-Usando **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Después de ejecutar uno de los dos comandos anteriores, puede ser necesario reiniciar el emulador de terminal antes de que el comando CLI `node` esté disponible.
-
 Usando **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/fa/download/package-manager/all.md
+++ b/apps/site/pages/fa/download/package-manager/all.md
@@ -358,16 +358,6 @@ xbps-install -Sy nodejs
 
 ### جایگزین
 
-با استفاده از **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-پس از اجرای یکی از دو دستور بالا، ممکن است لازم باشد ترمینال را دوباره راه‌اندازی کنید تا دستور `node` در CLI در دسترس قرار بگیرد.
-
 با استفاده از **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/fr/download/package-manager/all.md
+++ b/apps/site/pages/fr/download/package-manager/all.md
@@ -364,17 +364,6 @@ Téléchargez l'[Installateur Windowsr](/#home-downloadhead) directement depuis 
 
 ### Alternatives
 
-Utilisation **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Après avoir exécuté l'une des deux commandes ci-dessus, il peut être nécessaire de redémarrer l'émulateur de terminal avant que la commande CLI `node` ne soit disponible.
-l'émulateur de terminal avant que la commande CLI `node` ne soit disponible.
-
 Utilisation **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/id/download/package-manager/all.md
+++ b/apps/site/pages/id/download/package-manager/all.md
@@ -361,16 +361,6 @@ Unduh [Pemasang Windows](/#home-downloadhead) langsung dari situs web [nodejs.or
 
 ### Windows
 
-Unduh [Pemasang Windows](/#home-downloadhead) langsung dari situs web [nodejs.org](https://nodejs.org/).
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Menggunakan **[Winget](https://aka.ms/winget-cli)**:
-
 Menggunakan **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/ja/download/package-manager/all.md
+++ b/apps/site/pages/ja/download/package-manager/all.md
@@ -353,16 +353,6 @@ xbps-install -Sy nodejs
 
 ### その他のインストール方法
 
-\*\*[Winget](https://aka.ms/winget-cli)\*\*を使用：
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-上記のいずれかのコマンドを実行した後、`node` CLIコマンドが利用可能になる前にターミナルエミュレーターを再起動する必要があります。
-
 \*\*[Chocolatey](https://chocolatey.org/)\*\*を使用：
 
 ```bash

--- a/apps/site/pages/ko/download/package-manager/all.md
+++ b/apps/site/pages/ko/download/package-manager/all.md
@@ -356,16 +356,6 @@ xbps-install -Sy nodejs
 
 ### 대안
 
-\*\*[Winget](https://aka.ms/winget-cli)\*\*를 사용하여:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-위의 두 명령 중 하나를 실행한 후 `node` CLI 명령이 사용 가능해지기 전에 터미널 에뮬레이터를 재시작해야 할 수도 있습니다.
-
 \*\*[Chocolatey](https://chocolatey.org/)\*\*를 사용하여:
 
 ```bash

--- a/apps/site/pages/pt/download/package-manager/all.md
+++ b/apps/site/pages/pt/download/package-manager/all.md
@@ -353,16 +353,6 @@ Descarregamos o [instalador da Node.js](/#home-downloadhead) diretamente a parti
 
 ### Alternativas
 
-Com o uso do **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Após executarmos um dos dois comandos acima, pode ser necessário reiniciar o emulador de terminal antes do comando `node` da interface da linha de comando torne-se disponível.
-
 Com o uso do **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/tr/download/package-manager/all.md
+++ b/apps/site/pages/tr/download/package-manager/all.md
@@ -363,17 +363,6 @@ Windows Installer](/#home-downloadhead) doğrudan [nodejs.org](https://nodejs.or
 
 ### Alternatifler
 
-[Winget](https://aka.ms/winget-cli)\*\* kullanarak:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Yukarıdaki iki komuttan birini çalıştırdıktan sonra, yeniden başlatmak gerekebilir
-CLI komutu kullanılabilir hale gelmeden önce terminal emülatörü.
-
 [Chocolatey](https://chocolatey.org/)\*\* kullanarak:
 
 ```bash

--- a/apps/site/pages/uk/download/package-manager/all.md
+++ b/apps/site/pages/uk/download/package-manager/all.md
@@ -357,16 +357,6 @@ xbps-install -Sy nodejs
 
 ### Альтернативи
 
-Через **[Winget](https://aka.ms/winget-cli)**:
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-Після запуску однієї з двох команд вище, можливо, необхідно буде перезапустити емулятор термінала, перш ніж CLI-команда `node` стане доступною.
-
 Через **[Chocolatey](https://chocolatey.org/)**:
 
 ```bash

--- a/apps/site/pages/zh-cn/download/package-manager/all.md
+++ b/apps/site/pages/zh-cn/download/package-manager/all.md
@@ -355,16 +355,6 @@ xbps-install -Sy nodejs
 
 ### 备选资源
 
-使用 **[Winget](https://aka.ms/winget-cli)**：
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-在运行上述两个命令之后，可能需要重新启动终端模拟器，然后 `node` 命令行界面命令才能生效。
-
 使用 **[Chocolatey](https://chocolatey.org/)**：
 
 ```bash

--- a/apps/site/pages/zh-tw/download/package-manager/all.md
+++ b/apps/site/pages/zh-tw/download/package-manager/all.md
@@ -356,16 +356,6 @@ xbps-install -Sy nodejs
 
 ### 替代方案
 
-使用 **[Winget](https://aka.ms/winget-cli)**：
-
-```bash
-winget install OpenJS.NodeJS
-# or for LTS
-winget install OpenJS.NodeJS.LTS
-```
-
-執行上述的兩個命令之一後，可能需要重新啟動，這樣 `node` 的指令才能使用。
-
 使用 **[Chocolatey](https://chocolatey.org/)**：
 
 ```bash


### PR DESCRIPTION
Remove winget from documentation because it is unreliable

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

NodeJS versions are unreliably published to winget. Therefore, this reference falsy gives the impression that it will contain the latest versions.

## Validation

Current LTS is 22.13.1
![Image](https://github.com/user-attachments/assets/668af9d0-3b4f-4693-927a-537b8fb9f12d)

which is non existing

```
winget install --id=OpenJS.NodeJS -v "22.13.1" -e
No version found matching: 22.13.1
```

# Result of change
![image](https://github.com/user-attachments/assets/5d9388eb-a2da-4b42-9400-4bd68fb6a10f)

## Related Issues

<!--
   Addresses #7416
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
