### PR TITLE
Add CI check for Cloudflare Worker build

### DIFF
--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:

--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -61,4 +61,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Cloudflare Worker
-        run: pnpm exec turbo run --filter=@node-core/website cloudflare:build:worker ${{ env.TURBO_ARGS }}
+        run: pnpm exec turbo run cloudflare:build:worker ${{ env.TURBO_ARGS }}

--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -13,8 +13,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - labeled
 
 defaults:
   run:
@@ -33,7 +31,7 @@ env:
 
 jobs:
   build-cloudflare-worker:
-    name: Build Cloudflare Worker (on ubuntu)
+    name: Build Cloudflare Worker
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -1,0 +1,69 @@
+# Security Notes
+# Only selected Actions are allowed within this repository. Please refer to (https://github.com/nodejs/nodejs.org/settings/actions)
+# for the full list of available actions. If you want to add a new one, please reach out a maintainer with Admin permissions.
+# REVIEWERS, please always double-check security practices before merging a PR that contains Workflow changes!!
+# AUTHORS, please only use actions with explicit SHA references, and avoid using `@master` or `@main` references or `@version` tags.
+
+name: Cloudflare OpenNext Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - labeled
+
+defaults:
+  run:
+    # This ensures that the working directory is the root of the repository
+    working-directory: ./
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
+  TURBO_ARGS: --cache-dir=.turbo/cache
+  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
+  TURBO_FORCE: true
+
+jobs:
+  build-cloudflare-worker:
+    name: Build Cloudflare Worker on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Git Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          # We want to ensure that the Node.js version running here respects our supported versions
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Cloudflare Worker
+        run: pnpm turbo run --filter=@node-core/website cloudflare:build:worker

--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -61,4 +61,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Cloudflare Worker
-        run: pnpm turbo run --filter=@node-core/website cloudflare:build:worker
+        run: pnpm exec turbo run --filter=@node-core/website cloudflare:build:worker ${{ env.TURBO_ARGS }}

--- a/.github/workflows/cloudflare-open-next-build.yml
+++ b/.github/workflows/cloudflare-open-next-build.yml
@@ -33,13 +33,8 @@ env:
 
 jobs:
   build-cloudflare-worker:
-    name: Build Cloudflare Worker on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Build Cloudflare Worker (on ubuntu)
+    runs-on: ubuntu-latest
 
     steps:
       - name: Harden Runner

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -2,6 +2,7 @@
   "name": "@node-core/website",
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm build-blog-data",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
     "check-types": "tsc --noEmit",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true NODE_NO_WARNINGS=1 next build",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -2,11 +2,9 @@
   "name": "@node-core/website",
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm build-blog-data",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
     "check-types": "tsc --noEmit",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true NODE_NO_WARNINGS=1 next build",
-    "predev": "pnpm build-blog-data",
     "dev": "cross-env NODE_NO_WARNINGS=1 next dev",
     "lint": "turbo run lint:md lint:js lint:css",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input --cache --cache-strategy=content --cache-location=.stylelintcache",
@@ -23,8 +21,8 @@
     "build-blog-data": "node ./scripts/blog-data/generate.mjs",
     "build-blog-data:watch": "node --watch --watch-path=pages/en/blog ./scripts/blog-data/generate.mjs",
     "cloudflare:build:worker": "opennextjs-cloudflare build",
-    "cloudflare:preview": "pnpm run cloudflare:build:worker && wrangler dev",
-    "cloudflare:deploy": "pnpm run cloudflare:build:worker && wrangler deploy"
+    "cloudflare:preview": "wrangler dev",
+    "cloudflare:deploy": "wrangler deploy"
   },
   "dependencies": {
     "@heroicons/react": "~2.2.0",

--- a/apps/site/turbo.json
+++ b/apps/site/turbo.json
@@ -4,6 +4,7 @@
   "globalEnv": ["NODE_ENV"],
   "tasks": {
     "dev": {
+      "dependsOn": ["build-blog-data"],
       "cache": false,
       "persistent": true,
       "env": [
@@ -24,7 +25,7 @@
       ]
     },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build-blog-data", "^build"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -133,7 +134,19 @@
       "inputs": ["{pages}/**/*.{mdx,md}"],
       "outputs": ["public/blog-data.json"]
     },
+    "cloudflare:build:worker": {
+      "dependsOn": ["build-blog-data"],
+      "inputs": [
+        "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
+        "{app,components,layouts,pages,styles}/**/*.css",
+        "{next-data,scripts,i18n}/**/*.{mjs,json}",
+        "{app,pages}/**/*.{mdx,md}",
+        "*.{md,mdx,json,ts,tsx,mjs,yml}"
+      ],
+      "outputs": [".open-next/**"]
+    },
     "cloudflare:preview": {
+      "dependsOn": ["cloudflare:build:worker"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -144,6 +157,7 @@
       "outputs": [".open-next/**"]
     },
     "cloudflare:deploy": {
+      "dependsOn": ["cloudflare:build:worker"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",


### PR DESCRIPTION
## Description

As [suggested](https://github.com/nodejs/nodejs.org/pull/7383#issuecomment-2863779557) by @avivkeller I'm adding a CI check to make sure that the Cloudflare OpenNext adapter build succeeds on PRs/pushes to main.

As part of this I am removing the pre scripts I had before in favour of turborepo `dependsOn` configs (I am not super familiar with turborepo but I thing/guess that `dependsOn` configs should be preferred and replace pre scripts? 🤔)

> [!Note]
> This is a temporary CI check (that's also one of the reasons why I created a new, very easy to delete, workflow file for it instead of adding this to the build workflow) that can help us get some confidence in the OpenNext Cloudflare adapter and in the fact that the adapter doesn't effect DX. 
> However I think that this will become obsolete/unnecessary as soon as we have some e2e tests that also validate the OpenNext build.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

I've validated this workflow in my nodejs.org fork see [action run](https://github.com/dario-piotrowicz/nodejs.org/actions/runs/14999151591/job/42141131986). 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
