### PR TITLE
feat: display the reading time in a formatted for the locale

### DIFF
--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -20,6 +20,10 @@ const WithMetaBar: FC = () => {
   const lastUpdated = frontmatter.date
     ? formatter.dateTime(new Date(frontmatter.date), DEFAULT_DATE_FORMAT)
     : undefined;
+  const readingTimeText = formatter.number(Math.round(readingTime.minutes), {
+    style: 'unit',
+    unit: 'minute',
+  });
 
   const usernames =
     frontmatter.authors?.split(',').map(author => author.trim()) ?? [];
@@ -39,7 +43,7 @@ const WithMetaBar: FC = () => {
     <MetaBar
       items={{
         'components.metabar.lastUpdated': lastUpdated,
-        'components.metabar.readingTime': readingTime.text,
+        'components.metabar.readingTime': readingTimeText,
         ...(usernames.length && {
           [`components.metabar.${usernames.length > 1 ? 'authors' : 'author'}`]:
             (

--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -20,9 +20,10 @@ const WithMetaBar: FC = () => {
   const lastUpdated = frontmatter.date
     ? formatter.dateTime(new Date(frontmatter.date), DEFAULT_DATE_FORMAT)
     : undefined;
-  const readingTimeText = formatter.number(Math.round(readingTime.minutes), {
+  const readingTimeText = formatter.number(readingTime.minutes, {
     style: 'unit',
     unit: 'minute',
+    maximumFractionDigits: 0,
   });
 
   const usernames =


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The display of the reading time for each page is currently based on the assumption that the page is in English. This change makes the Intl API is used to display the reading time in a format appropriate for the locale of the translated language.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
