### PR TITLE
fix(codecov): don't upload from merge queue

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -142,13 +142,13 @@ jobs:
         run: npm run test:ci
 
       - name: Upload test coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'merge_group' }}
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           files: ./apps/site/lcov.info,./packages/ui-components/lcov.info
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'merge_group' }}
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
         with:
           files: ./apps/site/junit.xml,./packages/ui-components/junit.xml


### PR DESCRIPTION
Workaround for codecov/codecov-action#1733

The process goes like this:

1. The PR is added to the merge queue, triggering the creation of a temporary `gh-readonly-queue/...` branch.
2. A merge commit is generated in preparation for merging into `main`.
3. Codecov uploads the status report. (This PR removes this step)
4. The PR is merged into `main`.
5. Codecov skips another status upload, as the commit status was already uploaded in Step 3 — and therefore thinks the still exists on the `gh-readonly-queue/...` branch.

This causes our UI (https://app.codecov.io/github/nodejs/nodejs.org) to not have any `main` commits showing, but plenty of `gh-readonly-queue` ones.