### PR TITLE
fix(rss): add timestamp to guid

### DIFF
--- a/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
+++ b/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
@@ -26,7 +26,7 @@ describe('generateWebsiteFeeds', () => {
           slug: '/post-1',
           title: 'Post 1',
           author: 'Author 1',
-          date: '2024-02-18',
+          date: '2025-04-18',
           categories: ['all'],
         },
       ],
@@ -36,6 +36,7 @@ describe('generateWebsiteFeeds', () => {
     expect(result.size).toBe(3);
 
     const blogFeed = result.get('blog.xml');
+    const expectedDate = new Date('2025-04-18');
 
     expect(blogFeed.options.id).toBe('blog.xml');
     expect(blogFeed.options.title).toBe('Node.js Blog');
@@ -45,9 +46,10 @@ describe('generateWebsiteFeeds', () => {
     expect(blogFeed.items.length).toBe(1);
     const feedItem = blogFeed.items[0];
     expect(feedItem.id).toBe('/post-1');
+    expect(feedItem.guid).toBe(`/post-1?${expectedDate.getTime()}`);
     expect(feedItem.title).toBe('Post 1');
     expect(feedItem.author).toBe('Author 1');
-    expect(feedItem.date).toEqual(new Date('2024-02-18'));
+    expect(feedItem.date).toEqual(expectedDate);
     expect(feedItem.link).toBe('https://nodejs.org/en/post-1');
   });
 });

--- a/apps/site/next-data/generators/websiteFeeds.mjs
+++ b/apps/site/next-data/generators/websiteFeeds.mjs
@@ -9,6 +9,11 @@ import { siteConfig } from '../../next.json.mjs';
 // with English locale (which is where the website feeds run)
 const canonicalUrl = `${BASE_URL}${BASE_PATH}/en`;
 
+// This is April 16th, 2025, which is around the time that https://github.com/nodejs/nodejs.org/pull/7648
+// was merged. This ensures that future article edits are properly timestamped, while also preventing the
+// currently-published article GUIDs from changing
+const guidTimestampStartDate = 1744662623000;
+
 /**
  * This method generates RSS website feeds based on the current website configuration
  * and the current blog data that is available
@@ -35,13 +40,18 @@ const generateWebsiteFeeds = ({ posts }) => {
         .filter(post => post.categories.includes(category))
         .map(post => {
           const date = new Date(post.date);
+          const time = date.getTime();
+
           return {
             id: post.slug,
             title: post.title,
             author: post.author,
             date,
             link: `${canonicalUrl}${post.slug}`,
-            guid: `${post.slug}?${date.getTime()}`,
+            guid:
+              time > guidTimestampStartDate
+                ? `${post.slug}?${date.getTime()}`
+                : post.slug,
           };
         });
 

--- a/apps/site/next-data/generators/websiteFeeds.mjs
+++ b/apps/site/next-data/generators/websiteFeeds.mjs
@@ -33,13 +33,17 @@ const generateWebsiteFeeds = ({ posts }) => {
 
       const blogFeedEntries = posts
         .filter(post => post.categories.includes(category))
-        .map(post => ({
-          id: post.slug,
-          title: post.title,
-          author: post.author,
-          date: new Date(post.date),
-          link: `${canonicalUrl}${post.slug}`,
-        }));
+        .map(post => {
+          const date = new Date(post.date);
+          return {
+            id: post.slug,
+            title: post.title,
+            author: post.author,
+            date,
+            link: `${canonicalUrl}${post.slug}`,
+            guid: `${post.slug}?${date.getTime()}`,
+          };
+        });
 
       blogFeedEntries.forEach(entry => feed.addItem(entry));
 

--- a/apps/site/next-data/generators/websiteFeeds.mjs
+++ b/apps/site/next-data/generators/websiteFeeds.mjs
@@ -12,7 +12,7 @@ const canonicalUrl = `${BASE_URL}${BASE_PATH}/en`;
 // This is April 16th, 2025, which is around the time that https://github.com/nodejs/nodejs.org/pull/7648
 // was merged. This ensures that future article edits are properly timestamped, while also preventing the
 // currently-published article GUIDs from changing
-const guidTimestampStartDate = 1744662623000;
+const guidTimestampStartDate = 1744761600000;
 
 /**
  * This method generates RSS website feeds based on the current website configuration


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR appends a publishing timestamp to each RSS entry GUID.

My only concern is if this will trigger **every RSS feeder to display these articles again** on merge.

I can set it to only apply to future articles by checking the date?

## Validation

```xml
<item>
  <title>
    <![CDATA[ Node.js Test CI Security Incident ]]>
  </title>
  <link>https://nodejs.org/en/blog/vulnerability/march-2025-ci-incident</link>
  <guid>/blog/vulnerability/march-2025-ci-incident?1743438600617</guid>
  <pubDate>Mon, 31 Mar 2025 16:30:00 GMT</pubDate>
</item>
<item>
```
## Related Issues

Fixes #5996

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
