### PR TITLE
chore: use subpath imports instead of path aliases

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -356,7 +356,7 @@ To add a new download installation method, follow these steps:
    }
    ```
 
-3. **Update `InstallationMethodLabel` and `InstallationMethod` in `@/types/release.ts`:**
+3. **Update `InstallationMethodLabel` and `InstallationMethod` in `apps/site/types/release.ts`:**
 
    - Add the new method to the `InstallationMethodLabel` and `InstallationMethod` types.
 

--- a/apps/site/app/[locale]/[...path]/page.tsx
+++ b/apps/site/app/[locale]/[...path]/page.tsx
@@ -7,13 +7,13 @@
  * dynamic params, which will lead on static export errors and other sort of issues.
  */
 
-import * as basePage from '@/app/[locale]/page';
+import * as basePage from '#app/[locale]/page';
 import {
   ENABLE_STATIC_EXPORT_LOCALE,
   ENABLE_STATIC_EXPORT,
-} from '@/next.constants.mjs';
-import { dynamicRouter } from '@/next.dynamic.mjs';
-import { availableLocaleCodes, defaultLocale } from '@/next.locales.mjs';
+} from '#next.constants.mjs';
+import { dynamicRouter } from '#next.dynamic.mjs';
+import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
 
 // This is the default Viewport Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-viewport#generateviewport-function

--- a/apps/site/app/[locale]/[...path]/page.tsx
+++ b/apps/site/app/[locale]/[...path]/page.tsx
@@ -7,13 +7,13 @@
  * dynamic params, which will lead on static export errors and other sort of issues.
  */
 
-import * as basePage from '#app/[locale]/page';
+import * as basePage from '#site/app/[locale]/page';
 import {
   ENABLE_STATIC_EXPORT_LOCALE,
   ENABLE_STATIC_EXPORT,
-} from '#next.constants.mjs';
-import { dynamicRouter } from '#next.dynamic.mjs';
-import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
+} from '#site/next.constants.mjs';
+import { dynamicRouter } from '#site/next.dynamic.mjs';
+import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
 // This is the default Viewport Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-viewport#generateviewport-function

--- a/apps/site/app/[locale]/error.tsx
+++ b/apps/site/app/[locale]/error.tsx
@@ -4,8 +4,8 @@ import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Button from '@/components/Common/Button';
-import GlowingBackdropLayout from '@/layouts/GlowingBackdrop';
+import Button from '#components/Common/Button';
+import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
 
 const ErrorPage: FC<{ error: Error }> = () => {
   const t = useTranslations();

--- a/apps/site/app/[locale]/error.tsx
+++ b/apps/site/app/[locale]/error.tsx
@@ -4,8 +4,8 @@ import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Button from '#components/Common/Button';
-import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
+import Button from '#site/components/Common/Button';
+import GlowingBackdropLayout from '#site/layouts/GlowingBackdrop';
 
 const ErrorPage: FC<{ error: Error }> = () => {
   const t = useTranslations();

--- a/apps/site/app/[locale]/feed/[feed]/route.ts
+++ b/apps/site/app/[locale]/feed/[feed]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import provideWebsiteFeeds from '@/next-data/providers/websiteFeeds';
-import { siteConfig } from '@/next.json.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
+import provideWebsiteFeeds from '#next-data/providers/websiteFeeds';
+import { siteConfig } from '#next.json.mjs';
+import { defaultLocale } from '#next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string; feed: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/[locale]/feed/[feed]/route.ts
+++ b/apps/site/app/[locale]/feed/[feed]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import provideWebsiteFeeds from '#next-data/providers/websiteFeeds';
-import { siteConfig } from '#next.json.mjs';
-import { defaultLocale } from '#next.locales.mjs';
+import provideWebsiteFeeds from '#site/next-data/providers/websiteFeeds';
+import { siteConfig } from '#site/next.json.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string; feed: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -4,13 +4,13 @@ import classNames from 'classnames';
 import { NextIntlClientProvider } from 'next-intl';
 import type { FC, PropsWithChildren } from 'react';
 
-import BaseLayout from '#layouts/Base';
-import { VERCEL_ENV } from '#next.constants.mjs';
-import { IBM_PLEX_MONO, OPEN_SANS } from '#next.fonts';
-import { availableLocalesMap, defaultLocale } from '#next.locales.mjs';
-import { ThemeProvider } from '#providers/themeProvider';
+import BaseLayout from '#site/layouts/Base';
+import { VERCEL_ENV } from '#site/next.constants.mjs';
+import { IBM_PLEX_MONO, OPEN_SANS } from '#site/next.fonts';
+import { availableLocalesMap, defaultLocale } from '#site/next.locales.mjs';
+import { ThemeProvider } from '#site/providers/themeProvider';
 
-import '#styles/index.css';
+import '#site/styles/index.css';
 
 const fontClasses = classNames(IBM_PLEX_MONO.variable, OPEN_SANS.variable);
 

--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -4,13 +4,13 @@ import classNames from 'classnames';
 import { NextIntlClientProvider } from 'next-intl';
 import type { FC, PropsWithChildren } from 'react';
 
-import BaseLayout from '@/layouts/Base';
-import { VERCEL_ENV } from '@/next.constants.mjs';
-import { IBM_PLEX_MONO, OPEN_SANS } from '@/next.fonts';
-import { availableLocalesMap, defaultLocale } from '@/next.locales.mjs';
-import { ThemeProvider } from '@/providers/themeProvider';
+import BaseLayout from '#layouts/Base';
+import { VERCEL_ENV } from '#next.constants.mjs';
+import { IBM_PLEX_MONO, OPEN_SANS } from '#next.fonts';
+import { availableLocalesMap, defaultLocale } from '#next.locales.mjs';
+import { ThemeProvider } from '#providers/themeProvider';
 
-import '@/styles/index.css';
+import '#styles/index.css';
 
 const fontClasses = classNames(IBM_PLEX_MONO.variable, OPEN_SANS.variable);
 

--- a/apps/site/app/[locale]/next-data/api-data/route.ts
+++ b/apps/site/app/[locale]/next-data/api-data/route.ts
@@ -1,11 +1,11 @@
 import { deflateSync } from 'node:zlib';
 
-import provideReleaseData from '@/next-data/providers/releaseData';
-import { GITHUB_API_KEY } from '@/next.constants.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
-import type { GitHubApiFile } from '@/types';
-import { getGitHubApiDocsUrl } from '@/util/gitHubUtils';
-import { parseRichTextIntoPlainText } from '@/util/stringUtils';
+import provideReleaseData from '#next-data/providers/releaseData';
+import { GITHUB_API_KEY } from '#next.constants.mjs';
+import { defaultLocale } from '#next.locales.mjs';
+import type { GitHubApiFile } from '#types';
+import { getGitHubApiDocsUrl } from '#util/gitHubUtils';
+import { parseRichTextIntoPlainText } from '#util/stringUtils';
 
 // Defines if we should use the GitHub API Key for the request
 // based on the environment variable `GITHUB_API_KEY`

--- a/apps/site/app/[locale]/next-data/api-data/route.ts
+++ b/apps/site/app/[locale]/next-data/api-data/route.ts
@@ -1,11 +1,11 @@
 import { deflateSync } from 'node:zlib';
 
-import provideReleaseData from '#next-data/providers/releaseData';
-import { GITHUB_API_KEY } from '#next.constants.mjs';
-import { defaultLocale } from '#next.locales.mjs';
-import type { GitHubApiFile } from '#types';
-import { getGitHubApiDocsUrl } from '#util/gitHubUtils';
-import { parseRichTextIntoPlainText } from '#util/stringUtils';
+import provideReleaseData from '#site/next-data/providers/releaseData';
+import { GITHUB_API_KEY } from '#site/next.constants.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
+import type { GitHubApiFile } from '#site/types';
+import { getGitHubApiDocsUrl } from '#site/util/gitHubUtils';
+import { parseRichTextIntoPlainText } from '#site/util/stringUtils';
 
 // Defines if we should use the GitHub API Key for the request
 // based on the environment variable `GITHUB_API_KEY`

--- a/apps/site/app/[locale]/next-data/blog-data/[category]/[page]/route.ts
+++ b/apps/site/app/[locale]/next-data/blog-data/[category]/[page]/route.ts
@@ -1,9 +1,9 @@
 import {
   provideBlogPosts,
   providePaginatedBlogPosts,
-} from '#next-data/providers/blogData';
-import { defaultLocale } from '#next.locales.mjs';
-import type { BlogCategory } from '#types';
+} from '#site/next-data/providers/blogData';
+import { defaultLocale } from '#site/next.locales.mjs';
+import type { BlogCategory } from '#site/types';
 
 type DynamicStaticPaths = {
   locale: string;

--- a/apps/site/app/[locale]/next-data/blog-data/[category]/[page]/route.ts
+++ b/apps/site/app/[locale]/next-data/blog-data/[category]/[page]/route.ts
@@ -1,9 +1,9 @@
 import {
   provideBlogPosts,
   providePaginatedBlogPosts,
-} from '@/next-data/providers/blogData';
-import { defaultLocale } from '@/next.locales.mjs';
-import type { BlogCategory } from '@/types';
+} from '#next-data/providers/blogData';
+import { defaultLocale } from '#next.locales.mjs';
+import type { BlogCategory } from '#types';
 
 type DynamicStaticPaths = {
   locale: string;

--- a/apps/site/app/[locale]/next-data/download-snippets/route.tsx
+++ b/apps/site/app/[locale]/next-data/download-snippets/route.tsx
@@ -1,5 +1,5 @@
-import provideDownloadSnippets from '@/next-data/providers/downloadSnippets';
-import { defaultLocale } from '@/next.locales.mjs';
+import provideDownloadSnippets from '#next-data/providers/downloadSnippets';
+import { defaultLocale } from '#next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/[locale]/next-data/download-snippets/route.tsx
+++ b/apps/site/app/[locale]/next-data/download-snippets/route.tsx
@@ -1,5 +1,5 @@
-import provideDownloadSnippets from '#next-data/providers/downloadSnippets';
-import { defaultLocale } from '#next.locales.mjs';
+import provideDownloadSnippets from '#site/next-data/providers/downloadSnippets';
+import { defaultLocale } from '#site/next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/[locale]/next-data/og/[category]/[title]/route.tsx
+++ b/apps/site/app/[locale]/next-data/og/[category]/[title]/route.tsx
@@ -2,9 +2,9 @@ import HexagonGrid from '@node-core/ui-components/Icons/HexagonGrid';
 import JsWhiteIcon from '@node-core/ui-components/Icons/Logos/JsWhite';
 import { ImageResponse } from 'next/og';
 
-import { DEFAULT_CATEGORY_OG_TYPE } from '#next.constants.mjs';
-import { defaultLocale } from '#next.locales.mjs';
-import { hexToRGBA } from '#util/hexToRGBA';
+import { DEFAULT_CATEGORY_OG_TYPE } from '#site/next.constants.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
+import { hexToRGBA } from '#site/util/hexToRGBA';
 
 // TODO: use CSS variables instead of absolute values
 const CATEGORY_TO_THEME_COLOUR_MAP = {

--- a/apps/site/app/[locale]/next-data/og/[category]/[title]/route.tsx
+++ b/apps/site/app/[locale]/next-data/og/[category]/[title]/route.tsx
@@ -2,9 +2,9 @@ import HexagonGrid from '@node-core/ui-components/Icons/HexagonGrid';
 import JsWhiteIcon from '@node-core/ui-components/Icons/Logos/JsWhite';
 import { ImageResponse } from 'next/og';
 
-import { DEFAULT_CATEGORY_OG_TYPE } from '@/next.constants.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
-import { hexToRGBA } from '@/util/hexToRGBA';
+import { DEFAULT_CATEGORY_OG_TYPE } from '#next.constants.mjs';
+import { defaultLocale } from '#next.locales.mjs';
+import { hexToRGBA } from '#util/hexToRGBA';
 
 // TODO: use CSS variables instead of absolute values
 const CATEGORY_TO_THEME_COLOUR_MAP = {

--- a/apps/site/app/[locale]/next-data/page-data/route.ts
+++ b/apps/site/app/[locale]/next-data/page-data/route.ts
@@ -2,9 +2,9 @@ import { deflateSync } from 'node:zlib';
 
 import matter from 'gray-matter';
 
-import { dynamicRouter } from '@/next.dynamic.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
-import { parseRichTextIntoPlainText } from '@/util/stringUtils';
+import { dynamicRouter } from '#next.dynamic.mjs';
+import { defaultLocale } from '#next.locales.mjs';
+import { parseRichTextIntoPlainText } from '#util/stringUtils';
 
 // This is the Route Handler for the `GET` method which handles the request
 // for a digest and metadata of all existing pages on Node.js Website

--- a/apps/site/app/[locale]/next-data/page-data/route.ts
+++ b/apps/site/app/[locale]/next-data/page-data/route.ts
@@ -2,9 +2,9 @@ import { deflateSync } from 'node:zlib';
 
 import matter from 'gray-matter';
 
-import { dynamicRouter } from '#next.dynamic.mjs';
-import { defaultLocale } from '#next.locales.mjs';
-import { parseRichTextIntoPlainText } from '#util/stringUtils';
+import { dynamicRouter } from '#site/next.dynamic.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
+import { parseRichTextIntoPlainText } from '#site/util/stringUtils';
 
 // This is the Route Handler for the `GET` method which handles the request
 // for a digest and metadata of all existing pages on Node.js Website

--- a/apps/site/app/[locale]/next-data/release-data/route.ts
+++ b/apps/site/app/[locale]/next-data/release-data/route.ts
@@ -1,5 +1,5 @@
-import provideReleaseData from '@/next-data/providers/releaseData';
-import { defaultLocale } from '@/next.locales.mjs';
+import provideReleaseData from '#next-data/providers/releaseData';
+import { defaultLocale } from '#next.locales.mjs';
 
 // This is the Route Handler for the `GET` method which handles the request
 // for generating static data related to the Node.js Release Data

--- a/apps/site/app/[locale]/next-data/release-data/route.ts
+++ b/apps/site/app/[locale]/next-data/release-data/route.ts
@@ -1,5 +1,5 @@
-import provideReleaseData from '#next-data/providers/releaseData';
-import { defaultLocale } from '#next.locales.mjs';
+import provideReleaseData from '#site/next-data/providers/releaseData';
+import { defaultLocale } from '#site/next.locales.mjs';
 
 // This is the Route Handler for the `GET` method which handles the request
 // for generating static data related to the Node.js Release Data

--- a/apps/site/app/[locale]/not-found.tsx
+++ b/apps/site/app/[locale]/not-found.tsx
@@ -5,8 +5,8 @@ import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Button from '@/components/Common/Button';
-import GlowingBackdropLayout from '@/layouts/GlowingBackdrop';
+import Button from '#components/Common/Button';
+import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
 
 const NotFoundPage: FC = () => {
   const t = useTranslations();

--- a/apps/site/app/[locale]/not-found.tsx
+++ b/apps/site/app/[locale]/not-found.tsx
@@ -5,8 +5,8 @@ import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Button from '#components/Common/Button';
-import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
+import Button from '#site/components/Common/Button';
+import GlowingBackdropLayout from '#site/layouts/GlowingBackdrop';
 
 const NotFoundPage: FC = () => {
   const t = useTranslations();

--- a/apps/site/app/[locale]/page.tsx
+++ b/apps/site/app/[locale]/page.tsx
@@ -11,17 +11,17 @@ import { notFound, redirect } from 'next/navigation';
 import { setRequestLocale } from 'next-intl/server';
 import type { FC } from 'react';
 
-import { setClientContext } from '@/client-context';
-import WithLayout from '@/components/withLayout';
+import { setClientContext } from '#client-context';
+import WithLayout from '#components/withLayout';
 import {
   ENABLE_STATIC_EXPORT_LOCALE,
   ENABLE_STATIC_EXPORT,
-} from '@/next.constants.mjs';
-import { PAGE_VIEWPORT, DYNAMIC_ROUTES } from '@/next.dynamic.constants.mjs';
-import { dynamicRouter } from '@/next.dynamic.mjs';
-import { allLocaleCodes, availableLocaleCodes } from '@/next.locales.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
-import { MatterProvider } from '@/providers/matterProvider';
+} from '#next.constants.mjs';
+import { PAGE_VIEWPORT, DYNAMIC_ROUTES } from '#next.dynamic.constants.mjs';
+import { dynamicRouter } from '#next.dynamic.mjs';
+import { allLocaleCodes, availableLocaleCodes } from '#next.locales.mjs';
+import { defaultLocale } from '#next.locales.mjs';
+import { MatterProvider } from '#providers/matterProvider';
 
 type DynamicStaticPaths = { path: Array<string>; locale: string };
 type DynamicParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/[locale]/page.tsx
+++ b/apps/site/app/[locale]/page.tsx
@@ -11,17 +11,20 @@ import { notFound, redirect } from 'next/navigation';
 import { setRequestLocale } from 'next-intl/server';
 import type { FC } from 'react';
 
-import { setClientContext } from '#client-context';
-import WithLayout from '#components/withLayout';
+import { setClientContext } from '#site/client-context';
+import WithLayout from '#site/components/withLayout';
 import {
   ENABLE_STATIC_EXPORT_LOCALE,
   ENABLE_STATIC_EXPORT,
-} from '#next.constants.mjs';
-import { PAGE_VIEWPORT, DYNAMIC_ROUTES } from '#next.dynamic.constants.mjs';
-import { dynamicRouter } from '#next.dynamic.mjs';
-import { allLocaleCodes, availableLocaleCodes } from '#next.locales.mjs';
-import { defaultLocale } from '#next.locales.mjs';
-import { MatterProvider } from '#providers/matterProvider';
+} from '#site/next.constants.mjs';
+import {
+  PAGE_VIEWPORT,
+  DYNAMIC_ROUTES,
+} from '#site/next.dynamic.constants.mjs';
+import { dynamicRouter } from '#site/next.dynamic.mjs';
+import { allLocaleCodes, availableLocaleCodes } from '#site/next.locales.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
+import { MatterProvider } from '#site/providers/matterProvider';
 
 type DynamicStaticPaths = { path: Array<string>; locale: string };
 type DynamicParams = { params: Promise<DynamicStaticPaths> };

--- a/apps/site/app/global-error.tsx
+++ b/apps/site/app/global-error.tsx
@@ -3,9 +3,9 @@
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
-import Button from '#components/Common/Button';
-import BaseLayout from '#layouts/Base';
-import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
+import Button from '#site/components/Common/Button';
+import BaseLayout from '#site/layouts/Base';
+import GlowingBackdropLayout from '#site/layouts/GlowingBackdrop';
 
 const GlobalErrorPage: FC<{ error: Error }> = () => (
   <html>

--- a/apps/site/app/global-error.tsx
+++ b/apps/site/app/global-error.tsx
@@ -3,9 +3,9 @@
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
-import Button from '@/components/Common/Button';
-import BaseLayout from '@/layouts/Base';
-import GlowingBackdropLayout from '@/layouts/GlowingBackdrop';
+import Button from '#components/Common/Button';
+import BaseLayout from '#layouts/Base';
+import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
 
 const GlobalErrorPage: FC<{ error: Error }> = () => (
   <html>

--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -4,9 +4,9 @@ import {
   BASE_PATH,
   BASE_URL,
   EXTERNAL_LINKS_SITEMAP,
-} from '@/next.constants.mjs';
-import { dynamicRouter } from '@/next.dynamic.mjs';
-import { availableLocaleCodes, defaultLocale } from '@/next.locales.mjs';
+} from '#next.constants.mjs';
+import { dynamicRouter } from '#next.dynamic.mjs';
+import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
 
 // This is the combination of the Application Base URL and Base PATH
 const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;

--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -4,9 +4,9 @@ import {
   BASE_PATH,
   BASE_URL,
   EXTERNAL_LINKS_SITEMAP,
-} from '#next.constants.mjs';
-import { dynamicRouter } from '#next.dynamic.mjs';
-import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
+} from '#site/next.constants.mjs';
+import { dynamicRouter } from '#site/next.dynamic.mjs';
+import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
 // This is the combination of the Application Base URL and Base PATH
 const baseUrlAndPath = `${BASE_URL}${BASE_PATH}`;

--- a/apps/site/client-context.ts
+++ b/apps/site/client-context.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
-import type { ClientSharedServerContext } from '#types';
-import { assignClientContext } from '#util/assignClientContext';
+import type { ClientSharedServerContext } from '#site/types';
+import { assignClientContext } from '#site/util/assignClientContext';
 
 // This allows us to have Server-Side Context's of the shared "contextual" data
 // which includes the frontmatter, the current pathname from the dynamic segments

--- a/apps/site/client-context.ts
+++ b/apps/site/client-context.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
-import type { ClientSharedServerContext } from '@/types';
-import { assignClientContext } from '@/util/assignClientContext';
+import type { ClientSharedServerContext } from '#types';
+import { assignClientContext } from '#util/assignClientContext';
 
 // This allows us to have Server-Side Context's of the shared "contextual" data
 // which includes the frontmatter, the current pathname from the dynamic segments

--- a/apps/site/components/Blog/BlogHeader/__tests__/index.test.jsx
+++ b/apps/site/components/Blog/BlogHeader/__tests__/index.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { render, screen } from '@testing-library/react';
 
-import BlogHeader from '@/components/Blog/BlogHeader';
+import BlogHeader from '#components/Blog/BlogHeader';
 
 describe('BlogHeader', () => {
   it('should have correct href when category is all', () => {

--- a/apps/site/components/Blog/BlogHeader/__tests__/index.test.jsx
+++ b/apps/site/components/Blog/BlogHeader/__tests__/index.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { render, screen } from '@testing-library/react';
 
-import BlogHeader from '#components/Blog/BlogHeader';
+import BlogHeader from '#site/components/Blog/BlogHeader';
 
 describe('BlogHeader', () => {
   it('should have correct href when category is all', () => {

--- a/apps/site/components/Blog/BlogHeader/index.tsx
+++ b/apps/site/components/Blog/BlogHeader/index.tsx
@@ -2,8 +2,8 @@ import { RssIcon } from '@heroicons/react/24/solid';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { siteConfig } from '@/next.json.mjs';
+import Link from '#components/Link';
+import { siteConfig } from '#next.json.mjs';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Blog/BlogHeader/index.tsx
+++ b/apps/site/components/Blog/BlogHeader/index.tsx
@@ -2,8 +2,8 @@ import { RssIcon } from '@heroicons/react/24/solid';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { siteConfig } from '#next.json.mjs';
+import Link from '#site/components/Link';
+import { siteConfig } from '#site/next.json.mjs';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Blog/BlogPostCard/__tests__/index.test.jsx
+++ b/apps/site/components/Blog/BlogPostCard/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../../tests/utilities.mjs';
 
-import BlogPostCard from '@/components/Blog/BlogPostCard';
+import BlogPostCard from '#components/Blog/BlogPostCard';
 
 function renderBlogPostCard({
   title = 'Blog post title',

--- a/apps/site/components/Blog/BlogPostCard/__tests__/index.test.jsx
+++ b/apps/site/components/Blog/BlogPostCard/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../../tests/utilities.mjs';
 
-import BlogPostCard from '#components/Blog/BlogPostCard';
+import BlogPostCard from '#site/components/Blog/BlogPostCard';
 
 function renderBlogPostCard({
   title = 'Blog post title',

--- a/apps/site/components/Blog/BlogPostCard/index.tsx
+++ b/apps/site/components/Blog/BlogPostCard/index.tsx
@@ -2,11 +2,11 @@ import Preview from '@node-core/ui-components/Common/Preview';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import FormattedTime from '#components/Common/FormattedTime';
-import Link from '#components/Link';
-import WithAvatarGroup from '#components/withAvatarGroup';
-import type { BlogCategory } from '#types';
-import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
+import FormattedTime from '#site/components/Common/FormattedTime';
+import Link from '#site/components/Link';
+import WithAvatarGroup from '#site/components/withAvatarGroup';
+import type { BlogCategory } from '#site/types';
+import { mapBlogCategoryToPreviewType } from '#site/util/blogUtils';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Blog/BlogPostCard/index.tsx
+++ b/apps/site/components/Blog/BlogPostCard/index.tsx
@@ -2,11 +2,11 @@ import Preview from '@node-core/ui-components/Common/Preview';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import FormattedTime from '@/components/Common/FormattedTime';
-import Link from '@/components/Link';
-import WithAvatarGroup from '@/components/withAvatarGroup';
-import type { BlogCategory } from '@/types';
-import { mapBlogCategoryToPreviewType } from '@/util/blogUtils';
+import FormattedTime from '#components/Common/FormattedTime';
+import Link from '#components/Link';
+import WithAvatarGroup from '#components/withAvatarGroup';
+import type { BlogCategory } from '#types';
+import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Common/Button.tsx
+++ b/apps/site/components/Common/Button.tsx
@@ -3,7 +3,7 @@ import BaseButton, {
 } from '@node-core/ui-components/Common/BaseButton';
 import type { FC, ComponentProps } from 'react';
 
-import Link from '#components/Link';
+import Link from '#site/components/Link';
 
 const Button: FC<
   Omit<ButtonProps, 'as'> & Omit<ComponentProps<typeof Link>, 'as' | 'size'>

--- a/apps/site/components/Common/Button.tsx
+++ b/apps/site/components/Common/Button.tsx
@@ -3,7 +3,7 @@ import BaseButton, {
 } from '@node-core/ui-components/Common/BaseButton';
 import type { FC, ComponentProps } from 'react';
 
-import Link from '@/components/Link';
+import Link from '#components/Link';
 
 const Button: FC<
   Omit<ButtonProps, 'as'> & Omit<ComponentProps<typeof Link>, 'as' | 'size'>

--- a/apps/site/components/Common/CodeBox.tsx
+++ b/apps/site/components/Common/CodeBox.tsx
@@ -4,8 +4,8 @@ import BaseCodeBox from '@node-core/ui-components/Common/BaseCodeBox';
 import { useTranslations } from 'next-intl';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
-import Link from '@/components/Link';
-import { useCopyToClipboard, useNotification } from '@/hooks';
+import Link from '#components/Link';
+import { useCopyToClipboard, useNotification } from '#hooks';
 
 type CodeBoxProps = {
   language: string;

--- a/apps/site/components/Common/CodeBox.tsx
+++ b/apps/site/components/Common/CodeBox.tsx
@@ -4,8 +4,8 @@ import BaseCodeBox from '@node-core/ui-components/Common/BaseCodeBox';
 import { useTranslations } from 'next-intl';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
-import Link from '#components/Link';
-import { useCopyToClipboard, useNotification } from '#hooks';
+import Link from '#site/components/Link';
+import { useCopyToClipboard, useNotification } from '#site/hooks';
 
 type CodeBoxProps = {
   language: string;

--- a/apps/site/components/Common/CrossLink.tsx
+++ b/apps/site/components/Common/CrossLink.tsx
@@ -3,7 +3,7 @@ import type { CrossLinkProps } from '@node-core/ui-components/Common/BaseCrossLi
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
+import Link from '#site/components/Link';
 
 const CrossLink: FC<Omit<CrossLinkProps, 'as' | 'label'>> = props => {
   const t = useTranslations();

--- a/apps/site/components/Common/CrossLink.tsx
+++ b/apps/site/components/Common/CrossLink.tsx
@@ -3,7 +3,7 @@ import type { CrossLinkProps } from '@node-core/ui-components/Common/BaseCrossLi
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
+import Link from '#components/Link';
 
 const CrossLink: FC<Omit<CrossLinkProps, 'as' | 'label'>> = props => {
   const t = useTranslations();

--- a/apps/site/components/Common/FormattedTime.tsx
+++ b/apps/site/components/Common/FormattedTime.tsx
@@ -2,7 +2,7 @@ import type { DateTimeFormatOptions } from 'next-intl';
 import { useFormatter } from 'next-intl';
 import type { FC } from 'react';
 
-import { DEFAULT_DATE_FORMAT } from '#next.calendar.constants.mjs';
+import { DEFAULT_DATE_FORMAT } from '#site/next.calendar.constants.mjs';
 
 type FormattedTimeProps = {
   date: string | Date;

--- a/apps/site/components/Common/FormattedTime.tsx
+++ b/apps/site/components/Common/FormattedTime.tsx
@@ -2,7 +2,7 @@ import type { DateTimeFormatOptions } from 'next-intl';
 import { useFormatter } from 'next-intl';
 import type { FC } from 'react';
 
-import { DEFAULT_DATE_FORMAT } from '@/next.calendar.constants.mjs';
+import { DEFAULT_DATE_FORMAT } from '#next.calendar.constants.mjs';
 
 type FormattedTimeProps = {
   date: string | Date;

--- a/apps/site/components/Common/LinkTabs.tsx
+++ b/apps/site/components/Common/LinkTabs.tsx
@@ -4,8 +4,8 @@ import BaseLinkTabs from '@node-core/ui-components/Common/BaseLinkTabs';
 import type { LinkTabsProps } from '@node-core/ui-components/Common/BaseLinkTabs';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { useRouter } from '#navigation.mjs';
+import Link from '#site/components/Link';
+import { useRouter } from '#site/navigation.mjs';
 
 const LinkTabs: FC<Omit<LinkTabsProps, 'as' | 'onSelect'>> = props => {
   const { push } = useRouter();

--- a/apps/site/components/Common/LinkTabs.tsx
+++ b/apps/site/components/Common/LinkTabs.tsx
@@ -4,8 +4,8 @@ import BaseLinkTabs from '@node-core/ui-components/Common/BaseLinkTabs';
 import type { LinkTabsProps } from '@node-core/ui-components/Common/BaseLinkTabs';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { useRouter } from '@/navigation.mjs';
+import Link from '#components/Link';
+import { useRouter } from '#navigation.mjs';
 
 const LinkTabs: FC<Omit<LinkTabsProps, 'as' | 'onSelect'>> = props => {
   const { push } = useRouter();

--- a/apps/site/components/Common/Pagination.tsx
+++ b/apps/site/components/Common/Pagination.tsx
@@ -3,7 +3,7 @@ import type { PaginationProps } from '@node-core/ui-components/Common/BasePagina
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
+import Link from '#site/components/Link';
 
 const Pagination: FC<
   Omit<PaginationProps, 'as' | 'labels' | 'getPageLabel'>

--- a/apps/site/components/Common/Pagination.tsx
+++ b/apps/site/components/Common/Pagination.tsx
@@ -3,7 +3,7 @@ import type { PaginationProps } from '@node-core/ui-components/Common/BasePagina
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
+import Link from '#components/Link';
 
 const Pagination: FC<
   Omit<PaginationProps, 'as' | 'labels' | 'getPageLabel'>

--- a/apps/site/components/Common/Search/index.tsx
+++ b/apps/site/components/Common/Search/index.tsx
@@ -5,14 +5,14 @@ import { useTranslations, useLocale } from 'next-intl';
 import { useTheme } from 'next-themes';
 import type { FC } from 'react';
 
-import { useRouter } from '#navigation.mjs';
+import { useRouter } from '#site/navigation.mjs';
 import {
   ORAMA_CLOUD_ENDPOINT,
   ORAMA_CLOUD_API_KEY,
   DEFAULT_ORAMA_QUERY_PARAMS,
   DEFAULT_ORAMA_SUGGESTIONS,
   BASE_URL,
-} from '#next.constants.mjs';
+} from '#site/next.constants.mjs';
 
 type ResultMapDescription = {
   path: string;

--- a/apps/site/components/Common/Search/index.tsx
+++ b/apps/site/components/Common/Search/index.tsx
@@ -5,14 +5,14 @@ import { useTranslations, useLocale } from 'next-intl';
 import { useTheme } from 'next-themes';
 import type { FC } from 'react';
 
-import { useRouter } from '@/navigation.mjs';
+import { useRouter } from '#navigation.mjs';
 import {
   ORAMA_CLOUD_ENDPOINT,
   ORAMA_CLOUD_API_KEY,
   DEFAULT_ORAMA_QUERY_PARAMS,
   DEFAULT_ORAMA_SUGGESTIONS,
   BASE_URL,
-} from '@/next.constants.mjs';
+} from '#next.constants.mjs';
 
 type ResultMapDescription = {
   path: string;

--- a/apps/site/components/Downloads/DownloadButton/index.tsx
+++ b/apps/site/components/Downloads/DownloadButton/index.tsx
@@ -4,11 +4,11 @@ import { CloudArrowDownIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import type { FC, PropsWithChildren } from 'react';
 
-import Button from '#components/Common/Button';
-import { useClientContext } from '#hooks';
-import type { NodeRelease } from '#types';
-import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
-import { getUserPlatform } from '#util/getUserPlatform';
+import Button from '#site/components/Common/Button';
+import { useClientContext } from '#site/hooks';
+import type { NodeRelease } from '#site/types';
+import { getNodeDownloadUrl } from '#site/util/getNodeDownloadUrl';
+import { getUserPlatform } from '#site/util/getUserPlatform';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Downloads/DownloadButton/index.tsx
+++ b/apps/site/components/Downloads/DownloadButton/index.tsx
@@ -4,11 +4,11 @@ import { CloudArrowDownIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import type { FC, PropsWithChildren } from 'react';
 
-import Button from '@/components/Common/Button';
-import { useClientContext } from '@/hooks';
-import type { NodeRelease } from '@/types';
-import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
-import { getUserPlatform } from '@/util/getUserPlatform';
+import Button from '#components/Common/Button';
+import { useClientContext } from '#hooks';
+import type { NodeRelease } from '#types';
+import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
+import { getUserPlatform } from '#util/getUserPlatform';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Downloads/DownloadLink.tsx
+++ b/apps/site/components/Downloads/DownloadLink.tsx
@@ -2,12 +2,12 @@
 
 import type { FC, PropsWithChildren } from 'react';
 
-import LinkWithArrow from '#components/LinkWithArrow';
-import { useClientContext } from '#hooks';
-import type { NodeRelease } from '#types';
-import type { DownloadKind } from '#util/getNodeDownloadUrl';
-import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
-import { getUserPlatform } from '#util/getUserPlatform';
+import LinkWithArrow from '#site/components/LinkWithArrow';
+import { useClientContext } from '#site/hooks';
+import type { NodeRelease } from '#site/types';
+import type { DownloadKind } from '#site/util/getNodeDownloadUrl';
+import { getNodeDownloadUrl } from '#site/util/getNodeDownloadUrl';
+import { getUserPlatform } from '#site/util/getUserPlatform';
 
 type DownloadLinkProps = { release: NodeRelease; kind?: DownloadKind };
 

--- a/apps/site/components/Downloads/DownloadLink.tsx
+++ b/apps/site/components/Downloads/DownloadLink.tsx
@@ -2,12 +2,12 @@
 
 import type { FC, PropsWithChildren } from 'react';
 
-import LinkWithArrow from '@/components/LinkWithArrow';
-import { useClientContext } from '@/hooks';
-import type { NodeRelease } from '@/types';
-import type { DownloadKind } from '@/util/getNodeDownloadUrl';
-import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
-import { getUserPlatform } from '@/util/getUserPlatform';
+import LinkWithArrow from '#components/LinkWithArrow';
+import { useClientContext } from '#hooks';
+import type { NodeRelease } from '#types';
+import type { DownloadKind } from '#util/getNodeDownloadUrl';
+import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
+import { getUserPlatform } from '#util/getUserPlatform';
 
 type DownloadLinkProps = { release: NodeRelease; kind?: DownloadKind };
 

--- a/apps/site/components/Downloads/DownloadReleasesTable/DetailsButton.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable/DetailsButton.tsx
@@ -4,9 +4,9 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { use } from 'react';
 
-import LinkWithArrow from '@/components/LinkWithArrow';
-import { ReleaseModalContext } from '@/providers/releaseModalProvider';
-import type { NodeRelease } from '@/types';
+import LinkWithArrow from '#components/LinkWithArrow';
+import { ReleaseModalContext } from '#providers/releaseModalProvider';
+import type { NodeRelease } from '#types';
 
 type DetailsButtonProps = {
   versionData: NodeRelease;

--- a/apps/site/components/Downloads/DownloadReleasesTable/DetailsButton.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable/DetailsButton.tsx
@@ -4,9 +4,9 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { use } from 'react';
 
-import LinkWithArrow from '#components/LinkWithArrow';
-import { ReleaseModalContext } from '#providers/releaseModalProvider';
-import type { NodeRelease } from '#types';
+import LinkWithArrow from '#site/components/LinkWithArrow';
+import { ReleaseModalContext } from '#site/providers/releaseModalProvider';
+import type { NodeRelease } from '#site/types';
 
 type DetailsButtonProps = {
   versionData: NodeRelease;

--- a/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
@@ -2,9 +2,9 @@ import Badge from '@node-core/ui-components/Common/Badge';
 import { getTranslations } from 'next-intl/server';
 import type { FC } from 'react';
 
-import FormattedTime from '#components/Common/FormattedTime';
-import DetailsButton from '#components/Downloads/DownloadReleasesTable/DetailsButton';
-import getReleaseData from '#next-data/releaseData';
+import FormattedTime from '#site/components/Common/FormattedTime';
+import DetailsButton from '#site/components/Downloads/DownloadReleasesTable/DetailsButton';
+import getReleaseData from '#site/next-data/releaseData';
 
 const DownloadReleasesTable: FC = async () => {
   const releaseData = await getReleaseData();

--- a/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
@@ -2,9 +2,9 @@ import Badge from '@node-core/ui-components/Common/Badge';
 import { getTranslations } from 'next-intl/server';
 import type { FC } from 'react';
 
-import FormattedTime from '@/components/Common/FormattedTime';
-import DetailsButton from '@/components/Downloads/DownloadReleasesTable/DetailsButton';
-import getReleaseData from '@/next-data/releaseData';
+import FormattedTime from '#components/Common/FormattedTime';
+import DetailsButton from '#components/Downloads/DownloadReleasesTable/DetailsButton';
+import getReleaseData from '#next-data/releaseData';
 
 const DownloadReleasesTable: FC = async () => {
   const releaseData = await getReleaseData();

--- a/apps/site/components/Downloads/MinorReleasesTable/index.tsx
+++ b/apps/site/components/Downloads/MinorReleasesTable/index.tsx
@@ -4,10 +4,10 @@ import Separator from '@node-core/ui-components/Common/Separator';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { BASE_CHANGELOG_URL } from '#next.constants.mjs';
-import type { MinorVersion } from '#types';
-import { getNodeApiLink } from '#util/getNodeApiLink';
+import Link from '#site/components/Link';
+import { BASE_CHANGELOG_URL } from '#site/next.constants.mjs';
+import type { MinorVersion } from '#site/types';
+import { getNodeApiLink } from '#site/util/getNodeApiLink';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Downloads/MinorReleasesTable/index.tsx
+++ b/apps/site/components/Downloads/MinorReleasesTable/index.tsx
@@ -4,10 +4,10 @@ import Separator from '@node-core/ui-components/Common/Separator';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { BASE_CHANGELOG_URL } from '@/next.constants.mjs';
-import type { MinorVersion } from '@/types';
-import { getNodeApiLink } from '@/util/getNodeApiLink';
+import Link from '#components/Link';
+import { BASE_CHANGELOG_URL } from '#next.constants.mjs';
+import type { MinorVersion } from '#types';
+import { getNodeApiLink } from '#util/getNodeApiLink';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Downloads/Release/BlogPostLink.tsx
+++ b/apps/site/components/Downloads/Release/BlogPostLink.tsx
@@ -3,8 +3,8 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import Link from '@/components/Link';
-import { ReleaseContext } from '@/providers/releaseProvider';
+import Link from '#components/Link';
+import { ReleaseContext } from '#providers/releaseProvider';
 
 const BlogPostLink: FC<PropsWithChildren> = ({ children }) => {
   const { release } = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/BlogPostLink.tsx
+++ b/apps/site/components/Downloads/Release/BlogPostLink.tsx
@@ -3,8 +3,8 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import Link from '#components/Link';
-import { ReleaseContext } from '#providers/releaseProvider';
+import Link from '#site/components/Link';
+import { ReleaseContext } from '#site/providers/releaseProvider';
 
 const BlogPostLink: FC<PropsWithChildren> = ({ children }) => {
   const { release } = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/ChangelogLink.tsx
+++ b/apps/site/components/Downloads/Release/ChangelogLink.tsx
@@ -3,10 +3,10 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import Link from '#components/Link';
-import LinkWithArrow from '#components/LinkWithArrow';
-import { BASE_CHANGELOG_URL } from '#next.constants.mjs';
-import { ReleaseContext } from '#providers/releaseProvider';
+import Link from '#site/components/Link';
+import LinkWithArrow from '#site/components/LinkWithArrow';
+import { BASE_CHANGELOG_URL } from '#site/next.constants.mjs';
+import { ReleaseContext } from '#site/providers/releaseProvider';
 
 const ChangelogLink: FC<PropsWithChildren> = ({ children }) => {
   const { release } = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/ChangelogLink.tsx
+++ b/apps/site/components/Downloads/Release/ChangelogLink.tsx
@@ -3,10 +3,10 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import Link from '@/components/Link';
-import LinkWithArrow from '@/components/LinkWithArrow';
-import { BASE_CHANGELOG_URL } from '@/next.constants.mjs';
-import { ReleaseContext } from '@/providers/releaseProvider';
+import Link from '#components/Link';
+import LinkWithArrow from '#components/LinkWithArrow';
+import { BASE_CHANGELOG_URL } from '#next.constants.mjs';
+import { ReleaseContext } from '#providers/releaseProvider';
 
 const ChangelogLink: FC<PropsWithChildren> = ({ children }) => {
   const { release } = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/DownloadLink.tsx
+++ b/apps/site/components/Downloads/Release/DownloadLink.tsx
@@ -3,9 +3,9 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import DownloadLinkBase from '#components/Downloads/DownloadLink';
-import { ReleaseContext } from '#providers/releaseProvider';
-import type { DownloadKind } from '#util/getNodeDownloadUrl';
+import DownloadLinkBase from '#site/components/Downloads/DownloadLink';
+import { ReleaseContext } from '#site/providers/releaseProvider';
+import type { DownloadKind } from '#site/util/getNodeDownloadUrl';
 
 type DownloadLinkProps = { kind?: DownloadKind };
 

--- a/apps/site/components/Downloads/Release/DownloadLink.tsx
+++ b/apps/site/components/Downloads/Release/DownloadLink.tsx
@@ -3,9 +3,9 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
-import DownloadLinkBase from '@/components/Downloads/DownloadLink';
-import { ReleaseContext } from '@/providers/releaseProvider';
-import type { DownloadKind } from '@/util/getNodeDownloadUrl';
+import DownloadLinkBase from '#components/Downloads/DownloadLink';
+import { ReleaseContext } from '#providers/releaseProvider';
+import type { DownloadKind } from '#util/getNodeDownloadUrl';
 
 type DownloadLinkProps = { kind?: DownloadKind };
 

--- a/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
+++ b/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
@@ -5,9 +5,13 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { ReleaseContext } from '#providers/releaseProvider';
-import type { InstallationMethod } from '#types/release';
-import { nextItem, INSTALL_METHODS, parseCompat } from '#util/downloadUtils';
+import { ReleaseContext } from '#site/providers/releaseProvider';
+import type { InstallationMethod } from '#site/types/release';
+import {
+  nextItem,
+  INSTALL_METHODS,
+  parseCompat,
+} from '#site/util/downloadUtils';
 
 const InstallationMethodDropdown: FC = () => {
   const release = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
+++ b/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
@@ -5,9 +5,9 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { ReleaseContext } from '@/providers/releaseProvider';
-import type { InstallationMethod } from '@/types/release';
-import { nextItem, INSTALL_METHODS, parseCompat } from '@/util/downloadUtils';
+import { ReleaseContext } from '#providers/releaseProvider';
+import type { InstallationMethod } from '#types/release';
+import { nextItem, INSTALL_METHODS, parseCompat } from '#util/downloadUtils';
 
 const InstallationMethodDropdown: FC = () => {
   const release = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
+++ b/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
@@ -5,10 +5,14 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { useClientContext } from '#hooks';
-import { ReleaseContext } from '#providers/releaseProvider';
-import type { UserOS } from '#types/userOS';
-import { nextItem, OPERATING_SYSTEMS, parseCompat } from '#util/downloadUtils';
+import { useClientContext } from '#site/hooks';
+import { ReleaseContext } from '#site/providers/releaseProvider';
+import type { UserOS } from '#site/types/userOS';
+import {
+  nextItem,
+  OPERATING_SYSTEMS,
+  parseCompat,
+} from '#site/util/downloadUtils';
 
 type OperatingSystemDropdownProps = { exclude?: Array<UserOS> };
 

--- a/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
+++ b/apps/site/components/Downloads/Release/OperatingSystemDropdown.tsx
@@ -5,10 +5,10 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { useClientContext } from '@/hooks';
-import { ReleaseContext } from '@/providers/releaseProvider';
-import type { UserOS } from '@/types/userOS';
-import { nextItem, OPERATING_SYSTEMS, parseCompat } from '@/util/downloadUtils';
+import { useClientContext } from '#hooks';
+import { ReleaseContext } from '#providers/releaseProvider';
+import type { UserOS } from '#types/userOS';
+import { nextItem, OPERATING_SYSTEMS, parseCompat } from '#util/downloadUtils';
 
 type OperatingSystemDropdownProps = { exclude?: Array<UserOS> };
 

--- a/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
@@ -5,9 +5,9 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { ReleaseContext } from '@/providers/releaseProvider';
-import type { PackageManager } from '@/types/release';
-import { nextItem, PACKAGE_MANAGERS, parseCompat } from '@/util/downloadUtils';
+import { ReleaseContext } from '#providers/releaseProvider';
+import type { PackageManager } from '#types/release';
+import { nextItem, PACKAGE_MANAGERS, parseCompat } from '#util/downloadUtils';
 
 const PackageManagerDropdown: FC = () => {
   const release = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PackageManagerDropdown.tsx
@@ -5,9 +5,13 @@ import { useTranslations } from 'next-intl';
 import { useContext, useEffect, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { ReleaseContext } from '#providers/releaseProvider';
-import type { PackageManager } from '#types/release';
-import { nextItem, PACKAGE_MANAGERS, parseCompat } from '#util/downloadUtils';
+import { ReleaseContext } from '#site/providers/releaseProvider';
+import type { PackageManager } from '#site/types/release';
+import {
+  nextItem,
+  PACKAGE_MANAGERS,
+  parseCompat,
+} from '#site/util/downloadUtils';
 
 const PackageManagerDropdown: FC = () => {
   const release = useContext(ReleaseContext);

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -5,11 +5,11 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useEffect, useContext, useMemo } from 'react';
 
-import { useClientContext } from '#hooks';
-import { ReleaseContext } from '#providers/releaseProvider';
-import type { UserPlatform } from '#types/userOS';
-import { PLATFORMS, nextItem, parseCompat } from '#util/downloadUtils';
-import { getUserPlatform } from '#util/getUserPlatform';
+import { useClientContext } from '#site/hooks';
+import { ReleaseContext } from '#site/providers/releaseProvider';
+import type { UserPlatform } from '#site/types/userOS';
+import { PLATFORMS, nextItem, parseCompat } from '#site/util/downloadUtils';
+import { getUserPlatform } from '#site/util/getUserPlatform';
 
 const PlatformDropdown: FC = () => {
   const { architecture, bitness } = useClientContext();

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -5,11 +5,11 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useEffect, useContext, useMemo } from 'react';
 
-import { useClientContext } from '@/hooks';
-import { ReleaseContext } from '@/providers/releaseProvider';
-import type { UserPlatform } from '@/types/userOS';
-import { PLATFORMS, nextItem, parseCompat } from '@/util/downloadUtils';
-import { getUserPlatform } from '@/util/getUserPlatform';
+import { useClientContext } from '#hooks';
+import { ReleaseContext } from '#providers/releaseProvider';
+import type { UserPlatform } from '#types/userOS';
+import { PLATFORMS, nextItem, parseCompat } from '#util/downloadUtils';
+import { getUserPlatform } from '#util/getUserPlatform';
 
 const PlatformDropdown: FC = () => {
   const { architecture, bitness } = useClientContext();

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -6,13 +6,13 @@ import { useTranslations } from 'next-intl';
 import { useContext } from 'react';
 import type { FC } from 'react';
 
-import Button from '#components/Common/Button';
-import { ReleaseContext } from '#providers/releaseProvider';
+import Button from '#site/components/Common/Button';
+import { ReleaseContext } from '#site/providers/releaseProvider';
 import {
   OperatingSystemLabel,
   OS_NOT_SUPPORTING_INSTALLERS,
-} from '#util/downloadUtils';
-import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
+} from '#site/util/downloadUtils';
+import { getNodeDownloadUrl } from '#site/util/getNodeDownloadUrl';
 
 // Retrieves the pure extension piece from the input string
 const getExtension = (input: string) => String(input.split('.').slice(-1));

--- a/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
+++ b/apps/site/components/Downloads/Release/PrebuiltDownloadButtons.tsx
@@ -6,13 +6,13 @@ import { useTranslations } from 'next-intl';
 import { useContext } from 'react';
 import type { FC } from 'react';
 
-import Button from '@/components/Common/Button';
-import { ReleaseContext } from '@/providers/releaseProvider';
+import Button from '#components/Common/Button';
+import { ReleaseContext } from '#providers/releaseProvider';
 import {
   OperatingSystemLabel,
   OS_NOT_SUPPORTING_INSTALLERS,
-} from '@/util/downloadUtils';
-import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
+} from '#util/downloadUtils';
+import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
 
 // Retrieves the pure extension piece from the input string
 const getExtension = (input: string) => String(input.split('.').slice(-1));

--- a/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -6,14 +6,17 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useContext, useMemo } from 'react';
 
-import CodeBox from '#components/Common/CodeBox';
-import Link from '#components/Link';
-import LinkWithArrow from '#components/LinkWithArrow';
-import { createSval } from '#next.jsx.compiler.mjs';
-import { ReleaseContext, ReleasesContext } from '#providers/releaseProvider';
-import type { ReleaseContextType } from '#types/release';
-import { INSTALL_METHODS } from '#util/downloadUtils';
-import { highlightToHtml } from '#util/getHighlighter';
+import CodeBox from '#site/components/Common/CodeBox';
+import Link from '#site/components/Link';
+import LinkWithArrow from '#site/components/LinkWithArrow';
+import { createSval } from '#site/next.jsx.compiler.mjs';
+import {
+  ReleaseContext,
+  ReleasesContext,
+} from '#site/providers/releaseProvider';
+import type { ReleaseContextType } from '#site/types/release';
+import { INSTALL_METHODS } from '#site/util/downloadUtils';
+import { highlightToHtml } from '#site/util/getHighlighter';
 
 // Creates a minimal JavaScript interpreter for parsing the JavaScript code from the snippets
 // Note: that the code runs inside a sandboxed environment and cannot interact with any code outside of the sandbox

--- a/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -6,14 +6,14 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useContext, useMemo } from 'react';
 
-import CodeBox from '@/components/Common/CodeBox';
-import Link from '@/components/Link';
-import LinkWithArrow from '@/components/LinkWithArrow';
-import { createSval } from '@/next.jsx.compiler.mjs';
-import { ReleaseContext, ReleasesContext } from '@/providers/releaseProvider';
-import type { ReleaseContextType } from '@/types/release';
-import { INSTALL_METHODS } from '@/util/downloadUtils';
-import { highlightToHtml } from '@/util/getHighlighter';
+import CodeBox from '#components/Common/CodeBox';
+import Link from '#components/Link';
+import LinkWithArrow from '#components/LinkWithArrow';
+import { createSval } from '#next.jsx.compiler.mjs';
+import { ReleaseContext, ReleasesContext } from '#providers/releaseProvider';
+import type { ReleaseContextType } from '#types/release';
+import { INSTALL_METHODS } from '#util/downloadUtils';
+import { highlightToHtml } from '#util/getHighlighter';
 
 // Creates a minimal JavaScript interpreter for parsing the JavaScript code from the snippets
 // Note: that the code runs inside a sandboxed environment and cannot interact with any code outside of the sandbox

--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -5,7 +5,10 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useContext } from 'react';
 
-import { ReleaseContext, ReleasesContext } from '#providers/releaseProvider';
+import {
+  ReleaseContext,
+  ReleasesContext,
+} from '#site/providers/releaseProvider';
 
 const getDropDownStatus = (version: string, status: string) => {
   if (status === 'LTS') {

--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 import { useContext } from 'react';
 
-import { ReleaseContext, ReleasesContext } from '@/providers/releaseProvider';
+import { ReleaseContext, ReleasesContext } from '#providers/releaseProvider';
 
 const getDropDownStatus = (version: string, status: string) => {
   if (status === 'LTS') {

--- a/apps/site/components/Downloads/ReleaseModal/index.tsx
+++ b/apps/site/components/Downloads/ReleaseModal/index.tsx
@@ -3,10 +3,10 @@ import Modal from '@node-core/ui-components/Common/Modal';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import { MinorReleasesTable } from '#components/Downloads/MinorReleasesTable';
-import { ReleaseOverview } from '#components/Downloads/ReleaseOverview';
-import LinkWithArrow from '#components/LinkWithArrow';
-import type { NodeRelease } from '#types';
+import { MinorReleasesTable } from '#site/components/Downloads/MinorReleasesTable';
+import { ReleaseOverview } from '#site/components/Downloads/ReleaseOverview';
+import LinkWithArrow from '#site/components/LinkWithArrow';
+import type { NodeRelease } from '#site/types';
 
 type ReleaseModalProps = {
   isOpen: boolean;

--- a/apps/site/components/Downloads/ReleaseModal/index.tsx
+++ b/apps/site/components/Downloads/ReleaseModal/index.tsx
@@ -3,10 +3,10 @@ import Modal from '@node-core/ui-components/Common/Modal';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import { MinorReleasesTable } from '@/components/Downloads/MinorReleasesTable';
-import { ReleaseOverview } from '@/components/Downloads/ReleaseOverview';
-import LinkWithArrow from '@/components/LinkWithArrow';
-import type { NodeRelease } from '@/types';
+import { MinorReleasesTable } from '#components/Downloads/MinorReleasesTable';
+import { ReleaseOverview } from '#components/Downloads/ReleaseOverview';
+import LinkWithArrow from '#components/LinkWithArrow';
+import type { NodeRelease } from '#types';
 
 type ReleaseModalProps = {
   isOpen: boolean;

--- a/apps/site/components/Downloads/ReleaseOverview/index.tsx
+++ b/apps/site/components/Downloads/ReleaseOverview/index.tsx
@@ -8,8 +8,8 @@ import NpmIcon from '@node-core/ui-components/Icons/PackageManager/Npm';
 import { useTranslations } from 'next-intl';
 import type { FC, ReactNode, SVGProps } from 'react';
 
-import FormattedTime from '#components/Common/FormattedTime';
-import type { NodeRelease } from '#types';
+import FormattedTime from '#site/components/Common/FormattedTime';
+import type { NodeRelease } from '#site/types';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Downloads/ReleaseOverview/index.tsx
+++ b/apps/site/components/Downloads/ReleaseOverview/index.tsx
@@ -8,8 +8,8 @@ import NpmIcon from '@node-core/ui-components/Icons/PackageManager/Npm';
 import { useTranslations } from 'next-intl';
 import type { FC, ReactNode, SVGProps } from 'react';
 
-import FormattedTime from '@/components/Common/FormattedTime';
-import type { NodeRelease } from '@/types';
+import FormattedTime from '#components/Common/FormattedTime';
+import type { NodeRelease } from '#types';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/Link.tsx
+++ b/apps/site/components/Link.tsx
@@ -1,6 +1,6 @@
 import type { FC, HTMLProps } from 'react';
 
-import { Link as LocalizedLink } from '#navigation.mjs';
+import { Link as LocalizedLink } from '#site/navigation.mjs';
 
 const Link: FC<HTMLProps<HTMLAnchorElement>> = ({
   children,

--- a/apps/site/components/Link.tsx
+++ b/apps/site/components/Link.tsx
@@ -1,6 +1,6 @@
 import type { FC, HTMLProps } from 'react';
 
-import { Link as LocalizedLink } from '@/navigation.mjs';
+import { Link as LocalizedLink } from '#navigation.mjs';
 
 const Link: FC<HTMLProps<HTMLAnchorElement>> = ({
   children,

--- a/apps/site/components/LinkWithArrow.tsx
+++ b/apps/site/components/LinkWithArrow.tsx
@@ -3,7 +3,7 @@ import type { SlotProps } from '@radix-ui/react-slot';
 import { Slot } from '@radix-ui/react-slot';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
-import Link from '@/components/Link';
+import Link from '#components/Link';
 
 type LinkWithArrowProps =
   | ({ asChild?: false } & ComponentProps<typeof Link>)

--- a/apps/site/components/LinkWithArrow.tsx
+++ b/apps/site/components/LinkWithArrow.tsx
@@ -3,7 +3,7 @@ import type { SlotProps } from '@radix-ui/react-slot';
 import { Slot } from '@radix-ui/react-slot';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
-import Link from '#components/Link';
+import Link from '#site/components/Link';
 
 type LinkWithArrowProps =
   | ({ asChild?: false } & ComponentProps<typeof Link>)

--- a/apps/site/components/MDX/Calendar/Event/index.tsx
+++ b/apps/site/components/MDX/Calendar/Event/index.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 
-import FormattedTime from '@/components/Common/FormattedTime';
-import Link from '@/components/Link';
-import { getZoomLink, isZoned } from '@/components/MDX/Calendar/utils';
-import type { CalendarEvent } from '@/types';
+import FormattedTime from '#components/Common/FormattedTime';
+import Link from '#components/Link';
+import { getZoomLink, isZoned } from '#components/MDX/Calendar/utils';
+import type { CalendarEvent } from '#types';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/MDX/Calendar/Event/index.tsx
+++ b/apps/site/components/MDX/Calendar/Event/index.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 
-import FormattedTime from '#components/Common/FormattedTime';
-import Link from '#components/Link';
-import { getZoomLink, isZoned } from '#components/MDX/Calendar/utils';
-import type { CalendarEvent } from '#types';
+import FormattedTime from '#site/components/Common/FormattedTime';
+import Link from '#site/components/Link';
+import { getZoomLink, isZoned } from '#site/components/MDX/Calendar/utils';
+import type { CalendarEvent } from '#site/types';
 
 import styles from './index.module.css';
 

--- a/apps/site/components/MDX/Calendar/UpcomingMeetings.tsx
+++ b/apps/site/components/MDX/Calendar/UpcomingMeetings.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react';
 
-import FormattedTime from '#components/Common/FormattedTime';
-import Event from '#components/MDX/Calendar/Event';
-import { getZoomLink, isZoned } from '#components/MDX/Calendar/utils';
-import { CALENDAR_NODEJS_ID } from '#next.calendar.constants.mjs';
-import { getCalendarEvents } from '#next.calendar.mjs';
-import type { CalendarEvent } from '#types';
+import FormattedTime from '#site/components/Common/FormattedTime';
+import Event from '#site/components/MDX/Calendar/Event';
+import { getZoomLink, isZoned } from '#site/components/MDX/Calendar/utils';
+import { CALENDAR_NODEJS_ID } from '#site/next.calendar.constants.mjs';
+import { getCalendarEvents } from '#site/next.calendar.mjs';
+import type { CalendarEvent } from '#site/types';
 
 import styles from './calendar.module.css';
 

--- a/apps/site/components/MDX/Calendar/UpcomingMeetings.tsx
+++ b/apps/site/components/MDX/Calendar/UpcomingMeetings.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react';
 
-import FormattedTime from '@/components/Common/FormattedTime';
-import Event from '@/components/MDX/Calendar/Event';
-import { getZoomLink, isZoned } from '@/components/MDX/Calendar/utils';
-import { CALENDAR_NODEJS_ID } from '@/next.calendar.constants.mjs';
-import { getCalendarEvents } from '@/next.calendar.mjs';
-import type { CalendarEvent } from '@/types';
+import FormattedTime from '#components/Common/FormattedTime';
+import Event from '#components/MDX/Calendar/Event';
+import { getZoomLink, isZoned } from '#components/MDX/Calendar/utils';
+import { CALENDAR_NODEJS_ID } from '#next.calendar.constants.mjs';
+import { getCalendarEvents } from '#next.calendar.mjs';
+import type { CalendarEvent } from '#types';
 
 import styles from './calendar.module.css';
 

--- a/apps/site/components/MDX/Calendar/utils.ts
+++ b/apps/site/components/MDX/Calendar/utils.ts
@@ -1,4 +1,4 @@
-import type { CalendarEvent, ZonedCalendarTime } from '@/types';
+import type { CalendarEvent, ZonedCalendarTime } from '#types';
 
 export const isZoned = (d: object): d is ZonedCalendarTime =>
   'dateTime' in d && 'timeZone' in d;

--- a/apps/site/components/MDX/Calendar/utils.ts
+++ b/apps/site/components/MDX/Calendar/utils.ts
@@ -1,4 +1,4 @@
-import type { CalendarEvent, ZonedCalendarTime } from '#types';
+import type { CalendarEvent, ZonedCalendarTime } from '#site/types';
 
 export const isZoned = (d: object): d is ZonedCalendarTime =>
   'dateTime' in d && 'timeZone' in d;

--- a/apps/site/components/MDX/CodeBox/index.tsx
+++ b/apps/site/components/MDX/CodeBox/index.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import CodeBox from '#components/Common/CodeBox';
-import { getLanguageDisplayName } from '#util/getLanguageDisplayName';
+import CodeBox from '#site/components/Common/CodeBox';
+import { getLanguageDisplayName } from '#site/util/getLanguageDisplayName';
 
 type CodeBoxProps = { className?: string; showCopyButton?: string };
 

--- a/apps/site/components/MDX/CodeBox/index.tsx
+++ b/apps/site/components/MDX/CodeBox/index.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import CodeBox from '@/components/Common/CodeBox';
-import { getLanguageDisplayName } from '@/util/getLanguageDisplayName';
+import CodeBox from '#components/Common/CodeBox';
+import { getLanguageDisplayName } from '#util/getLanguageDisplayName';
 
 type CodeBoxProps = { className?: string; showCopyButton?: string };
 

--- a/apps/site/components/MDX/Image/index.tsx
+++ b/apps/site/components/MDX/Image/index.tsx
@@ -2,7 +2,7 @@ import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import type { FC } from 'react';
 
-import { isSvgImage } from '@/util/imageUtils';
+import { isSvgImage } from '#util/imageUtils';
 
 const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
   const isUnoptimizedImage = isSvgImage(src.toString());

--- a/apps/site/components/MDX/Image/index.tsx
+++ b/apps/site/components/MDX/Image/index.tsx
@@ -2,7 +2,7 @@ import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import type { FC } from 'react';
 
-import { isSvgImage } from '#util/imageUtils';
+import { isSvgImage } from '#site/util/imageUtils';
 
 const MDXImage: FC<ImageProps> = ({ width, height, alt, src, ...props }) => {
   const isUnoptimizedImage = isSvgImage(src.toString());

--- a/apps/site/components/withAvatarGroup.tsx
+++ b/apps/site/components/withAvatarGroup.tsx
@@ -4,9 +4,9 @@ import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
 import Image from 'next/image';
 import type { ComponentProps, FC } from 'react';
 
-import Link from '#components/Link';
-import type { AuthorProps } from '#types';
-import { getAuthors } from '#util/authorUtils';
+import Link from '#site/components/Link';
+import type { AuthorProps } from '#site/types';
+import { getAuthors } from '#site/util/authorUtils';
 
 type WithAvatarGroupProps = Omit<
   ComponentProps<typeof AvatarGroup>,

--- a/apps/site/components/withAvatarGroup.tsx
+++ b/apps/site/components/withAvatarGroup.tsx
@@ -4,9 +4,9 @@ import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
 import Image from 'next/image';
 import type { ComponentProps, FC } from 'react';
 
-import Link from '@/components/Link';
-import type { AuthorProps } from '@/types';
-import { getAuthors } from '@/util/authorUtils';
+import Link from '#components/Link';
+import type { AuthorProps } from '#types';
+import { getAuthors } from '#util/authorUtils';
 
 type WithAvatarGroupProps = Omit<
   ComponentProps<typeof AvatarGroup>,

--- a/apps/site/components/withBadgeGroup.tsx
+++ b/apps/site/components/withBadgeGroup.tsx
@@ -1,9 +1,9 @@
 import BadgeGroup from '@node-core/ui-components/Common/BadgeGroup';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { siteConfig } from '#next.json.mjs';
-import { dateIsBetween } from '#util/dateUtils';
+import Link from '#site/components/Link';
+import { siteConfig } from '#site/next.json.mjs';
+import { dateIsBetween } from '#site/util/dateUtils';
 
 const WithBadgeGroup: FC<{ section: string }> = ({ section }) => {
   const badge = siteConfig.websiteBadges[section];

--- a/apps/site/components/withBadgeGroup.tsx
+++ b/apps/site/components/withBadgeGroup.tsx
@@ -1,9 +1,9 @@
 import BadgeGroup from '@node-core/ui-components/Common/BadgeGroup';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { siteConfig } from '@/next.json.mjs';
-import { dateIsBetween } from '@/util/dateUtils';
+import Link from '#components/Link';
+import { siteConfig } from '#next.json.mjs';
+import { dateIsBetween } from '#util/dateUtils';
 
 const WithBadgeGroup: FC<{ section: string }> = ({ section }) => {
   const badge = siteConfig.websiteBadges[section];

--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -2,9 +2,9 @@ import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import Banner from '@node-core/ui-components/Common/Banner';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { siteConfig } from '#next.json.mjs';
-import { dateIsBetween } from '#util/dateUtils';
+import Link from '#site/components/Link';
+import { siteConfig } from '#site/next.json.mjs';
+import { dateIsBetween } from '#site/util/dateUtils';
 
 const WithBanner: FC<{ section: string }> = ({ section }) => {
   const banner = siteConfig.websiteBanners[section];

--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -2,9 +2,9 @@ import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import Banner from '@node-core/ui-components/Common/Banner';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { siteConfig } from '@/next.json.mjs';
-import { dateIsBetween } from '@/util/dateUtils';
+import Link from '#components/Link';
+import { siteConfig } from '#next.json.mjs';
+import { dateIsBetween } from '#util/dateUtils';
 
 const WithBanner: FC<{ section: string }> = ({ section }) => {
   const banner = siteConfig.websiteBanners[section];

--- a/apps/site/components/withBlogCategories.tsx
+++ b/apps/site/components/withBlogCategories.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from 'next-intl';
 import type { ComponentProps, FC } from 'react';
 
-import BlogPostCard from '@/components/Blog/BlogPostCard';
-import LinkTabs from '@/components/Common/LinkTabs';
-import Pagination from '@/components/Common/Pagination';
-import type { BlogPostsRSC } from '@/types';
-import { mapAuthorToCardAuthors } from '@/util/authorUtils';
+import BlogPostCard from '#components/Blog/BlogPostCard';
+import LinkTabs from '#components/Common/LinkTabs';
+import Pagination from '#components/Common/Pagination';
+import type { BlogPostsRSC } from '#types';
+import { mapAuthorToCardAuthors } from '#util/authorUtils';
 
 type WithBlogCategoriesProps = {
   categories: ComponentProps<typeof LinkTabs>['tabs'];

--- a/apps/site/components/withBlogCategories.tsx
+++ b/apps/site/components/withBlogCategories.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from 'next-intl';
 import type { ComponentProps, FC } from 'react';
 
-import BlogPostCard from '#components/Blog/BlogPostCard';
-import LinkTabs from '#components/Common/LinkTabs';
-import Pagination from '#components/Common/Pagination';
-import type { BlogPostsRSC } from '#types';
-import { mapAuthorToCardAuthors } from '#util/authorUtils';
+import BlogPostCard from '#site/components/Blog/BlogPostCard';
+import LinkTabs from '#site/components/Common/LinkTabs';
+import Pagination from '#site/components/Common/Pagination';
+import type { BlogPostsRSC } from '#site/types';
+import { mapAuthorToCardAuthors } from '#site/util/authorUtils';
 
 type WithBlogCategoriesProps = {
   categories: ComponentProps<typeof LinkTabs>['tabs'];

--- a/apps/site/components/withBlogCrossLinks.tsx
+++ b/apps/site/components/withBlogCrossLinks.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 
-import { getClientContext } from '#client-context';
-import CrossLink from '#components/Common/CrossLink';
-import getBlogData from '#next-data/blogData';
-import type { BlogCategory } from '#types';
+import { getClientContext } from '#site/client-context';
+import CrossLink from '#site/components/Common/CrossLink';
+import getBlogData from '#site/next-data/blogData';
+import type { BlogCategory } from '#site/types';
 
 const WithBlogCrossLinks: FC = async () => {
   const { pathname } = getClientContext();

--- a/apps/site/components/withBlogCrossLinks.tsx
+++ b/apps/site/components/withBlogCrossLinks.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 
-import { getClientContext } from '@/client-context';
-import CrossLink from '@/components/Common/CrossLink';
-import getBlogData from '@/next-data/blogData';
-import type { BlogCategory } from '@/types';
+import { getClientContext } from '#client-context';
+import CrossLink from '#components/Common/CrossLink';
+import getBlogData from '#next-data/blogData';
+import type { BlogCategory } from '#types';
 
 const WithBlogCrossLinks: FC = async () => {
   const { pathname } = getClientContext();

--- a/apps/site/components/withBreadcrumbs.tsx
+++ b/apps/site/components/withBreadcrumbs.tsx
@@ -5,10 +5,10 @@ import Breadcrumbs from '@node-core/ui-components/Common/Breadcrumbs';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { useClientContext, useMediaQuery, useSiteNavigation } from '@/hooks';
-import type { NavigationKeys } from '@/types';
-import { dashToCamelCase } from '@/util/stringUtils';
+import Link from '#components/Link';
+import { useClientContext, useMediaQuery, useSiteNavigation } from '#hooks';
+import type { NavigationKeys } from '#types';
+import { dashToCamelCase } from '#util/stringUtils';
 
 type WithBreadcrumbsProps = {
   navKeys?: Array<NavigationKeys>;

--- a/apps/site/components/withBreadcrumbs.tsx
+++ b/apps/site/components/withBreadcrumbs.tsx
@@ -5,10 +5,14 @@ import Breadcrumbs from '@node-core/ui-components/Common/Breadcrumbs';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { useClientContext, useMediaQuery, useSiteNavigation } from '#hooks';
-import type { NavigationKeys } from '#types';
-import { dashToCamelCase } from '#util/stringUtils';
+import Link from '#site/components/Link';
+import {
+  useClientContext,
+  useMediaQuery,
+  useSiteNavigation,
+} from '#site/hooks';
+import type { NavigationKeys } from '#site/types';
+import { dashToCamelCase } from '#site/util/stringUtils';
 
 type WithBreadcrumbsProps = {
   navKeys?: Array<NavigationKeys>;

--- a/apps/site/components/withDownloadSection.tsx
+++ b/apps/site/components/withDownloadSection.tsx
@@ -1,12 +1,12 @@
 import { getLocale } from 'next-intl/server';
 import type { FC, PropsWithChildren } from 'react';
 
-import { getClientContext } from '@/client-context';
-import WithNodeRelease from '@/components/withNodeRelease';
-import getDownloadSnippets from '@/next-data/downloadSnippets';
-import getReleaseData from '@/next-data/releaseData';
-import { defaultLocale } from '@/next.locales.mjs';
-import { ReleaseProvider, ReleasesProvider } from '@/providers/releaseProvider';
+import { getClientContext } from '#client-context';
+import WithNodeRelease from '#components/withNodeRelease';
+import getDownloadSnippets from '#next-data/downloadSnippets';
+import getReleaseData from '#next-data/releaseData';
+import { defaultLocale } from '#next.locales.mjs';
+import { ReleaseProvider, ReleasesProvider } from '#providers/releaseProvider';
 
 // By default the translated languages do not contain all the download snippets
 // Hence we always merge any translated snippet with the fallbacks for missing snippets

--- a/apps/site/components/withDownloadSection.tsx
+++ b/apps/site/components/withDownloadSection.tsx
@@ -1,12 +1,15 @@
 import { getLocale } from 'next-intl/server';
 import type { FC, PropsWithChildren } from 'react';
 
-import { getClientContext } from '#client-context';
-import WithNodeRelease from '#components/withNodeRelease';
-import getDownloadSnippets from '#next-data/downloadSnippets';
-import getReleaseData from '#next-data/releaseData';
-import { defaultLocale } from '#next.locales.mjs';
-import { ReleaseProvider, ReleasesProvider } from '#providers/releaseProvider';
+import { getClientContext } from '#site/client-context';
+import WithNodeRelease from '#site/components/withNodeRelease';
+import getDownloadSnippets from '#site/next-data/downloadSnippets';
+import getReleaseData from '#site/next-data/releaseData';
+import { defaultLocale } from '#site/next.locales.mjs';
+import {
+  ReleaseProvider,
+  ReleasesProvider,
+} from '#site/providers/releaseProvider';
 
 // By default the translated languages do not contain all the download snippets
 // Hence we always merge any translated snippet with the fallbacks for missing snippets

--- a/apps/site/components/withFooter.tsx
+++ b/apps/site/components/withFooter.tsx
@@ -4,9 +4,9 @@ import Footer from '@node-core/ui-components/Containers/Footer';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { usePathname } from '#navigation.mjs';
-import { siteNavigation } from '#next.json.mjs';
+import Link from '#site/components/Link';
+import { usePathname } from '#site/navigation.mjs';
+import { siteNavigation } from '#site/next.json.mjs';
 
 const WithFooter: FC = () => {
   const t = useTranslations();

--- a/apps/site/components/withFooter.tsx
+++ b/apps/site/components/withFooter.tsx
@@ -4,9 +4,9 @@ import Footer from '@node-core/ui-components/Containers/Footer';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { usePathname } from '@/navigation.mjs';
-import { siteNavigation } from '@/next.json.mjs';
+import Link from '#components/Link';
+import { usePathname } from '#navigation.mjs';
+import { siteNavigation } from '#next.json.mjs';
 
 const WithFooter: FC = () => {
   const t = useTranslations();

--- a/apps/site/components/withLayout.tsx
+++ b/apps/site/components/withLayout.tsx
@@ -1,14 +1,14 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import AboutLayout from '#layouts/About';
-import ArticlePageLayout from '#layouts/ArticlePage';
-import BlogLayout from '#layouts/Blog';
-import DefaultLayout from '#layouts/Default';
-import DownloadLayout from '#layouts/Download';
-import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
-import LearnLayout from '#layouts/Learn';
-import PostLayout from '#layouts/Post';
-import type { Layouts } from '#types';
+import AboutLayout from '#site/layouts/About';
+import ArticlePageLayout from '#site/layouts/ArticlePage';
+import BlogLayout from '#site/layouts/Blog';
+import DefaultLayout from '#site/layouts/Default';
+import DownloadLayout from '#site/layouts/Download';
+import GlowingBackdropLayout from '#site/layouts/GlowingBackdrop';
+import LearnLayout from '#site/layouts/Learn';
+import PostLayout from '#site/layouts/Post';
+import type { Layouts } from '#site/types';
 
 const layouts = {
   about: AboutLayout,

--- a/apps/site/components/withLayout.tsx
+++ b/apps/site/components/withLayout.tsx
@@ -1,14 +1,14 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import AboutLayout from '@/layouts/About';
-import ArticlePageLayout from '@/layouts/ArticlePage';
-import BlogLayout from '@/layouts/Blog';
-import DefaultLayout from '@/layouts/Default';
-import DownloadLayout from '@/layouts/Download';
-import GlowingBackdropLayout from '@/layouts/GlowingBackdrop';
-import LearnLayout from '@/layouts/Learn';
-import PostLayout from '@/layouts/Post';
-import type { Layouts } from '@/types';
+import AboutLayout from '#layouts/About';
+import ArticlePageLayout from '#layouts/ArticlePage';
+import BlogLayout from '#layouts/Blog';
+import DefaultLayout from '#layouts/Default';
+import DownloadLayout from '#layouts/Download';
+import GlowingBackdropLayout from '#layouts/GlowingBackdrop';
+import LearnLayout from '#layouts/Learn';
+import PostLayout from '#layouts/Post';
+import type { Layouts } from '#types';
 
 const layouts = {
   about: AboutLayout,

--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -5,14 +5,14 @@ import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 import { useFormatter, useLocale, useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import WithAvatarGroup from '#components/withAvatarGroup';
-import { useClientContext } from '#hooks/react-client';
-import useMediaQuery from '#hooks/react-client/useMediaQuery';
-import { DEFAULT_DATE_FORMAT } from '#next.calendar.constants.mjs';
-import { TRANSLATION_URL } from '#next.constants.mjs';
-import { defaultLocale } from '#next.locales.mjs';
-import { getGitHubBlobUrl } from '#util/gitHubUtils';
+import Link from '#site/components/Link';
+import WithAvatarGroup from '#site/components/withAvatarGroup';
+import { useClientContext } from '#site/hooks/react-client';
+import useMediaQuery from '#site/hooks/react-client/useMediaQuery';
+import { DEFAULT_DATE_FORMAT } from '#site/next.calendar.constants.mjs';
+import { TRANSLATION_URL } from '#site/next.constants.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
+import { getGitHubBlobUrl } from '#site/util/gitHubUtils';
 
 const WithMetaBar: FC = () => {
   const { headings, readingTime, frontmatter, filename } = useClientContext();

--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -5,14 +5,14 @@ import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 import { useFormatter, useLocale, useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import WithAvatarGroup from '@/components/withAvatarGroup';
-import { useClientContext } from '@/hooks/react-client';
-import useMediaQuery from '@/hooks/react-client/useMediaQuery';
-import { DEFAULT_DATE_FORMAT } from '@/next.calendar.constants.mjs';
-import { TRANSLATION_URL } from '@/next.constants.mjs';
-import { defaultLocale } from '@/next.locales.mjs';
-import { getGitHubBlobUrl } from '@/util/gitHubUtils';
+import Link from '#components/Link';
+import WithAvatarGroup from '#components/withAvatarGroup';
+import { useClientContext } from '#hooks/react-client';
+import useMediaQuery from '#hooks/react-client/useMediaQuery';
+import { DEFAULT_DATE_FORMAT } from '#next.calendar.constants.mjs';
+import { TRANSLATION_URL } from '#next.constants.mjs';
+import { defaultLocale } from '#next.locales.mjs';
+import { getGitHubBlobUrl } from '#util/gitHubUtils';
 
 const WithMetaBar: FC = () => {
   const { headings, readingTime, frontmatter, filename } = useClientContext();

--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -13,14 +13,14 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import WithBanner from '#components/withBanner';
-import WithNodejsLogo from '#components/withNodejsLogo';
-import { useSiteNavigation } from '#hooks';
-import { useRouter, usePathname } from '#navigation.mjs';
-import { availableLocales } from '#next.locales.mjs';
+import Link from '#site/components/Link';
+import WithBanner from '#site/components/withBanner';
+import WithNodejsLogo from '#site/components/withNodejsLogo';
+import { useSiteNavigation } from '#site/hooks';
+import { useRouter, usePathname } from '#site/navigation.mjs';
+import { availableLocales } from '#site/next.locales.mjs';
 
-const SearchButton = dynamic(() => import('#components/Common/Search'), {
+const SearchButton = dynamic(() => import('#site/components/Common/Search'), {
   ssr: false,
   loading: () => (
     <Skeleton className={styles.searchButtonSkeleton} loading={true} />

--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -13,14 +13,14 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import WithBanner from '@/components/withBanner';
-import WithNodejsLogo from '@/components/withNodejsLogo';
-import { useSiteNavigation } from '@/hooks';
-import { useRouter, usePathname } from '@/navigation.mjs';
-import { availableLocales } from '@/next.locales.mjs';
+import Link from '#components/Link';
+import WithBanner from '#components/withBanner';
+import WithNodejsLogo from '#components/withNodejsLogo';
+import { useSiteNavigation } from '#hooks';
+import { useRouter, usePathname } from '#navigation.mjs';
+import { availableLocales } from '#next.locales.mjs';
 
-const SearchButton = dynamic(() => import('@/components/Common/Search'), {
+const SearchButton = dynamic(() => import('#components/Common/Search'), {
   ssr: false,
   loading: () => (
     <Skeleton className={styles.searchButtonSkeleton} loading={true} />

--- a/apps/site/components/withNodeRelease.tsx
+++ b/apps/site/components/withNodeRelease.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
-import getReleaseData from '#next-data/releaseData';
-import type { NodeRelease, NodeReleaseStatus } from '#types';
+import getReleaseData from '#site/next-data/releaseData';
+import type { NodeRelease, NodeReleaseStatus } from '#site/types';
 
 type WithNodeReleaseProps = {
   status: Array<NodeReleaseStatus> | NodeReleaseStatus;

--- a/apps/site/components/withNodeRelease.tsx
+++ b/apps/site/components/withNodeRelease.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
-import getReleaseData from '@/next-data/releaseData';
-import type { NodeRelease, NodeReleaseStatus } from '@/types';
+import getReleaseData from '#next-data/releaseData';
+import type { NodeRelease, NodeReleaseStatus } from '#types';
 
 type WithNodeReleaseProps = {
   status: Array<NodeReleaseStatus> | NodeReleaseStatus;

--- a/apps/site/components/withNodejsLogo.tsx
+++ b/apps/site/components/withNodejsLogo.tsx
@@ -2,7 +2,7 @@ import NodejsLogo from '@node-core/ui-components/Common/NodejsLogo';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import { siteConfig } from '#next.json.mjs';
+import { siteConfig } from '#site/next.json.mjs';
 
 const WithNodejsLogo: FC = () => {
   const t = useTranslations();

--- a/apps/site/components/withNodejsLogo.tsx
+++ b/apps/site/components/withNodejsLogo.tsx
@@ -2,7 +2,7 @@ import NodejsLogo from '@node-core/ui-components/Common/NodejsLogo';
 import { useTranslations } from 'next-intl';
 import type { FC } from 'react';
 
-import { siteConfig } from '@/next.json.mjs';
+import { siteConfig } from '#next.json.mjs';
 
 const WithNodejsLogo: FC = () => {
   const t = useTranslations();

--- a/apps/site/components/withProgressionSidebar.tsx
+++ b/apps/site/components/withProgressionSidebar.tsx
@@ -6,10 +6,10 @@ import { useLocale, useTranslations } from 'next-intl';
 import type { RichTranslationValues } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { useSiteNavigation } from '#hooks/server';
-import { useRouter } from '#navigation.mjs';
-import type { NavigationKeys } from '#types';
+import Link from '#site/components/Link';
+import { useSiteNavigation } from '#site/hooks/server';
+import { useRouter } from '#site/navigation.mjs';
+import type { NavigationKeys } from '#site/types';
 
 type WithProgressionSidebarProps = {
   navKey: NavigationKeys;

--- a/apps/site/components/withProgressionSidebar.tsx
+++ b/apps/site/components/withProgressionSidebar.tsx
@@ -6,10 +6,10 @@ import { useLocale, useTranslations } from 'next-intl';
 import type { RichTranslationValues } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { useSiteNavigation } from '@/hooks/server';
-import { useRouter } from '@/navigation.mjs';
-import type { NavigationKeys } from '@/types';
+import Link from '#components/Link';
+import { useSiteNavigation } from '#hooks/server';
+import { useRouter } from '#navigation.mjs';
+import type { NavigationKeys } from '#types';
 
 type WithProgressionSidebarProps = {
   navKey: NavigationKeys;

--- a/apps/site/components/withSidebar.tsx
+++ b/apps/site/components/withSidebar.tsx
@@ -6,10 +6,10 @@ import { useLocale, useTranslations } from 'next-intl';
 import type { RichTranslationValues } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '#components/Link';
-import { useSiteNavigation } from '#hooks/server';
-import { useRouter } from '#navigation.mjs';
-import type { NavigationKeys } from '#types';
+import Link from '#site/components/Link';
+import { useSiteNavigation } from '#site/hooks/server';
+import { useRouter } from '#site/navigation.mjs';
+import type { NavigationKeys } from '#site/types';
 
 type WithSidebarProps = {
   navKeys: Array<NavigationKeys>;

--- a/apps/site/components/withSidebar.tsx
+++ b/apps/site/components/withSidebar.tsx
@@ -6,10 +6,10 @@ import { useLocale, useTranslations } from 'next-intl';
 import type { RichTranslationValues } from 'next-intl';
 import type { FC } from 'react';
 
-import Link from '@/components/Link';
-import { useSiteNavigation } from '@/hooks/server';
-import { useRouter } from '@/navigation.mjs';
-import type { NavigationKeys } from '@/types';
+import Link from '#components/Link';
+import { useSiteNavigation } from '#hooks/server';
+import { useRouter } from '#navigation.mjs';
+import type { NavigationKeys } from '#types';
 
 type WithSidebarProps = {
   navKeys: Array<NavigationKeys>;

--- a/apps/site/components/withSidebarCrossLinks.tsx
+++ b/apps/site/components/withSidebarCrossLinks.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
-import CrossLink from '#components/Common/CrossLink';
-import { useClientContext, useSiteNavigation } from '#hooks/server';
-import type { NavigationKeys } from '#types';
+import CrossLink from '#site/components/Common/CrossLink';
+import { useClientContext, useSiteNavigation } from '#site/hooks/server';
+import type { NavigationKeys } from '#site/types';
 
 type WithCrossLinksProps = { navKey: NavigationKeys };
 

--- a/apps/site/components/withSidebarCrossLinks.tsx
+++ b/apps/site/components/withSidebarCrossLinks.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
-import CrossLink from '@/components/Common/CrossLink';
-import { useClientContext, useSiteNavigation } from '@/hooks/server';
-import type { NavigationKeys } from '@/types';
+import CrossLink from '#components/Common/CrossLink';
+import { useClientContext, useSiteNavigation } from '#hooks/server';
+import type { NavigationKeys } from '#types';
 
 type WithCrossLinksProps = { navKey: NavigationKeys };
 

--- a/apps/site/hooks/react-client/__tests__/useClientContext.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useClientContext.test.jsx
@@ -3,8 +3,8 @@ import { renderHook } from '@testing-library/react';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import useClientContext from '#hooks/react-client/useClientContext';
-import { MatterContext } from '#providers/matterProvider';
+import useClientContext from '#site/hooks/react-client/useClientContext';
+import { MatterContext } from '#site/providers/matterProvider';
 
 describe('useClientContext', () => {
   it('should return client context values', () => {

--- a/apps/site/hooks/react-client/__tests__/useClientContext.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useClientContext.test.jsx
@@ -3,8 +3,8 @@ import { renderHook } from '@testing-library/react';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import useClientContext from '@/hooks/react-client/useClientContext';
-import { MatterContext } from '@/providers/matterProvider';
+import useClientContext from '#hooks/react-client/useClientContext';
+import { MatterContext } from '#providers/matterProvider';
 
 describe('useClientContext', () => {
   it('should return client context values', () => {

--- a/apps/site/hooks/react-client/__tests__/useCopyToClipboard.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useCopyToClipboard.test.jsx
@@ -4,7 +4,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import useCopyToClipboard from '@/hooks/react-client/useCopyToClipboard';
+import useCopyToClipboard from '#hooks/react-client/useCopyToClipboard';
 
 navigator.clipboard = { writeText: () => {} };
 

--- a/apps/site/hooks/react-client/__tests__/useCopyToClipboard.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useCopyToClipboard.test.jsx
@@ -4,7 +4,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import useCopyToClipboard from '#hooks/react-client/useCopyToClipboard';
+import useCopyToClipboard from '#site/hooks/react-client/useCopyToClipboard';
 
 navigator.clipboard = { writeText: () => {} };
 

--- a/apps/site/hooks/react-client/__tests__/useDetectOS.test.mjs
+++ b/apps/site/hooks/react-client/__tests__/useDetectOS.test.mjs
@@ -3,7 +3,7 @@ import { describe, it, afterEach } from 'node:test';
 
 import { renderHook, waitFor } from '@testing-library/react';
 
-import useDetectOS from '@/hooks/react-client/useDetectOS';
+import useDetectOS from '#hooks/react-client/useDetectOS';
 
 const windowsUserAgent =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36';

--- a/apps/site/hooks/react-client/__tests__/useDetectOS.test.mjs
+++ b/apps/site/hooks/react-client/__tests__/useDetectOS.test.mjs
@@ -3,7 +3,7 @@ import { describe, it, afterEach } from 'node:test';
 
 import { renderHook, waitFor } from '@testing-library/react';
 
-import useDetectOS from '#hooks/react-client/useDetectOS';
+import useDetectOS from '#site/hooks/react-client/useDetectOS';
 
 const windowsUserAgent =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36';

--- a/apps/site/hooks/react-client/__tests__/useMediaQuery.test.mjs
+++ b/apps/site/hooks/react-client/__tests__/useMediaQuery.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { renderHook } from '@testing-library/react';
 
-import useMediaQuery from '#hooks/react-client/useMediaQuery';
+import useMediaQuery from '#site/hooks/react-client/useMediaQuery';
 
 const noop = () => {};
 

--- a/apps/site/hooks/react-client/__tests__/useMediaQuery.test.mjs
+++ b/apps/site/hooks/react-client/__tests__/useMediaQuery.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { renderHook } from '@testing-library/react';
 
-import useMediaQuery from '@/hooks/react-client/useMediaQuery';
+import useMediaQuery from '#hooks/react-client/useMediaQuery';
 
 const noop = () => {};
 

--- a/apps/site/hooks/react-client/__tests__/useNotification.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useNotification.test.jsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import useNotification from '@/hooks/react-client/useNotification';
-import { NotificationProvider } from '@/providers/notificationProvider';
+import useNotification from '#hooks/react-client/useNotification';
+import { NotificationProvider } from '#providers/notificationProvider';
 
 describe('useNotification', () => {
   it('should return the notification dispatch function', () => {

--- a/apps/site/hooks/react-client/__tests__/useNotification.test.jsx
+++ b/apps/site/hooks/react-client/__tests__/useNotification.test.jsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import useNotification from '#hooks/react-client/useNotification';
-import { NotificationProvider } from '#providers/notificationProvider';
+import useNotification from '#site/hooks/react-client/useNotification';
+import { NotificationProvider } from '#site/providers/notificationProvider';
 
 describe('useNotification', () => {
   it('should return the notification dispatch function', () => {

--- a/apps/site/hooks/react-client/useClientContext.ts
+++ b/apps/site/hooks/react-client/useClientContext.ts
@@ -2,8 +2,8 @@
 
 import { useContext } from 'react';
 
-import { MatterContext } from '@/providers/matterProvider';
-import type { ClientSharedServerContext } from '@/types';
+import { MatterContext } from '#providers/matterProvider';
+import type { ClientSharedServerContext } from '#types';
 
 const useClientContext = (): ClientSharedServerContext => {
   const {

--- a/apps/site/hooks/react-client/useClientContext.ts
+++ b/apps/site/hooks/react-client/useClientContext.ts
@@ -2,8 +2,8 @@
 
 import { useContext } from 'react';
 
-import { MatterContext } from '#providers/matterProvider';
-import type { ClientSharedServerContext } from '#types';
+import { MatterContext } from '#site/providers/matterProvider';
+import type { ClientSharedServerContext } from '#site/types';
 
 const useClientContext = (): ClientSharedServerContext => {
   const {

--- a/apps/site/hooks/react-client/useDetectOS.ts
+++ b/apps/site/hooks/react-client/useDetectOS.ts
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from 'react';
 
-import type { UserArchitecture, UserBitness, UserOS } from '#types/userOS';
-import { detectOS } from '#util/detectOS';
-import { getHighEntropyValues } from '#util/getHighEntropyValues';
+import type { UserArchitecture, UserBitness, UserOS } from '#site/types/userOS';
+import { detectOS } from '#site/util/detectOS';
+import { getHighEntropyValues } from '#site/util/getHighEntropyValues';
 
 type UserOSState = {
   os: UserOS | 'LOADING';

--- a/apps/site/hooks/react-client/useDetectOS.ts
+++ b/apps/site/hooks/react-client/useDetectOS.ts
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from 'react';
 
-import type { UserArchitecture, UserBitness, UserOS } from '@/types/userOS';
-import { detectOS } from '@/util/detectOS';
-import { getHighEntropyValues } from '@/util/getHighEntropyValues';
+import type { UserArchitecture, UserBitness, UserOS } from '#types/userOS';
+import { detectOS } from '#util/detectOS';
+import { getHighEntropyValues } from '#util/getHighEntropyValues';
 
 type UserOSState = {
   os: UserOS | 'LOADING';

--- a/apps/site/hooks/react-client/useNavigationState.ts
+++ b/apps/site/hooks/react-client/useNavigationState.ts
@@ -3,8 +3,8 @@
 import type { RefObject } from 'react';
 import { useContext, useEffect } from 'react';
 
-import { NavigationStateContext } from '#providers/navigationStateProvider';
-import { debounce } from '#util/debounce';
+import { NavigationStateContext } from '#site/providers/navigationStateProvider';
+import { debounce } from '#site/util/debounce';
 
 const useNavigationState = <T extends HTMLElement>(
   id: string,

--- a/apps/site/hooks/react-client/useNavigationState.ts
+++ b/apps/site/hooks/react-client/useNavigationState.ts
@@ -3,8 +3,8 @@
 import type { RefObject } from 'react';
 import { useContext, useEffect } from 'react';
 
-import { NavigationStateContext } from '@/providers/navigationStateProvider';
-import { debounce } from '@/util/debounce';
+import { NavigationStateContext } from '#providers/navigationStateProvider';
+import { debounce } from '#util/debounce';
 
 const useNavigationState = <T extends HTMLElement>(
   id: string,

--- a/apps/site/hooks/react-client/useNotification.ts
+++ b/apps/site/hooks/react-client/useNotification.ts
@@ -2,7 +2,7 @@
 
 import { useContext } from 'react';
 
-import { NotificationDispatch } from '#providers/notificationProvider';
+import { NotificationDispatch } from '#site/providers/notificationProvider';
 
 const useNotification = () => useContext(NotificationDispatch);
 

--- a/apps/site/hooks/react-client/useNotification.ts
+++ b/apps/site/hooks/react-client/useNotification.ts
@@ -2,7 +2,7 @@
 
 import { useContext } from 'react';
 
-import { NotificationDispatch } from '@/providers/notificationProvider';
+import { NotificationDispatch } from '#providers/notificationProvider';
 
 const useNotification = () => useContext(NotificationDispatch);
 

--- a/apps/site/hooks/react-generic/useSiteNavigation.ts
+++ b/apps/site/hooks/react-generic/useSiteNavigation.ts
@@ -2,12 +2,8 @@ import type { RichTranslationValues } from 'next-intl';
 import { useTranslations } from 'next-intl';
 import type { HTMLAttributeAnchorTarget } from 'react';
 
-import { siteNavigation } from '@/next.json.mjs';
-import type {
-  FormattedMessage,
-  NavigationEntry,
-  NavigationKeys,
-} from '@/types';
+import { siteNavigation } from '#next.json.mjs';
+import type { FormattedMessage, NavigationEntry, NavigationKeys } from '#types';
 
 type Context = Record<string, RichTranslationValues>;
 type Navigation = Record<string, NavigationEntry>;

--- a/apps/site/hooks/react-generic/useSiteNavigation.ts
+++ b/apps/site/hooks/react-generic/useSiteNavigation.ts
@@ -2,8 +2,12 @@ import type { RichTranslationValues } from 'next-intl';
 import { useTranslations } from 'next-intl';
 import type { HTMLAttributeAnchorTarget } from 'react';
 
-import { siteNavigation } from '#next.json.mjs';
-import type { FormattedMessage, NavigationEntry, NavigationKeys } from '#types';
+import { siteNavigation } from '#site/next.json.mjs';
+import type {
+  FormattedMessage,
+  NavigationEntry,
+  NavigationKeys,
+} from '#site/types';
 
 type Context = Record<string, RichTranslationValues>;
 type Navigation = Record<string, NavigationEntry>;

--- a/apps/site/hooks/react-server/useClientContext.ts
+++ b/apps/site/hooks/react-server/useClientContext.ts
@@ -1,4 +1,4 @@
-import { getClientContext } from '@/client-context';
+import { getClientContext } from '#client-context';
 
 const useClientContext = () => getClientContext();
 

--- a/apps/site/hooks/react-server/useClientContext.ts
+++ b/apps/site/hooks/react-server/useClientContext.ts
@@ -1,4 +1,4 @@
-import { getClientContext } from '#client-context';
+import { getClientContext } from '#site/client-context';
 
 const useClientContext = () => getClientContext();
 

--- a/apps/site/i18n.tsx
+++ b/apps/site/i18n.tsx
@@ -2,7 +2,7 @@ import { importLocale } from '@node-core/website-i18n';
 import defaultMessages from '@node-core/website-i18n/locales/en.json';
 import { getRequestConfig } from 'next-intl/server';
 
-import { availableLocaleCodes, defaultLocale } from '@/next.locales.mjs';
+import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
 
 import deepMerge from './util/deepMerge';
 

--- a/apps/site/i18n.tsx
+++ b/apps/site/i18n.tsx
@@ -2,7 +2,7 @@ import { importLocale } from '@node-core/website-i18n';
 import defaultMessages from '@node-core/website-i18n/locales/en.json';
 import { getRequestConfig } from 'next-intl/server';
 
-import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
+import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
 import deepMerge from './util/deepMerge';
 

--- a/apps/site/layouts/About.tsx
+++ b/apps/site/layouts/About.tsx
@@ -1,12 +1,12 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithBreadcrumbs from '@/components/withBreadcrumbs';
-import WithFooter from '@/components/withFooter';
-import WithMetaBar from '@/components/withMetaBar';
-import WithNavBar from '@/components/withNavBar';
-import WithSidebar from '@/components/withSidebar';
-import ArticleLayout from '@/layouts/Article';
-import { ReleaseModalProvider } from '@/providers/releaseModalProvider';
+import WithBreadcrumbs from '#components/withBreadcrumbs';
+import WithFooter from '#components/withFooter';
+import WithMetaBar from '#components/withMetaBar';
+import WithNavBar from '#components/withNavBar';
+import WithSidebar from '#components/withSidebar';
+import ArticleLayout from '#layouts/Article';
+import { ReleaseModalProvider } from '#providers/releaseModalProvider';
 
 const AboutLayout: FC<PropsWithChildren> = ({ children }) => (
   <ReleaseModalProvider>

--- a/apps/site/layouts/About.tsx
+++ b/apps/site/layouts/About.tsx
@@ -1,12 +1,12 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithBreadcrumbs from '#components/withBreadcrumbs';
-import WithFooter from '#components/withFooter';
-import WithMetaBar from '#components/withMetaBar';
-import WithNavBar from '#components/withNavBar';
-import WithSidebar from '#components/withSidebar';
-import ArticleLayout from '#layouts/Article';
-import { ReleaseModalProvider } from '#providers/releaseModalProvider';
+import WithBreadcrumbs from '#site/components/withBreadcrumbs';
+import WithFooter from '#site/components/withFooter';
+import WithMetaBar from '#site/components/withMetaBar';
+import WithNavBar from '#site/components/withNavBar';
+import WithSidebar from '#site/components/withSidebar';
+import ArticleLayout from '#site/layouts/Article';
+import { ReleaseModalProvider } from '#site/providers/releaseModalProvider';
 
 const AboutLayout: FC<PropsWithChildren> = ({ children }) => (
   <ReleaseModalProvider>

--- a/apps/site/layouts/ArticlePage.tsx
+++ b/apps/site/layouts/ArticlePage.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithMetaBar from '@/components/withMetaBar';
-import WithNavBar from '@/components/withNavBar';
-import WithSidebar from '@/components/withSidebar';
-import ArticleLayout from '@/layouts/Article';
+import WithMetaBar from '#components/withMetaBar';
+import WithNavBar from '#components/withNavBar';
+import WithSidebar from '#components/withSidebar';
+import ArticleLayout from '#layouts/Article';
 
 const ArticlePageLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/ArticlePage.tsx
+++ b/apps/site/layouts/ArticlePage.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithMetaBar from '#components/withMetaBar';
-import WithNavBar from '#components/withNavBar';
-import WithSidebar from '#components/withSidebar';
-import ArticleLayout from '#layouts/Article';
+import WithMetaBar from '#site/components/withMetaBar';
+import WithNavBar from '#site/components/withNavBar';
+import WithSidebar from '#site/components/withSidebar';
+import ArticleLayout from '#site/layouts/Article';
 
 const ArticlePageLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/Base.tsx
+++ b/apps/site/layouts/Base.tsx
@@ -2,8 +2,8 @@
 
 import type { FC, PropsWithChildren } from 'react';
 
-import { NavigationStateProvider } from '#providers/navigationStateProvider';
-import { NotificationProvider } from '#providers/notificationProvider';
+import { NavigationStateProvider } from '#site/providers/navigationStateProvider';
+import { NotificationProvider } from '#site/providers/notificationProvider';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Base.tsx
+++ b/apps/site/layouts/Base.tsx
@@ -2,8 +2,8 @@
 
 import type { FC, PropsWithChildren } from 'react';
 
-import { NavigationStateProvider } from '@/providers/navigationStateProvider';
-import { NotificationProvider } from '@/providers/notificationProvider';
+import { NavigationStateProvider } from '#providers/navigationStateProvider';
+import { NotificationProvider } from '#providers/notificationProvider';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Blog.tsx
+++ b/apps/site/layouts/Blog.tsx
@@ -1,13 +1,13 @@
 import { getTranslations } from 'next-intl/server';
 import type { FC } from 'react';
 
-import { getClientContext } from '#client-context';
-import BlogHeader from '#components/Blog/BlogHeader';
-import WithBlogCategories from '#components/withBlogCategories';
-import WithFooter from '#components/withFooter';
-import WithNavBar from '#components/withNavBar';
-import getBlogData from '#next-data/blogData';
-import type { BlogCategory } from '#types';
+import { getClientContext } from '#site/client-context';
+import BlogHeader from '#site/components/Blog/BlogHeader';
+import WithBlogCategories from '#site/components/withBlogCategories';
+import WithFooter from '#site/components/withFooter';
+import WithNavBar from '#site/components/withNavBar';
+import getBlogData from '#site/next-data/blogData';
+import type { BlogCategory } from '#site/types';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Blog.tsx
+++ b/apps/site/layouts/Blog.tsx
@@ -1,13 +1,13 @@
 import { getTranslations } from 'next-intl/server';
 import type { FC } from 'react';
 
-import { getClientContext } from '@/client-context';
-import BlogHeader from '@/components/Blog/BlogHeader';
-import WithBlogCategories from '@/components/withBlogCategories';
-import WithFooter from '@/components/withFooter';
-import WithNavBar from '@/components/withNavBar';
-import getBlogData from '@/next-data/blogData';
-import type { BlogCategory } from '@/types';
+import { getClientContext } from '#client-context';
+import BlogHeader from '#components/Blog/BlogHeader';
+import WithBlogCategories from '#components/withBlogCategories';
+import WithFooter from '#components/withFooter';
+import WithNavBar from '#components/withNavBar';
+import getBlogData from '#next-data/blogData';
+import type { BlogCategory } from '#types';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Default.tsx
+++ b/apps/site/layouts/Default.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithFooter from '@/components/withFooter';
-import WithNavBar from '@/components/withNavBar';
-import WithSidebar from '@/components/withSidebar';
-import ArticleLayout from '@/layouts/Article';
+import WithFooter from '#components/withFooter';
+import WithNavBar from '#components/withNavBar';
+import WithSidebar from '#components/withSidebar';
+import ArticleLayout from '#layouts/Article';
 
 const DefaultLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/Default.tsx
+++ b/apps/site/layouts/Default.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithFooter from '#components/withFooter';
-import WithNavBar from '#components/withNavBar';
-import WithSidebar from '#components/withSidebar';
-import ArticleLayout from '#layouts/Article';
+import WithFooter from '#site/components/withFooter';
+import WithNavBar from '#site/components/withNavBar';
+import WithSidebar from '#site/components/withSidebar';
+import ArticleLayout from '#site/layouts/Article';
 
 const DefaultLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/Download.tsx
+++ b/apps/site/layouts/Download.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import { getClientContext } from '#client-context';
-import WithDownloadSection from '#components/withDownloadSection';
-import WithFooter from '#components/withFooter';
-import WithNavBar from '#components/withNavBar';
+import { getClientContext } from '#site/client-context';
+import WithDownloadSection from '#site/components/withDownloadSection';
+import WithFooter from '#site/components/withFooter';
+import WithNavBar from '#site/components/withNavBar';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Download.tsx
+++ b/apps/site/layouts/Download.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import { getClientContext } from '@/client-context';
-import WithDownloadSection from '@/components/withDownloadSection';
-import WithFooter from '@/components/withFooter';
-import WithNavBar from '@/components/withNavBar';
+import { getClientContext } from '#client-context';
+import WithDownloadSection from '#components/withDownloadSection';
+import WithFooter from '#components/withFooter';
+import WithNavBar from '#components/withNavBar';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/GlowingBackdrop.tsx
+++ b/apps/site/layouts/GlowingBackdrop.tsx
@@ -2,8 +2,8 @@ import GlowingBackdrop from '@node-core/ui-components/Common/GlowingBackdrop';
 import classNames from 'classnames';
 import type { FC, PropsWithChildren } from 'react';
 
-import WithFooter from '@/components/withFooter';
-import WithNavBar from '@/components/withNavBar';
+import WithFooter from '#components/withFooter';
+import WithNavBar from '#components/withNavBar';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/GlowingBackdrop.tsx
+++ b/apps/site/layouts/GlowingBackdrop.tsx
@@ -2,8 +2,8 @@ import GlowingBackdrop from '@node-core/ui-components/Common/GlowingBackdrop';
 import classNames from 'classnames';
 import type { FC, PropsWithChildren } from 'react';
 
-import WithFooter from '#components/withFooter';
-import WithNavBar from '#components/withNavBar';
+import WithFooter from '#site/components/withFooter';
+import WithNavBar from '#site/components/withNavBar';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Learn.tsx
+++ b/apps/site/layouts/Learn.tsx
@@ -1,12 +1,12 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithBreadcrumbs from '@/components/withBreadcrumbs';
-import WithFooter from '@/components/withFooter';
-import WithMetaBar from '@/components/withMetaBar';
-import WithNavBar from '@/components/withNavBar';
-import WithProgressionSidebar from '@/components/withProgressionSidebar';
-import WithSidebarCrossLinks from '@/components/withSidebarCrossLinks';
-import ArticleLayout from '@/layouts/Article';
+import WithBreadcrumbs from '#components/withBreadcrumbs';
+import WithFooter from '#components/withFooter';
+import WithMetaBar from '#components/withMetaBar';
+import WithNavBar from '#components/withNavBar';
+import WithProgressionSidebar from '#components/withProgressionSidebar';
+import WithSidebarCrossLinks from '#components/withSidebarCrossLinks';
+import ArticleLayout from '#layouts/Article';
 
 const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/Learn.tsx
+++ b/apps/site/layouts/Learn.tsx
@@ -1,12 +1,12 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import WithBreadcrumbs from '#components/withBreadcrumbs';
-import WithFooter from '#components/withFooter';
-import WithMetaBar from '#components/withMetaBar';
-import WithNavBar from '#components/withNavBar';
-import WithProgressionSidebar from '#components/withProgressionSidebar';
-import WithSidebarCrossLinks from '#components/withSidebarCrossLinks';
-import ArticleLayout from '#layouts/Article';
+import WithBreadcrumbs from '#site/components/withBreadcrumbs';
+import WithFooter from '#site/components/withFooter';
+import WithMetaBar from '#site/components/withMetaBar';
+import WithNavBar from '#site/components/withNavBar';
+import WithProgressionSidebar from '#site/components/withProgressionSidebar';
+import WithSidebarCrossLinks from '#site/components/withSidebarCrossLinks';
+import ArticleLayout from '#site/layouts/Article';
 
 const LearnLayout: FC<PropsWithChildren> = ({ children }) => (
   <>

--- a/apps/site/layouts/Post.tsx
+++ b/apps/site/layouts/Post.tsx
@@ -1,14 +1,14 @@
 import Preview from '@node-core/ui-components/Common/Preview';
 import type { FC, PropsWithChildren } from 'react';
 
-import WithAvatarGroup from '#components/withAvatarGroup';
-import WithBlogCrossLinks from '#components/withBlogCrossLinks';
-import WithFooter from '#components/withFooter';
-import WithMetaBar from '#components/withMetaBar';
-import WithNavBar from '#components/withNavBar';
-import { useClientContext } from '#hooks/react-server';
-import { mapAuthorToCardAuthors } from '#util/authorUtils';
-import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
+import WithAvatarGroup from '#site/components/withAvatarGroup';
+import WithBlogCrossLinks from '#site/components/withBlogCrossLinks';
+import WithFooter from '#site/components/withFooter';
+import WithMetaBar from '#site/components/withMetaBar';
+import WithNavBar from '#site/components/withNavBar';
+import { useClientContext } from '#site/hooks/react-server';
+import { mapAuthorToCardAuthors } from '#site/util/authorUtils';
+import { mapBlogCategoryToPreviewType } from '#site/util/blogUtils';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/layouts/Post.tsx
+++ b/apps/site/layouts/Post.tsx
@@ -1,14 +1,14 @@
 import Preview from '@node-core/ui-components/Common/Preview';
 import type { FC, PropsWithChildren } from 'react';
 
-import WithAvatarGroup from '@/components/withAvatarGroup';
-import WithBlogCrossLinks from '@/components/withBlogCrossLinks';
-import WithFooter from '@/components/withFooter';
-import WithMetaBar from '@/components/withMetaBar';
-import WithNavBar from '@/components/withNavBar';
-import { useClientContext } from '@/hooks/react-server';
-import { mapAuthorToCardAuthors } from '@/util/authorUtils';
-import { mapBlogCategoryToPreviewType } from '@/util/blogUtils';
+import WithAvatarGroup from '#components/withAvatarGroup';
+import WithBlogCrossLinks from '#components/withBlogCrossLinks';
+import WithFooter from '#components/withFooter';
+import WithMetaBar from '#components/withMetaBar';
+import WithNavBar from '#components/withNavBar';
+import { useClientContext } from '#hooks/react-server';
+import { mapAuthorToCardAuthors } from '#util/authorUtils';
+import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
 
 import styles from './layouts.module.css';
 

--- a/apps/site/middleware.ts
+++ b/apps/site/middleware.ts
@@ -1,6 +1,6 @@
 import createMiddleware from 'next-intl/middleware';
 
-import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
+import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
 export default createMiddleware({
   // A list of all locales that are supported

--- a/apps/site/middleware.ts
+++ b/apps/site/middleware.ts
@@ -1,6 +1,6 @@
 import createMiddleware from 'next-intl/middleware';
 
-import { availableLocaleCodes, defaultLocale } from '@/next.locales.mjs';
+import { availableLocaleCodes, defaultLocale } from '#next.locales.mjs';
 
 export default createMiddleware({
   // A list of all locales that are supported

--- a/apps/site/next-data/blogData.ts
+++ b/apps/site/next-data/blogData.ts
@@ -2,8 +2,8 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '#next.constants.mjs';
-import type { BlogCategory, BlogPostsRSC } from '#types';
+} from '#site/next.constants.mjs';
+import type { BlogCategory, BlogPostsRSC } from '#site/types';
 
 const getBlogData = (
   cat: BlogCategory,
@@ -14,7 +14,7 @@ const getBlogData = (
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
-    return import('#next-data/providers/blogData').then(
+    return import('#site/next-data/providers/blogData').then(
       ({ provideBlogPosts, providePaginatedBlogPosts }) =>
         page ? providePaginatedBlogPosts(cat, page) : provideBlogPosts(cat)
     );

--- a/apps/site/next-data/blogData.ts
+++ b/apps/site/next-data/blogData.ts
@@ -2,8 +2,8 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '@/next.constants.mjs';
-import type { BlogCategory, BlogPostsRSC } from '@/types';
+} from '#next.constants.mjs';
+import type { BlogCategory, BlogPostsRSC } from '#types';
 
 const getBlogData = (
   cat: BlogCategory,
@@ -14,7 +14,7 @@ const getBlogData = (
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
-    return import('@/next-data/providers/blogData').then(
+    return import('#next-data/providers/blogData').then(
       ({ provideBlogPosts, providePaginatedBlogPosts }) =>
         page ? providePaginatedBlogPosts(cat, page) : provideBlogPosts(cat)
     );

--- a/apps/site/next-data/downloadSnippets.ts
+++ b/apps/site/next-data/downloadSnippets.ts
@@ -2,9 +2,9 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '#next.constants.mjs';
-import { availableLocaleCodes } from '#next.locales.mjs';
-import type { DownloadSnippet } from '#types';
+} from '#site/next.constants.mjs';
+import { availableLocaleCodes } from '#site/next.locales.mjs';
+import type { DownloadSnippet } from '#site/types';
 
 export default async function getDownloadSnippets(
   lang: string
@@ -21,7 +21,7 @@ export default async function getDownloadSnippets(
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
     const { default: provideDownloadSnippets } = await import(
-      '#next-data/providers/downloadSnippets'
+      '#site/next-data/providers/downloadSnippets'
     );
     return provideDownloadSnippets(lang)!;
   }

--- a/apps/site/next-data/downloadSnippets.ts
+++ b/apps/site/next-data/downloadSnippets.ts
@@ -2,9 +2,9 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '@/next.constants.mjs';
-import { availableLocaleCodes } from '@/next.locales.mjs';
-import type { DownloadSnippet } from '@/types';
+} from '#next.constants.mjs';
+import { availableLocaleCodes } from '#next.locales.mjs';
+import type { DownloadSnippet } from '#types';
 
 export default async function getDownloadSnippets(
   lang: string
@@ -21,7 +21,7 @@ export default async function getDownloadSnippets(
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
     const { default: provideDownloadSnippets } = await import(
-      '@/next-data/providers/downloadSnippets'
+      '#next-data/providers/downloadSnippets'
     );
     return provideDownloadSnippets(lang)!;
   }

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -32,7 +32,7 @@ describe('generateReleaseData', () => {
     });
 
     const { default: generateReleaseData } = await import(
-      '#next-data/generators/releaseData.mjs'
+      '#site/next-data/generators/releaseData.mjs'
     );
 
     const result = await generateReleaseData();

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -32,7 +32,7 @@ describe('generateReleaseData', () => {
     });
 
     const { default: generateReleaseData } = await import(
-      '@/next-data/generators/releaseData.mjs'
+      '#next-data/generators/releaseData.mjs'
     );
 
     const result = await generateReleaseData();

--- a/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
+++ b/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import generateWebsiteFeeds from '@/next-data/generators/websiteFeeds.mjs';
+import generateWebsiteFeeds from '#next-data/generators/websiteFeeds.mjs';
 
 import { BASE_URL, BASE_PATH } from '../../../next.constants.mjs';
 import { siteConfig } from '../../../next.json.mjs';

--- a/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
+++ b/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import generateWebsiteFeeds from '#next-data/generators/websiteFeeds.mjs';
+import generateWebsiteFeeds from '#site/next-data/generators/websiteFeeds.mjs';
 
 import { BASE_URL, BASE_PATH } from '../../../next.constants.mjs';
 import { siteConfig } from '../../../next.json.mjs';

--- a/apps/site/next-data/providers/blogData.ts
+++ b/apps/site/next-data/providers/blogData.ts
@@ -1,8 +1,8 @@
 import { cache } from 'react';
 
-import generateBlogData from '#next-data/generators/blogData.mjs';
-import { BLOG_POSTS_PER_PAGE } from '#next.constants.mjs';
-import type { BlogCategory, BlogPostsRSC } from '#types';
+import generateBlogData from '#site/next-data/generators/blogData.mjs';
+import { BLOG_POSTS_PER_PAGE } from '#site/next.constants.mjs';
+import type { BlogCategory, BlogPostsRSC } from '#site/types';
 
 const { categories, posts } = await generateBlogData();
 

--- a/apps/site/next-data/providers/blogData.ts
+++ b/apps/site/next-data/providers/blogData.ts
@@ -1,8 +1,8 @@
 import { cache } from 'react';
 
-import generateBlogData from '@/next-data/generators/blogData.mjs';
-import { BLOG_POSTS_PER_PAGE } from '@/next.constants.mjs';
-import type { BlogCategory, BlogPostsRSC } from '@/types';
+import generateBlogData from '#next-data/generators/blogData.mjs';
+import { BLOG_POSTS_PER_PAGE } from '#next.constants.mjs';
+import type { BlogCategory, BlogPostsRSC } from '#types';
 
 const { categories, posts } = await generateBlogData();
 

--- a/apps/site/next-data/providers/downloadSnippets.ts
+++ b/apps/site/next-data/providers/downloadSnippets.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 
-import generateDownloadSnippets from '#next-data/generators/downloadSnippets.mjs';
+import generateDownloadSnippets from '#site/next-data/generators/downloadSnippets.mjs';
 
 const downloadSnippets = await generateDownloadSnippets();
 

--- a/apps/site/next-data/providers/downloadSnippets.ts
+++ b/apps/site/next-data/providers/downloadSnippets.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 
-import generateDownloadSnippets from '@/next-data/generators/downloadSnippets.mjs';
+import generateDownloadSnippets from '#next-data/generators/downloadSnippets.mjs';
 
 const downloadSnippets = await generateDownloadSnippets();
 

--- a/apps/site/next-data/providers/releaseData.ts
+++ b/apps/site/next-data/providers/releaseData.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 
-import generateReleaseData from '@/next-data/generators/releaseData.mjs';
+import generateReleaseData from '#next-data/generators/releaseData.mjs';
 
 const releaseData = await generateReleaseData();
 

--- a/apps/site/next-data/providers/releaseData.ts
+++ b/apps/site/next-data/providers/releaseData.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 
-import generateReleaseData from '#next-data/generators/releaseData.mjs';
+import generateReleaseData from '#site/next-data/generators/releaseData.mjs';
 
 const releaseData = await generateReleaseData();
 

--- a/apps/site/next-data/providers/websiteFeeds.ts
+++ b/apps/site/next-data/providers/websiteFeeds.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
-import generateWebsiteFeeds from '@/next-data/generators/websiteFeeds.mjs';
-import { provideBlogPosts } from '@/next-data/providers/blogData';
+import generateWebsiteFeeds from '#next-data/generators/websiteFeeds.mjs';
+import { provideBlogPosts } from '#next-data/providers/blogData';
 
 const websiteFeeds = generateWebsiteFeeds(provideBlogPosts('all'));
 

--- a/apps/site/next-data/providers/websiteFeeds.ts
+++ b/apps/site/next-data/providers/websiteFeeds.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
-import generateWebsiteFeeds from '#next-data/generators/websiteFeeds.mjs';
-import { provideBlogPosts } from '#next-data/providers/blogData';
+import generateWebsiteFeeds from '#site/next-data/generators/websiteFeeds.mjs';
+import { provideBlogPosts } from '#site/next-data/providers/blogData';
 
 const websiteFeeds = generateWebsiteFeeds(provideBlogPosts('all'));
 

--- a/apps/site/next-data/releaseData.ts
+++ b/apps/site/next-data/releaseData.ts
@@ -2,8 +2,8 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '@/next.constants.mjs';
-import type { NodeRelease } from '@/types';
+} from '#next.constants.mjs';
+import type { NodeRelease } from '#types';
 
 const getReleaseData = (): Promise<Array<NodeRelease>> => {
   // When we're using Static Exports the Next.js Server is not running (during build-time)
@@ -11,7 +11,7 @@ const getReleaseData = (): Promise<Array<NodeRelease>> => {
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
-    return import('@/next-data/providers/releaseData').then(
+    return import('#next-data/providers/releaseData').then(
       ({ default: provideReleaseData }) => provideReleaseData()
     );
   }

--- a/apps/site/next-data/releaseData.ts
+++ b/apps/site/next-data/releaseData.ts
@@ -2,8 +2,8 @@ import {
   ENABLE_STATIC_EXPORT,
   NEXT_DATA_URL,
   IS_NOT_VERCEL_RUNTIME_ENV,
-} from '#next.constants.mjs';
-import type { NodeRelease } from '#types';
+} from '#site/next.constants.mjs';
+import type { NodeRelease } from '#site/types';
 
 const getReleaseData = (): Promise<Array<NodeRelease>> => {
   // When we're using Static Exports the Next.js Server is not running (during build-time)
@@ -11,7 +11,7 @@ const getReleaseData = (): Promise<Array<NodeRelease>> => {
   // the data directly within the current thread, which will anyways be loaded only once
   // We use lazy-imports to prevent `provideBlogData` from executing on import
   if (ENABLE_STATIC_EXPORT || IS_NOT_VERCEL_RUNTIME_ENV) {
-    return import('#next-data/providers/releaseData').then(
+    return import('#site/next-data/providers/releaseData').then(
       ({ default: provideReleaseData }) => provideReleaseData()
     );
   }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -108,5 +108,16 @@
     "typescript-eslint": "~8.31.1",
     "unified": "^11.0.5",
     "user-agent-data-types": "0.4.2"
+  },
+  "imports": {
+    "#*": [
+      "./*",
+      "./*.tsx",
+      "./*/index.tsx",
+      "./*.ts",
+      "./*/index.ts",
+      "./*.mjs",
+      "./*/index.mjs"
+    ]
   }
 }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -110,7 +110,7 @@
     "user-agent-data-types": "0.4.2"
   },
   "imports": {
-    "#*": [
+    "#site/*": [
       "./*",
       "./*.tsx",
       "./*/index.tsx",

--- a/apps/site/providers/__tests__/matterProvider.test.jsx
+++ b/apps/site/providers/__tests__/matterProvider.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { act, render } from '@testing-library/react';
 
-import { MatterProvider, MatterContext } from '@/providers/matterProvider';
+import { MatterProvider, MatterContext } from '#providers/matterProvider';
 
 const mockContext = {
   frontmatter: {},

--- a/apps/site/providers/__tests__/matterProvider.test.jsx
+++ b/apps/site/providers/__tests__/matterProvider.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { act, render } from '@testing-library/react';
 
-import { MatterProvider, MatterContext } from '#providers/matterProvider';
+import { MatterProvider, MatterContext } from '#site/providers/matterProvider';
 
 const mockContext = {
   frontmatter: {},

--- a/apps/site/providers/__tests__/navigationStateProvider.test.jsx
+++ b/apps/site/providers/__tests__/navigationStateProvider.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { render } from '@testing-library/react';
 
-import { NavigationStateProvider } from '@/providers/navigationStateProvider';
+import { NavigationStateProvider } from '#providers/navigationStateProvider';
 
 describe('NavigationStateProvider', () => {
   it('should render without crashing', () => {

--- a/apps/site/providers/__tests__/navigationStateProvider.test.jsx
+++ b/apps/site/providers/__tests__/navigationStateProvider.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { render } from '@testing-library/react';
 
-import { NavigationStateProvider } from '#providers/navigationStateProvider';
+import { NavigationStateProvider } from '#site/providers/navigationStateProvider';
 
 describe('NavigationStateProvider', () => {
   it('should render without crashing', () => {

--- a/apps/site/providers/__tests__/notificationProvider.test.jsx
+++ b/apps/site/providers/__tests__/notificationProvider.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import {
   NotificationProvider,
   NotificationDispatch,
-} from '#providers/notificationProvider';
+} from '#site/providers/notificationProvider';
 
 describe('NotificationProvider', () => {
   it('renders children and shows notification with the provided message', async t => {

--- a/apps/site/providers/__tests__/notificationProvider.test.jsx
+++ b/apps/site/providers/__tests__/notificationProvider.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import {
   NotificationProvider,
   NotificationDispatch,
-} from '@/providers/notificationProvider';
+} from '#providers/notificationProvider';
 
 describe('NotificationProvider', () => {
   it('renders children and shows notification with the provided message', async t => {

--- a/apps/site/providers/__tests__/releaseProvider.test.jsx
+++ b/apps/site/providers/__tests__/releaseProvider.test.jsx
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict';
 
 import { render } from '@testing-library/react';
 
-import { ReleaseProvider, ReleasesProvider } from '#providers/releaseProvider';
+import {
+  ReleaseProvider,
+  ReleasesProvider,
+} from '#site/providers/releaseProvider';
 
 describe('ReleaseProvider', () => {
   it('should render without crashing', () => {

--- a/apps/site/providers/__tests__/releaseProvider.test.jsx
+++ b/apps/site/providers/__tests__/releaseProvider.test.jsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { render } from '@testing-library/react';
 
-import { ReleaseProvider, ReleasesProvider } from '@/providers/releaseProvider';
+import { ReleaseProvider, ReleasesProvider } from '#providers/releaseProvider';
 
 describe('ReleaseProvider', () => {
   it('should render without crashing', () => {

--- a/apps/site/providers/__tests__/themeProvider.test.jsx
+++ b/apps/site/providers/__tests__/themeProvider.test.jsx
@@ -16,7 +16,7 @@ describe('ThemeProvider', () => {
       },
     });
 
-    const { ThemeProvider } = await import('#providers/themeProvider');
+    const { ThemeProvider } = await import('#site/providers/themeProvider');
 
     const { container } = render(
       <ThemeProvider>

--- a/apps/site/providers/__tests__/themeProvider.test.jsx
+++ b/apps/site/providers/__tests__/themeProvider.test.jsx
@@ -16,7 +16,7 @@ describe('ThemeProvider', () => {
       },
     });
 
-    const { ThemeProvider } = await import('@/providers/themeProvider');
+    const { ThemeProvider } = await import('#providers/themeProvider');
 
     const { container } = render(
       <ThemeProvider>

--- a/apps/site/providers/matterProvider.tsx
+++ b/apps/site/providers/matterProvider.tsx
@@ -3,9 +3,9 @@
 import { createContext } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
-import { useDetectOS } from '@/hooks';
-import type { ClientSharedServerContext } from '@/types';
-import { assignClientContext } from '@/util/assignClientContext';
+import { useDetectOS } from '#hooks';
+import type { ClientSharedServerContext } from '#types';
+import { assignClientContext } from '#util/assignClientContext';
 
 export const MatterContext = createContext<ClientSharedServerContext>(
   assignClientContext({})

--- a/apps/site/providers/matterProvider.tsx
+++ b/apps/site/providers/matterProvider.tsx
@@ -3,9 +3,9 @@
 import { createContext } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
-import { useDetectOS } from '#hooks';
-import type { ClientSharedServerContext } from '#types';
-import { assignClientContext } from '#util/assignClientContext';
+import { useDetectOS } from '#site/hooks';
+import type { ClientSharedServerContext } from '#site/types';
+import { assignClientContext } from '#site/util/assignClientContext';
 
 export const MatterContext = createContext<ClientSharedServerContext>(
   assignClientContext({})

--- a/apps/site/providers/releaseModalProvider.tsx
+++ b/apps/site/providers/releaseModalProvider.tsx
@@ -3,8 +3,8 @@
 import { createContext, useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
-import ReleaseModal from '#components/Downloads/ReleaseModal';
-import type { NodeRelease } from '#types';
+import ReleaseModal from '#site/components/Downloads/ReleaseModal';
+import type { NodeRelease } from '#site/types';
 
 type ReleaseModalContextType = {
   activeRelease: NodeRelease | null;

--- a/apps/site/providers/releaseModalProvider.tsx
+++ b/apps/site/providers/releaseModalProvider.tsx
@@ -3,8 +3,8 @@
 import { createContext, useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 
-import ReleaseModal from '@/components/Downloads/ReleaseModal';
-import type { NodeRelease } from '@/types';
+import ReleaseModal from '#components/Downloads/ReleaseModal';
+import type { NodeRelease } from '#types';
 
 type ReleaseModalContextType = {
   activeRelease: NodeRelease | null;

--- a/apps/site/providers/releaseProvider.tsx
+++ b/apps/site/providers/releaseProvider.tsx
@@ -9,9 +9,12 @@ import {
   useReducer,
 } from 'react';
 
-import reducer, { getActions, releaseState } from '#reducers/releaseReducer';
-import type { NodeRelease } from '#types';
-import type * as Types from '#types/release';
+import reducer, {
+  getActions,
+  releaseState,
+} from '#site/reducers/releaseReducer';
+import type { NodeRelease } from '#site/types';
+import type * as Types from '#site/types/release';
 
 export const ReleasesContext = createContext<Types.ReleasesContextType>({
   releases: [],

--- a/apps/site/providers/releaseProvider.tsx
+++ b/apps/site/providers/releaseProvider.tsx
@@ -9,9 +9,9 @@ import {
   useReducer,
 } from 'react';
 
-import reducer, { getActions, releaseState } from '@/reducers/releaseReducer';
-import type { NodeRelease } from '@/types';
-import type * as Types from '@/types/release';
+import reducer, { getActions, releaseState } from '#reducers/releaseReducer';
+import type { NodeRelease } from '#types';
+import type * as Types from '#types/release';
 
 export const ReleasesContext = createContext<Types.ReleasesContextType>({
   releases: [],

--- a/apps/site/providers/themeProvider.tsx
+++ b/apps/site/providers/themeProvider.tsx
@@ -3,7 +3,7 @@
 import { ThemeProvider as NextThemeProvider } from 'next-themes';
 import type { FC, PropsWithChildren } from 'react';
 
-import { THEME_STORAGE_KEY } from '#next.constants.mjs';
+import { THEME_STORAGE_KEY } from '#site/next.constants.mjs';
 
 export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => (
   <NextThemeProvider

--- a/apps/site/providers/themeProvider.tsx
+++ b/apps/site/providers/themeProvider.tsx
@@ -3,7 +3,7 @@
 import { ThemeProvider as NextThemeProvider } from 'next-themes';
 import type { FC, PropsWithChildren } from 'react';
 
-import { THEME_STORAGE_KEY } from '@/next.constants.mjs';
+import { THEME_STORAGE_KEY } from '#next.constants.mjs';
 
 export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => (
   <NextThemeProvider

--- a/apps/site/reducers/__tests__/releaseReducer.test.mjs
+++ b/apps/site/reducers/__tests__/releaseReducer.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import reducer, { releaseState, getActions } from '#reducers/releaseReducer';
+import reducer, {
+  releaseState,
+  getActions,
+} from '#site/reducers/releaseReducer';
 
 describe('releaseReducer', () => {
   it('should return the initial state', () => {

--- a/apps/site/reducers/__tests__/releaseReducer.test.mjs
+++ b/apps/site/reducers/__tests__/releaseReducer.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import reducer, { releaseState, getActions } from '@/reducers/releaseReducer';
+import reducer, { releaseState, getActions } from '#reducers/releaseReducer';
 
 describe('releaseReducer', () => {
   it('should return the initial state', () => {

--- a/apps/site/reducers/releaseReducer.ts
+++ b/apps/site/reducers/releaseReducer.ts
@@ -1,6 +1,6 @@
 import type { Dispatch } from 'react';
 
-import type * as Types from '#types/release';
+import type * as Types from '#site/types/release';
 
 export const releaseState: Types.ReleaseState = {
   // The selected Node.js version to be downloaded

--- a/apps/site/reducers/releaseReducer.ts
+++ b/apps/site/reducers/releaseReducer.ts
@@ -1,6 +1,6 @@
 import type { Dispatch } from 'react';
 
-import type * as Types from '@/types/release';
+import type * as Types from '#types/release';
 
 export const releaseState: Types.ReleaseState = {
   // The selected Node.js version to be downloaded

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -14,10 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "paths": {
-      "@/*": ["./*"],
-      "@node-core/ui-components/*": ["../../packages/ui-components/*"]
-    },
     "plugins": [{ "name": "next" }],
     "baseUrl": "."
   },

--- a/apps/site/types/release.ts
+++ b/apps/site/types/release.ts
@@ -1,6 +1,6 @@
-import type { DownloadSnippet } from '@/types/downloads';
-import type { NodeRelease } from '@/types/releases';
-import type { UserOS, UserPlatform } from '@/types/userOS';
+import type { DownloadSnippet } from '#types/downloads';
+import type { NodeRelease } from '#types/releases';
+import type { UserOS, UserPlatform } from '#types/userOS';
 
 export type InstallationMethod =
   | 'NVM'

--- a/apps/site/types/release.ts
+++ b/apps/site/types/release.ts
@@ -1,6 +1,6 @@
-import type { DownloadSnippet } from '#types/downloads';
-import type { NodeRelease } from '#types/releases';
-import type { UserOS, UserPlatform } from '#types/userOS';
+import type { DownloadSnippet } from '#site/types/downloads';
+import type { NodeRelease } from '#site/types/releases';
+import type { UserOS, UserPlatform } from '#site/types/userOS';
 
 export type InstallationMethod =
   | 'NVM'

--- a/apps/site/types/server.ts
+++ b/apps/site/types/server.ts
@@ -1,8 +1,8 @@
 import type { Heading } from '@vcarl/remark-headings';
 import type { ReadTimeResults } from 'reading-time';
 
-import type { useDetectOS } from '@/hooks';
-import type { LegacyFrontMatter } from '@/types/frontmatter';
+import type { useDetectOS } from '#hooks';
+import type { LegacyFrontMatter } from '#types/frontmatter';
 
 export interface ClientSharedServerContext
   extends ReturnType<typeof useDetectOS> {

--- a/apps/site/types/server.ts
+++ b/apps/site/types/server.ts
@@ -1,8 +1,8 @@
 import type { Heading } from '@vcarl/remark-headings';
 import type { ReadTimeResults } from 'reading-time';
 
-import type { useDetectOS } from '#hooks';
-import type { LegacyFrontMatter } from '#types/frontmatter';
+import type { useDetectOS } from '#site/hooks';
+import type { LegacyFrontMatter } from '#site/types/frontmatter';
 
 export interface ClientSharedServerContext
   extends ReturnType<typeof useDetectOS> {

--- a/apps/site/util/__tests__/assignClientContext.test.mjs
+++ b/apps/site/util/__tests__/assignClientContext.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { assignClientContext } from '#util/assignClientContext';
+import { assignClientContext } from '#site/util/assignClientContext';
 
 const mockContext = {
   frontmatter: { title: 'Sample Title' },

--- a/apps/site/util/__tests__/assignClientContext.test.mjs
+++ b/apps/site/util/__tests__/assignClientContext.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { assignClientContext } from '@/util/assignClientContext';
+import { assignClientContext } from '#util/assignClientContext';
 
 const mockContext = {
   frontmatter: { title: 'Sample Title' },

--- a/apps/site/util/__tests__/authorUtils.test.mjs
+++ b/apps/site/util/__tests__/authorUtils.test.mjs
@@ -6,7 +6,7 @@ import {
   getAuthorWithId,
   getAuthorWithName,
   getAuthors,
-} from '#util/authorUtils';
+} from '#site/util/authorUtils';
 
 describe('mapAuthorToCardAuthors', () => {
   it('maps authors to card authors with default avatar source', () => {

--- a/apps/site/util/__tests__/authorUtils.test.mjs
+++ b/apps/site/util/__tests__/authorUtils.test.mjs
@@ -6,7 +6,7 @@ import {
   getAuthorWithId,
   getAuthorWithName,
   getAuthors,
-} from '@/util/authorUtils';
+} from '#util/authorUtils';
 
 describe('mapAuthorToCardAuthors', () => {
   it('maps authors to card authors with default avatar source', () => {

--- a/apps/site/util/__tests__/blogUtils.test.mjs
+++ b/apps/site/util/__tests__/blogUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
+import { mapBlogCategoryToPreviewType } from '#site/util/blogUtils';
 
 describe('mapBlogCategoryToPreviewType', () => {
   it('returns the correct preview type for recognized categories', () => {

--- a/apps/site/util/__tests__/blogUtils.test.mjs
+++ b/apps/site/util/__tests__/blogUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { mapBlogCategoryToPreviewType } from '@/util/blogUtils';
+import { mapBlogCategoryToPreviewType } from '#util/blogUtils';
 
 describe('mapBlogCategoryToPreviewType', () => {
   it('returns the correct preview type for recognized categories', () => {

--- a/apps/site/util/__tests__/dateUtils.test.mjs
+++ b/apps/site/util/__tests__/dateUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { dateIsBetween } from '@/util/dateUtils';
+import { dateIsBetween } from '#util/dateUtils';
 
 describe('dateIsBetween', () => {
   it('should return true when the current date is between start and end dates', () => {

--- a/apps/site/util/__tests__/dateUtils.test.mjs
+++ b/apps/site/util/__tests__/dateUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { dateIsBetween } from '#util/dateUtils';
+import { dateIsBetween } from '#site/util/dateUtils';
 
 describe('dateIsBetween', () => {
   it('should return true when the current date is between start and end dates', () => {

--- a/apps/site/util/__tests__/debounce.test.mjs
+++ b/apps/site/util/__tests__/debounce.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'node:test';
 
-import { debounce } from '#util/debounce';
+import { debounce } from '#site/util/debounce';
 
 describe('debounce', () => {
   beforeEach(t => {

--- a/apps/site/util/__tests__/debounce.test.mjs
+++ b/apps/site/util/__tests__/debounce.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'node:test';
 
-import { debounce } from '@/util/debounce';
+import { debounce } from '#util/debounce';
 
 describe('debounce', () => {
   beforeEach(t => {

--- a/apps/site/util/__tests__/deepMerge.test.mjs
+++ b/apps/site/util/__tests__/deepMerge.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import deepMerge from '@/util/deepMerge';
+import deepMerge from '#util/deepMerge';
 
 describe('deepMerge', () => {
   it('should merge nested objects', () => {

--- a/apps/site/util/__tests__/deepMerge.test.mjs
+++ b/apps/site/util/__tests__/deepMerge.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import deepMerge from '#util/deepMerge';
+import deepMerge from '#site/util/deepMerge';
 
 describe('deepMerge', () => {
   it('should merge nested objects', () => {

--- a/apps/site/util/__tests__/detectOS.test.mjs
+++ b/apps/site/util/__tests__/detectOS.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { detectOsInUserAgent, detectOS } from '#util/detectOS';
+import { detectOsInUserAgent, detectOS } from '#site/util/detectOS';
 
 const userAgentTestCases = [
   [

--- a/apps/site/util/__tests__/detectOS.test.mjs
+++ b/apps/site/util/__tests__/detectOS.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { detectOsInUserAgent, detectOS } from '@/util/detectOS';
+import { detectOsInUserAgent, detectOS } from '#util/detectOS';
 
 const userAgentTestCases = [
   [

--- a/apps/site/util/__tests__/downloadUtils.test.mjs
+++ b/apps/site/util/__tests__/downloadUtils.test.mjs
@@ -8,7 +8,7 @@ import {
   INSTALL_METHODS,
   PACKAGE_MANAGERS,
   PLATFORMS,
-} from '#util/downloadUtils';
+} from '#site/util/downloadUtils';
 
 describe('parseCompat', () => {
   it('should handle all OS, install methods, and package managers', () => {

--- a/apps/site/util/__tests__/downloadUtils.test.mjs
+++ b/apps/site/util/__tests__/downloadUtils.test.mjs
@@ -8,7 +8,7 @@ import {
   INSTALL_METHODS,
   PACKAGE_MANAGERS,
   PLATFORMS,
-} from '@/util/downloadUtils';
+} from '#util/downloadUtils';
 
 describe('parseCompat', () => {
   it('should handle all OS, install methods, and package managers', () => {

--- a/apps/site/util/__tests__/getHighEntropyValues.test.mjs
+++ b/apps/site/util/__tests__/getHighEntropyValues.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'node:test';
 
-import { getHighEntropyValues } from '#util/getHighEntropyValues';
+import { getHighEntropyValues } from '#site/util/getHighEntropyValues';
 
 const mock = () => Promise.resolve({ platform: 'Win32', architecture: 'x86' });
 

--- a/apps/site/util/__tests__/getHighEntropyValues.test.mjs
+++ b/apps/site/util/__tests__/getHighEntropyValues.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'node:test';
 
-import { getHighEntropyValues } from '@/util/getHighEntropyValues';
+import { getHighEntropyValues } from '#util/getHighEntropyValues';
 
 const mock = () => Promise.resolve({ platform: 'Win32', architecture: 'x86' });
 

--- a/apps/site/util/__tests__/getLanguageDisplayName.test.mjs
+++ b/apps/site/util/__tests__/getLanguageDisplayName.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { it, describe, mock } from 'node:test';
 
 describe('getLanguageDisplayName', async () => {
-  mock.module('@/shiki.config.mjs', {
+  mock.module('#shiki.config.mjs', {
     namedExports: {
       LANGUAGES: [
         { name: 'javascript', aliases: ['js'], displayName: 'JavaScript' },
@@ -12,7 +12,7 @@ describe('getLanguageDisplayName', async () => {
   });
 
   const { getLanguageDisplayName } = await import(
-    '@/util/getLanguageDisplayName'
+    '#util/getLanguageDisplayName'
   );
 
   it('should return the display name for a known language', () => {

--- a/apps/site/util/__tests__/getLanguageDisplayName.test.mjs
+++ b/apps/site/util/__tests__/getLanguageDisplayName.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { it, describe, mock } from 'node:test';
 
 describe('getLanguageDisplayName', async () => {
-  mock.module('#shiki.config.mjs', {
+  mock.module('#site/shiki.config.mjs', {
     namedExports: {
       LANGUAGES: [
         { name: 'javascript', aliases: ['js'], displayName: 'JavaScript' },
@@ -12,7 +12,7 @@ describe('getLanguageDisplayName', async () => {
   });
 
   const { getLanguageDisplayName } = await import(
-    '#util/getLanguageDisplayName'
+    '#site/util/getLanguageDisplayName'
   );
 
   it('should return the display name for a known language', () => {

--- a/apps/site/util/__tests__/getNodeApiLink.test.mjs
+++ b/apps/site/util/__tests__/getNodeApiLink.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getNodeApiLink } from '@/util/getNodeApiLink';
+import { getNodeApiLink } from '#util/getNodeApiLink';
 
 describe('getNodeApiLink', () => {
   it('should return the correct API link for versions >=0.3.1 and <0.5.1', () => {

--- a/apps/site/util/__tests__/getNodeApiLink.test.mjs
+++ b/apps/site/util/__tests__/getNodeApiLink.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getNodeApiLink } from '#util/getNodeApiLink';
+import { getNodeApiLink } from '#site/util/getNodeApiLink';
 
 describe('getNodeApiLink', () => {
   it('should return the correct API link for versions >=0.3.1 and <0.5.1', () => {

--- a/apps/site/util/__tests__/getNodeDownloadUrl.test.mjs
+++ b/apps/site/util/__tests__/getNodeDownloadUrl.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
+import { getNodeDownloadUrl } from '#site/util/getNodeDownloadUrl';
 
 const version = 'v18.16.0';
 

--- a/apps/site/util/__tests__/getNodeDownloadUrl.test.mjs
+++ b/apps/site/util/__tests__/getNodeDownloadUrl.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getNodeDownloadUrl } from '@/util/getNodeDownloadUrl';
+import { getNodeDownloadUrl } from '#util/getNodeDownloadUrl';
 
 const version = 'v18.16.0';
 

--- a/apps/site/util/__tests__/getUserPlatform.test.mjs
+++ b/apps/site/util/__tests__/getUserPlatform.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getUserPlatform } from '@/util/getUserPlatform';
+import { getUserPlatform } from '#util/getUserPlatform';
 
 describe('getUserPlatform', () => {
   it('should return arm64 for arm + 64', () => {

--- a/apps/site/util/__tests__/getUserPlatform.test.mjs
+++ b/apps/site/util/__tests__/getUserPlatform.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getUserPlatform } from '#util/getUserPlatform';
+import { getUserPlatform } from '#site/util/getUserPlatform';
 
 describe('getUserPlatform', () => {
   it('should return arm64 for arm + 64', () => {

--- a/apps/site/util/__tests__/gitHubUtils.test.mjs
+++ b/apps/site/util/__tests__/gitHubUtils.test.mjs
@@ -10,7 +10,7 @@ const {
   createGitHubSlugger,
   getGitHubBlobUrl,
   getGitHubApiDocsUrl,
-} = await import('@/util/gitHubUtils');
+} = await import('#util/gitHubUtils');
 
 describe('gitHubUtils', () => {
   it('getGitHubAvatarUrl returns the correct URL', () => {

--- a/apps/site/util/__tests__/gitHubUtils.test.mjs
+++ b/apps/site/util/__tests__/gitHubUtils.test.mjs
@@ -10,7 +10,7 @@ const {
   createGitHubSlugger,
   getGitHubBlobUrl,
   getGitHubApiDocsUrl,
-} = await import('#util/gitHubUtils');
+} = await import('#site/util/gitHubUtils');
 
 describe('gitHubUtils', () => {
   it('getGitHubAvatarUrl returns the correct URL', () => {

--- a/apps/site/util/__tests__/hexToRGBA.test.mjs
+++ b/apps/site/util/__tests__/hexToRGBA.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { hexToRGBA } from '#util/hexToRGBA';
+import { hexToRGBA } from '#site/util/hexToRGBA';
 
 describe('hexToRGBA', () => {
   it('should convert a hex color to an rgba color', () => {

--- a/apps/site/util/__tests__/hexToRGBA.test.mjs
+++ b/apps/site/util/__tests__/hexToRGBA.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { hexToRGBA } from '@/util/hexToRGBA';
+import { hexToRGBA } from '#util/hexToRGBA';
 
 describe('hexToRGBA', () => {
   it('should convert a hex color to an rgba color', () => {

--- a/apps/site/util/__tests__/imageUtils.test.mjs
+++ b/apps/site/util/__tests__/imageUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { isSvgImage } from '#util/imageUtils';
+import { isSvgImage } from '#site/util/imageUtils';
 describe('isSvgImage', () => {
   const testCases = [
     {

--- a/apps/site/util/__tests__/imageUtils.test.mjs
+++ b/apps/site/util/__tests__/imageUtils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { isSvgImage } from '@/util/imageUtils';
+import { isSvgImage } from '#util/imageUtils';
 describe('isSvgImage', () => {
   const testCases = [
     {

--- a/apps/site/util/__tests__/stringUtils.test.mjs
+++ b/apps/site/util/__tests__/stringUtils.test.mjs
@@ -5,7 +5,7 @@ import {
   getAcronymFromString,
   parseRichTextIntoPlainText,
   dashToCamelCase,
-} from '#util/stringUtils';
+} from '#site/util/stringUtils';
 
 describe('String utils', () => {
   it('getAcronymFromString returns the correct acronym', () => {

--- a/apps/site/util/__tests__/stringUtils.test.mjs
+++ b/apps/site/util/__tests__/stringUtils.test.mjs
@@ -5,7 +5,7 @@ import {
   getAcronymFromString,
   parseRichTextIntoPlainText,
   dashToCamelCase,
-} from '@/util/stringUtils';
+} from '#util/stringUtils';
 
 describe('String utils', () => {
   it('getAcronymFromString returns the correct acronym', () => {

--- a/apps/site/util/assignClientContext.ts
+++ b/apps/site/util/assignClientContext.ts
@@ -1,4 +1,4 @@
-import type { ClientSharedServerContext } from '#types';
+import type { ClientSharedServerContext } from '#site/types';
 
 export const assignClientContext = <T extends ClientSharedServerContext>(
   props: Partial<T>

--- a/apps/site/util/assignClientContext.ts
+++ b/apps/site/util/assignClientContext.ts
@@ -1,4 +1,4 @@
-import type { ClientSharedServerContext } from '@/types';
+import type { ClientSharedServerContext } from '#types';
 
 export const assignClientContext = <T extends ClientSharedServerContext>(
   props: Partial<T>

--- a/apps/site/util/authorUtils.ts
+++ b/apps/site/util/authorUtils.ts
@@ -1,7 +1,7 @@
-import { authors } from '#next.json.mjs';
-import type { AuthorProps } from '#types';
-import { getGitHubAvatarUrl } from '#util/gitHubUtils';
-import { getAcronymFromString } from '#util/stringUtils';
+import { authors } from '#site/next.json.mjs';
+import type { AuthorProps } from '#site/types';
+import { getGitHubAvatarUrl } from '#site/util/gitHubUtils';
+import { getAcronymFromString } from '#site/util/stringUtils';
 
 export const mapAuthorToCardAuthors = (author: string) => {
   // Clears text in parentheses

--- a/apps/site/util/authorUtils.ts
+++ b/apps/site/util/authorUtils.ts
@@ -1,7 +1,7 @@
-import { authors } from '@/next.json.mjs';
-import type { AuthorProps } from '@/types';
-import { getGitHubAvatarUrl } from '@/util/gitHubUtils';
-import { getAcronymFromString } from '@/util/stringUtils';
+import { authors } from '#next.json.mjs';
+import type { AuthorProps } from '#types';
+import { getGitHubAvatarUrl } from '#util/gitHubUtils';
+import { getAcronymFromString } from '#util/stringUtils';
 
 export const mapAuthorToCardAuthors = (author: string) => {
   // Clears text in parentheses

--- a/apps/site/util/blogUtils.ts
+++ b/apps/site/util/blogUtils.ts
@@ -1,4 +1,4 @@
-import type { BlogPreviewType } from '#types';
+import type { BlogPreviewType } from '#site/types';
 
 export const mapBlogCategoryToPreviewType = (type: string): BlogPreviewType => {
   switch (type) {

--- a/apps/site/util/blogUtils.ts
+++ b/apps/site/util/blogUtils.ts
@@ -1,4 +1,4 @@
-import type { BlogPreviewType } from '@/types';
+import type { BlogPreviewType } from '#types';
 
 export const mapBlogCategoryToPreviewType = (type: string): BlogPreviewType => {
   switch (type) {

--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -1,4 +1,4 @@
-import type { UserOS } from '#types/userOS';
+import type { UserOS } from '#site/types/userOS';
 
 export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
   // Match OS names and convert to uppercase directly if there's a match

--- a/apps/site/util/detectOS.ts
+++ b/apps/site/util/detectOS.ts
@@ -1,4 +1,4 @@
-import type { UserOS } from '@/types/userOS';
+import type { UserOS } from '#types/userOS';
 
 export const detectOsInUserAgent = (userAgent: string | undefined): UserOS => {
   // Match OS names and convert to uppercase directly if there's a match

--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -4,9 +4,9 @@ import * as OSIcons from '@node-core/ui-components/Icons/OperatingSystem';
 import * as PackageManagerIcons from '@node-core/ui-components/Icons/PackageManager';
 import satisfies from 'semver/functions/satisfies';
 
-import type { NodeReleaseStatus } from '#types';
-import type * as Types from '#types/release';
-import type { UserOS, UserPlatform } from '#types/userOS';
+import type { NodeReleaseStatus } from '#site/types';
+import type * as Types from '#site/types/release';
+import type { UserOS, UserPlatform } from '#site/types/userOS';
 
 // This is a manual list of OS's that do not support/have a way of being installed
 // with an executable installer. This is used to disable the installer button.

--- a/apps/site/util/downloadUtils.tsx
+++ b/apps/site/util/downloadUtils.tsx
@@ -4,9 +4,9 @@ import * as OSIcons from '@node-core/ui-components/Icons/OperatingSystem';
 import * as PackageManagerIcons from '@node-core/ui-components/Icons/PackageManager';
 import satisfies from 'semver/functions/satisfies';
 
-import type { NodeReleaseStatus } from '@/types';
-import type * as Types from '@/types/release';
-import type { UserOS, UserPlatform } from '@/types/userOS';
+import type { NodeReleaseStatus } from '#types';
+import type * as Types from '#types/release';
+import type { UserOS, UserPlatform } from '#types/userOS';
 
 // This is a manual list of OS's that do not support/have a way of being installed
 // with an executable installer. This is used to disable the installer button.

--- a/apps/site/util/getHighlighter.ts
+++ b/apps/site/util/getHighlighter.ts
@@ -1,7 +1,7 @@
 import { createHighlighterCoreSync } from '@shikijs/core';
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
 
-import { LANGUAGES, DEFAULT_THEME } from '@/shiki.config.mjs';
+import { LANGUAGES, DEFAULT_THEME } from '#shiki.config.mjs';
 
 // This creates a memoized minimal Shikiji Syntax Highlighter
 export const shiki = createHighlighterCoreSync({

--- a/apps/site/util/getHighlighter.ts
+++ b/apps/site/util/getHighlighter.ts
@@ -1,7 +1,7 @@
 import { createHighlighterCoreSync } from '@shikijs/core';
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
 
-import { LANGUAGES, DEFAULT_THEME } from '#shiki.config.mjs';
+import { LANGUAGES, DEFAULT_THEME } from '#site/shiki.config.mjs';
 
 // This creates a memoized minimal Shikiji Syntax Highlighter
 export const shiki = createHighlighterCoreSync({

--- a/apps/site/util/getLanguageDisplayName.ts
+++ b/apps/site/util/getLanguageDisplayName.ts
@@ -1,4 +1,4 @@
-import { LANGUAGES } from '@/shiki.config.mjs';
+import { LANGUAGES } from '#shiki.config.mjs';
 
 export const getLanguageDisplayName = (language: string): string => {
   const languageByIdOrAlias = LANGUAGES.find(

--- a/apps/site/util/getLanguageDisplayName.ts
+++ b/apps/site/util/getLanguageDisplayName.ts
@@ -1,4 +1,4 @@
-import { LANGUAGES } from '#shiki.config.mjs';
+import { LANGUAGES } from '#site/shiki.config.mjs';
 
 export const getLanguageDisplayName = (language: string): string => {
   const languageByIdOrAlias = LANGUAGES.find(

--- a/apps/site/util/getNodeApiLink.ts
+++ b/apps/site/util/getNodeApiLink.ts
@@ -1,6 +1,6 @@
 import semVer from 'semver';
 
-import { DOCS_URL, DIST_URL } from '#next.constants.mjs';
+import { DOCS_URL, DIST_URL } from '#site/next.constants.mjs';
 
 export const getNodeApiLink = (version: string) => {
   if (semVer.satisfies(version, '>=0.3.1 <0.5.1')) {

--- a/apps/site/util/getNodeApiLink.ts
+++ b/apps/site/util/getNodeApiLink.ts
@@ -1,6 +1,6 @@
 import semVer from 'semver';
 
-import { DOCS_URL, DIST_URL } from '@/next.constants.mjs';
+import { DOCS_URL, DIST_URL } from '#next.constants.mjs';
 
 export const getNodeApiLink = (version: string) => {
   if (semVer.satisfies(version, '>=0.3.1 <0.5.1')) {

--- a/apps/site/util/getNodeDownloadUrl.ts
+++ b/apps/site/util/getNodeDownloadUrl.ts
@@ -1,5 +1,5 @@
-import { DIST_URL } from '@/next.constants.mjs';
-import type { UserOS, UserPlatform } from '@/types/userOS';
+import { DIST_URL } from '#next.constants.mjs';
+import type { UserOS, UserPlatform } from '#types/userOS';
 
 export type DownloadKind = 'installer' | 'binary' | 'source';
 

--- a/apps/site/util/getNodeDownloadUrl.ts
+++ b/apps/site/util/getNodeDownloadUrl.ts
@@ -1,5 +1,5 @@
-import { DIST_URL } from '#next.constants.mjs';
-import type { UserOS, UserPlatform } from '#types/userOS';
+import { DIST_URL } from '#site/next.constants.mjs';
+import type { UserOS, UserPlatform } from '#site/types/userOS';
 
 export type DownloadKind = 'installer' | 'binary' | 'source';
 

--- a/apps/site/util/getUserPlatform.ts
+++ b/apps/site/util/getUserPlatform.ts
@@ -1,4 +1,4 @@
-import type * as Types from '@/types/userOS';
+import type * as Types from '#types/userOS';
 
 // This method is used to retrieve a User's platform based on their architecture and bitness.
 // Note: This is only used for automatic Platform detection for supported platforms by using `useDetectOS`

--- a/apps/site/util/getUserPlatform.ts
+++ b/apps/site/util/getUserPlatform.ts
@@ -1,4 +1,4 @@
-import type * as Types from '#types/userOS';
+import type * as Types from '#site/types/userOS';
 
 // This method is used to retrieve a User's platform based on their architecture and bitness.
 // Note: This is only used for automatic Platform detection for supported platforms by using `useDetectOS`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "storybook": "turbo run storybook",
     "storybook:build": "turbo run storybook:build",
     "test": "turbo test:unit",
-    "test:ci": "cross-env NODE_OPTIONS=\"--test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=junit.xml --test-reporter=@reporters/github --test-reporter-destination=stdout --test-reporter=spec --test-reporter-destination=stdout\" turbo test:unit"
+    "test:ci": "cross-env NODE_OPTIONS=\"--test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=junit --test-reporter-destination=junit.xml --test-reporter=@reporters/github --test-reporter-destination=stdout\" turbo test:unit"
   },
   "dependencies": {
     "acorn": "^8.14.1",

--- a/packages/i18n/lib/index.mjs
+++ b/packages/i18n/lib/index.mjs
@@ -1,6 +1,6 @@
 'use strict';
 
-import localeConfig from '@node-core/website-i18n/config.json' with { type: 'json' };
+import localeConfig from '../config.json' with { type: 'json' };
 
 /**
  * Imports a locale when exists from the locales directory

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -12,7 +12,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "paths": { "@/*": ["./*"] },
     "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "."

--- a/packages/ui-components/Common/AlertBox/index.stories.tsx
+++ b/packages/ui-components/Common/AlertBox/index.stories.tsx
@@ -1,7 +1,7 @@
 import { ExclamationCircleIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AlertBox from '#Common/AlertBox';
+import AlertBox from '#ui/Common/AlertBox';
 
 type Story = StoryObj<typeof AlertBox>;
 type Meta = MetaObj<typeof AlertBox>;

--- a/packages/ui-components/Common/AlertBox/index.stories.tsx
+++ b/packages/ui-components/Common/AlertBox/index.stories.tsx
@@ -1,7 +1,7 @@
 import { ExclamationCircleIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AlertBox from '@node-core/ui-components/Common/AlertBox';
+import AlertBox from '#Common/AlertBox';
 
 type Story = StoryObj<typeof AlertBox>;
 type Meta = MetaObj<typeof AlertBox>;

--- a/packages/ui-components/Common/AvatarGroup/Avatar/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Avatar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Avatar from '#Common/AvatarGroup/Avatar';
+import Avatar from '#ui/Common/AvatarGroup/Avatar';
 
 type Story = StoryObj<typeof Avatar>;
 type Meta = MetaObj<typeof Avatar>;

--- a/packages/ui-components/Common/AvatarGroup/Avatar/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Avatar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Avatar from '@node-core/ui-components/Common/AvatarGroup/Avatar';
+import Avatar from '#Common/AvatarGroup/Avatar';
 
 type Story = StoryObj<typeof Avatar>;
 type Meta = MetaObj<typeof Avatar>;

--- a/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
@@ -2,9 +2,9 @@ import classNames from 'classnames';
 import type { HTMLAttributes, ElementType } from 'react';
 import { forwardRef } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { LinkLike } from '#types';
 
 export type AvatarProps = {
   image?: string;

--- a/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
@@ -2,9 +2,9 @@ import classNames from 'classnames';
 import type { HTMLAttributes, ElementType } from 'react';
 import { forwardRef } from 'react';
 
-import styles from './index.module.css';
-
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 export type AvatarProps = {
   image?: string;

--- a/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Avatar/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import type { HTMLAttributes, ElementType } from 'react';
 import { forwardRef } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/AvatarGroup/Overlay/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Overlay/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AvatarOverlay from '#Common/AvatarGroup/Overlay';
+import AvatarOverlay from '#ui/Common/AvatarGroup/Overlay';
 
 type Story = StoryObj<typeof AvatarOverlay>;
 type Meta = MetaObj<typeof AvatarOverlay>;

--- a/packages/ui-components/Common/AvatarGroup/Overlay/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Overlay/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AvatarOverlay from '@node-core/ui-components/Common/AvatarGroup/Overlay';
+import AvatarOverlay from '#Common/AvatarGroup/Overlay';
 
 type Story = StoryObj<typeof AvatarOverlay>;
 type Meta = MetaObj<typeof AvatarOverlay>;

--- a/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
@@ -1,9 +1,9 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { ComponentProps, FC } from 'react';
 
-import Avatar from '@node-core/ui-components/Common/AvatarGroup/Avatar';
-
 import styles from './index.module.css';
+
+import Avatar from '#Common/AvatarGroup/Avatar';
 
 export type AvatarOverlayProps = ComponentProps<typeof Avatar> & {
   url?: string;

--- a/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
@@ -1,9 +1,9 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import Avatar from '#Common/AvatarGroup/Avatar';
+
+import styles from './index.module.css';
 
 export type AvatarOverlayProps = ComponentProps<typeof Avatar> & {
   url?: string;

--- a/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/Overlay/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { ComponentProps, FC } from 'react';
 
-import Avatar from '#Common/AvatarGroup/Avatar';
+import Avatar from '#ui/Common/AvatarGroup/Avatar';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/AvatarGroup/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AvatarGroup from '#Common/AvatarGroup';
+import AvatarGroup from '#ui/Common/AvatarGroup';
 
 type Story = StoryObj<typeof AvatarGroup>;
 type Meta = MetaObj<typeof AvatarGroup>;

--- a/packages/ui-components/Common/AvatarGroup/index.stories.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
+import AvatarGroup from '#Common/AvatarGroup';
 
 type Story = StoryObj<typeof AvatarGroup>;
 type Meta = MetaObj<typeof AvatarGroup>;

--- a/packages/ui-components/Common/AvatarGroup/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.tsx
@@ -4,14 +4,14 @@ import classNames from 'classnames';
 import type { FC, ElementType } from 'react';
 import { useState, useMemo } from 'react';
 
-import type { AvatarProps } from '@node-core/ui-components/Common/AvatarGroup/Avatar';
-import Avatar from '@node-core/ui-components/Common/AvatarGroup/Avatar';
-import avatarstyles from '@node-core/ui-components/Common/AvatarGroup/Avatar/index.module.css';
-import AvatarOverlay from '@node-core/ui-components/Common/AvatarGroup/Overlay';
-import Tooltip from '@node-core/ui-components/Common/Tooltip';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { AvatarProps } from '#Common/AvatarGroup/Avatar';
+import Avatar from '#Common/AvatarGroup/Avatar';
+import avatarstyles from '#Common/AvatarGroup/Avatar/index.module.css';
+import AvatarOverlay from '#Common/AvatarGroup/Overlay';
+import Tooltip from '#Common/Tooltip';
+import type { LinkLike } from '#types';
 
 type AvatarGroupProps = {
   avatars: Array<AvatarProps>;

--- a/packages/ui-components/Common/AvatarGroup/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.tsx
@@ -4,12 +4,12 @@ import classNames from 'classnames';
 import type { FC, ElementType } from 'react';
 import { useState, useMemo } from 'react';
 
-import type { AvatarProps } from '#Common/AvatarGroup/Avatar';
-import Avatar from '#Common/AvatarGroup/Avatar';
-import avatarstyles from '#Common/AvatarGroup/Avatar/index.module.css';
-import AvatarOverlay from '#Common/AvatarGroup/Overlay';
-import Tooltip from '#Common/Tooltip';
-import type { LinkLike } from '#types';
+import type { AvatarProps } from '#ui/Common/AvatarGroup/Avatar';
+import Avatar from '#ui/Common/AvatarGroup/Avatar';
+import avatarstyles from '#ui/Common/AvatarGroup/Avatar/index.module.css';
+import AvatarOverlay from '#ui/Common/AvatarGroup/Overlay';
+import Tooltip from '#ui/Common/Tooltip';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/AvatarGroup/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.tsx
@@ -4,14 +4,14 @@ import classNames from 'classnames';
 import type { FC, ElementType } from 'react';
 import { useState, useMemo } from 'react';
 
-import styles from './index.module.css';
-
 import type { AvatarProps } from '#Common/AvatarGroup/Avatar';
 import Avatar from '#Common/AvatarGroup/Avatar';
 import avatarstyles from '#Common/AvatarGroup/Avatar/index.module.css';
 import AvatarOverlay from '#Common/AvatarGroup/Overlay';
 import Tooltip from '#Common/Tooltip';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type AvatarGroupProps = {
   avatars: Array<AvatarProps>;

--- a/packages/ui-components/Common/Badge/index.stories.tsx
+++ b/packages/ui-components/Common/Badge/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Badge from '@node-core/ui-components/Common/Badge';
+import Badge from '#Common/Badge';
 
 type Story = StoryObj<typeof Badge>;
 type Meta = MetaObj<typeof Badge>;

--- a/packages/ui-components/Common/Badge/index.stories.tsx
+++ b/packages/ui-components/Common/Badge/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Badge from '#Common/Badge';
+import Badge from '#ui/Common/Badge';
 
 type Story = StoryObj<typeof Badge>;
 type Meta = MetaObj<typeof Badge>;

--- a/packages/ui-components/Common/BadgeGroup/index.stories.tsx
+++ b/packages/ui-components/Common/BadgeGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BadgeGroup from '#Common/BadgeGroup';
+import BadgeGroup from '#ui/Common/BadgeGroup';
 
 type Story = StoryObj<typeof BadgeGroup>;
 type Meta = MetaObj<typeof BadgeGroup>;

--- a/packages/ui-components/Common/BadgeGroup/index.stories.tsx
+++ b/packages/ui-components/Common/BadgeGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BadgeGroup from '@node-core/ui-components/Common/BadgeGroup';
+import BadgeGroup from '#Common/BadgeGroup';
 
 type Story = StoryObj<typeof BadgeGroup>;
 type Meta = MetaObj<typeof BadgeGroup>;

--- a/packages/ui-components/Common/BadgeGroup/index.tsx
+++ b/packages/ui-components/Common/BadgeGroup/index.tsx
@@ -1,8 +1,8 @@
 import ArrowRightIcon from '@heroicons/react/24/solid/ArrowRightIcon';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
-import Badge from '#Common/Badge';
-import type { LinkLike } from '#types';
+import Badge from '#ui/Common/Badge';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BadgeGroup/index.tsx
+++ b/packages/ui-components/Common/BadgeGroup/index.tsx
@@ -1,10 +1,10 @@
 import ArrowRightIcon from '@heroicons/react/24/solid/ArrowRightIcon';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
-import Badge from '@node-core/ui-components/Common/Badge';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import Badge from '#Common/Badge';
+import type { LinkLike } from '#types';
 
 type BadgeGroupKind = 'default' | 'warning' | 'error';
 

--- a/packages/ui-components/Common/BadgeGroup/index.tsx
+++ b/packages/ui-components/Common/BadgeGroup/index.tsx
@@ -1,10 +1,10 @@
 import ArrowRightIcon from '@heroicons/react/24/solid/ArrowRightIcon';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
-import styles from './index.module.css';
-
 import Badge from '#Common/Badge';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type BadgeGroupKind = 'default' | 'warning' | 'error';
 

--- a/packages/ui-components/Common/Banner/index.stories.tsx
+++ b/packages/ui-components/Common/Banner/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Banner from '#Common/Banner';
+import Banner from '#ui/Common/Banner';
 
 type Story = StoryObj<typeof Banner>;
 type Meta = MetaObj<typeof Banner>;

--- a/packages/ui-components/Common/Banner/index.stories.tsx
+++ b/packages/ui-components/Common/Banner/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Banner from '@node-core/ui-components/Common/Banner';
+import Banner from '#Common/Banner';
 
 type Story = StoryObj<typeof Banner>;
 type Meta = MetaObj<typeof Banner>;

--- a/packages/ui-components/Common/BaseActiveLink/index.tsx
+++ b/packages/ui-components/Common/BaseActiveLink/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
+import type { LinkLike } from '#types';
 
 export type ActiveLocalizedLinkProps = ComponentProps<LinkLike> & {
   activeClassName?: string;

--- a/packages/ui-components/Common/BaseActiveLink/index.tsx
+++ b/packages/ui-components/Common/BaseActiveLink/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 export type ActiveLocalizedLinkProps = ComponentProps<LinkLike> & {
   activeClassName?: string;

--- a/packages/ui-components/Common/BaseButton/index.stories.tsx
+++ b/packages/ui-components/Common/BaseButton/index.stories.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseButton from '#Common/BaseButton';
+import BaseButton from '#ui/Common/BaseButton';
 
 type Story = StoryObj<typeof BaseButton>;
 type Meta = MetaObj<typeof BaseButton>;

--- a/packages/ui-components/Common/BaseButton/index.stories.tsx
+++ b/packages/ui-components/Common/BaseButton/index.stories.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseButton from '@node-core/ui-components/Common/BaseButton';
+import BaseButton from '#Common/BaseButton';
 
 type Story = StoryObj<typeof BaseButton>;
 type Meta = MetaObj<typeof BaseButton>;

--- a/packages/ui-components/Common/BaseButton/index.tsx
+++ b/packages/ui-components/Common/BaseButton/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import type { FC, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { LinkLike } from '#types';
 
 export type ButtonProps = (
   | AnchorHTMLAttributes<HTMLAnchorElement>

--- a/packages/ui-components/Common/BaseButton/index.tsx
+++ b/packages/ui-components/Common/BaseButton/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { FC, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BaseButton/index.tsx
+++ b/packages/ui-components/Common/BaseButton/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import type { FC, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
-import styles from './index.module.css';
-
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 export type ButtonProps = (
   | AnchorHTMLAttributes<HTMLAnchorElement>

--- a/packages/ui-components/Common/BaseCodeBox/index.stories.tsx
+++ b/packages/ui-components/Common/BaseCodeBox/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseCodeBox from '#Common/BaseCodeBox';
+import BaseCodeBox from '#ui/Common/BaseCodeBox';
 
 type Story = StoryObj<typeof BaseCodeBox>;
 type Meta = MetaObj<typeof BaseCodeBox>;

--- a/packages/ui-components/Common/BaseCodeBox/index.stories.tsx
+++ b/packages/ui-components/Common/BaseCodeBox/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseCodeBox from '@node-core/ui-components/Common/BaseCodeBox';
+import BaseCodeBox from '#Common/BaseCodeBox';
 
 type Story = StoryObj<typeof BaseCodeBox>;
 type Meta = MetaObj<typeof BaseCodeBox>;

--- a/packages/ui-components/Common/BaseCodeBox/index.tsx
+++ b/packages/ui-components/Common/BaseCodeBox/index.tsx
@@ -8,8 +8,8 @@ import classNames from 'classnames';
 import type { FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { Fragment, isValidElement, useRef } from 'react';
 
-import BaseButton from '#Common/BaseButton';
-import type { LinkLike } from '#types';
+import BaseButton from '#ui/Common/BaseButton';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BaseCodeBox/index.tsx
+++ b/packages/ui-components/Common/BaseCodeBox/index.tsx
@@ -8,10 +8,10 @@ import classNames from 'classnames';
 import type { FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { Fragment, isValidElement, useRef } from 'react';
 
-import styles from './index.module.css';
-
 import BaseButton from '#Common/BaseButton';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 // Transforms a code element with plain text content into a more structured
 // format for rendering with line numbers

--- a/packages/ui-components/Common/BaseCodeBox/index.tsx
+++ b/packages/ui-components/Common/BaseCodeBox/index.tsx
@@ -8,10 +8,10 @@ import classNames from 'classnames';
 import type { FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { Fragment, isValidElement, useRef } from 'react';
 
-import BaseButton from '@node-core/ui-components/Common/BaseButton';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import BaseButton from '#Common/BaseButton';
+import type { LinkLike } from '#types';
 
 // Transforms a code element with plain text content into a more structured
 // format for rendering with line numbers

--- a/packages/ui-components/Common/BaseCrossLink/index.stories.tsx
+++ b/packages/ui-components/Common/BaseCrossLink/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseCrossLink from '#Common/BaseCrossLink';
+import BaseCrossLink from '#ui/Common/BaseCrossLink';
 
 type Story = StoryObj<typeof BaseCrossLink>;
 type Meta = MetaObj<typeof BaseCrossLink>;

--- a/packages/ui-components/Common/BaseCrossLink/index.stories.tsx
+++ b/packages/ui-components/Common/BaseCrossLink/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseCrossLink from '@node-core/ui-components/Common/BaseCrossLink';
+import BaseCrossLink from '#Common/BaseCrossLink';
 
 type Story = StoryObj<typeof BaseCrossLink>;
 type Meta = MetaObj<typeof BaseCrossLink>;

--- a/packages/ui-components/Common/BaseCrossLink/index.tsx
+++ b/packages/ui-components/Common/BaseCrossLink/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import PrevNextArrow from '#Common/BasePagination/PrevNextArrow';
-import type { LinkLike, FormattedMessage } from '#types';
+import PrevNextArrow from '#ui/Common/BasePagination/PrevNextArrow';
+import type { LinkLike, FormattedMessage } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BaseCrossLink/index.tsx
+++ b/packages/ui-components/Common/BaseCrossLink/index.tsx
@@ -2,10 +2,9 @@ import classNames from 'classnames';
 import type { FC } from 'react';
 
 import PrevNextArrow from '#Common/BasePagination/PrevNextArrow';
+import type { LinkLike, FormattedMessage } from '#types';
 
 import styles from './index.module.css';
-
-import type { LinkLike, FormattedMessage } from '#types';
 
 export type CrossLinkProps = {
   type: 'previous' | 'next';

--- a/packages/ui-components/Common/BaseCrossLink/index.tsx
+++ b/packages/ui-components/Common/BaseCrossLink/index.tsx
@@ -1,13 +1,11 @@
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import PrevNextArrow from '@node-core/ui-components/Common/BasePagination/PrevNextArrow';
-import type {
-  LinkLike,
-  FormattedMessage,
-} from '@node-core/ui-components/types';
+import PrevNextArrow from '#Common/BasePagination/PrevNextArrow';
 
 import styles from './index.module.css';
+
+import type { LinkLike, FormattedMessage } from '#types';
 
 export type CrossLinkProps = {
   type: 'previous' | 'next';

--- a/packages/ui-components/Common/BaseLinkTabs/index.stories.tsx
+++ b/packages/ui-components/Common/BaseLinkTabs/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseLinkTabs from '#Common/BaseLinkTabs';
+import BaseLinkTabs from '#ui/Common/BaseLinkTabs';
 
 type Story = StoryObj<typeof BaseLinkTabs>;
 type Meta = MetaObj<typeof BaseLinkTabs>;

--- a/packages/ui-components/Common/BaseLinkTabs/index.stories.tsx
+++ b/packages/ui-components/Common/BaseLinkTabs/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BaseLinkTabs from '@node-core/ui-components/Common/BaseLinkTabs';
+import BaseLinkTabs from '#Common/BaseLinkTabs';
 
 type Story = StoryObj<typeof BaseLinkTabs>;
 type Meta = MetaObj<typeof BaseLinkTabs>;

--- a/packages/ui-components/Common/BaseLinkTabs/index.tsx
+++ b/packages/ui-components/Common/BaseLinkTabs/index.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import styles from './index.module.css';
-
 import Select from '#Common/Select';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type LinkTab = { key: string; label: string; link: string };
 

--- a/packages/ui-components/Common/BaseLinkTabs/index.tsx
+++ b/packages/ui-components/Common/BaseLinkTabs/index.tsx
@@ -1,9 +1,9 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import Select from '@node-core/ui-components/Common/Select';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import Select from '#Common/Select';
+import type { LinkLike } from '#types';
 
 type LinkTab = { key: string; label: string; link: string };
 

--- a/packages/ui-components/Common/BaseLinkTabs/index.tsx
+++ b/packages/ui-components/Common/BaseLinkTabs/index.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import Select from '#Common/Select';
-import type { LinkLike } from '#types';
+import Select from '#ui/Common/Select';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BasePagination/Ellipsis/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/Ellipsis/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Ellipsis from '#Common/BasePagination/Ellipsis';
+import Ellipsis from '#ui/Common/BasePagination/Ellipsis';
 
 type Story = StoryObj<typeof Ellipsis>;
 type Meta = MetaObj<typeof Ellipsis>;

--- a/packages/ui-components/Common/BasePagination/Ellipsis/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/Ellipsis/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Ellipsis from '@node-core/ui-components/Common/BasePagination/Ellipsis';
+import Ellipsis from '#Common/BasePagination/Ellipsis';
 
 type Story = StoryObj<typeof Ellipsis>;
 type Meta = MetaObj<typeof Ellipsis>;

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/__tests__/index.test.jsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../../tests/utilities.mjs';
 
-import PaginationListItem from '@node-core/ui-components/Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#Common/BasePagination/PaginationListItem';
 
 function renderPaginationListItem({
   url,

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/__tests__/index.test.jsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../../tests/utilities.mjs';
 
-import PaginationListItem from '#Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#ui/Common/BasePagination/PaginationListItem';
 
 function renderPaginationListItem({
   url,

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import PaginationListItem from '@node-core/ui-components/Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#Common/BasePagination/PaginationListItem';
 
 type Story = StoryObj<typeof PaginationListItem>;
 type Meta = MetaObj<typeof PaginationListItem>;

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import PaginationListItem from '#Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#ui/Common/BasePagination/PaginationListItem';
 
 type Story = StoryObj<typeof PaginationListItem>;
 type Meta = MetaObj<typeof PaginationListItem>;

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { LinkLike } from '#types';
 
 export type PaginationListItemProps = {
   url: string;

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
+++ b/packages/ui-components/Common/BasePagination/PaginationListItem/index.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
-import styles from './index.module.css';
-
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 export type PaginationListItemProps = {
   url: string;

--- a/packages/ui-components/Common/BasePagination/__tests__/index.test.jsx
+++ b/packages/ui-components/Common/BasePagination/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../tests/utilities.mjs';
 
-import BasePagination from '@node-core/ui-components/Common/BasePagination';
+import BasePagination from '#Common/BasePagination';
 
 const getPageLabel = number => number.toString();
 const labels = {

--- a/packages/ui-components/Common/BasePagination/__tests__/index.test.jsx
+++ b/packages/ui-components/Common/BasePagination/__tests__/index.test.jsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 
 import { isVisible } from '../../../../../tests/utilities.mjs';
 
-import BasePagination from '#Common/BasePagination';
+import BasePagination from '#ui/Common/BasePagination';
 
 const getPageLabel = number => number.toString();
 const labels = {

--- a/packages/ui-components/Common/BasePagination/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BasePagination from '#Common/BasePagination';
+import BasePagination from '#ui/Common/BasePagination';
 
 type Story = StoryObj<typeof BasePagination>;
 type Meta = MetaObj<typeof BasePagination>;

--- a/packages/ui-components/Common/BasePagination/index.stories.tsx
+++ b/packages/ui-components/Common/BasePagination/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import BasePagination from '@node-core/ui-components/Common/BasePagination';
+import BasePagination from '#Common/BasePagination';
 
 type Story = StoryObj<typeof BasePagination>;
 type Meta = MetaObj<typeof BasePagination>;

--- a/packages/ui-components/Common/BasePagination/index.tsx
+++ b/packages/ui-components/Common/BasePagination/index.tsx
@@ -1,12 +1,11 @@
 import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/react/20/solid';
 import type { FC } from 'react';
 
+import Button from '#Common/BaseButton';
 import { useGetPageElements } from '#Common/BasePagination/useGetPageElements';
+import type { LinkLike } from '#types';
 
 import styles from './index.module.css';
-
-import Button from '#Common/BaseButton';
-import type { LinkLike } from '#types';
 
 type Page = { url: string };
 

--- a/packages/ui-components/Common/BasePagination/index.tsx
+++ b/packages/ui-components/Common/BasePagination/index.tsx
@@ -1,11 +1,12 @@
 import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/react/20/solid';
 import type { FC } from 'react';
 
-import Button from '@node-core/ui-components/Common/BaseButton';
-import { useGetPageElements } from '@node-core/ui-components/Common/BasePagination/useGetPageElements';
-import type { LinkLike } from '@node-core/ui-components/types';
+import { useGetPageElements } from '#Common/BasePagination/useGetPageElements';
 
 import styles from './index.module.css';
+
+import Button from '#Common/BaseButton';
+import type { LinkLike } from '#types';
 
 type Page = { url: string };
 

--- a/packages/ui-components/Common/BasePagination/index.tsx
+++ b/packages/ui-components/Common/BasePagination/index.tsx
@@ -1,9 +1,9 @@
 import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/react/20/solid';
 import type { FC } from 'react';
 
-import Button from '#Common/BaseButton';
-import { useGetPageElements } from '#Common/BasePagination/useGetPageElements';
-import type { LinkLike } from '#types';
+import Button from '#ui/Common/BaseButton';
+import { useGetPageElements } from '#ui/Common/BasePagination/useGetPageElements';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/BasePagination/useGetPageElements.tsx
+++ b/packages/ui-components/Common/BasePagination/useGetPageElements.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps } from 'react';
 
-import type BasePagination from '#Common/BasePagination';
-import Ellipsis from '#Common/BasePagination/Ellipsis';
-import type { PaginationListItemProps } from '#Common/BasePagination/PaginationListItem';
-import PaginationListItem from '#Common/BasePagination/PaginationListItem';
-import type { LinkLike } from '#types';
+import type BasePagination from '#ui/Common/BasePagination';
+import Ellipsis from '#ui/Common/BasePagination/Ellipsis';
+import type { PaginationListItemProps } from '#ui/Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#ui/Common/BasePagination/PaginationListItem';
+import type { LinkLike } from '#ui/types';
 
 const parsePages = (
   pages: ComponentProps<typeof BasePagination>['pages'],

--- a/packages/ui-components/Common/BasePagination/useGetPageElements.tsx
+++ b/packages/ui-components/Common/BasePagination/useGetPageElements.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps } from 'react';
 
-import type BasePagination from '@node-core/ui-components/Common/BasePagination';
-import Ellipsis from '@node-core/ui-components/Common/BasePagination/Ellipsis';
-import type { PaginationListItemProps } from '@node-core/ui-components/Common/BasePagination/PaginationListItem';
-import PaginationListItem from '@node-core/ui-components/Common/BasePagination/PaginationListItem';
-import type { LinkLike } from '@node-core/ui-components/types';
+import type BasePagination from '#Common/BasePagination';
+import Ellipsis from '#Common/BasePagination/Ellipsis';
+import type { PaginationListItemProps } from '#Common/BasePagination/PaginationListItem';
+import PaginationListItem from '#Common/BasePagination/PaginationListItem';
+import type { LinkLike } from '#types';
 
 const parsePages = (
   pages: ComponentProps<typeof BasePagination>['pages'],

--- a/packages/ui-components/Common/Blockquote/index.stories.tsx
+++ b/packages/ui-components/Common/Blockquote/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Blockquote from '#Common/Blockquote';
+import Blockquote from '#ui/Common/Blockquote';
 
 type Story = StoryObj<typeof Blockquote>;
 type Meta = MetaObj<typeof Blockquote>;

--- a/packages/ui-components/Common/Blockquote/index.stories.tsx
+++ b/packages/ui-components/Common/Blockquote/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Blockquote from '@node-core/ui-components/Common/Blockquote';
+import Blockquote from '#Common/Blockquote';
 
 type Story = StoryObj<typeof Blockquote>;
 type Meta = MetaObj<typeof Blockquote>;

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
@@ -1,9 +1,9 @@
 import HomeIcon from '@heroicons/react/24/outline/HomeIcon';
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import BreadcrumbLink from '#Common/Breadcrumbs/BreadcrumbLink';
+
+import styles from './index.module.css';
 
 type BreadcrumbHomeLinkProps = Omit<
   ComponentProps<typeof BreadcrumbLink>,

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
@@ -1,7 +1,7 @@
 import HomeIcon from '@heroicons/react/24/outline/HomeIcon';
 import type { ComponentProps, FC } from 'react';
 
-import BreadcrumbLink from '#Common/Breadcrumbs/BreadcrumbLink';
+import BreadcrumbLink from '#ui/Common/Breadcrumbs/BreadcrumbLink';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink/index.tsx
@@ -1,9 +1,9 @@
 import HomeIcon from '@heroicons/react/24/outline/HomeIcon';
 import type { ComponentProps, FC } from 'react';
 
-import BreadcrumbLink from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbLink';
-
 import styles from './index.module.css';
+
+import BreadcrumbLink from '#Common/Breadcrumbs/BreadcrumbLink';
 
 type BreadcrumbHomeLinkProps = Omit<
   ComponentProps<typeof BreadcrumbLink>,

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { LinkLike } from '#types';
 
 type BreadcrumbLinkProps = {
   active?: boolean;

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type BreadcrumbLinkProps = {
   active?: boolean;

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbTruncatedItem/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbTruncatedItem/index.tsx
@@ -1,4 +1,4 @@
-import BreadcrumbItem from '#Common/Breadcrumbs/BreadcrumbItem';
+import BreadcrumbItem from '#ui/Common/Breadcrumbs/BreadcrumbItem';
 
 const BreadcrumbTruncatedItem = () => (
   <BreadcrumbItem disableMicrodata>

--- a/packages/ui-components/Common/Breadcrumbs/BreadcrumbTruncatedItem/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/BreadcrumbTruncatedItem/index.tsx
@@ -1,4 +1,4 @@
-import BreadcrumbItem from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbItem';
+import BreadcrumbItem from '#Common/Breadcrumbs/BreadcrumbItem';
 
 const BreadcrumbTruncatedItem = () => (
   <BreadcrumbItem disableMicrodata>

--- a/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Breadcrumbs from '#Common/Breadcrumbs';
+import Breadcrumbs from '#ui/Common/Breadcrumbs';
 
 type Story = StoryObj<typeof Breadcrumbs>;
 type Meta = MetaObj<typeof Breadcrumbs>;

--- a/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Breadcrumbs from '@node-core/ui-components/Common/Breadcrumbs';
+import Breadcrumbs from '#Common/Breadcrumbs';
 
 type Story = StoryObj<typeof Breadcrumbs>;
 type Meta = MetaObj<typeof Breadcrumbs>;

--- a/packages/ui-components/Common/Breadcrumbs/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.tsx
@@ -1,12 +1,12 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 
-import BreadcrumbHomeLink from '#Common/Breadcrumbs/BreadcrumbHomeLink';
-import BreadcrumbItem from '#Common/Breadcrumbs/BreadcrumbItem';
-import BreadcrumbLink from '#Common/Breadcrumbs/BreadcrumbLink';
-import BreadcrumbRoot from '#Common/Breadcrumbs/BreadcrumbRoot';
-import BreadcrumbTruncatedItem from '#Common/Breadcrumbs/BreadcrumbTruncatedItem';
-import type { FormattedMessage, LinkLike } from '#types';
+import BreadcrumbHomeLink from '#ui/Common/Breadcrumbs/BreadcrumbHomeLink';
+import BreadcrumbItem from '#ui/Common/Breadcrumbs/BreadcrumbItem';
+import BreadcrumbLink from '#ui/Common/Breadcrumbs/BreadcrumbLink';
+import BreadcrumbRoot from '#ui/Common/Breadcrumbs/BreadcrumbRoot';
+import BreadcrumbTruncatedItem from '#ui/Common/Breadcrumbs/BreadcrumbTruncatedItem';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 export type BreadcrumbLink = {
   label: FormattedMessage;

--- a/packages/ui-components/Common/Breadcrumbs/index.tsx
+++ b/packages/ui-components/Common/Breadcrumbs/index.tsx
@@ -1,15 +1,12 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 
-import BreadcrumbHomeLink from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbHomeLink';
-import BreadcrumbItem from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbItem';
-import BreadcrumbLink from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbLink';
-import BreadcrumbRoot from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbRoot';
-import BreadcrumbTruncatedItem from '@node-core/ui-components/Common/Breadcrumbs/BreadcrumbTruncatedItem';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
+import BreadcrumbHomeLink from '#Common/Breadcrumbs/BreadcrumbHomeLink';
+import BreadcrumbItem from '#Common/Breadcrumbs/BreadcrumbItem';
+import BreadcrumbLink from '#Common/Breadcrumbs/BreadcrumbLink';
+import BreadcrumbRoot from '#Common/Breadcrumbs/BreadcrumbRoot';
+import BreadcrumbTruncatedItem from '#Common/Breadcrumbs/BreadcrumbTruncatedItem';
+import type { FormattedMessage, LinkLike } from '#types';
 
 export type BreadcrumbLink = {
   label: FormattedMessage;

--- a/packages/ui-components/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/Common/CodeTabs/index.stories.tsx
@@ -2,8 +2,8 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 import type { FC } from 'react';
 
-import BaseCodeBox from '@node-core/ui-components/Common/BaseCodeBox';
-import CodeTabs from '@node-core/ui-components/Common/CodeTabs';
+import BaseCodeBox from '#Common/BaseCodeBox';
+import CodeTabs from '#Common/CodeTabs';
 
 type Story = StoryObj<typeof CodeTabs>;
 type Meta = MetaObj<typeof CodeTabs>;

--- a/packages/ui-components/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/Common/CodeTabs/index.stories.tsx
@@ -2,8 +2,8 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 import type { FC } from 'react';
 
-import BaseCodeBox from '#Common/BaseCodeBox';
-import CodeTabs from '#Common/CodeTabs';
+import BaseCodeBox from '#ui/Common/BaseCodeBox';
+import CodeTabs from '#ui/Common/CodeTabs';
 
 type Story = StoryObj<typeof CodeTabs>;
 type Meta = MetaObj<typeof CodeTabs>;

--- a/packages/ui-components/Common/CodeTabs/index.tsx
+++ b/packages/ui-components/Common/CodeTabs/index.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import Tabs from '#Common/Tabs';
+
+import styles from './index.module.css';
 
 type CodeTabsProps = Pick<
   ComponentProps<typeof Tabs>,

--- a/packages/ui-components/Common/CodeTabs/index.tsx
+++ b/packages/ui-components/Common/CodeTabs/index.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, FC } from 'react';
 
-import Tabs from '#Common/Tabs';
+import Tabs from '#ui/Common/Tabs';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/CodeTabs/index.tsx
+++ b/packages/ui-components/Common/CodeTabs/index.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps, FC } from 'react';
 
-import Tabs from '@node-core/ui-components/Common/Tabs';
-
 import styles from './index.module.css';
+
+import Tabs from '#Common/Tabs';
 
 type CodeTabsProps = Pick<
   ComponentProps<typeof Tabs>,

--- a/packages/ui-components/Common/GlowingBackdrop/index.stories.tsx
+++ b/packages/ui-components/Common/GlowingBackdrop/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import GlowingBackdrop from '#Common/GlowingBackdrop';
+import GlowingBackdrop from '#ui/Common/GlowingBackdrop';
 
 type Story = StoryObj<typeof GlowingBackdrop>;
 type Meta = MetaObj<typeof GlowingBackdrop>;

--- a/packages/ui-components/Common/GlowingBackdrop/index.stories.tsx
+++ b/packages/ui-components/Common/GlowingBackdrop/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import GlowingBackdrop from '@node-core/ui-components/Common/GlowingBackdrop';
+import GlowingBackdrop from '#Common/GlowingBackdrop';
 
 type Story = StoryObj<typeof GlowingBackdrop>;
 type Meta = MetaObj<typeof GlowingBackdrop>;

--- a/packages/ui-components/Common/GlowingBackdrop/index.tsx
+++ b/packages/ui-components/Common/GlowingBackdrop/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import HexagonGrid from '@node-core/ui-components/Icons/HexagonGrid';
+import HexagonGrid from '#Icons/HexagonGrid';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/GlowingBackdrop/index.tsx
+++ b/packages/ui-components/Common/GlowingBackdrop/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import HexagonGrid from '#Icons/HexagonGrid';
+import HexagonGrid from '#ui/Icons/HexagonGrid';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/LanguageDropDown/index.stories.tsx
+++ b/packages/ui-components/Common/LanguageDropDown/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import LanguageDropDown from '@node-core/ui-components/Common/LanguageDropDown';
+import LanguageDropDown from '#Common/LanguageDropDown';
 
 type Story = StoryObj<typeof LanguageDropDown>;
 type Meta = MetaObj<typeof LanguageDropDown>;

--- a/packages/ui-components/Common/LanguageDropDown/index.stories.tsx
+++ b/packages/ui-components/Common/LanguageDropDown/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import LanguageDropDown from '#Common/LanguageDropDown';
+import LanguageDropDown from '#ui/Common/LanguageDropDown';
 
 type Story = StoryObj<typeof LanguageDropDown>;
 type Meta = MetaObj<typeof LanguageDropDown>;

--- a/packages/ui-components/Common/LanguageDropDown/index.tsx
+++ b/packages/ui-components/Common/LanguageDropDown/index.tsx
@@ -3,7 +3,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import type { SimpleLocaleConfig } from '#types';
+import type { SimpleLocaleConfig } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/LanguageDropDown/index.tsx
+++ b/packages/ui-components/Common/LanguageDropDown/index.tsx
@@ -3,9 +3,9 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import type { SimpleLocaleConfig } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { SimpleLocaleConfig } from '#types';
 
 type LanguageDropDownProps = {
   onChange?: (newLocale: SimpleLocaleConfig) => void;

--- a/packages/ui-components/Common/LanguageDropDown/index.tsx
+++ b/packages/ui-components/Common/LanguageDropDown/index.tsx
@@ -3,9 +3,9 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import styles from './index.module.css';
-
 import type { SimpleLocaleConfig } from '#types';
+
+import styles from './index.module.css';
 
 type LanguageDropDownProps = {
   onChange?: (newLocale: SimpleLocaleConfig) => void;

--- a/packages/ui-components/Common/Modal/index.stories.tsx
+++ b/packages/ui-components/Common/Modal/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Modal from '#Common/Modal';
+import Modal from '#ui/Common/Modal';
 
 type Story = StoryObj<typeof Modal>;
 type Meta = MetaObj<typeof Modal>;

--- a/packages/ui-components/Common/Modal/index.stories.tsx
+++ b/packages/ui-components/Common/Modal/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Modal from '@node-core/ui-components/Common/Modal';
+import Modal from '#Common/Modal';
 
 type Story = StoryObj<typeof Modal>;
 type Meta = MetaObj<typeof Modal>;

--- a/packages/ui-components/Common/NodejsLogo/index.stories.tsx
+++ b/packages/ui-components/Common/NodejsLogo/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NodejsLogo from '@node-core/ui-components/Common/NodejsLogo';
+import NodejsLogo from '#Common/NodejsLogo';
 
 type Story = StoryObj<typeof NodejsLogo>;
 type Meta = MetaObj<typeof NodejsLogo>;

--- a/packages/ui-components/Common/NodejsLogo/index.stories.tsx
+++ b/packages/ui-components/Common/NodejsLogo/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NodejsLogo from '#Common/NodejsLogo';
+import NodejsLogo from '#ui/Common/NodejsLogo';
 
 type Story = StoryObj<typeof NodejsLogo>;
 type Meta = MetaObj<typeof NodejsLogo>;

--- a/packages/ui-components/Common/NodejsLogo/index.tsx
+++ b/packages/ui-components/Common/NodejsLogo/index.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react';
 
-import NodejsIcon from '@node-core/ui-components/Icons/Logos/Nodejs';
-import type { LogoVariant } from '@node-core/ui-components/types';
+import NodejsIcon from '#Icons/Logos/Nodejs';
 
 import style from './index.module.css';
+
+import type { LogoVariant } from '#types';
 
 type NodejsLogoProps = {
   variant?: LogoVariant;

--- a/packages/ui-components/Common/NodejsLogo/index.tsx
+++ b/packages/ui-components/Common/NodejsLogo/index.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react';
 
 import NodejsIcon from '#Icons/Logos/Nodejs';
+import type { LogoVariant } from '#types';
 
 import style from './index.module.css';
-
-import type { LogoVariant } from '#types';
 
 type NodejsLogoProps = {
   variant?: LogoVariant;

--- a/packages/ui-components/Common/NodejsLogo/index.tsx
+++ b/packages/ui-components/Common/NodejsLogo/index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
-import NodejsIcon from '#Icons/Logos/Nodejs';
-import type { LogoVariant } from '#types';
+import NodejsIcon from '#ui/Icons/Logos/Nodejs';
+import type { LogoVariant } from '#ui/types';
 
 import style from './index.module.css';
 

--- a/packages/ui-components/Common/Notification/index.stories.tsx
+++ b/packages/ui-components/Common/Notification/index.stories.tsx
@@ -1,7 +1,7 @@
 import { CodeBracketIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Notification from '@node-core/ui-components/Common/Notification';
+import Notification from '#Common/Notification';
 
 type Story = StoryObj<typeof Notification>;
 type Meta = MetaObj<typeof Notification>;

--- a/packages/ui-components/Common/Notification/index.stories.tsx
+++ b/packages/ui-components/Common/Notification/index.stories.tsx
@@ -1,7 +1,7 @@
 import { CodeBracketIcon } from '@heroicons/react/24/solid';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Notification from '#Common/Notification';
+import Notification from '#ui/Common/Notification';
 
 type Story = StoryObj<typeof Notification>;
 type Meta = MetaObj<typeof Notification>;

--- a/packages/ui-components/Common/Preview/index.stories.tsx
+++ b/packages/ui-components/Common/Preview/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Preview from '#Common/Preview';
+import Preview from '#ui/Common/Preview';
 
 type Story = StoryObj<typeof Preview>;
 type Meta = MetaObj<typeof Preview>;

--- a/packages/ui-components/Common/Preview/index.stories.tsx
+++ b/packages/ui-components/Common/Preview/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Preview from '@node-core/ui-components/Common/Preview';
+import Preview from '#Common/Preview';
 
 type Story = StoryObj<typeof Preview>;
 type Meta = MetaObj<typeof Preview>;

--- a/packages/ui-components/Common/Preview/index.tsx
+++ b/packages/ui-components/Common/Preview/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import HexagonGrid from '#Icons/HexagonGrid';
-import JsWhiteIcon from '#Icons/Logos/JsWhite';
-import type { BlogPreviewType } from '#types';
+import HexagonGrid from '#ui/Icons/HexagonGrid';
+import JsWhiteIcon from '#ui/Icons/Logos/JsWhite';
+import type { BlogPreviewType } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/Preview/index.tsx
+++ b/packages/ui-components/Common/Preview/index.tsx
@@ -1,11 +1,12 @@
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import HexagonGrid from '@node-core/ui-components/Icons/HexagonGrid';
-import JsWhiteIcon from '@node-core/ui-components/Icons/Logos/JsWhite';
-import type { BlogPreviewType } from '@node-core/ui-components/types';
+import HexagonGrid from '#Icons/HexagonGrid';
+import JsWhiteIcon from '#Icons/Logos/JsWhite';
 
 import styles from './index.module.css';
+
+import type { BlogPreviewType } from '#types';
 
 type PreviewProps = {
   title: string;

--- a/packages/ui-components/Common/Preview/index.tsx
+++ b/packages/ui-components/Common/Preview/index.tsx
@@ -3,10 +3,9 @@ import type { FC } from 'react';
 
 import HexagonGrid from '#Icons/HexagonGrid';
 import JsWhiteIcon from '#Icons/Logos/JsWhite';
+import type { BlogPreviewType } from '#types';
 
 import styles from './index.module.css';
-
-import type { BlogPreviewType } from '#types';
 
 type PreviewProps = {
   title: string;

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
@@ -1,9 +1,9 @@
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import ProgressionSidebarItem from '#Common/ProgressionSidebar/ProgressionSidebarItem';
 import type { FormattedMessage, LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type ProgressionSidebarGroupProps = {
   groupName: FormattedMessage;

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, FC } from 'react';
 
-import ProgressionSidebarItem from '#Common/ProgressionSidebar/ProgressionSidebarItem';
-import type { FormattedMessage, LinkLike } from '#types';
+import ProgressionSidebarItem from '#ui/Common/ProgressionSidebar/ProgressionSidebarItem';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup/index.tsx
@@ -1,12 +1,9 @@
 import type { ComponentProps, FC } from 'react';
 
-import ProgressionSidebarItem from '@node-core/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import ProgressionSidebarItem from '#Common/ProgressionSidebar/ProgressionSidebarItem';
+import type { FormattedMessage, LinkLike } from '#types';
 
 type ProgressionSidebarGroupProps = {
   groupName: FormattedMessage;

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
@@ -1,13 +1,10 @@
 import type { FC } from 'react';
 
-import BaseActiveLink from '@node-core/ui-components/Common/BaseActiveLink';
-import ProgressionSidebarIcon from '@node-core/ui-components/Common/ProgressionSidebar/ProgressionSidebarIcon';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import BaseActiveLink from '#Common/BaseActiveLink';
+import ProgressionSidebarIcon from '#Common/ProgressionSidebar/ProgressionSidebarIcon';
+import type { FormattedMessage, LinkLike } from '#types';
 
 type ProgressionSidebarItemProps = {
   label: FormattedMessage;

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
@@ -1,10 +1,10 @@
 import type { FC } from 'react';
 
-import styles from './index.module.css';
-
 import BaseActiveLink from '#Common/BaseActiveLink';
 import ProgressionSidebarIcon from '#Common/ProgressionSidebar/ProgressionSidebarIcon';
 import type { FormattedMessage, LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type ProgressionSidebarItemProps = {
   label: FormattedMessage;

--- a/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/ProgressionSidebarItem/index.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
-import BaseActiveLink from '#Common/BaseActiveLink';
-import ProgressionSidebarIcon from '#Common/ProgressionSidebar/ProgressionSidebarIcon';
-import type { FormattedMessage, LinkLike } from '#types';
+import BaseActiveLink from '#ui/Common/BaseActiveLink';
+import ProgressionSidebarIcon from '#ui/Common/ProgressionSidebar/ProgressionSidebarIcon';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/ProgressionSidebar/index.stories.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import ProgressionSidebar from '@node-core/ui-components/Common/ProgressionSidebar';
+import ProgressionSidebar from '#Common/ProgressionSidebar';
 
 type Story = StoryObj<typeof ProgressionSidebar>;
 type Meta = MetaObj<typeof ProgressionSidebar>;

--- a/packages/ui-components/Common/ProgressionSidebar/index.stories.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import ProgressionSidebar from '#Common/ProgressionSidebar';
+import ProgressionSidebar from '#ui/Common/ProgressionSidebar';
 
 type Story = StoryObj<typeof ProgressionSidebar>;
 type Meta = MetaObj<typeof ProgressionSidebar>;

--- a/packages/ui-components/Common/ProgressionSidebar/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/index.tsx
@@ -2,9 +2,9 @@
 
 import { useRef, type ComponentProps, type FC } from 'react';
 
-import ProgressionSidebarGroup from '#Common/ProgressionSidebar/ProgressionSidebarGroup';
-import Select from '#Common/Select';
-import type { LinkLike } from '#types';
+import ProgressionSidebarGroup from '#ui/Common/ProgressionSidebar/ProgressionSidebarGroup';
+import Select from '#ui/Common/Select';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/ProgressionSidebar/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/index.tsx
@@ -2,11 +2,11 @@
 
 import { useRef, type ComponentProps, type FC } from 'react';
 
-import ProgressionSidebarGroup from '@node-core/ui-components/Common/ProgressionSidebar/ProgressionSidebarGroup';
-import Select from '@node-core/ui-components/Common/Select';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import ProgressionSidebarGroup from '#Common/ProgressionSidebar/ProgressionSidebarGroup';
+import Select from '#Common/Select';
+import type { LinkLike } from '#types';
 
 type ProgressionSidebarProps = {
   groups: Array<ComponentProps<typeof ProgressionSidebarGroup>>;

--- a/packages/ui-components/Common/ProgressionSidebar/index.tsx
+++ b/packages/ui-components/Common/ProgressionSidebar/index.tsx
@@ -2,11 +2,11 @@
 
 import { useRef, type ComponentProps, type FC } from 'react';
 
-import styles from './index.module.css';
-
 import ProgressionSidebarGroup from '#Common/ProgressionSidebar/ProgressionSidebarGroup';
 import Select from '#Common/Select';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type ProgressionSidebarProps = {
   groups: Array<ComponentProps<typeof ProgressionSidebarGroup>>;

--- a/packages/ui-components/Common/Select/index.stories.tsx
+++ b/packages/ui-components/Common/Select/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Select from '#Common/Select';
-import * as OSIcons from '#Icons/OperatingSystem';
+import Select from '#ui/Common/Select';
+import * as OSIcons from '#ui/Icons/OperatingSystem';
 
 type Story = StoryObj<typeof Select>;
 type Meta = MetaObj<typeof Select>;

--- a/packages/ui-components/Common/Select/index.stories.tsx
+++ b/packages/ui-components/Common/Select/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Select from '@node-core/ui-components/Common/Select';
-import * as OSIcons from '@node-core/ui-components/Icons/OperatingSystem';
+import Select from '#Common/Select';
+import * as OSIcons from '#Icons/OperatingSystem';
 
 type Story = StoryObj<typeof Select>;
 type Meta = MetaObj<typeof Select>;

--- a/packages/ui-components/Common/Select/index.tsx
+++ b/packages/ui-components/Common/Select/index.tsx
@@ -6,10 +6,10 @@ import classNames from 'classnames';
 import { useEffect, useId, useMemo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
-import styles from './index.module.css';
-
 import Skeleton from '#Common/Skeleton';
 import type { FormattedMessage } from '#types';
+
+import styles from './index.module.css';
 
 export type SelectValue<T extends string> = {
   label: FormattedMessage | string;

--- a/packages/ui-components/Common/Select/index.tsx
+++ b/packages/ui-components/Common/Select/index.tsx
@@ -6,8 +6,8 @@ import classNames from 'classnames';
 import { useEffect, useId, useMemo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
-import Skeleton from '#Common/Skeleton';
-import type { FormattedMessage } from '#types';
+import Skeleton from '#ui/Common/Skeleton';
+import type { FormattedMessage } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Common/Select/index.tsx
+++ b/packages/ui-components/Common/Select/index.tsx
@@ -6,10 +6,10 @@ import classNames from 'classnames';
 import { useEffect, useId, useMemo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
-import Skeleton from '@node-core/ui-components/Common/Skeleton';
-import type { FormattedMessage } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import Skeleton from '#Common/Skeleton';
+import type { FormattedMessage } from '#types';
 
 export type SelectValue<T extends string> = {
   label: FormattedMessage | string;

--- a/packages/ui-components/Common/Separator/index.stories.tsx
+++ b/packages/ui-components/Common/Separator/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Separator from '@node-core/ui-components/Common/Separator';
+import Separator from '#Common/Separator';
 
 type Story = StoryObj<typeof Separator>;
 type Meta = MetaObj<typeof Separator>;

--- a/packages/ui-components/Common/Separator/index.stories.tsx
+++ b/packages/ui-components/Common/Separator/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Separator from '#Common/Separator';
+import Separator from '#ui/Common/Separator';
 
 type Story = StoryObj<typeof Separator>;
 type Meta = MetaObj<typeof Separator>;

--- a/packages/ui-components/Common/Tabs/index.stories.tsx
+++ b/packages/ui-components/Common/Tabs/index.stories.tsx
@@ -2,7 +2,7 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
-import Tabs from '#Common/Tabs';
+import Tabs from '#ui/Common/Tabs';
 
 type Story = StoryObj<typeof Tabs>;
 type Meta = MetaObj<typeof Tabs>;

--- a/packages/ui-components/Common/Tabs/index.stories.tsx
+++ b/packages/ui-components/Common/Tabs/index.stories.tsx
@@ -2,7 +2,7 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
-import Tabs from '@node-core/ui-components/Common/Tabs';
+import Tabs from '#Common/Tabs';
 
 type Story = StoryObj<typeof Tabs>;
 type Meta = MetaObj<typeof Tabs>;

--- a/packages/ui-components/Common/ThemeToggle/index.stories.tsx
+++ b/packages/ui-components/Common/ThemeToggle/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import ThemeToggle from '#Common/ThemeToggle';
+import ThemeToggle from '#ui/Common/ThemeToggle';
 
 type Story = StoryObj<typeof ThemeToggle>;
 type Meta = MetaObj<typeof ThemeToggle>;

--- a/packages/ui-components/Common/ThemeToggle/index.stories.tsx
+++ b/packages/ui-components/Common/ThemeToggle/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import ThemeToggle from '@node-core/ui-components/Common/ThemeToggle';
+import ThemeToggle from '#Common/ThemeToggle';
 
 type Story = StoryObj<typeof ThemeToggle>;
 type Meta = MetaObj<typeof ThemeToggle>;

--- a/packages/ui-components/Common/Tooltip/index.stories.tsx
+++ b/packages/ui-components/Common/Tooltip/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Tooltip from '@node-core/ui-components/Common/Tooltip';
+import Tooltip from '#Common/Tooltip';
 
 type Story = StoryObj<typeof Tooltip>;
 type Meta = MetaObj<typeof Tooltip>;

--- a/packages/ui-components/Common/Tooltip/index.stories.tsx
+++ b/packages/ui-components/Common/Tooltip/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Tooltip from '#Common/Tooltip';
+import Tooltip from '#ui/Common/Tooltip';
 
 type Story = StoryObj<typeof Tooltip>;
 type Meta = MetaObj<typeof Tooltip>;

--- a/packages/ui-components/Containers/Footer/index.stories.tsx
+++ b/packages/ui-components/Containers/Footer/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Footer from '@node-core/ui-components/Containers/Footer';
+import Footer from '#Containers/Footer';
 
 type Story = StoryObj<typeof Footer>;
 type Meta = MetaObj<typeof Footer>;

--- a/packages/ui-components/Containers/Footer/index.stories.tsx
+++ b/packages/ui-components/Containers/Footer/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Footer from '#Containers/Footer';
+import Footer from '#ui/Containers/Footer';
 
 type Story = StoryObj<typeof Footer>;
 type Meta = MetaObj<typeof Footer>;

--- a/packages/ui-components/Containers/Footer/index.tsx
+++ b/packages/ui-components/Containers/Footer/index.tsx
@@ -2,8 +2,6 @@
 
 import type { FC, SVGProps } from 'react';
 
-import styles from './index.module.css';
-
 import NavItem from '#Containers/NavBar/NavItem';
 import {
   Bluesky,
@@ -15,6 +13,8 @@ import {
   X,
 } from '#Icons/Social';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 const footerSocialIcons: Record<string, React.FC<SVGProps<SVGSVGElement>>> = {
   github: GitHub,

--- a/packages/ui-components/Containers/Footer/index.tsx
+++ b/packages/ui-components/Containers/Footer/index.tsx
@@ -2,7 +2,7 @@
 
 import type { FC, SVGProps } from 'react';
 
-import NavItem from '#Containers/NavBar/NavItem';
+import NavItem from '#ui/Containers/NavBar/NavItem';
 import {
   Bluesky,
   Discord,
@@ -11,8 +11,8 @@ import {
   Mastodon,
   Slack,
   X,
-} from '#Icons/Social';
-import type { LinkLike } from '#types';
+} from '#ui/Icons/Social';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Containers/Footer/index.tsx
+++ b/packages/ui-components/Containers/Footer/index.tsx
@@ -2,7 +2,9 @@
 
 import type { FC, SVGProps } from 'react';
 
-import NavItem from '@node-core/ui-components/Containers/NavBar/NavItem';
+import styles from './index.module.css';
+
+import NavItem from '#Containers/NavBar/NavItem';
 import {
   Bluesky,
   Discord,
@@ -11,10 +13,8 @@ import {
   Mastodon,
   Slack,
   X,
-} from '@node-core/ui-components/Icons/Social';
-import type { LinkLike } from '@node-core/ui-components/types';
-
-import styles from './index.module.css';
+} from '#Icons/Social';
+import type { LinkLike } from '#types';
 
 const footerSocialIcons: Record<string, React.FC<SVGProps<SVGSVGElement>>> = {
   github: GitHub,

--- a/packages/ui-components/Containers/MetaBar/index.stories.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.stories.tsx
@@ -1,8 +1,9 @@
 import { CodeBracketIcon } from '@heroicons/react/24/outline';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import MetaBar from '@node-core/ui-components/Containers/MetaBar';
-import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
+import GitHubIcon from '#Icons/Social/GitHub';
+
+import MetaBar from '#Containers/MetaBar';
 
 type Story = StoryObj<typeof MetaBar>;
 type Meta = MetaObj<typeof MetaBar>;

--- a/packages/ui-components/Containers/MetaBar/index.stories.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.stories.tsx
@@ -1,8 +1,8 @@
 import { CodeBracketIcon } from '@heroicons/react/24/outline';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import MetaBar from '#Containers/MetaBar';
-import GitHubIcon from '#Icons/Social/GitHub';
+import MetaBar from '#ui/Containers/MetaBar';
+import GitHubIcon from '#ui/Icons/Social/GitHub';
 
 type Story = StoryObj<typeof MetaBar>;
 type Meta = MetaObj<typeof MetaBar>;

--- a/packages/ui-components/Containers/MetaBar/index.stories.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.stories.tsx
@@ -1,9 +1,8 @@
 import { CodeBracketIcon } from '@heroicons/react/24/outline';
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import GitHubIcon from '#Icons/Social/GitHub';
-
 import MetaBar from '#Containers/MetaBar';
+import GitHubIcon from '#Icons/Social/GitHub';
 
 type Story = StoryObj<typeof MetaBar>;
 type Meta = MetaObj<typeof MetaBar>;

--- a/packages/ui-components/Containers/MetaBar/index.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.tsx
@@ -2,9 +2,9 @@ import type { Heading } from '@vcarl/remark-headings';
 import { Fragment, useMemo } from 'react';
 import type { FC } from 'react';
 
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import type { LinkLike } from '#types';
 
 type MetaBarProps = {
   items: Partial<Record<string, React.ReactNode>>;

--- a/packages/ui-components/Containers/MetaBar/index.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.tsx
@@ -2,9 +2,9 @@ import type { Heading } from '@vcarl/remark-headings';
 import { Fragment, useMemo } from 'react';
 import type { FC } from 'react';
 
-import styles from './index.module.css';
-
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type MetaBarProps = {
   items: Partial<Record<string, React.ReactNode>>;

--- a/packages/ui-components/Containers/MetaBar/index.tsx
+++ b/packages/ui-components/Containers/MetaBar/index.tsx
@@ -2,7 +2,7 @@ import type { Heading } from '@vcarl/remark-headings';
 import { Fragment, useMemo } from 'react';
 import type { FC } from 'react';
 
-import type { LinkLike } from '#types';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Containers/NavBar/NavItem/index.stories.tsx
+++ b/packages/ui-components/Containers/NavBar/NavItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NavItem from '#Containers/NavBar/NavItem';
+import NavItem from '#ui/Containers/NavBar/NavItem';
 
 type Story = StoryObj<typeof NavItem>;
 type Meta = MetaObj<typeof NavItem>;

--- a/packages/ui-components/Containers/NavBar/NavItem/index.stories.tsx
+++ b/packages/ui-components/Containers/NavBar/NavItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NavItem from '@node-core/ui-components/Containers/NavBar/NavItem';
+import NavItem from '#Containers/NavBar/NavItem';
 
 type Story = StoryObj<typeof NavItem>;
 type Meta = MetaObj<typeof NavItem>;

--- a/packages/ui-components/Containers/NavBar/NavItem/index.tsx
+++ b/packages/ui-components/Containers/NavBar/NavItem/index.tsx
@@ -2,10 +2,10 @@ import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import classNames from 'classnames';
 import type { FC, HTMLAttributeAnchorTarget, PropsWithChildren } from 'react';
 
-import BaseActiveLink from '@node-core/ui-components/Common/BaseActiveLink';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import BaseActiveLink from '#Common/BaseActiveLink';
+import type { LinkLike } from '#types';
 
 type NavItemType = 'nav' | 'footer';
 

--- a/packages/ui-components/Containers/NavBar/NavItem/index.tsx
+++ b/packages/ui-components/Containers/NavBar/NavItem/index.tsx
@@ -2,10 +2,10 @@ import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import classNames from 'classnames';
 import type { FC, HTMLAttributeAnchorTarget, PropsWithChildren } from 'react';
 
-import styles from './index.module.css';
-
 import BaseActiveLink from '#Common/BaseActiveLink';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type NavItemType = 'nav' | 'footer';
 

--- a/packages/ui-components/Containers/NavBar/NavItem/index.tsx
+++ b/packages/ui-components/Containers/NavBar/NavItem/index.tsx
@@ -2,8 +2,8 @@ import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import classNames from 'classnames';
 import type { FC, HTMLAttributeAnchorTarget, PropsWithChildren } from 'react';
 
-import BaseActiveLink from '#Common/BaseActiveLink';
-import type { LinkLike } from '#types';
+import BaseActiveLink from '#ui/Common/BaseActiveLink';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Containers/NavBar/index.stories.tsx
+++ b/packages/ui-components/Containers/NavBar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NavBar from '#Containers/NavBar';
+import NavBar from '#ui/Containers/NavBar';
 
 type Story = StoryObj<typeof NavBar>;
 type Meta = MetaObj<typeof NavBar>;

--- a/packages/ui-components/Containers/NavBar/index.stories.tsx
+++ b/packages/ui-components/Containers/NavBar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import NavBar from '@node-core/ui-components/Containers/NavBar';
+import NavBar from '#Containers/NavBar';
 
 type Story = StoryObj<typeof NavBar>;
 type Meta = MetaObj<typeof NavBar>;

--- a/packages/ui-components/Containers/NavBar/index.tsx
+++ b/packages/ui-components/Containers/NavBar/index.tsx
@@ -12,10 +12,10 @@ import type {
   ElementType,
 } from 'react';
 
-import style from './index.module.css';
-
 import NavItem from '#Containers/NavBar/NavItem';
 import type { FormattedMessage, LinkLike } from '#types';
+
+import style from './index.module.css';
 
 const navInteractionIcons = {
   show: <Hamburger className={style.navInteractionIcon} />,

--- a/packages/ui-components/Containers/NavBar/index.tsx
+++ b/packages/ui-components/Containers/NavBar/index.tsx
@@ -12,13 +12,10 @@ import type {
   ElementType,
 } from 'react';
 
-import NavItem from '@node-core/ui-components/Containers/NavBar/NavItem';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
-
 import style from './index.module.css';
+
+import NavItem from '#Containers/NavBar/NavItem';
+import type { FormattedMessage, LinkLike } from '#types';
 
 const navInteractionIcons = {
   show: <Hamburger className={style.navInteractionIcon} />,

--- a/packages/ui-components/Containers/NavBar/index.tsx
+++ b/packages/ui-components/Containers/NavBar/index.tsx
@@ -12,8 +12,8 @@ import type {
   ElementType,
 } from 'react';
 
-import NavItem from '#Containers/NavBar/NavItem';
-import type { FormattedMessage, LinkLike } from '#types';
+import NavItem from '#ui/Containers/NavBar/NavItem';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 import style from './index.module.css';
 

--- a/packages/ui-components/Containers/Sidebar/SidebarGroup/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import SidebarGroup from '#Containers/Sidebar/SidebarGroup';
+import SidebarGroup from '#ui/Containers/Sidebar/SidebarGroup';
 
 type Story = StoryObj<typeof SidebarGroup>;
 type Meta = MetaObj<typeof SidebarGroup>;

--- a/packages/ui-components/Containers/Sidebar/SidebarGroup/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarGroup/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import SidebarGroup from '@node-core/ui-components/Containers/Sidebar/SidebarGroup';
+import SidebarGroup from '#Containers/Sidebar/SidebarGroup';
 
 type Story = StoryObj<typeof SidebarGroup>;
 type Meta = MetaObj<typeof SidebarGroup>;

--- a/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
@@ -1,12 +1,9 @@
 import type { ComponentProps, FC } from 'react';
 
-import SidebarItem from '@node-core/ui-components/Containers/Sidebar/SidebarItem';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import SidebarItem from '#Containers/Sidebar/SidebarItem';
+import type { FormattedMessage, LinkLike } from '#types';
 
 type SidebarGroupProps = {
   groupName: FormattedMessage;

--- a/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
@@ -1,9 +1,9 @@
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import SidebarItem from '#Containers/Sidebar/SidebarItem';
 import type { FormattedMessage, LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type SidebarGroupProps = {
   groupName: FormattedMessage;

--- a/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarGroup/index.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, FC } from 'react';
 
-import SidebarItem from '#Containers/Sidebar/SidebarItem';
-import type { FormattedMessage, LinkLike } from '#types';
+import SidebarItem from '#ui/Containers/Sidebar/SidebarItem';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import SidebarItem from '#Containers/Sidebar/SidebarItem';
+import SidebarItem from '#ui/Containers/Sidebar/SidebarItem';
 
 type Story = StoryObj<typeof SidebarItem>;
 type Meta = MetaObj<typeof SidebarItem>;

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import SidebarItem from '@node-core/ui-components/Containers/Sidebar/SidebarItem';
+import SidebarItem from '#Containers/Sidebar/SidebarItem';
 
 type Story = StoryObj<typeof SidebarItem>;
 type Meta = MetaObj<typeof SidebarItem>;

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
@@ -1,10 +1,10 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
-import styles from './index.module.css';
-
 import ActiveLink from '#Common/BaseActiveLink';
 import type { FormattedMessage, LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type SidebarItemProps = {
   label: FormattedMessage;

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
@@ -1,8 +1,8 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
-import ActiveLink from '#Common/BaseActiveLink';
-import type { FormattedMessage, LinkLike } from '#types';
+import ActiveLink from '#ui/Common/BaseActiveLink';
+import type { FormattedMessage, LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
@@ -1,13 +1,10 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/solid';
 import type { FC } from 'react';
 
-import ActiveLink from '@node-core/ui-components/Common/BaseActiveLink';
-import type {
-  FormattedMessage,
-  LinkLike,
-} from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import ActiveLink from '#Common/BaseActiveLink';
+import type { FormattedMessage, LinkLike } from '#types';
 
 type SidebarItemProps = {
   label: FormattedMessage;

--- a/packages/ui-components/Containers/Sidebar/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Sidebar from '@node-core/ui-components/Containers/Sidebar';
+import Sidebar from '#Containers/Sidebar';
 
 type Story = StoryObj<typeof Sidebar>;
 type Meta = MetaObj<typeof Sidebar>;

--- a/packages/ui-components/Containers/Sidebar/index.stories.tsx
+++ b/packages/ui-components/Containers/Sidebar/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import Sidebar from '#Containers/Sidebar';
+import Sidebar from '#ui/Containers/Sidebar';
 
 type Story = StoryObj<typeof Sidebar>;
 type Meta = MetaObj<typeof Sidebar>;

--- a/packages/ui-components/Containers/Sidebar/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/index.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps, FC } from 'react';
 
-import Select from '@node-core/ui-components/Common/Select';
-import SidebarGroup from '@node-core/ui-components/Containers/Sidebar/SidebarGroup';
-import type { LinkLike } from '@node-core/ui-components/types';
-
 import styles from './index.module.css';
+
+import Select from '#Common/Select';
+import SidebarGroup from '#Containers/Sidebar/SidebarGroup';
+import type { LinkLike } from '#types';
 
 type SidebarProps = {
   groups: Array<Omit<ComponentProps<typeof SidebarGroup>, 'as' | 'pathname'>>;

--- a/packages/ui-components/Containers/Sidebar/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/index.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps, FC } from 'react';
 
-import styles from './index.module.css';
-
 import Select from '#Common/Select';
 import SidebarGroup from '#Containers/Sidebar/SidebarGroup';
 import type { LinkLike } from '#types';
+
+import styles from './index.module.css';
 
 type SidebarProps = {
   groups: Array<Omit<ComponentProps<typeof SidebarGroup>, 'as' | 'pathname'>>;

--- a/packages/ui-components/Containers/Sidebar/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/index.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps, FC } from 'react';
 
-import Select from '#Common/Select';
-import SidebarGroup from '#Containers/Sidebar/SidebarGroup';
-import type { LinkLike } from '#types';
+import Select from '#ui/Common/Select';
+import SidebarGroup from '#ui/Containers/Sidebar/SidebarGroup';
+import type { LinkLike } from '#ui/types';
 
 import styles from './index.module.css';
 

--- a/packages/ui-components/Icons/HexagonGrid.stories.tsx
+++ b/packages/ui-components/Icons/HexagonGrid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import HexagonGrid from '#Icons/HexagonGrid';
+import HexagonGrid from '#ui/Icons/HexagonGrid';
 
 type Story = StoryObj<typeof HexagonGrid>;
 type Meta = MetaObj<typeof HexagonGrid>;

--- a/packages/ui-components/Icons/HexagonGrid.stories.tsx
+++ b/packages/ui-components/Icons/HexagonGrid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta as MetaObj, StoryObj } from '@storybook/react';
 
-import HexagonGrid from '@node-core/ui-components/Icons/HexagonGrid';
+import HexagonGrid from '#Icons/HexagonGrid';
 
 type Story = StoryObj<typeof HexagonGrid>;
 type Meta = MetaObj<typeof HexagonGrid>;

--- a/packages/ui-components/Icons/InstallationMethod/index.ts
+++ b/packages/ui-components/Icons/InstallationMethod/index.ts
@@ -1,10 +1,10 @@
-import Choco from '@node-core/ui-components/Icons/InstallationMethod/Choco';
-import Devbox from '@node-core/ui-components/Icons/InstallationMethod/Devbox';
-import Docker from '@node-core/ui-components/Icons/InstallationMethod/Docker';
-import FNM from '@node-core/ui-components/Icons/InstallationMethod/FNM';
-import Homebrew from '@node-core/ui-components/Icons/InstallationMethod/Homebrew';
-import N from '@node-core/ui-components/Icons/InstallationMethod/N';
-import NVM from '@node-core/ui-components/Icons/InstallationMethod/NVM';
-import Volta from '@node-core/ui-components/Icons/InstallationMethod/Volta';
+import Choco from '#Icons/InstallationMethod/Choco';
+import Devbox from '#Icons/InstallationMethod/Devbox';
+import Docker from '#Icons/InstallationMethod/Docker';
+import FNM from '#Icons/InstallationMethod/FNM';
+import Homebrew from '#Icons/InstallationMethod/Homebrew';
+import N from '#Icons/InstallationMethod/N';
+import NVM from '#Icons/InstallationMethod/NVM';
+import Volta from '#Icons/InstallationMethod/Volta';
 
 export { Choco, Devbox, Docker, FNM, Homebrew, N, NVM, Volta };

--- a/packages/ui-components/Icons/InstallationMethod/index.ts
+++ b/packages/ui-components/Icons/InstallationMethod/index.ts
@@ -1,10 +1,10 @@
-import Choco from '#Icons/InstallationMethod/Choco';
-import Devbox from '#Icons/InstallationMethod/Devbox';
-import Docker from '#Icons/InstallationMethod/Docker';
-import FNM from '#Icons/InstallationMethod/FNM';
-import Homebrew from '#Icons/InstallationMethod/Homebrew';
-import N from '#Icons/InstallationMethod/N';
-import NVM from '#Icons/InstallationMethod/NVM';
-import Volta from '#Icons/InstallationMethod/Volta';
+import Choco from '#ui/Icons/InstallationMethod/Choco';
+import Devbox from '#ui/Icons/InstallationMethod/Devbox';
+import Docker from '#ui/Icons/InstallationMethod/Docker';
+import FNM from '#ui/Icons/InstallationMethod/FNM';
+import Homebrew from '#ui/Icons/InstallationMethod/Homebrew';
+import N from '#ui/Icons/InstallationMethod/N';
+import NVM from '#ui/Icons/InstallationMethod/NVM';
+import Volta from '#ui/Icons/InstallationMethod/Volta';
 
 export { Choco, Devbox, Docker, FNM, Homebrew, N, NVM, Volta };

--- a/packages/ui-components/Icons/Logos/JsWhite.tsx
+++ b/packages/ui-components/Icons/Logos/JsWhite.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import type { TailwindSVG } from '@node-core/ui-components/types';
+import type { TailwindSVG } from '#types';
 
 const JsWhiteIcon: FC<TailwindSVG> = props => (
   <svg

--- a/packages/ui-components/Icons/Logos/JsWhite.tsx
+++ b/packages/ui-components/Icons/Logos/JsWhite.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import type { TailwindSVG } from '#types';
+import type { TailwindSVG } from '#ui/types';
 
 const JsWhiteIcon: FC<TailwindSVG> = props => (
   <svg

--- a/packages/ui-components/Icons/Logos/Nodejs.tsx
+++ b/packages/ui-components/Icons/Logos/Nodejs.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { FC, SVGProps } from 'react';
 
-import type { LogoVariant } from '#types';
+import type { LogoVariant } from '#ui/types';
 
 type NodeJsLogoProps = SVGProps<SVGSVGElement> & {
   variant?: LogoVariant;

--- a/packages/ui-components/Icons/Logos/Nodejs.tsx
+++ b/packages/ui-components/Icons/Logos/Nodejs.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { FC, SVGProps } from 'react';
 
-import type { LogoVariant } from '@node-core/ui-components/types';
+import type { LogoVariant } from '#types';
 
 type NodeJsLogoProps = SVGProps<SVGSVGElement> & {
   variant?: LogoVariant;

--- a/packages/ui-components/Icons/Logos/index.ts
+++ b/packages/ui-components/Icons/Logos/index.ts
@@ -1,10 +1,10 @@
-import JsGreen from '@node-core/ui-components/Icons/Logos/JsGreen';
-import JsWhite from '@node-core/ui-components/Icons/Logos/JsWhite';
-import Nodejs from '@node-core/ui-components/Icons/Logos/Nodejs';
-import NodejsStackedBlack from '@node-core/ui-components/Icons/Logos/NodejsStackedBlack';
-import NodejsStackedDark from '@node-core/ui-components/Icons/Logos/NodejsStackedDark';
-import NodejsStackedLight from '@node-core/ui-components/Icons/Logos/NodejsStackedLight';
-import NodejsStackedWhite from '@node-core/ui-components/Icons/Logos/NodejsStackedWhite';
+import JsGreen from '#Icons/Logos/JsGreen';
+import JsWhite from '#Icons/Logos/JsWhite';
+import Nodejs from '#Icons/Logos/Nodejs';
+import NodejsStackedBlack from '#Icons/Logos/NodejsStackedBlack';
+import NodejsStackedDark from '#Icons/Logos/NodejsStackedDark';
+import NodejsStackedLight from '#Icons/Logos/NodejsStackedLight';
+import NodejsStackedWhite from '#Icons/Logos/NodejsStackedWhite';
 
 export {
   JsGreen,

--- a/packages/ui-components/Icons/Logos/index.ts
+++ b/packages/ui-components/Icons/Logos/index.ts
@@ -1,10 +1,10 @@
-import JsGreen from '#Icons/Logos/JsGreen';
-import JsWhite from '#Icons/Logos/JsWhite';
-import Nodejs from '#Icons/Logos/Nodejs';
-import NodejsStackedBlack from '#Icons/Logos/NodejsStackedBlack';
-import NodejsStackedDark from '#Icons/Logos/NodejsStackedDark';
-import NodejsStackedLight from '#Icons/Logos/NodejsStackedLight';
-import NodejsStackedWhite from '#Icons/Logos/NodejsStackedWhite';
+import JsGreen from '#ui/Icons/Logos/JsGreen';
+import JsWhite from '#ui/Icons/Logos/JsWhite';
+import Nodejs from '#ui/Icons/Logos/Nodejs';
+import NodejsStackedBlack from '#ui/Icons/Logos/NodejsStackedBlack';
+import NodejsStackedDark from '#ui/Icons/Logos/NodejsStackedDark';
+import NodejsStackedLight from '#ui/Icons/Logos/NodejsStackedLight';
+import NodejsStackedWhite from '#ui/Icons/Logos/NodejsStackedWhite';
 
 export {
   JsGreen,

--- a/packages/ui-components/Icons/OperatingSystem/index.ts
+++ b/packages/ui-components/Icons/OperatingSystem/index.ts
@@ -1,6 +1,6 @@
-import AIX from '#Icons/OperatingSystem/AIX';
-import Apple from '#Icons/OperatingSystem/Apple';
-import Linux from '#Icons/OperatingSystem/Linux';
-import Microsoft from '#Icons/OperatingSystem/Microsoft';
+import AIX from '#ui/Icons/OperatingSystem/AIX';
+import Apple from '#ui/Icons/OperatingSystem/Apple';
+import Linux from '#ui/Icons/OperatingSystem/Linux';
+import Microsoft from '#ui/Icons/OperatingSystem/Microsoft';
 
 export { AIX, Apple, Linux, Microsoft };

--- a/packages/ui-components/Icons/OperatingSystem/index.ts
+++ b/packages/ui-components/Icons/OperatingSystem/index.ts
@@ -1,6 +1,6 @@
-import AIX from '@node-core/ui-components/Icons/OperatingSystem/AIX';
-import Apple from '@node-core/ui-components/Icons/OperatingSystem/Apple';
-import Linux from '@node-core/ui-components/Icons/OperatingSystem/Linux';
-import Microsoft from '@node-core/ui-components/Icons/OperatingSystem/Microsoft';
+import AIX from '#Icons/OperatingSystem/AIX';
+import Apple from '#Icons/OperatingSystem/Apple';
+import Linux from '#Icons/OperatingSystem/Linux';
+import Microsoft from '#Icons/OperatingSystem/Microsoft';
 
 export { AIX, Apple, Linux, Microsoft };

--- a/packages/ui-components/Icons/PackageManager/index.ts
+++ b/packages/ui-components/Icons/PackageManager/index.ts
@@ -1,5 +1,5 @@
-import NPM from '@node-core/ui-components/Icons/PackageManager/Npm';
-import PNPM from '@node-core/ui-components/Icons/PackageManager/Pnpm';
-import YARN from '@node-core/ui-components/Icons/PackageManager/Yarn';
+import NPM from '#Icons/PackageManager/Npm';
+import PNPM from '#Icons/PackageManager/Pnpm';
+import YARN from '#Icons/PackageManager/Yarn';
 
 export { NPM, PNPM, YARN };

--- a/packages/ui-components/Icons/PackageManager/index.ts
+++ b/packages/ui-components/Icons/PackageManager/index.ts
@@ -1,5 +1,5 @@
-import NPM from '#Icons/PackageManager/Npm';
-import PNPM from '#Icons/PackageManager/Pnpm';
-import YARN from '#Icons/PackageManager/Yarn';
+import NPM from '#ui/Icons/PackageManager/Npm';
+import PNPM from '#ui/Icons/PackageManager/Pnpm';
+import YARN from '#ui/Icons/PackageManager/Yarn';
 
 export { NPM, PNPM, YARN };

--- a/packages/ui-components/Icons/Social/index.ts
+++ b/packages/ui-components/Icons/Social/index.ts
@@ -1,9 +1,9 @@
-import Bluesky from '@node-core/ui-components/Icons/Social/Bluesky';
-import Discord from '@node-core/ui-components/Icons/Social/Discord';
-import GitHub from '@node-core/ui-components/Icons/Social/GitHub';
-import LinkedIn from '@node-core/ui-components/Icons/Social/LinkedIn';
-import Mastodon from '@node-core/ui-components/Icons/Social/Mastodon';
-import Slack from '@node-core/ui-components/Icons/Social/Slack';
-import X from '@node-core/ui-components/Icons/Social/X';
+import Bluesky from '#Icons/Social/Bluesky';
+import Discord from '#Icons/Social/Discord';
+import GitHub from '#Icons/Social/GitHub';
+import LinkedIn from '#Icons/Social/LinkedIn';
+import Mastodon from '#Icons/Social/Mastodon';
+import Slack from '#Icons/Social/Slack';
+import X from '#Icons/Social/X';
 
 export { Bluesky, Discord, GitHub, LinkedIn, Mastodon, Slack, X };

--- a/packages/ui-components/Icons/Social/index.ts
+++ b/packages/ui-components/Icons/Social/index.ts
@@ -1,9 +1,9 @@
-import Bluesky from '#Icons/Social/Bluesky';
-import Discord from '#Icons/Social/Discord';
-import GitHub from '#Icons/Social/GitHub';
-import LinkedIn from '#Icons/Social/LinkedIn';
-import Mastodon from '#Icons/Social/Mastodon';
-import Slack from '#Icons/Social/Slack';
-import X from '#Icons/Social/X';
+import Bluesky from '#ui/Icons/Social/Bluesky';
+import Discord from '#ui/Icons/Social/Discord';
+import GitHub from '#ui/Icons/Social/GitHub';
+import LinkedIn from '#ui/Icons/Social/LinkedIn';
+import Mastodon from '#ui/Icons/Social/Mastodon';
+import Slack from '#ui/Icons/Social/Slack';
+import X from '#ui/Icons/Social/X';
 
 export { Bluesky, Discord, GitHub, LinkedIn, Mastodon, Slack, X };

--- a/packages/ui-components/__design__/node-logos.stories.tsx
+++ b/packages/ui-components/__design__/node-logos.stories.tsx
@@ -8,7 +8,7 @@ import {
   NodejsStackedDark,
   NodejsStackedLight,
   NodejsStackedWhite,
-} from '@node-core/ui-components/Icons/Logos';
+} from '#Icons/Logos';
 
 export const HorizontalLogo: StoryObj = {
   render: () => <Nodejs width={267} height={80} />,

--- a/packages/ui-components/__design__/node-logos.stories.tsx
+++ b/packages/ui-components/__design__/node-logos.stories.tsx
@@ -8,7 +8,7 @@ import {
   NodejsStackedDark,
   NodejsStackedLight,
   NodejsStackedWhite,
-} from '#Icons/Logos';
+} from '#ui/Icons/Logos';
 
 export const HorizontalLogo: StoryObj = {
   render: () => <Nodejs width={267} height={80} />,

--- a/packages/ui-components/__design__/platform-logos.stories.tsx
+++ b/packages/ui-components/__design__/platform-logos.stories.tsx
@@ -8,13 +8,8 @@ import {
   Choco,
   N,
   Volta,
-} from '@node-core/ui-components/Icons/InstallationMethod';
-import {
-  Apple,
-  Linux,
-  Microsoft,
-  AIX,
-} from '@node-core/ui-components/Icons/OperatingSystem';
+} from '#Icons/InstallationMethod';
+import { Apple, Linux, Microsoft, AIX } from '#Icons/OperatingSystem';
 
 const osIcons = [Apple, Linux, Microsoft, AIX];
 const installMethodIcons = [Docker, Homebrew, NVM, Devbox, Choco, N, Volta];

--- a/packages/ui-components/__design__/platform-logos.stories.tsx
+++ b/packages/ui-components/__design__/platform-logos.stories.tsx
@@ -8,8 +8,8 @@ import {
   Choco,
   N,
   Volta,
-} from '#Icons/InstallationMethod';
-import { Apple, Linux, Microsoft, AIX } from '#Icons/OperatingSystem';
+} from '#ui/Icons/InstallationMethod';
+import { Apple, Linux, Microsoft, AIX } from '#ui/Icons/OperatingSystem';
 
 const osIcons = [Apple, Linux, Microsoft, AIX];
 const installMethodIcons = [Docker, Homebrew, NVM, Devbox, Choco, N, Volta];

--- a/packages/ui-components/__design__/social-logos.stories.tsx
+++ b/packages/ui-components/__design__/social-logos.stories.tsx
@@ -8,7 +8,7 @@ import {
   Mastodon,
   Slack,
   X,
-} from '@node-core/ui-components/Icons/Social';
+} from '#Icons/Social';
 
 const socialIcons = [
   [GitHub, Mastodon, LinkedIn],

--- a/packages/ui-components/__design__/social-logos.stories.tsx
+++ b/packages/ui-components/__design__/social-logos.stories.tsx
@@ -8,7 +8,7 @@ import {
   Mastodon,
   Slack,
   X,
-} from '#Icons/Social';
+} from '#ui/Icons/Social';
 
 const socialIcons = [
   [GitHub, Mastodon, LinkedIn],

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -2,15 +2,13 @@
   "name": "@node-core/ui-components",
   "type": "module",
   "exports": {
-    "./Common/*": "./Common/*",
-    "./Common/*/*": "./Common/*/*",
-    "./Containers/*": "./Containers/*",
-    "./Containers/*/*": "./Containers/*/*",
-    "./Icons/*": "./Icons/*",
-    "./Icons/*/*": "./Icons/*/*",
-    "./styles/*": "./styles/*",
-    "./types": "./types.ts",
-    "./stylelint/*": "./stylelint/*"
+    "./*": [
+      "./*",
+      "./*.tsx",
+      "./*/index.tsx",
+      "./*.ts",
+      "./*/index.ts"
+    ]
   },
   "files": [
     "Common",
@@ -77,6 +75,15 @@
     "tsx": "^4.19.3",
     "typescript": "~5.8.2",
     "typescript-eslint": "~8.31.1"
+  },
+  "imports": {
+    "#*": [
+      "./*",
+      "./*.tsx",
+      "./*/index.tsx",
+      "./*.ts",
+      "./*/index.ts"
+    ]
   },
   "engines": {
     "node": ">=20"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -77,7 +77,7 @@
     "typescript-eslint": "~8.31.1"
   },
   "imports": {
-    "#*": [
+    "#ui/*": [
       "./*",
       "./*.tsx",
       "./*/index.tsx",

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "paths": { "@node-core/ui-components/*": ["./*"] }
+    "baseUrl": "."
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR uses Node.js's native subpath imports in place of the `tsconfig.json` `paths`, since these are natively supported

## Validation

Nothing should change, everything should build and test correctly

## Related Issues

Fixes #7732

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
