### PR TITLE
fix(learn): improve the learn Asynchronous Work doc

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -31,11 +31,11 @@ Use `nextTick()` when you want to make sure that in the next event loop iteratio
 console.log('Hello => number 1');
 
 setImmediate(() => {
-  console.log('Running before the timeout => number 3');
+  console.log('Running at order 3 or 4, setImmediate');
 });
 
 setTimeout(() => {
-  console.log('The timeout running last => number 4');
+  console.log('Running at order 3 or 4, setTimeout');
 }, 0);
 
 process.nextTick(() => {
@@ -43,13 +43,13 @@ process.nextTick(() => {
 });
 ```
 
-#### Example output:
+#### Example output(possible):
 
 ```bash
 Hello => number 1
 Running at next tick => number 2
-Running before the timeout => number 3
-The timeout running last => number 4
+Running at order 3 or 4, setImmediate
+Running at order 3 or 4, setTimeout
 ```
 
-The exact output may differ from run to run.
+The exact output may differ from run to run. [setImmediate vs setTimeout](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout) explain the reason.

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -54,4 +54,4 @@ Running at order 3 or 4, setTimeout
 
 In that case, `console.log('Hello => number 1');` will first run because event loop only starts after call stack is cleared.The `nextTick` queue is processed before entering the next phase, which is why the `process.nextTick()` callback runs immediately after.
 
-The execution order of `serImmediate` and `setTimeout` can not be determined in the main module. For a detailed explanation, refer to [setImmediate vs setTimeout](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout).
+The execution order of `setImmediate()` and `setTimeout()` can very based on the execution contexts. For more information, refer to [`setImmediate()` vs `setTimeout()`](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout).

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -25,4 +25,4 @@ Calling `setTimeout(() => {}, 0)` will execute the function at the end of next t
 
 Use `nextTick()` when you want to make sure that in the next event loop iteration that code is already executed.
 
-To learn more about the order of execution and how the event loop works, check out [the dedicated article](learn/asynchronous-work/event-loop-timers-and-nexttick)
+To learn more about the order of execution and how the event loop works, check out [the dedicated article](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick)

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -25,7 +25,7 @@ Calling `setTimeout(() => {}, 0)` will execute the function at the end of next t
 
 Use `nextTick()` when you want to make sure that in the next event loop iteration that code is already executed.
 
-#### An Example of the order of events:
+#### An Example of the [order of events](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick):
 
 ```js
 console.log('Hello => number 1');

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -52,4 +52,6 @@ Running at order 3 or 4, setImmediate
 Running at order 3 or 4, setTimeout
 ```
 
-The exact output may differ from run to run. [setImmediate vs setTimeout](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout) explain the reason.
+In that case, `console.log('Hello => number 1');` will first run because event loop only starts after call stack is cleared.The `nextTick` queue is processed before entering the next phase, which is why the `process.nextTick()` callback runs immediately after.
+
+The execution order of `serImmediate` and `setTimeout` can not be determined in the main module. For a detailed explanation, refer to [setImmediate vs setTimeout](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout).

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -25,4 +25,4 @@ Calling `setTimeout(() => {}, 0)` will execute the function at the end of next t
 
 Use `nextTick()` when you want to make sure that in the next event loop iteration that code is already executed.
 
-For more details on the order of events, refer to [Event loop](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick).
+To learn more about the order of execution and how the event loop works, check out [the dedicated article](learn/asynchronous-work/event-loop-timers-and-nexttick)

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -25,33 +25,4 @@ Calling `setTimeout(() => {}, 0)` will execute the function at the end of next t
 
 Use `nextTick()` when you want to make sure that in the next event loop iteration that code is already executed.
 
-#### An Example of the [order of events](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick):
-
-```js
-console.log('Hello => number 1');
-
-setImmediate(() => {
-  console.log('Running at order 3 or 4, setImmediate');
-});
-
-setTimeout(() => {
-  console.log('Running at order 3 or 4, setTimeout');
-}, 0);
-
-process.nextTick(() => {
-  console.log('Running at next tick => number 2');
-});
-```
-
-#### Example output(possible):
-
-```bash
-Hello => number 1
-Running at next tick => number 2
-Running at order 3 or 4, setImmediate
-Running at order 3 or 4, setTimeout
-```
-
-In that case, `console.log('Hello => number 1');` will first run because event loop only starts after call stack is cleared.The `nextTick` queue is processed before entering the next phase, which is why the `process.nextTick()` callback runs immediately after.
-
-The execution order of `setImmediate()` and `setTimeout()` can very based on the execution contexts. For more information, refer to [`setImmediate()` vs `setTimeout()`](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout).
+For more details on the order of events, refer to [Event loop](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick).


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The ['Understanding process.nextTick()' doc](https://nodejs.org/en/learn/asynchronous-work/understanding-processnexttick) have one messy example code and example ouput caused by [setImmediate() vs setTimeout()](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout). Example code in that doc saying that setImmediate will always have higher order been executed, which may confused for the readers
<!-- Write a brief description of the changes introduced by this PR -->

## Validation
The example code has been reviewed to correctly reflect the behavior of the executed order for both setImmediate and setTimeout.
Reviewers should verify that the updated explanation is both technically correct and clearly communicates. No functional or visual changes—only documentation improvements.
<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
nodejs/nodejs.org#7681
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [Yes] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [Yes] I have run `npm run format` to ensure the code follows the style guide.
- [Yes] I have run `npm run test` to check if all tests are passing.
- [Yes] I have run `npx turbo build` to check if the website builds without errors.
- [Yes] I've covered new added functionality with unit tests if necessary.
