### PR TITLE
chore(download): remove windows instructions from fnm

### DIFF
--- a/apps/site/util/downloadUtils/constants.json
+++ b/apps/site/util/downloadUtils/constants.json
@@ -127,10 +127,10 @@
     },
     {
       "id": "FNM",
-      "icon": "NVM",
+      "icon": "FNM",
       "name": "fnm",
       "compatibility": {
-        "os": ["MAC", "LINUX", "WIN"]
+        "os": ["MAC", "LINUX"]
       },
       "recommended": true,
       "url": "https://github.com/Schniz/fnm",


### PR DESCRIPTION
Unfortunately, because there was response in #7487 to multiple requests over the past few weeks, this PR removes the Windows instructions from fnm.

CC @Schniz