### PR TITLE
Fix typo: rename outoutPath to outputPath in "reading-files-with-node…

### DIFF
--- a/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
+++ b/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
@@ -97,15 +97,15 @@ import { pipeline } from 'node:stream/promises';
 const fileUrl = 'https://www.gutenberg.org/files/2701/2701-0.txt';
 const outputFilePath = path.join(process.cwd(), 'moby.md');
 
-async function downloadFile(url, outoutPath) {
+async function downloadFile(url, outputPath) {
   const response = await fetch(url);
 
   if (!response.ok || !response.body) {
     throw new Error(`Failed to fetch ${url}. Status: ${response.status}`);
   }
 
-  const fileStream = fs.createWriteStream(outoutPath);
-  console.log(`Downloading file from ${url} to ${outoutPath}`);
+  const fileStream = fs.createWriteStream(outputPath);
+  console.log(`Downloading file from ${url} to ${outputPath}`);
 
   await pipeline(response.body, fileStream);
   console.log('File downloaded successfully');


### PR DESCRIPTION
## Description
Fixed a typo in the downloadFile function example in the documentation.
Renamed outoutPath to outputPath for correctness.
## Validation
The corrected variable name now matches the intended usage, improving clarity and avoiding confusion.