### PR TITLE
fix(learn): improve 'Understanding process.nextTick()' doc page example code.

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -31,11 +31,11 @@ Use `nextTick()` when you want to make sure that in the next event loop iteratio
 console.log('Hello => number 1');
 
 setImmediate(() => {
-  console.log('Running before the timeout => number 3');
+  console.log('Running at order 3 or 4, setImmediate');
 });
 
 setTimeout(() => {
-  console.log('The timeout running last => number 4');
+  console.log('Running at order 3 or 4, setTimeout');
 }, 0);
 
 process.nextTick(() => {
@@ -43,13 +43,13 @@ process.nextTick(() => {
 });
 ```
 
-#### Example output:
+#### Example output(possible):
 
 ```bash
 Hello => number 1
 Running at next tick => number 2
-Running before the timeout => number 3
-The timeout running last => number 4
+Running at order 3 or 4, setImmediate
+Running at order 3 or 4, setTimeout
 ```
 
-The exact output may differ from run to run.
+The exact output may differ from run to run. [setImmediate vs setTimeout](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout) explain the reason.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The ['Understanding process.nextTick()' doc](https://nodejs.org/en/learn/asynchronous-work/understanding-processnexttick) have one messy example code and example ouput caused by [setImmediate() vs setTimeout()](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout). Example code in that doc saying that setImmediate will always have higher order been executed, which may confused for the readers
<!-- Write a brief description of the changes introduced by this PR -->

## Validation
The example code has been reviewed to correctly reflect the behavior of the executed order for both setImmediate and setTimeout.
Reviewers should verify that the updated explanation is both technically correct and clearly communicates. No functional or visual changes—only documentation improvements.

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Fixes nodejs/node#58000
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [yes] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [yes] I have run `npm run format` to ensure the code follows the style guide.
- [yes] I have run `npm run test` to check if all tests are passing.
- [yes] I have run `npx turbo build` to check if the website builds without errors.
- [yes] I've covered new added functionality with unit tests if necessary.
