### PR TITLE
Replace jargon in reading-files-with-nodejs.md

### DIFF
--- a/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
+++ b/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
@@ -85,7 +85,7 @@ try {
 
 All three of `fs.readFile()`, `fs.readFileSync()` and `fsPromises.readFile()` read the full content of the file in memory before returning the data.
 
-This means that big files are going to have a major impact on your memory consumption and speed of execution of the program.
+This means that big files are going to have a major effect on your memory consumption and speed of execution of the program.
 
 In this case, a better option is to read the file content using streams.
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This commit replaces the jargon word "impact", which is also used incorrectly, with the neutral "effect" in reading-files-with-nodejs.md.

## Validation

It's a doc change.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
