### PR TITLE
fix(header): set `tabIndex` to `-1`

### DIFF
--- a/packages/ui-components/Containers/NavBar/index.tsx
+++ b/packages/ui-components/Containers/NavBar/index.tsx
@@ -68,6 +68,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         type="checkbox"
         onChange={e => setIsMenuOpen(() => e.target.checked)}
         aria-label={sidebarItemTogglerAriaLabel}
+        tabIndex={-1}
       />
 
       <div className={`${style.main} peer-checked:flex`}>


### PR DESCRIPTION

## Related Issues

Closes #7585 

## A11y Test

![correct-header-tab-sequence](https://github.com/user-attachments/assets/35c7200a-91dd-4155-8e04-ae9f16396fc2)


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
