### PR TITLE
fix: remove GlowingBackdrop from accessibility tree

### DIFF
--- a/apps/site/components/Icons/HexagonGrid.tsx
+++ b/apps/site/components/Icons/HexagonGrid.tsx
@@ -7,6 +7,7 @@ const HexagonGrid: FC<HexagonGridProps> = props => (
     viewBox="0 0 1216 726"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
     {...props}
   >
     <mask


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When navigating the website using a screen reader, the glowing backdrop doesn't bring anything to the experience, it only adds confusion as it has no label. Let's remove it from the accessibility tree.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
