### PR TITLE
chore: refactor the `generateBlogData` function (again) (#7607)

### DIFF
--- a/apps/site/next-data/generators/__tests__/blogData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/blogData.test.mjs
@@ -1,13 +1,9 @@
+import { normalize } from 'node:path';
 import { Readable } from 'node:stream';
 
 import generateBlogData from '@/next-data/generators/blogData.mjs';
 
 let files = [];
-
-jest.mock('node:path', () => ({
-  ...jest.requireActual('node:path'),
-  join: jest.fn((_base, filePath) => filePath),
-}));
 
 jest.mock('node:fs', () => {
   const originalFs = jest.requireActual('node:fs');
@@ -15,7 +11,7 @@ jest.mock('node:fs', () => {
     ...originalFs,
     createReadStream: jest.fn(filename => {
       const readable = new Readable();
-      const file = files.find(f => f.path === filename);
+      const file = files.find(f => filename.endsWith(normalize(f.path)));
       readable.push(`---\n`);
       file.frontMatterContent.forEach(line => readable.push(`${line}\n`));
       readable.push(`---\n`);

--- a/apps/site/next-data/generators/__tests__/blogData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/blogData.test.mjs
@@ -1,0 +1,189 @@
+import { Readable } from 'node:stream';
+
+import generateBlogData from '@/next-data/generators/blogData.mjs';
+
+let files = [];
+
+jest.mock('node:path', () => ({
+  ...jest.requireActual('node:path'),
+  join: jest.fn((_base, filePath) => filePath),
+}));
+
+jest.mock('node:fs', () => {
+  const originalFs = jest.requireActual('node:fs');
+  return {
+    ...originalFs,
+    createReadStream: jest.fn(filename => {
+      const readable = new Readable();
+      const file = files.find(f => f.path === filename);
+      readable.push(`---\n`);
+      file.frontMatterContent.forEach(line => readable.push(`${line}\n`));
+      readable.push(`---\n`);
+      readable.push(null);
+      readable.close = () => {};
+      return readable;
+    }),
+  };
+});
+
+jest.mock('../../../next.helpers.mjs', () => {
+  const originalHelpers = jest.requireActual('../../../next.helpers.mjs');
+  return {
+    ...originalHelpers,
+    getMarkdownFiles: () => Promise.resolve(files.map(file => file.path)),
+  };
+});
+
+describe('generateBlogData', () => {
+  it('should return zero posts and only the default "all" category is no md file is found', async () => {
+    files = [];
+
+    const blogData = await generateBlogData();
+
+    expect(blogData.categories).toStrictEqual(['all']);
+    expect(blogData.posts).toStrictEqual([]);
+  });
+
+  it('should collect the data from a single md file if only one is found', async () => {
+    files = [
+      {
+        path: 'pages/en/blog/post1.md',
+        frontMatterContent: [
+          `date: '2020-01-01T00:00:00.000Z'`,
+          `title: POST 1`,
+          `author: author`,
+        ],
+      },
+    ];
+
+    const blogData = await generateBlogData();
+
+    expect(blogData.posts.length).toBe(1);
+    const post = blogData.posts[0];
+    expect(post.title).toEqual('POST 1');
+    expect(post.date).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+    expect(post.author).toEqual('author');
+  });
+
+  it('should collect the data from multiple md files', async () => {
+    const currentDate = new Date();
+
+    files = [
+      {
+        path: 'pages/en/blog/post1.md',
+        frontMatterContent: [
+          `date: '2020-01-01T00:00:00.000Z'`,
+          `title: POST 1`,
+          `author: author-a`,
+        ],
+      },
+      {
+        path: 'pages/en/blog/post2.md',
+        frontMatterContent: [
+          `date: '2020-01-02T00:00:00.000Z'`,
+          `title: POST 2`,
+          `author: author-b`,
+        ],
+      },
+      {
+        path: 'pages/en/blog/post3.md',
+        frontMatterContent: [
+          // no date specified (the date defaults to the current date)
+          `title: POST 3`,
+          `author: author-c`,
+        ],
+      },
+    ];
+
+    const blogData = await generateBlogData();
+
+    expect(blogData.posts.length).toBe(3);
+    expect(blogData.posts[0].title).toEqual('POST 1');
+    expect(blogData.posts[0].date).toEqual(
+      new Date('2020-01-01T00:00:00.000Z')
+    );
+    expect(blogData.posts[0].author).toEqual('author-a');
+    expect(blogData.posts[1].title).toEqual('POST 2');
+    expect(blogData.posts[1].date).toEqual(
+      new Date('2020-01-02T00:00:00.000Z')
+    );
+    expect(blogData.posts[1].author).toEqual('author-b');
+    expect(blogData.posts[2].title).toEqual('POST 3');
+    expect(blogData.posts[2].date.setMilliseconds(0)).toEqual(
+      currentDate.setMilliseconds(0)
+    );
+    expect(blogData.posts[2].author).toEqual('author-c');
+  });
+
+  it('should generate categories based on the categories of md files and their years', async () => {
+    files = [
+      {
+        path: 'pages/en/blog/post1.md',
+        frontMatterContent: [
+          "date: '2020-01-01T00:00:00.000Z'",
+          'category: category-a',
+        ],
+      },
+      {
+        path: 'pages/en/blog/sub-dir/post2.md',
+        frontMatterContent: [
+          "date: '2020-01-02T00:00:00.000Z'",
+          'category: category-b',
+        ],
+      },
+      {
+        path: 'pages/en/blog/post3.md',
+        frontMatterContent: [
+          "date: '2021-03-13T00:00:00.000Z'",
+          // no category specified (it should be "uncategorized")
+        ],
+      },
+      {
+        path: 'pages/en/blog/post4.md',
+        frontMatterContent: [
+          // no date specified (the date defaults to the current date)
+          'category: category-b',
+        ],
+      },
+    ];
+
+    const blogData = await generateBlogData();
+
+    expect(blogData.categories.sort()).toStrictEqual([
+      'all',
+      'category-a',
+      'category-b',
+      'uncategorized',
+      'year-2020',
+      'year-2021',
+      `year-${new Date().getUTCFullYear()}`,
+    ]);
+  });
+
+  it('should generate slugs based on the md filenames and categories', async () => {
+    files = [
+      {
+        path: 'pages/en/blog/post1.md',
+        frontMatterContent: ['category: category-a'],
+      },
+      {
+        path: 'pages/en/blog/post2.md',
+        frontMatterContent: ['category: category-b'],
+      },
+      {
+        path: 'pages/en/blog/post3.md',
+        frontMatterContent: [
+          // no category specified
+        ],
+      },
+    ];
+
+    const blogData = await generateBlogData();
+
+    expect(blogData.posts.map(p => p.slug).sort()).toStrictEqual([
+      '/blog/category-a/post1',
+      '/blog/category-b/post2',
+      '/blog/uncategorized/post3',
+    ]);
+  });
+});

--- a/apps/site/next-data/generators/__tests__/blogData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/blogData.test.mjs
@@ -5,30 +5,22 @@ import generateBlogData from '@/next-data/generators/blogData.mjs';
 
 let files = [];
 
-jest.mock('node:fs', () => {
-  const originalFs = jest.requireActual('node:fs');
-  return {
-    ...originalFs,
-    createReadStream: jest.fn(filename => {
-      const readable = new Readable();
-      const file = files.find(f => filename.endsWith(normalize(f.path)));
-      readable.push(`---\n`);
-      file.frontMatterContent.forEach(line => readable.push(`${line}\n`));
-      readable.push(`---\n`);
-      readable.push(null);
-      readable.close = () => {};
-      return readable;
-    }),
-  };
-});
+jest.mock('node:fs', () => ({
+  createReadStream: jest.fn(filename => {
+    const readable = new Readable();
+    const file = files.find(f => filename.endsWith(normalize(f.path)));
+    readable.push(`---\n`);
+    file.frontMatterContent.forEach(line => readable.push(`${line}\n`));
+    readable.push(`---\n`);
+    readable.push(null);
+    readable.close = () => {};
+    return readable;
+  }),
+}));
 
-jest.mock('../../../next.helpers.mjs', () => {
-  const originalHelpers = jest.requireActual('../../../next.helpers.mjs');
-  return {
-    ...originalHelpers,
-    getMarkdownFiles: () => Promise.resolve(files.map(file => file.path)),
-  };
-});
+jest.mock('../../../next.helpers.mjs', () => ({
+  getMarkdownFiles: () => Promise.resolve(files.map(file => file.path)),
+}));
 
 describe('generateBlogData', () => {
   it('should return zero posts and only the default "all" category is no md file is found', async () => {


### PR DESCRIPTION
## Description

Reintroducing the refactoring I added in https://github.com/nodejs/nodejs.org/pull/7607 that actually broke production ( :see_no_evil: ) and I had to quickly revert in https://github.com/nodejs/nodejs.org/pull/7617

### What went wrong / what I changed from my previous PR

Basically with my previous code the Next.js compiler would move code around breaking things, this is the code it generated for [my previous iteration of the file](https://github.com/dario-piotrowicz/nodejs.org/blob/a0c01a747d5311b135ca533a75cfe7e866dfac9c/apps/site/next-data/generators/blogData.mjs):
![Screenshot at 2025-04-03 23-28-17](https://github.com/user-attachments/assets/d1645eef-7c96-457b-913b-31a1c4a46b2e)

The problem being that `f` (which is the minified version of `blogCategories`) gets spread in the result before the `await Promise.all` that actually side-effectfully populates it

In this PR I am then also moving `blogCategories` inside `generateBlogData` , this is arguably cleaner than the previous iteration anyways (in my opinion) and it seems to help the Next.js compiler not to move things around, no longer introducing the issue

![Screenshot at 2025-04-03 23-34-10](https://github.com/user-attachments/assets/a0c8582f-b065-4a43-ae48-a546c0677c6b)

(as you can see now the `await Promise.all` is correctly run before the return statement)

</details> 


## Validation

I've manually tested this both in `next dev` and `next build + next start` (both this time! :see_no_evil:)

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
