### PR TITLE
fix(dep-review): incorrect trigger

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@
 name: Review Dependencies
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
As it currently stands, this workflow is reviewing the main branch for vulnerabilities whenever a PR is opened. Rather, it should be reviewing the PRs. Running on `pull_request` instead will cause this to execute in the context of the PR, rather than the context of the base branch.

Ref: https://github.com/actions/dependency-review-action#installation-standard