### PR TITLE
chore(const): add IS_NOT_VERCEL_RUNTIME_ENV

### DIFF
--- a/apps/site/next-data/blogData.ts
+++ b/apps/site/next-data/blogData.ts
@@ -1,9 +1,7 @@
 import {
   ENABLE_STATIC_EXPORT,
-  IS_DEV_ENV,
   NEXT_DATA_URL,
-  VERCEL_ENV,
-  VERCEL_REGION,
+  IS_NOT_VERCEL_RUNTIME_ENV,
 } from '@/next.constants.mjs';
 import type { BlogCategory, BlogPostsRSC } from '@/types';
 
@@ -11,10 +9,6 @@ const getBlogData = (
   cat: BlogCategory,
   page?: number
 ): Promise<BlogPostsRSC> => {
-  const IS_NOT_VERCEL_RUNTIME_ENV =
-    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
-    (!IS_DEV_ENV && !VERCEL_ENV);
-
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load
   // the data directly within the current thread, which will anyways be loaded only once

--- a/apps/site/next-data/downloadSnippets.ts
+++ b/apps/site/next-data/downloadSnippets.ts
@@ -1,9 +1,7 @@
 import {
   ENABLE_STATIC_EXPORT,
-  IS_DEV_ENV,
   NEXT_DATA_URL,
-  VERCEL_ENV,
-  VERCEL_REGION,
+  IS_NOT_VERCEL_RUNTIME_ENV,
 } from '@/next.constants.mjs';
 import { availableLocaleCodes } from '@/next.locales.mjs';
 import type { DownloadSnippet } from '@/types';
@@ -16,10 +14,6 @@ export default async function getDownloadSnippets(
   if (!availableLocaleCodes.includes(lang)) {
     return [];
   }
-
-  const IS_NOT_VERCEL_RUNTIME_ENV =
-    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
-    (!IS_DEV_ENV && !VERCEL_ENV);
 
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load

--- a/apps/site/next-data/releaseData.ts
+++ b/apps/site/next-data/releaseData.ts
@@ -1,17 +1,11 @@
 import {
   ENABLE_STATIC_EXPORT,
-  IS_DEV_ENV,
   NEXT_DATA_URL,
-  VERCEL_ENV,
-  VERCEL_REGION,
+  IS_NOT_VERCEL_RUNTIME_ENV,
 } from '@/next.constants.mjs';
 import type { NodeRelease } from '@/types';
 
 const getReleaseData = (): Promise<Array<NodeRelease>> => {
-  const IS_NOT_VERCEL_RUNTIME_ENV =
-    (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) ||
-    (!IS_DEV_ENV && !VERCEL_ENV);
-
   // When we're using Static Exports the Next.js Server is not running (during build-time)
   // hence the self-ingestion APIs will not be available. In this case we want to load
   // the data directly within the current thread, which will anyways be loaded only once

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -23,6 +23,15 @@ export const VERCEL_ENV = process.env.VERCEL_ENV || undefined;
  */
 export const VERCEL_REGION = process.env.VERCEL_REGION || undefined;
 
+/**
+ * This constant determines if the current environment is NOT a Vercel runtime environment.
+ *
+ * The logic is as follows:
+ * - If we are NOT in a development environment (`!IS_DEV_ENV`) AND:
+ *   - Vercel environment variable (`VERCEL_ENV`) is defined but the Vercel region (`VERCEL_REGION`) is NOT defined, OR
+ *   - Vercel environment variable (`VERCEL_ENV`) is NOT defined at all.
+ * This helps identify cases where the application is running outside of Vercel's runtime environment.
+ */
 export const IS_NOT_VERCEL_RUNTIME_ENV =
   (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) || (!IS_DEV_ENV && !VERCEL_ENV);
 

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -23,6 +23,9 @@ export const VERCEL_ENV = process.env.VERCEL_ENV || undefined;
  */
 export const VERCEL_REGION = process.env.VERCEL_REGION || undefined;
 
+export const IS_NOT_VERCEL_RUNTIME_ENV =
+  (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) || (!IS_DEV_ENV && !VERCEL_ENV);
+
 /**
  * This is used for telling Next.js to do a Static Export Build of the Website
  *

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -33,7 +33,7 @@ export const VERCEL_REGION = process.env.VERCEL_REGION || undefined;
  * This helps identify cases where the application is running outside of Vercel's runtime environment.
  */
 export const IS_NOT_VERCEL_RUNTIME_ENV =
-  (!IS_DEV_ENV && VERCEL_ENV && !VERCEL_REGION) || (!IS_DEV_ENV && !VERCEL_ENV);
+  !IS_DEV_ENV && ((VERCEL_ENV && !VERCEL_REGION) || !VERCEL_ENV);
 
 /**
  * This is used for telling Next.js to do a Static Export Build of the Website


### PR DESCRIPTION
We use this in several places, so it should be a constant, no?

https://en.wikipedia.org/wiki/Don%27t_repeat_yourself