### PR TITLE
refactor: remove useless promise.all

### DIFF
--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -33,35 +33,33 @@ const generateReleaseData = () => {
     // Basically those not in schedule.json
     const majors = Object.values(nodevuOutput).filter(major => !!major.support);
 
-    const nodeReleases = Promise.all(
-      majors.map(async major => {
-        const [latestVersion] = Object.values(major.releases);
+    const nodeReleases = majors.map(major => {
+      const [latestVersion] = Object.values(major.releases);
 
-        const support = {
-          currentStart: major.support.phases.dates.start,
-          ltsStart: major.support.phases.dates.lts,
-          maintenanceStart: major.support.phases.dates.maintenance,
-          endOfLife: major.support.phases.dates.end,
-        };
+      const support = {
+        currentStart: major.support.phases.dates.start,
+        ltsStart: major.support.phases.dates.lts,
+        maintenanceStart: major.support.phases.dates.maintenance,
+        endOfLife: major.support.phases.dates.end,
+      };
 
-        // Get the major release status based on our Release Schedule
-        const status = getNodeReleaseStatus(new Date(), support);
+      // Get the major release status based on our Release Schedule
+      const status = getNodeReleaseStatus(new Date(), support);
 
-        return {
-          ...support,
-          status,
-          major: latestVersion.semver.major,
-          version: latestVersion.semver.raw,
-          versionWithPrefix: `v${latestVersion.semver.raw}`,
-          codename: major.support.codename || '',
-          isLts: status === 'LTS',
-          npm: latestVersion.dependencies.npm || '',
-          v8: latestVersion.dependencies.v8 || '',
-          releaseDate: latestVersion.releaseDate || '',
-          modules: latestVersion.modules.version || '',
-        };
-      })
-    );
+      return {
+        ...support,
+        status,
+        major: latestVersion.semver.major,
+        version: latestVersion.semver.raw,
+        versionWithPrefix: `v${latestVersion.semver.raw}`,
+        codename: major.support.codename || '',
+        isLts: status === 'LTS',
+        npm: latestVersion.dependencies.npm || '',
+        v8: latestVersion.dependencies.v8 || '',
+        releaseDate: latestVersion.releaseDate || '',
+        modules: latestVersion.modules.version || '',
+      };
+    });
 
     // nodevu returns duplicated v0.x versions (v0.12, v0.10, ...).
     // This behavior seems intentional as the case is hardcoded in nodevu,
@@ -69,9 +67,7 @@ const generateReleaseData = () => {
     // This line ignores those duplicated versions and takes the latest
     // v0.x version (v0.12.18). It is also consistent with the legacy
     // nodejs.org implementation.
-    return nodeReleases.then(releases =>
-      releases.filter(r => r.major !== 0 || r.version === '0.12.18')
-    );
+    return nodeReleases.filter(r => r.major !== 0 || r.version === '0.12.18');
   });
 };
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes useless `Promise.all` since there's nothing async in the loop.

## Validation

```sh 
curl http://localhost:3000/en/next-data/release-data
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
