### PR TITLE
fix(chromatic): run if a user adds the label to a Dependabot PR

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -31,12 +31,11 @@ jobs:
   chromatic:
     # We only need to run Storybook Builds and Storybook Visual Regression Tests within Pull Requests that actually
     # introduce changes to the Storybook. Hence, we skip running these on Crowdin PRs and Dependabot PRs
-    # sha reference has no stable git tag reference or URL. see https://github.com/chromaui/chromatic-cli/issues/797
     if: |
       github.event_name != 'pull_request_target' ||
       (
         github.event.label.name == 'github_actions:pull-request' &&
-        startsWith(github.event.pull_request.head.ref, 'dependabot/') == false &&
+        github.actor == 'dependabot[bot]' &&
         github.event.pull_request.head.ref != 'chore/crowdin'
       )
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -35,7 +35,7 @@ jobs:
       github.event_name != 'pull_request_target' ||
       (
         github.event.label.name == 'github_actions:pull-request' &&
-        github.actor == 'dependabot[bot]' &&
+        github.actor != 'dependabot[bot]' &&
         github.event.pull_request.head.ref != 'chore/crowdin'
       )
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/nodejs.org/issues/7709

---

Maintainers can now manually re-add the trigger label to Dependabot PRs to run Storybook if needed. These workflows still won’t run automatically, as the upgrades aren’t always necessary.

