### PR TITLE
fix: convert incorrect breadcrumb links to opaque spans

### DIFF
--- a/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
@@ -24,6 +24,25 @@ export const Default: Story = {
   },
 };
 
+export const Linkless: Story = {
+  args: {
+    links: [
+      {
+        label: 'Learn',
+        href: '',
+      },
+      {
+        label: 'Getting Started',
+        href: '',
+      },
+      {
+        label: 'Introduction to Node.js',
+        href: '',
+      },
+    ],
+  },
+};
+
 export const Truncate: Story = {
   args: {
     links: [

--- a/packages/ui-components/Common/Breadcrumbs/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.tsx
@@ -51,9 +51,13 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
             hideSeparator={isLastItem}
             position={position + +!hideHome}
           >
-            <BreadcrumbLink as={as} href={link.href} active={isLastItem}>
-              {link.label}
-            </BreadcrumbLink>
+            {link.href ? (
+              <BreadcrumbLink as={as} href={link.href} active={isLastItem}>
+                {link.label}
+              </BreadcrumbLink>
+            ) : (
+              <span className="opacity-70">{link.label}</span>
+            )}
           </BreadcrumbItem>
         );
       }),

--- a/packages/ui-components/Common/Breadcrumbs/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.tsx
@@ -51,8 +51,12 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({
             hideSeparator={isLastItem}
             position={position + +!hideHome}
           >
-            {link.href ? (
-              <BreadcrumbLink as={as} href={link.href} active={isLastItem}>
+            {link.href || isLastItem ? (
+              <BreadcrumbLink
+                as={as}
+                href={link.href || undefined}
+                active={isLastItem}
+              >
                 {link.label}
               </BreadcrumbLink>
             ) : (


### PR DESCRIPTION
## Description

It's pretty minor but I figured I could just open a PR to fix this small UI bug I noticed :slightly_smiling_face: 

The fact is that in pages with breadcrumbs at the bottom of the screen most of the time the first breadcrumbs link is not really a valid link and clicking it results in a hard reload of the app:

See:
![issue](https://github.com/user-attachments/assets/152063f0-c0e2-4f78-8b97-6f2304529aab)

My changes here make breadcrumb items with falsy hrefs simple text elements instead of a links, for good measure they are also dimmed to make it more evident that they are not clickable

## Validation

I manually validated this check with `npm run dev` and also `npm run build && npm run start`


### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
