### PR TITLE
chore(ui): don't depend on pnpm syntax

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -48,7 +48,6 @@
     "tailwindcss": "~4.0.17"
   },
   "devDependencies": {
-    "@node-core/website-i18n": "workspace:*",
     "@storybook/addon-controls": "^8.6.12",
     "@storybook/addon-interactions": "^8.6.12",
     "@storybook/addon-styling-webpack": "^1.0.1",

--- a/packages/ui-components/types.ts
+++ b/packages/ui-components/types.ts
@@ -1,4 +1,3 @@
-import type { LocaleConfig } from '@node-core/website-i18n/types';
 import type {
   SVGProps,
   AnchorHTMLAttributes,
@@ -19,7 +18,8 @@ export type FormattedMessage =
   | ReactElement<HTMLElement, string | JSXElementConstructor<HTMLElement>>
   | ReadonlyArray<ReactNode>;
 
-export type SimpleLocaleConfig = Pick<
-  LocaleConfig,
-  'name' | 'code' | 'localName'
->;
+export type SimpleLocaleConfig = {
+  code: string;
+  localName: string;
+  name: string;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,9 +368,6 @@ importers:
         specifier: ~4.0.17
         version: 4.0.17
     devDependencies:
-      '@node-core/website-i18n':
-        specifier: workspace:*
-        version: link:../i18n
       '@storybook/addon-controls':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))


### PR DESCRIPTION
When we import `@node-core/ui-components` from `api-docs-tooling`, it can't contain non-npm syntax in it's `package.json`. Therefore, this PR removes the dependency on the `workspace:*` syntax.