### PR TITLE
fix(ui): hover active item

### DIFF
--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.module.css
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.module.css
@@ -5,8 +5,10 @@
 .listItem:active {
   @apply aria-current:bg-green-600
     aria-current:text-white
+    aria-current:cursor-default
     flex
     size-10
+    cursor-pointer
     items-center
     justify-center
     rounded-sm
@@ -16,7 +18,7 @@
     motion-safe:transition-colors
     dark:text-neutral-200;
 
-  &:hover {
+  &:hover:not([aria-current='page']) {
     @apply bg-neutral-100
       text-neutral-800
       dark:bg-neutral-900


### PR DESCRIPTION
## Description

without this change when hover active item it's take the style of the over and that's strange

## Related Issues

No Related issues

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run format` to ensure the code follows the style guide.
- [ ] I have run `npm run test` to check if all tests are passing.
- [ ] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
