### PR TITLE
fix(learn): improve `setImmediate` in Promises article

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -367,7 +367,7 @@ console.log('Synchronous task executed');
 
 ### `setImmediate()`
 
-`setImmediate()` is used to execute a callback immediately after all of the current loop's I/O callbacks have completed.
+`setImmediate()` is used to execute a callback after all of the current loop's I/O callbacks have completed.
 
 ```js
 setImmediate(() => {

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -381,7 +381,7 @@ console.log('Synchronous task executed');
 
 - Use `queueMicrotask()` for tasks that need to run immediately after the current script and before any I/O or timer callbacks, typically for Promise resolutions.
 - Use `process.nextTick()` for tasks that should execute before any I/O events, often useful for deferring operations or handling errors synchronously.
-– Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
+  – Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
 
 Because these tasks execute outside of the current synchronous flow, uncaught exceptions inside these callbacks won't be caught by surrounding `try/catch` blocks and may crash the application if not properly managed (e.g., by attaching `.catch()` to Promises or using global error handlers like `process.on('uncaughtException')`).
 

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -367,22 +367,12 @@ console.log('Synchronous task executed');
 
 ### `setImmediate()`
 
-`setImmediate()` schedules its callback for the event loop’s check phase—i.e. it will run immediately after all of the current loop’s I/O callbacks (poll phase) have completed.
+`setImmediate()` is used to execute a callback immediately after all of the current loop's I/O callbacks have completed.
 
 ```js
-const fs = require('fs');
-
 setImmediate(() => {
   console.log('Immediate callback');
 });
-
-fs.readFile('./some.txt', () => {
-  console.log('I/O callback (file read)');
-});
-
-setTimeout(() => {
-  console.log('Timeout callback')
-}, 0)
 
 console.log('Synchronous task executed');
 ```
@@ -391,7 +381,7 @@ console.log('Synchronous task executed');
 
 - Use `queueMicrotask()` for tasks that need to run immediately after the current script and before any I/O or timer callbacks, typically for Promise resolutions.
 - Use `process.nextTick()` for tasks that should execute before any I/O events, often useful for deferring operations or handling errors synchronously.
-– Use `setImmediate()` for tasks that should run after the current event loop’s I/O events, but before timers scheduled for the next loop iteration.
+– Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
 
 Because these tasks execute outside of the current synchronous flow, uncaught exceptions inside these callbacks won't be caught by surrounding `try/catch` blocks and may crash the application if not properly managed (e.g., by attaching `.catch()` to Promises or using global error handlers like `process.on('uncaughtException')`).
 

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -367,7 +367,7 @@ console.log('Synchronous task executed');
 
 ### `setImmediate()`
 
-`setImmediate()` schedules a callback to be executed in the check phase of the Node.js event loop, which runs after the poll phase, where most I/O callbacks are processed.
+`setImmediate()` schedules a callback to be executed in the check phase of the Node.js [event loop](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick), which runs after the poll phase, where most I/O callbacks are processed.
 
 ```js
 setImmediate(() => {

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -381,7 +381,7 @@ console.log('Synchronous task executed');
 
 - Use `queueMicrotask()` for tasks that need to run immediately after the current script and before any I/O or timer callbacks, typically for Promise resolutions.
 - Use `process.nextTick()` for tasks that should execute before any I/O events, often useful for deferring operations or handling errors synchronously.
-  – Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
+- Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
 
 Because these tasks execute outside of the current synchronous flow, uncaught exceptions inside these callbacks won't be caught by surrounding `try/catch` blocks and may crash the application if not properly managed (e.g., by attaching `.catch()` to Promises or using global error handlers like `process.on('uncaughtException')`).
 

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -367,7 +367,7 @@ console.log('Synchronous task executed');
 
 ### `setImmediate()`
 
-`setImmediate()` is used to execute a callback after all of the current loop's I/O callbacks have completed.
+`setImmediate()` schedules a callback to be executed in the check phase of the Node.js event loop, which runs after the poll phase, where most I/O callbacks are processed.
 
 ```js
 setImmediate(() => {
@@ -381,7 +381,7 @@ console.log('Synchronous task executed');
 
 - Use `queueMicrotask()` for tasks that need to run immediately after the current script and before any I/O or timer callbacks, typically for Promise resolutions.
 - Use `process.nextTick()` for tasks that should execute before any I/O events, often useful for deferring operations or handling errors synchronously.
-- Use `setImmediate()` for tasks that should run after the current event loop's I/O events.
+- Use `setImmediate()` for tasks that should run after the poll phase, once most I/O callbacks have been processed.
 
 Because these tasks execute outside of the current synchronous flow, uncaught exceptions inside these callbacks won't be caught by surrounding `try/catch` blocks and may crash the application if not properly managed (e.g., by attaching `.catch()` to Promises or using global error handlers like `process.on('uncaughtException')`).
 

--- a/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
+++ b/apps/site/pages/en/learn/asynchronous-work/discover-promises-in-nodejs.md
@@ -367,12 +367,22 @@ console.log('Synchronous task executed');
 
 ### `setImmediate()`
 
-`setImmediate()` is used to execute a callback after the current event loop cycle finishes and all I/O events have been processed. This means that `setImmediate()` callbacks run after any I/O callbacks, but before timers.
+`setImmediate()` schedules its callback for the event loop’s check phase—i.e. it will run immediately after all of the current loop’s I/O callbacks (poll phase) have completed.
 
 ```js
+const fs = require('fs');
+
 setImmediate(() => {
   console.log('Immediate callback');
 });
+
+fs.readFile('./some.txt', () => {
+  console.log('I/O callback (file read)');
+});
+
+setTimeout(() => {
+  console.log('Timeout callback')
+}, 0)
 
 console.log('Synchronous task executed');
 ```
@@ -381,7 +391,7 @@ console.log('Synchronous task executed');
 
 - Use `queueMicrotask()` for tasks that need to run immediately after the current script and before any I/O or timer callbacks, typically for Promise resolutions.
 - Use `process.nextTick()` for tasks that should execute before any I/O events, often useful for deferring operations or handling errors synchronously.
-- Use `setImmediate()` for tasks that should run after I/O events but before timers.
+– Use `setImmediate()` for tasks that should run after the current event loop’s I/O events, but before timers scheduled for the next loop iteration.
 
 Because these tasks execute outside of the current synchronous flow, uncaught exceptions inside these callbacks won't be caught by surrounding `try/catch` blocks and may crash the application if not properly managed (e.g., by attaching `.catch()` to Promises or using global error handlers like `process.on('uncaughtException')`).
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates the documentation for setImmediate() to provide a more accurate and precise explanation of its behavior within the Node.js event loop. The new description clarifies that setImmediate() callbacks run during the check phase, immediately after I/O callbacks (poll phase), and helps distinguish its timing relative to other asynchronous mechanisms like setTimeout().

It also refines the usage guidance in the "When to Use Each" section, removing redundant and potentially confusing statements.

## Validation

The example code has been reviewed to correctly reflect the behavior of setImmediate() in relation to I/O and timers.

Reviewers should verify that the updated explanation is both technically correct and clearly communicates when and why to use setImmediate(). No functional or visual changes—only documentation improvements.

## Related Issues

Fixes: https://github.com/nodejs/node/issues/57993

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run format` to ensure the code follows the style guide.
- [x] I have run `npm run test` to check if all tests are passing.
- [x] I have run `npx turbo build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
