### PR TITLE
chore(blog): add and normalize authors

### DIFF
--- a/apps/site/authors.json
+++ b/apps/site/authors.json
@@ -59,6 +59,11 @@
     "name": "Danielle Adams",
     "website": "https://github.com/danielleadams"
   },
+  "Daniel Bevenius": {
+    "id": "danbev",
+    "name": "Daniel Bevenius",
+    "webiste": "https://github.com/danbev"
+  },
   "Dave Pacheco": {
     "id": "dave-pacheco",
     "name": "Dave Pacheco"
@@ -138,6 +143,11 @@
     "name": "Node.js Technical Steering Committee",
     "website": "https://github.com/nodejs"
   },
+  "Matteo Collina": {
+    "id": "mcollina",
+    "name": "Matteo Collina",
+    "webiste": "https://github.com/mcollina"
+  },
   "Marco Ippolito": {
     "id": "marco-ippolito",
     "name": "Marco Ippolito",
@@ -177,6 +187,11 @@
     "name": "Myles Borins",
     "website": "https://github.com/mylesborins"
   },
+  "piscisaureus": {
+    "id": "piscisaureus",
+    "name": "Bert Belder",
+    "website": "https://github.com/piscisaureus"
+  },
   "Rafael Gonzaga": {
     "id": "rafaelgss",
     "name": "Rafael Gonzaga",
@@ -206,6 +221,11 @@
     "id": "ry",
     "name": "Ryan Dahl",
     "website": "https://github.com/ry"
+  },
+  "Sam Roberts": {
+    "id": "sam-github",
+    "name": "Sam Roberts",
+    "webiste": "https://github.com/sam-github"
   },
   "Scott Hammond": {
     "id": "scott-hammond",
@@ -249,6 +269,11 @@
     "id": "UlisesGascon",
     "name": "Ulises Gascón",
     "website": "https://github.com/UlisesGascon"
+  },
+  "Vladimir de Turckheim": {
+    "id": "vdeturckheim",
+    "name": "Vladimir de Turckheim",
+    "webiste": "https://github.com/vdeturckheim"
   },
   "Yosuke Furukawa": {
     "id": "yosuke-furukawa",

--- a/apps/site/authors.json
+++ b/apps/site/authors.json
@@ -141,7 +141,7 @@
   "Node.js Technical Steering Committee": {
     "id": "nodejs",
     "name": "Node.js Technical Steering Committee",
-    "website": "https://github.com/nodejs"
+    "website": "https://github.com/nodejs/tsc"
   },
   "Matteo Collina": {
     "id": "mcollina",

--- a/apps/site/authors.json
+++ b/apps/site/authors.json
@@ -15,7 +15,7 @@
     "website": "https://github.com/AugustinMauroy"
   },
   "Ben Noordhuis": {
-    "id": "bennoordhuis",
+    "id": "bnoordhuis",
     "name": "Ben Noordhuis",
     "website": "https://github.com/bnoordhuis"
   },
@@ -230,6 +230,11 @@
     "id": "nodejs",
     "name": "The Node.js Project",
     "website": "https://github.com/nodejs"
+  },
+  "Tierney Cyren": {
+    "id": "bnb",
+    "name": "Tierney Cyren",
+    "website": "https://github.com/bnb"
   },
   "Timothy J Fontaine": {
     "id": "tjfontaine",

--- a/apps/site/authors.json
+++ b/apps/site/authors.json
@@ -133,6 +133,11 @@
     "name": "Julián Duque",
     "website": "https://github.com/julianduque"
   },
+  "Node.js Technical Steering Committee": {
+    "id": "nodejs",
+    "name": "Node.js Technical Steering Committee",
+    "website": "https://github.com/nodejs"
+  },
   "Marco Ippolito": {
     "id": "marco-ippolito",
     "name": "Marco Ippolito",
@@ -172,9 +177,10 @@
     "name": "Myles Borins",
     "website": "https://github.com/mylesborins"
   },
-  "Node.js Advisory Board": {
-    "id": "advisory-board",
-    "name": "Node.js Advisory Board"
+  "Rafael Gonzaga": {
+    "id": "rafaelgss",
+    "name": "Rafael Gonzaga",
+    "website": "https://github.com/RafaelGSS"
   },
   "Richard Lau": {
     "id": "richardlau",

--- a/apps/site/pages/en/blog/release/v0.4.10.md
+++ b/apps/site/pages/en/blog/release/v0.4.10.md
@@ -3,7 +3,7 @@ date: '2011-07-20T14:36:38.000Z'
 category: release
 title: Node v0.4.10
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.07.19, Version 0.4.10 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.11.md
+++ b/apps/site/pages/en/blog/release/v0.4.11.md
@@ -3,7 +3,7 @@ date: '2011-08-18T08:44:42.000Z'
 category: release
 title: Node v0.4.11
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.08.17, Version 0.4.11 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.12.md
+++ b/apps/site/pages/en/blog/release/v0.4.12.md
@@ -3,7 +3,7 @@ date: '2011-09-16T00:32:07.000Z'
 category: release
 title: Node v0.4.12
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.09.15, Version 0.4.12 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.3.md
+++ b/apps/site/pages/en/blog/release/v0.4.3.md
@@ -3,7 +3,7 @@ date: '2011-03-19T05:17:59.000Z'
 category: release
 title: Node v0.4.3
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.03.18, Version 0.4.3 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.4.md
+++ b/apps/site/pages/en/blog/release/v0.4.4.md
@@ -3,7 +3,7 @@ date: '2011-03-26T15:58:45.000Z'
 category: release
 title: Node v0.4.4
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.03.26, Version 0.4.4 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.5.md
+++ b/apps/site/pages/en/blog/release/v0.4.5.md
@@ -3,7 +3,7 @@ date: '2011-04-02T09:04:58.000Z'
 category: release
 title: node v0.4.5
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.04.01, Version 0.4.5 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.6.md
+++ b/apps/site/pages/en/blog/release/v0.4.6.md
@@ -3,7 +3,7 @@ date: '2011-04-14T12:00:30.000Z'
 category: release
 title: Node v0.4.6
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.04.13, Version 0.4.6 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.7.md
+++ b/apps/site/pages/en/blog/release/v0.4.7.md
@@ -3,7 +3,7 @@ date: '2011-04-23T07:47:55.000Z'
 category: release
 title: Node v0.4.7
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.04.22, Version 0.4.7 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.8.md
+++ b/apps/site/pages/en/blog/release/v0.4.8.md
@@ -3,7 +3,7 @@ date: '2011-05-21T14:06:00.000Z'
 category: release
 title: Node v0.4.8
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.05.20, Version 0.4.8 (stable)

--- a/apps/site/pages/en/blog/release/v0.4.9.md
+++ b/apps/site/pages/en/blog/release/v0.4.9.md
@@ -3,7 +3,7 @@ date: '2011-06-29T18:41:05.000Z'
 category: release
 title: Node v0.4.9
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.06.29, Version 0.4.9 (stable)

--- a/apps/site/pages/en/blog/release/v0.5.0.md
+++ b/apps/site/pages/en/blog/release/v0.5.0.md
@@ -3,7 +3,7 @@ date: '2011-07-06T09:23:17.000Z'
 category: release
 title: Node v0.5.0 (Unstable)
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.07.05, Version 0.5.0 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.1.md
+++ b/apps/site/pages/en/blog/release/v0.5.1.md
@@ -3,7 +3,7 @@ date: '2011-07-15T06:48:08.000Z'
 category: release
 title: Node v0.5.1
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.07.14, Version 0.5.1 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.10.md
+++ b/apps/site/pages/en/blog/release/v0.5.10.md
@@ -3,7 +3,7 @@ date: '2011-10-22T02:12:31.000Z'
 category: release
 title: Node v0.5.10
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.10.21, Version 0.5.10 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.2.md
+++ b/apps/site/pages/en/blog/release/v0.5.2.md
@@ -3,7 +3,7 @@ date: '2011-07-22T18:40:22.000Z'
 category: release
 title: Node v0.5.2
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.07.22, Version 0.5.2 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.3.md
+++ b/apps/site/pages/en/blog/release/v0.5.3.md
@@ -3,7 +3,7 @@ date: '2011-08-02T15:03:06.000Z'
 category: release
 title: Node v0.5.3
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.08.01, Version 0.5.3 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.4.md
+++ b/apps/site/pages/en/blog/release/v0.5.4.md
@@ -3,7 +3,7 @@ date: '2011-08-12T15:38:26.000Z'
 category: release
 title: Node v0.5.4
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.08.12, Version 0.5.4 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.5.md
+++ b/apps/site/pages/en/blog/release/v0.5.5.md
@@ -3,7 +3,7 @@ date: '2011-08-27T06:20:10.000Z'
 category: release
 title: Node v0.5.5
 layout: blog-post
-author: bennoordhuis
+author: Ben Noordhuis
 ---
 
 2011.08.26, Version 0.5.5 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.7.md
+++ b/apps/site/pages/en/blog/release/v0.5.7.md
@@ -3,7 +3,7 @@ date: '2011-09-17T01:57:03.000Z'
 category: release
 title: Node v0.5.7 (unstable)
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.09.16, Version 0.5.7 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.8.md
+++ b/apps/site/pages/en/blog/release/v0.5.8.md
@@ -3,7 +3,7 @@ date: '2011-09-30T23:47:11.000Z'
 category: release
 title: Node v0.5.8
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.09.30, Version 0.5.8 (unstable)

--- a/apps/site/pages/en/blog/release/v0.5.9.md
+++ b/apps/site/pages/en/blog/release/v0.5.9.md
@@ -3,7 +3,7 @@ date: '2011-10-11T02:06:21.000Z'
 category: release
 title: Node v0.5.9
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.10.10, Version 0.5.9 (unstable)

--- a/apps/site/pages/en/blog/release/v0.6.0.md
+++ b/apps/site/pages/en/blog/release/v0.6.0.md
@@ -3,7 +3,7 @@ date: '2011-11-05T09:07:10.000Z'
 category: release
 title: Node v0.6.0
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 We are happy to announce the third stable branch of Node v0.6. We will be freezing JavaScript, C++, and binary interfaces for all v0.6 releases.

--- a/apps/site/pages/en/blog/release/v0.6.1.md
+++ b/apps/site/pages/en/blog/release/v0.6.1.md
@@ -3,7 +3,7 @@ date: '2011-11-11T23:34:15.000Z'
 category: release
 title: Node v0.6.1
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.11.11, Version 0.6.1 (stable)

--- a/apps/site/pages/en/blog/release/v0.6.2.md
+++ b/apps/site/pages/en/blog/release/v0.6.2.md
@@ -3,7 +3,7 @@ date: '2011-11-18T23:35:32.000Z'
 category: release
 title: Node v0.6.2
 layout: blog-post
-author: bennoordhuis
+author: Ben Noordhuis
 ---
 
 2011.11.18, Version 0.6.2 (stable)

--- a/apps/site/pages/en/blog/release/v0.6.4.md
+++ b/apps/site/pages/en/blog/release/v0.6.4.md
@@ -3,7 +3,7 @@ date: '2011-12-02T02:20:14.000Z'
 category: release
 title: Node v0.6.4
 layout: blog-post
-author: bennoordhuis
+author: Ben Noordhuis
 ---
 
 2011.12.02, Version 0.6.4 (stable)

--- a/apps/site/pages/en/blog/release/v0.6.5.md
+++ b/apps/site/pages/en/blog/release/v0.6.5.md
@@ -3,7 +3,7 @@ date: '2011-12-04T08:59:57.000Z'
 category: release
 title: Node v0.6.5
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 2011.12.04, Version 0.6.5 (stable)

--- a/apps/site/pages/en/blog/release/v0.7.0.md
+++ b/apps/site/pages/en/blog/release/v0.7.0.md
@@ -3,7 +3,7 @@ date: '2012-01-17T03:58:28.000Z'
 category: release
 title: Node v0.7.0 (Unstable)
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 **This is the first release in the unstable v0.7 series. Almost all users will want to remain using the stable v0.6 releases.**

--- a/apps/site/pages/en/blog/uncategorized/an-easy-way-to-build-scalable-network-programs.md
+++ b/apps/site/pages/en/blog/uncategorized/an-easy-way-to-build-scalable-network-programs.md
@@ -3,7 +3,7 @@ date: '2011-10-04T22:39:56.000Z'
 category: uncategorized
 title: An Easy Way to Build Scalable Network Programs
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 Suppose you're writing a web server which does video encoding on each file upload. Video encoding is very much compute bound. Some recent blog posts suggest that Node.js would fail miserably at this.

--- a/apps/site/pages/en/blog/uncategorized/development-environment.md
+++ b/apps/site/pages/en/blog/uncategorized/development-environment.md
@@ -3,7 +3,7 @@ date: '2011-04-05T03:16:27.000Z'
 category: uncategorized
 title: Development Environment
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 If you're compiling a software package because you need a particular version (e.g. the latest), then it requires a little bit more maintenance than using a package manager like `dpkg`. Software that you compile yourself should _not_ go into `/usr`, it should go into your home directory. This is part of being a software developer.

--- a/apps/site/pages/en/blog/uncategorized/growing-up.md
+++ b/apps/site/pages/en/blog/uncategorized/growing-up.md
@@ -3,7 +3,7 @@ date: '2011-12-15T19:59:15.000Z'
 category: uncategorized
 title: Growing up
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 This week Microsoft announced [support for Node in Windows Azure](https://www.windowsazure.com/en-us/develop/nodejs/), their cloud computing platform. For the Node core team and the community, this is an important milestone. We've worked hard over the past six months reworking Node's machinery to support IO completion ports and Visual Studio to provide a good native port to Windows. The overarching goal of the port was to expand our user base to the largest number of developers. Happily, this has paid off in the form of being a first class citizen on Azure. Many users who would have never used Node as a pure Unix tool are now up and running on the Windows platform. More users translates into a deeper and better ecosystem of modules, which makes for a better experience for everyone.

--- a/apps/site/pages/en/blog/uncategorized/jobs-nodejs-org.md
+++ b/apps/site/pages/en/blog/uncategorized/jobs-nodejs-org.md
@@ -3,7 +3,7 @@ date: '2011-03-25T06:05:22.000Z'
 category: uncategorized
 title: jobs.nodejs.org
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 We are starting an official jobs board for Node. There are two goals for this

--- a/apps/site/pages/en/blog/uncategorized/libuv-status-report.md
+++ b/apps/site/pages/en/blog/uncategorized/libuv-status-report.md
@@ -3,7 +3,7 @@ date: '2011-09-23T19:45:50.000Z'
 category: uncategorized
 title: libuv status report
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 We [announced](http://blog.nodejs.org/2011/06/23/porting-node-to-windows-with-microsoft%E2%80%99s-help/) back in July that with Microsoft's support Joyent would be porting Node to Windows. This effort is ongoing but I thought it would be nice to make a status report post about the new platform library [`libuv`](https://github.com/libuv/libuv) which has resulted from porting Node to Windows.

--- a/apps/site/pages/en/blog/uncategorized/node-meetup-this-thursday.md
+++ b/apps/site/pages/en/blog/uncategorized/node-meetup-this-thursday.md
@@ -3,7 +3,7 @@ date: '2011-08-03T04:37:02.000Z'
 category: uncategorized
 title: Node Meetup this Thursday
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 [https://nodejs.org/meetup/](https://nodejs.org/meetup/)

--- a/apps/site/pages/en/blog/uncategorized/node-office-hours-cut-short.md
+++ b/apps/site/pages/en/blog/uncategorized/node-office-hours-cut-short.md
@@ -3,7 +3,7 @@ date: '2011-04-28T16:04:35.000Z'
 category: uncategorized
 title: Node Office Hours Cut Short
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 This week office hours are only from 4pm to 6pm. Isaac will be in the Joyent office in SF - everyone else is out of town. Sign up at http://nodeworkup.eventbrite.com/ if you would like to come.

--- a/apps/site/pages/en/blog/uncategorized/office-hours.md
+++ b/apps/site/pages/en/blog/uncategorized/office-hours.md
@@ -3,7 +3,7 @@ date: '2011-03-24T04:42:47.000Z'
 category: uncategorized
 title: Office Hours
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 Starting next Thursday Isaac, Tom, and I will be holding weekly office hours at [Joyent HQ](http://maps.google.com/maps?q=345+California+St,+San+Francisco,+CA+94104&layer=c&sll=37.793040,-122.400491&cbp=13,178.31,,0,-60.77&cbll=37.793131,-122.400484&hl=en&sspn=0.006295,0.006295&ie=UTF8&hq=&hnear=345+California+St,+San+Francisco,+California+94104&ll=37.793131,-122.400484&spn=0.001295,0.003428&z=19&panoid=h0dlz3VG-hMKlzOu0LxMIg) in San Francisco. Office hours are meant to be subdued working time - there are no talks and no alcohol. Bring your bugs or just come and hack with us.

--- a/apps/site/pages/en/blog/uncategorized/porting-node-to-windows-with-microsofts-help.md
+++ b/apps/site/pages/en/blog/uncategorized/porting-node-to-windows-with-microsofts-help.md
@@ -3,7 +3,7 @@ date: '2011-06-23T22:22:58.000Z'
 category: uncategorized
 title: 'Porting Node to Windows With Microsoft’s Help'
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 I'm pleased to announce that Microsoft is partnering with Joyent in formally contributing resources towards porting Node to Windows. As you may have heard in [a talk](/static/documents/nodeconf.pdf) we gave earlier this year, we have started the undertaking of a native port to Windows - targeting the high-performance IOCP API.

--- a/apps/site/pages/en/blog/uncategorized/some-new-node-projects.md
+++ b/apps/site/pages/en/blog/uncategorized/some-new-node-projects.md
@@ -3,7 +3,7 @@ date: '2011-08-29T15:30:41.000Z'
 category: uncategorized
 title: Some New Node Projects
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 - Superfeedr released [a Node XMPP Server](http://blog.superfeedr.com/node-xmpp-server/). "_Since [astro](http://spaceboyz.net/~astro/) had been doing an **amazing work** with his [node-xmpp](https://github.com/astro/node-xmpp) library to build \_Client_, _Components_ and even _Server to server_ modules, the logical next step was to try to build a _Client to Server_ module so that we could have a full blown server. That’s what we worked on the past couple days, and [it’s now on GitHub](https://github.com/superfeedr/node-xmpp)!\_

--- a/apps/site/pages/en/blog/uncategorized/the-videos-from-node-meetup.md
+++ b/apps/site/pages/en/blog/uncategorized/the-videos-from-node-meetup.md
@@ -3,7 +3,7 @@ date: '2011-08-12T07:14:34.000Z'
 category: uncategorized
 title: The Videos from the Meetup
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 Uber, Voxer, and Joyent described how they use Node in production

--- a/apps/site/pages/en/blog/uncategorized/trademark.md
+++ b/apps/site/pages/en/blog/uncategorized/trademark.md
@@ -3,7 +3,7 @@ date: '2011-04-29T08:54:18.000Z'
 category: uncategorized
 title: Trademark
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 One of the things Joyent accepted when we took on the Node project was to provide resources to help the community grow. The Node project is amazing because of the expertise, dedication and hard work of the community. However in all communities there is the possibility of people acting inappropriately. We decided to introduce trademarks on the “Node.js” and the “Node logo” in order to ensure that people or organizations who are not investing in the Node community misrepresent, or create confusion about the role of themselves or their products with Node.

--- a/apps/site/pages/en/blog/uncategorized/version-0-6.md
+++ b/apps/site/pages/en/blog/uncategorized/version-0-6.md
@@ -3,7 +3,7 @@ date: '2011-10-25T22:26:23.000Z'
 category: uncategorized
 title: Version 0.6 Coming Soon
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 Version 0.6.0 will be released next week. Please spend some time this week upgrading your code to v0.5.10. Report any API differences at <https://github.com/joyent/node/wiki/API-changes-between-v0.4-and-v0.6> or report a bug to us at <http://github.com/joyent/node/issues> if you hit problems.

--- a/apps/site/pages/en/blog/video/welcome-to-the-node-blog.md
+++ b/apps/site/pages/en/blog/video/welcome-to-the-node-blog.md
@@ -3,7 +3,7 @@ date: '2011-03-18T03:17:12.000Z'
 category: video
 title: Welcome to the Node blog
 layout: blog-post
-author: ryandahl
+author: Ryan Dahl
 ---
 
 Since Livejournal is disintegrating into Russian spam, I'm moving my technical blog to <http://blog.nodejs.org/>. I hope to do frequent small posts about what's going on in Node development and include posts from other core Node developers. Please subscribe to the RSS feed.

--- a/apps/site/util/__tests__/authorUtils.test.mjs
+++ b/apps/site/util/__tests__/authorUtils.test.mjs
@@ -61,9 +61,9 @@ describe('getAuthorWithId', () => {
 
     expect(result).toEqual([
       {
-        name: 'The Node.js Project',
+        name: 'Node.js Technical Steering Committee',
         nickname: 'nodejs',
-        fallback: 'TNJP',
+        fallback: 'NJTSC',
         url: 'https://github.com/nodejs',
         image: 'https://avatars.githubusercontent.com/nodejs',
       },

--- a/apps/site/util/__tests__/authorUtils.test.mjs
+++ b/apps/site/util/__tests__/authorUtils.test.mjs
@@ -64,7 +64,7 @@ describe('getAuthorWithId', () => {
         name: 'Node.js Technical Steering Committee',
         nickname: 'nodejs',
         fallback: 'NJTSC',
-        url: 'https://github.com/nodejs',
+        url: 'https://github.com/nodejs/tsc',
         image: 'https://avatars.githubusercontent.com/nodejs',
       },
     ]);


### PR DESCRIPTION
## Description

Clean and normalize  authors in blog

<img width="450" alt="Capture d’écran 2025-04-04 à 10 02 20" src="https://github.com/user-attachments/assets/b7def31b-8801-480a-932b-3741ae7d759a" />
<img width="399" alt="Capture d’écran 2025-04-04 à 10 02 41" src="https://github.com/user-attachments/assets/d315e5ec-964c-4c9f-ae9a-8311281e175f" />
<img width="399" alt="Capture d’écran 2025-04-04 à 10 02 58" src="https://github.com/user-attachments/assets/bd9a0a2e-a2ff-4ab3-a4ab-569641b9012d" />

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
