### PR TITLE
feat(test): replace cloudflare open-next build test with playwright tests

### DIFF
--- a/.github/workflows/playwright-cloudflare-open-next.yml
+++ b/.github/workflows/playwright-cloudflare-open-next.yml
@@ -4,7 +4,7 @@
 # REVIEWERS, please always double-check security practices before merging a PR that contains Workflow changes!!
 # AUTHORS, please only use actions with explicit SHA references, and avoid using `@master` or `@main` references or `@version` tags.
 
-name: Cloudflare OpenNext Build
+name: Playwright Tests on Cloudflare Open-Next
 
 on:
   push:
@@ -14,24 +14,17 @@ on:
     branches:
       - main
 
-defaults:
-  run:
-    # This ensures that the working directory is the root of the repository
-    working-directory: ./
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
   actions: read
 
-env:
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--cache-dir
-  TURBO_ARGS: --cache-dir=.turbo/cache
-  # See https://turbo.build/repo/docs/reference/command-line-reference/run#--force
-  TURBO_FORCE: true
-
 jobs:
-  build-cloudflare-worker:
-    name: Build Cloudflare Worker
+  playwright:
+    name: Playwright Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -58,5 +51,32 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile
 
-      - name: Build Cloudflare Worker
-        run: pnpm exec turbo run cloudflare:build:worker ${{ env.TURBO_ARGS }}
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: apps/site
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Browsers
+        working-directory: apps/site
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run Playwright tests
+        working-directory: apps/site
+        run: pnpm playwright
+        env:
+          PLAYWRIGHT_WEB_SERVER_COMMAND: pnpm turbo run cloudflare:preview
+          PLAYWRIGHT_WEB_SERVER_PORT: 8787
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: apps/site/playwright-report/

--- a/.github/workflows/playwright-cloudflare-open-next.yml
+++ b/.github/workflows/playwright-cloudflare-open-next.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: apps/site
         run: pnpm playwright
         env:
-          PLAYWRIGHT_WEB_SERVER_COMMAND: pnpm turbo run cloudflare:preview
+          PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW: true
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:8787
 
       - name: Upload Playwright test results

--- a/.github/workflows/playwright-cloudflare-open-next.yml
+++ b/.github/workflows/playwright-cloudflare-open-next.yml
@@ -72,7 +72,7 @@ jobs:
         run: pnpm playwright
         env:
           PLAYWRIGHT_WEB_SERVER_COMMAND: pnpm turbo run cloudflare:preview
-          PLAYWRIGHT_WEB_SERVER_PORT: 8787
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:8787
 
       - name: Upload Playwright test results
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: apps/site
         run: pnpm playwright
         env:
-          VERCEL_PREVIEW_URL: ${{ needs.get-vercel-preview.outputs.url }}
+          PLAYWRIGHT_BASE_URL: ${{ needs.get-vercel-preview.outputs.url }}
 
       - name: Upload Playwright test results
         if: always()

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test';
-import type { PlaywrightTestConfig } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 
@@ -11,34 +10,19 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   workers: isCI ? 1 : undefined,
   reporter: isCI ? [['html'], ['github']] : [['html']],
-  ...(() => {
-    const use: PlaywrightTestConfig['use'] = {
-      baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
-      trace: 'on-first-retry',
-    };
-
-    const webServerCommand = process.env.PLAYWRIGHT_WEB_SERVER_COMMAND;
-    const webServerPort = parseInt(
-      process.env.PLAYWRIGHT_WEB_SERVER_PORT ?? ''
-    );
-    if (webServerCommand && !isNaN(webServerPort)) {
-      use.baseURL = `http://127.0.0.1:${webServerPort}`;
-      return {
+  ...(process.env.PLAYWRIGHT_WEB_SERVER_COMMAND
+    ? {
         webServer: {
-          command: webServerCommand,
-          port: webServerPort,
-          stdout: 'pipe',
-          stderr: 'pipe',
+          command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND,
+          url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
           timeout: 60_000 * 3,
         },
-        use,
-      };
-    }
-
-    return {
-      use,
-    };
-  })(),
+      }
+    : {}),
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+  },
   projects: [
     {
       name: 'chromium',

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   workers: isCI ? 1 : undefined,
   reporter: isCI ? [['html'], ['github']] : [['html']],
-  ...(process.env.PLAYWRIGHT_WEB_SERVER_COMMAND
+  ...(process.env.PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW
     ? {
         webServer: {
-          command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND,
+          command: 'pnpm turbo run cloudflare:preview',
           url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
           timeout: 60_000 * 3,
         },

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices, type Config } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 
@@ -10,15 +10,7 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   workers: isCI ? 1 : undefined,
   reporter: isCI ? [['html'], ['github']] : [['html']],
-  ...(process.env.PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW
-    ? {
-        webServer: {
-          command: 'pnpm turbo run cloudflare:preview',
-          url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
-          timeout: 60_000 * 3,
-        },
-      }
-    : {}),
+  ...getWebServerConfig(),
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
@@ -38,3 +30,17 @@ export default defineConfig({
     },
   ],
 });
+
+function getWebServerConfig(): Pick<Config, 'webServer'> {
+  if (process.env.PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW) {
+    return {
+      webServer: {
+        command: 'pnpm turbo run cloudflare:preview',
+        url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
+        timeout: 60_000 * 3,
+      },
+    };
+  }
+
+  return {};
+}

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -14,12 +14,7 @@ export default defineConfig({
     ? {
         webServer: {
           command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND,
-          url:
-            // TODO: remove the VERCEL_PREVIEW_URL option once
-            // https://github.com/nodejs/nodejs.org/pull/7782 is merged
-            process.env.VERCEL_PREVIEW_URL ||
-            process.env.PLAYWRIGHT_BASE_URL ||
-            'http://127.0.0.1:3000',
+          url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
           timeout: 60_000 * 3,
         },
       }

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices, type Config } from '@playwright/test';
 
+import json from './package.json' with { type: 'json' };
+
 const isCI = !!process.env.CI;
 
 // https://playwright.dev/docs/test-configuration
@@ -32,6 +34,10 @@ export default defineConfig({
 });
 
 function getWebServerConfig(): Pick<Config, 'webServer'> {
+  if (!json.scripts['cloudflare:preview']) {
+    throw new Error('cloudflare:preview script not defined');
+  }
+
   if (process.env.PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW) {
     return {
       webServer: {

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -14,7 +14,12 @@ export default defineConfig({
     ? {
         webServer: {
           command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND,
-          url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
+          url:
+            // TODO: remove the VERCEL_PREVIEW_URL option once
+            // https://github.com/nodejs/nodejs.org/pull/7782 is merged
+            process.env.VERCEL_PREVIEW_URL ||
+            process.env.PLAYWRIGHT_BASE_URL ||
+            'http://127.0.0.1:3000',
           timeout: 60_000 * 3,
         },
       }


### PR DESCRIPTION
## Description

Replaces the github workflow checking that the Cloudflare open-next build process works on PRs and pushes to main with a workflow that runs and checks the open-next build using playwright (built on top of the changes introduced in https://github.com/nodejs/nodejs.org/pull/7749)

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

I've validated this change by pushing this onto my fork's main branch and you can see the workflow working as expected there by checking the action runs ([example](https://github.com/dario-piotrowicz/nodejs.org/actions/runs/15277724080/job/42968396420))

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
