### PR TITLE
fix(learn): fix horizontal scroll issue on `publishing-a-package`

### DIFF
--- a/apps/site/layouts/Learn.tsx
+++ b/apps/site/layouts/Learn.tsx
@@ -16,7 +16,7 @@ const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
       <WithProgressionSidebar navKey="learn" />
 
       <div>
-        <main>
+        <main className="md:w-[65vw] lg:w-[48vw]">
           {children}
 
           <WithSidebarCrossLinks navKey="learn" />


### PR DESCRIPTION
 This PR resolves the horizontal scroll issue on the publishing-a-package page.
I add tailwind breakpoints to fix this.
