### PR TITLE
Add thin scrollbar styling to CodeBox and Tabs components

### DIFF
--- a/apps/site/components/Common/CodeBox/index.module.css
+++ b/apps/site/components/Common/CodeBox/index.module.css
@@ -21,6 +21,8 @@
         text-neutral-400
         [counter-reset:line];
 
+      scrollbar-width: thin;
+
       & > [class='line'] {
         @apply relative
           min-w-0

--- a/apps/site/components/Common/CodeBox/index.module.css
+++ b/apps/site/components/Common/CodeBox/index.module.css
@@ -12,6 +12,7 @@
     & > code {
       @apply font-ibm-plex-mono
         font-regular
+        scrollbar-thin
         grid
         overflow-x-auto
         bg-transparent
@@ -20,8 +21,6 @@
         leading-snug
         text-neutral-400
         [counter-reset:line];
-
-      scrollbar-width: thin;
 
       & > [class='line'] {
         @apply relative

--- a/apps/site/components/Common/Tabs/index.module.css
+++ b/apps/site/components/Common/Tabs/index.module.css
@@ -3,11 +3,10 @@
 
   .tabsList {
     @apply font-open-sans
+      scrollbar-thin
       flex
       gap-2
       overflow-x-auto;
-
-    scrollbar-width: thin;
 
     .tabsTrigger {
       @apply whitespace-nowrap

--- a/apps/site/components/Common/Tabs/index.module.css
+++ b/apps/site/components/Common/Tabs/index.module.css
@@ -7,6 +7,8 @@
       gap-2
       overflow-x-auto;
 
+    scrollbar-width: thin;
+
     .tabsTrigger {
       @apply whitespace-nowrap
         border-b-2

--- a/apps/site/tailwind.config.ts
+++ b/apps/site/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
 
 export default {
   content: [
@@ -174,5 +175,12 @@ export default {
   plugins: [
     require('@savvywombat/tailwindcss-grid-areas'),
     require('@tailwindcss/container-queries'),
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.scrollbar-thin': {
+          'scrollbar-width': 'thin',
+        },
+      });
+    }),
   ],
 } satisfies Config;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The default scrollbar size seems too big for some components

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

before
![image](https://github.com/user-attachments/assets/f898ea21-067a-4080-a904-d7f2b0d8227e)

after
![image](https://github.com/user-attachments/assets/611c47e3-bef4-46fe-b37c-df0a02e7ed9d)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
