### PR TITLE
fix: Button accessibility

### DIFF
--- a/apps/site/components/Common/Button/index.tsx
+++ b/apps/site/components/Common/Button/index.tsx
@@ -36,6 +36,7 @@ const Button: FC<ButtonProps> = ({
           styles[size],
           className
         )}
+        tabIndex={disabled ? -1 : 0}
         {...props}
       >
         {children}

--- a/apps/site/components/Common/Button/index.tsx
+++ b/apps/site/components/Common/Button/index.tsx
@@ -1,18 +1,16 @@
 'use client';
 
 import classNames from 'classnames';
-import type {
-  FC,
-  AnchorHTMLAttributes,
-  KeyboardEvent,
-  MouseEvent,
-} from 'react';
+import type { FC, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
 import Link from '@/components/Link';
 
 import styles from './index.module.css';
 
-type ButtonProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+type ButtonProps = (
+  | AnchorHTMLAttributes<HTMLAnchorElement>
+  | ButtonHTMLAttributes<HTMLButtonElement>
+) & {
   kind?: 'neutral' | 'primary' | 'secondary' | 'special';
   size?: 'default' | 'small';
   disabled?: boolean;
@@ -22,55 +20,43 @@ const Button: FC<ButtonProps> = ({
   kind = 'primary',
   size = 'default',
   disabled = false,
-  href = undefined,
   children,
   className,
-  onClick,
   ...props
 }) => {
-  const onKeyDownHandler = (e: KeyboardEvent<HTMLAnchorElement>) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
-
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      if (typeof onClick === 'function') {
-        onClick(e as unknown as MouseEvent<HTMLAnchorElement>);
-      }
-    }
-  };
-
-  const onClickHandler = (e: MouseEvent<HTMLAnchorElement>) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
-
-    if (typeof onClick === 'function') {
-      onClick(e);
-    }
-  };
+  if ('href' in props) {
+    return (
+      <Link
+        role="button"
+        href={disabled ? undefined : props.href}
+        aria-disabled={disabled}
+        className={classNames(
+          styles.button,
+          styles[kind],
+          styles[size],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </Link>
+    );
+  }
 
   return (
-    <Link
-      role="button"
-      href={disabled ? undefined : href}
-      aria-disabled={disabled}
+    <button
+      disabled={disabled}
       className={classNames(
         styles.button,
         styles[kind],
         styles[size],
         className
       )}
-      tabIndex={disabled ? -1 : 0} // Ensure focusable if not disabled
-      onClick={onClickHandler}
-      onKeyDown={onKeyDownHandler}
-      {...props}
+      type="button"
+      {...(props as ButtonHTMLAttributes<HTMLButtonElement>)}
     >
       {children}
-    </Link>
+    </button>
   );
 };
 


### PR DESCRIPTION
## Description

In the `Button` component, the native event listener provided by the browser for anchors is modified, so in some cases it does not work as it should

For example, the download button on the home page with a tab and press enter does not start the download

With this PR, I changed the current approach a little bit so that if there is a `href` in the `props`, the button acts like an `anchor`, and if there is no `href`, it acts like a `button`

## Validation

The places where the `Button` component is used in the preview must be accessible

## Related Issues

related to #7390, #7287, #7247

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
