### PR TITLE
fix(download): Devbox is not supported on Windows

### DIFF
--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -189,7 +189,7 @@ export const INSTALL_METHODS: Array<
   {
     label: InstallationMethodLabel.DEVBOX,
     value: 'DEVBOX',
-    compatibility: { os: ['WIN', 'MAC', 'LINUX'] },
+    compatibility: { os: ['MAC', 'LINUX'] },
     iconImage: <InstallMethodIcons.Devbox width={16} height={16} />,
     url: 'https://jetify.com/devbox/',
     info: 'layouts.download.codeBox.platformInfo.devbox',


### PR DESCRIPTION
DevBox is not supported on Windows without WSL. If you are using WSL, you should refer to the Linux instructions