### PR TITLE
fix: Ensure links maintain green color within bold text

### DIFF
--- a/packages/ui-components/__design__/text.stories.tsx
+++ b/packages/ui-components/__design__/text.stories.tsx
@@ -77,4 +77,24 @@ export const HeadingsWithLinks: StoryObj = {
   ),
 };
 
+export const BoldAndLinks: StoryObj = {
+  render: () => (
+    <main>
+      <p>
+        <strong>Bold text (should inherit normal text color)</strong>
+      </p>
+      <p>
+        <strong>
+          <a href="#">Bold green link (link inside bold)</a>
+        </strong>
+      </p>
+      <p>
+        <a href="#">
+          <strong>Bold green link (bold inside link)</strong>
+        </a>
+      </p>
+    </main>
+  ),
+};
+
 export default { title: 'Design System' } as MetaObj;

--- a/packages/ui-components/styles/markdown.css
+++ b/packages/ui-components/styles/markdown.css
@@ -40,22 +40,18 @@ main {
   h4,
   h5,
   h6 {
+    @apply font-semibold
+      text-neutral-900
+      dark:text-white;
+
     &[id] a {
       @apply text-neutral-900
         dark:text-white;
     }
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
   strong {
-    @apply font-semibold
-      text-neutral-900
-      dark:text-white;
+    @apply font-semibold;
   }
 
   code {
@@ -77,17 +73,14 @@ main {
 
   /* link that isn't inside a heading */
   a:not(h1 > a):not(h2 > a):not(h3 > a):not(h4 > a):not(h5 > a):not(h6 > a),
-  .anchor,
-  a strong,
-  strong a,
-  p a {
+  .anchor {
     @apply max-xs:font-semibold
-      !text-green-600
-      dark:!text-green-400;
+      text-green-600
+      dark:text-green-400;
 
     &:hover {
-      @apply !text-green-900
-        dark:!text-green-300;
+      @apply text-green-900
+        dark:text-green-300;
     }
 
     &[role='button'] {

--- a/packages/ui-components/styles/markdown.css
+++ b/packages/ui-components/styles/markdown.css
@@ -77,14 +77,17 @@ main {
 
   /* link that isn't inside a heading */
   a:not(h1 > a):not(h2 > a):not(h3 > a):not(h4 > a):not(h5 > a):not(h6 > a),
-  .anchor {
+  .anchor,
+  a strong,
+  strong a,
+  p a {
     @apply max-xs:font-semibold
-      text-green-600
-      dark:text-green-400;
+      !text-green-600
+      dark:!text-green-400;
 
     &:hover {
-      @apply text-green-900
-        dark:text-green-300;
+      @apply !text-green-900
+        dark:!text-green-300;
     }
 
     &[role='button'] {


### PR DESCRIPTION
## Description

This PR fixes an issue where links within bold text (using markdown `**text**` syntax) were inheriting the white color from the strong tags instead of maintaining their green color. The fix adds specific CSS selectors to ensure links maintain their green color regardless of whether they are inside or contain bold text.

## Validation

The fix ensures that:
1. Links within bold text maintain their green color
2. Links containing bold text maintain their green color
3. The styling is consistent in both light and dark modes
4. Hover states work correctly for all link variations

Before:
<img width="1680" alt="SCR-20250514-cpfb-2" src="https://github.com/user-attachments/assets/f9601208-eea6-452a-b56e-e026b1df021b" />
<img width="1680" alt="SCR-20250514-cpxs-2" src="https://github.com/user-attachments/assets/27cb6603-19fc-4299-8d11-86cbc58d1cf4" />

After:

<img width="1680" alt="SCR-20250514-cpmr-2" src="https://github.com/user-attachments/assets/bc4d572b-8a01-4a44-8efd-72c6273417db" />
<img width="1680" alt="SCR-20250514-cpsz-2" src="https://github.com/user-attachments/assets/859d986f-1db1-4ac1-86b3-a7a13e78265a" />


## Related Issues

This PR addresses the issue #7742 (Bold Links are not Green)

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary. (NOT REQUIRED)

