### PR TITLE
fix(chromatic): better job name

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -43,7 +43,7 @@ jobs:
         github.event.pull_request.head.ref != 'chore/crowdin'
       )
 
-    name: Tests
+    name: Chromatic
     runs-on: ubuntu-latest
 
     environment:


### PR DESCRIPTION
Looks like the required status checks might confuse the `chromatic` job id with the `Tests` job name. Naming them both Chromatic is probably a better idea