### PR TITLE
feat(download): include link to releases about page from downloads

### DIFF
--- a/apps/site/pages/en/download/current.mdx
+++ b/apps/site/pages/en/download/current.mdx
@@ -21,9 +21,9 @@ Or get a prebuilt Node.js® for <Release.OperatingSystemDropdown /> running a <R
 
 <section>
 
-Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version.
+Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version, or the <Release.BlogPostLink>blog post</Release.BlogPostLink> for it.
 
-Read the <Release.BlogPostLink>blog post</Release.BlogPostLink> for this version.
+Learn more about [Node.js releases](/about/previous-releases), including the release schedule and LTS status.
 
 Learn how to <LinkWithArrow href="https://github.com/nodejs/node#verifying-binaries">verify</LinkWithArrow> signed SHASUMS.
 

--- a/apps/site/pages/en/download/current.mdx
+++ b/apps/site/pages/en/download/current.mdx
@@ -21,7 +21,7 @@ Or get a prebuilt Node.js® for <Release.OperatingSystemDropdown /> running a <R
 
 <section>
 
-Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version, or the <Release.BlogPostLink>blog post</Release.BlogPostLink> for it.
+Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> or <Release.BlogPostLink>blog post</Release.BlogPostLink> for this version.
 
 Learn more about [Node.js releases](/about/previous-releases), including the release schedule and LTS status.
 

--- a/apps/site/pages/en/download/index.mdx
+++ b/apps/site/pages/en/download/index.mdx
@@ -21,9 +21,9 @@ Or get a prebuilt Node.js® for <Release.OperatingSystemDropdown /> running a <R
 
 <section>
 
-Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version.
+Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version, or the <Release.BlogPostLink>blog post</Release.BlogPostLink> for it.
 
-Read the <Release.BlogPostLink>blog post</Release.BlogPostLink> for this version.
+Learn more about [Node.js releases](/about/previous-releases), including the release schedule and LTS status.
 
 Learn how to <LinkWithArrow href="https://github.com/nodejs/node#verifying-binaries">verify</LinkWithArrow> signed SHASUMS.
 

--- a/apps/site/pages/en/download/index.mdx
+++ b/apps/site/pages/en/download/index.mdx
@@ -21,7 +21,7 @@ Or get a prebuilt Node.js® for <Release.OperatingSystemDropdown /> running a <R
 
 <section>
 
-Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> for this version, or the <Release.BlogPostLink>blog post</Release.BlogPostLink> for it.
+Read the <Release.ChangelogLink>changelog</Release.ChangelogLink> or <Release.BlogPostLink>blog post</Release.BlogPostLink> for this version.
 
 Learn more about [Node.js releases](/about/previous-releases), including the release schedule and LTS status.
 


### PR DESCRIPTION
## Description

Includes a link on the main download page to the about page covering release cycles et al. to help with discovery of this page when users are looking at what version of Node.js to get started with.

## Validation

Access /download, confirm link to /about/previous-releases present and works.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
