### PR TITLE
fix(content): broken link in TypeScript runner

### DIFF
--- a/apps/site/pages/en/learn/typescript/run.md
+++ b/apps/site/pages/en/learn/typescript/run.md
@@ -6,7 +6,7 @@ authors: AugustinMauroy
 
 # Running TypeScript with a runner
 
-If you want more advanced processing of TypeScript than the built-in support (or you're using Node.js prior to v22.7.0), you have 2 options: use a runner (which handles much of the complexity for you), or handle it all yourself via [transpilation](./transpile.md).
+If you want more advanced processing of TypeScript than the built-in support (or you're using Node.js prior to v22.7.0), you have 2 options: use a runner (which handles much of the complexity for you), or handle it all yourself via [transpilation](./transpile).
 
 ## Running TypeScript code with `ts-node`
 


### PR DESCRIPTION
# Description
There's a broken link in the [Running TypeScript with a runner](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner) article