### PR TITLE
Update run.md

### DIFF
--- a/apps/site/pages/en/learn/typescript/run.md
+++ b/apps/site/pages/en/learn/typescript/run.md
@@ -10,7 +10,7 @@ In the previous article, we learned how to run TypeScript code using transpilati
 
 ## Running TypeScript code with `ts-node`
 
-[ts-node](https://typestrong.org/ts-node/) is a TypeScript execution environment for Node.js. It allows you to run TypeScript code directly in Node.js without the need to compile it first. Note, however, that it does not type check your code. So we recommend to type check your code first with `tsc` and then run it with `ts-node` before shipping it.
+[ts-node](https://typestrong.org/ts-node/) is a TypeScript execution environment for Node.js. It allows you to run TypeScript code directly in Node.js without the need to compile it first. By default, `ts-node` performs type checking unless `transpileOnly` is enabled. While `ts-node` can catch type errors at runtime, we still recommend type-checking your code first with `tsc` before shipping it.
 
 To use `ts-node`, you need to install it first:
 


### PR DESCRIPTION
## Description

This PR updates the documentation to clarify that `ts-node` performs type checking by default unless `transpileOnly` is enabled.

The previous documentation suggested that `ts-node` does not perform type checking. However, testing confirms that it does type checking unless `transpileOnly` is explicitly enabled.  

## Validation

```typescript
// example.ts
let username: string;
username = 22; // Type error
```

Running `ts-node example.ts` results in:  
```bash
TSError: ⨯ Unable to compile TypeScript:
example.ts:3:1 - error TS2322: Type 'number' is not assignable to type 'string'.
```

`ts-node -v` output:  
```
v10.9.2
```

This confirms that `ts-node` performs type checking by default in this version.  
