### PR TITLE
add package-lock=true to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 # See bug in peerdeps resolution: https://github.com/npm/cli/issues/2999
 legacy-peer-deps = false
-package-lock=true
+# TODO(@mcollina): Currently, the lockfile is needed to build, so we explicitly require it's use
+package-lock = true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # See bug in peerdeps resolution: https://github.com/npm/cli/issues/2999
 legacy-peer-deps = false
+package-lock=true


### PR DESCRIPTION
As titled. A user can override this with their global `.npmrc` setting.

Note that the project _does not build_ if the deps are not installed from the lockfile.