### PR TITLE
docs: corrected example code of fetch API mocking in test runner.

### DIFF
--- a/apps/site/pages/en/learn/test-runner/mocking.md
+++ b/apps/site/pages/en/learn/test-runner/mocking.md
@@ -208,7 +208,7 @@ describe('endpoints', { concurrency: true }, () => {
     };
 
     agent
-      .get('example.com')
+      .get('https://example.com')
       .intercept({
         path: endpoint,
         method: 'GET',
@@ -230,7 +230,7 @@ describe('endpoints', { concurrency: true }, () => {
     };
 
     agent
-      .get('example.com')
+      .get('https://example.com')
       .intercept({
         path: endpoint,
         method: 'PUT',


### PR DESCRIPTION
The current example code throws `TypeError [Error]: Invalid URL at new URL (node:internal/url:816:29)` error when ran.
The correct usage for `MockAgent.get()` API of **undici** is to pass the base URL with the protocol(https, http, etc).

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
