### PR TITLE
style: code fallback font

### DIFF
--- a/apps/site/next.fonts.ts
+++ b/apps/site/next.fonts.ts
@@ -16,5 +16,6 @@ export const OPEN_SANS = Open_Sans({
 export const IBM_PLEX_MONO = IBM_Plex_Mono({
   weight: ['400', '600'],
   subsets: ['latin'],
+  fallback: ['ui-monospace'],
   variable: '--font-ibm-plex-mono',
 });

--- a/apps/site/pages/en/learn/typescript/publishing-a-ts-package.md
+++ b/apps/site/pages/en/learn/typescript/publishing-a-ts-package.md
@@ -61,10 +61,10 @@ example-ts-pkg/
 │ │ ├ foo.fixture.js
 │ │ ├ main.test.ts
 │ ├ main.ts
-│ └ some-util.ts
-│ │ ├ __test__
-│ │   └ some-util.test.ts
-│ │ └ some-util.ts
+│ └ some-util/
+│   ├ __test__
+│   │ └ some-util.test.ts
+│   └ some-util.ts
 ├ LICENSE
 ├ package.json
 ├ README.md


### PR DESCRIPTION
## Description

This change uses "ui-monospace" as fallback font for IBM Plex Mono. Since Box Drawings don't appear to be aligned correctly.
This also fixes a code example which renders a file structure in ascii

## Validation

before:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/71d94107-8c59-45a3-b62a-8846eced7df3" />

new:
<img width="718" alt="image" src="https://github.com/user-attachments/assets/b0ee35d6-8d17-4377-9a59-68c52bdc39c8" />

## Related Issues

Fixes #7469 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
