### PR TITLE
chore(jsconf): re-add badge

### DIFF
--- a/apps/site/site.json
+++ b/apps/site/site.json
@@ -37,12 +37,12 @@
   },
   "websiteBadges": {
     "index": {
-      "startDate": "2025-05-06",
-      "endDate": "2025-05-31",
+      "startDate": "2025-04-01T00:00:00.000Z",
+      "endDate": "2025-07-01T00:00:00.000Z",
       "kind": "default",
-      "title": "Next-10 Survey",
-      "text": "We need your feedback to help us shape Node.js",
-      "link": "https://linuxfoundation.research.net/r/2025nodenext10"
+      "title": "JSConf",
+      "text": "General Admission Tickets are on sale now!",
+      "link": "https://events.linuxfoundation.org/jsconf-north-america"
     }
   }
 }

--- a/apps/site/site.json
+++ b/apps/site/site.json
@@ -41,7 +41,7 @@
       "endDate": "2025-07-01T00:00:00.000Z",
       "kind": "default",
       "title": "JSConf",
-      "text": "General Admission Tickets are on sale now!",
+      "text": "Get your tickets now!",
       "link": "https://events.linuxfoundation.org/jsconf-north-america"
     }
   }


### PR DESCRIPTION
## Description

This PR is to bring the JSConf badge back which was initially shown on homepage, and was changed and replaced with Next-10 survey badge link to the issue https://github.com/nodejs/nodejs.org/issues/7730, and a link to the pr where it was modified - https://github.com/nodejs/nodejs.org/pull/7726, the only change done is replace the changes back with original badge, code from this above PR is referred for that.

## Validation

Changes are visible on hompage. [Screenshot 2025-05-28 195100](https://github.com/user-attachments/assets/e935b9d6-1ef5-4b2c-b303-507134e62e9e)

## Related Issues

https://github.com/nodejs/nodejs.org/issues/7730

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
