### PR TITLE
fix: remove confusing close label for navigation menu

### DIFF
--- a/apps/site/components/Containers/NavBar/index.tsx
+++ b/apps/site/components/Containers/NavBar/index.tsx
@@ -70,9 +70,7 @@ const NavBar: FC<NavbarProps> = ({
         id="sidebarItemToggler"
         type="checkbox"
         onChange={e => setIsMenuOpen(() => e.target.checked)}
-        aria-label={t(
-          `components.containers.navBar.controls.${isMenuOpen ? 'close' : 'open'}`
-        )}
+        aria-label={t(`components.containers.navBar.controls.open`)}
       />
 
       <div className={`${style.main} peer-checked:flex`}>

--- a/apps/site/components/Containers/NavBar/index.tsx
+++ b/apps/site/components/Containers/NavBar/index.tsx
@@ -70,7 +70,7 @@ const NavBar: FC<NavbarProps> = ({
         id="sidebarItemToggler"
         type="checkbox"
         onChange={e => setIsMenuOpen(() => e.target.checked)}
-        aria-label={t(`components.containers.navBar.controls.open`)}
+        aria-label={t(`components.containers.navBar.controls.toggle`)}
       />
 
       <div className={`${style.main} peer-checked:flex`}>

--- a/packages/i18n/locales/en.json
+++ b/packages/i18n/locales/en.json
@@ -12,8 +12,7 @@
       },
       "navBar": {
         "controls": {
-          "open": "Show navigation menu",
-          "close": "Close navigation menu"
+          "open": "Show navigation menu"
         },
         "links": {
           "about": "About",

--- a/packages/i18n/locales/en.json
+++ b/packages/i18n/locales/en.json
@@ -12,7 +12,7 @@
       },
       "navBar": {
         "controls": {
-          "open": "Show navigation menu"
+          "toggle": "Toggle navigation menu"
         },
         "links": {
           "about": "About",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
As I was trying around navigating the website with VoiceOver, I noticed the current design is kinda confusing:

- when the nav menu is closed, and the user focuses the checkbox, VoiceOver says "Show navigation menu, tickbox, unticked" (so far so good).
- when the nav menu is open, and the user focuses the checkbox, VoiceOver says "Close navigation menu, tickbox, ticked", which may be kind of confusing. If the user is not able to get visual clues to know if the menu is actually currently opened, they might assume the menu is actually closed (since the checkbox is ticked).

TBH I'm not at all confident which version is the correct one, if someone who are a screen reader user could chime in, that'd be much appreciated.
An alternative would be to use a more verbose label (such as "Navigation menu is currently closed, tick the box to open it", and "Navigation menu is currently open, untick the box to close it"), not sure if this is preferable.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

https://github.com/nodejs/nodejs.org/pull/7427

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
