### PR TITLE
chore(actions): update chromaui

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -202,7 +202,7 @@ jobs:
             startsWith(github.event.pull_request.head.ref, 'dependabot/') == false &&
             github.event.pull_request.head.ref != 'chore/crowdin')
         # sha reference has no stable git tag reference or URL. see https://github.com/chromaui/chromatic-cli/issues/797
-        uses: chromaui/action@30b6228aa809059d46219e0f556752e8672a7e26
+        uses: chromaui/action@c93e0bc3a63aa176e14a75b61a31847cbfdd341c
         with:
           workingDir: packages/ui-components
           buildScriptName: storybook:build


### PR DESCRIPTION
Dependabot doesn't automatically update this dependency, since there are no release tags