### PR TITLE
fix(ui): Fix tabs component overflow issue

### DIFF
--- a/packages/ui-components/Common/Tabs/index.module.css
+++ b/packages/ui-components/Common/Tabs/index.module.css
@@ -1,7 +1,8 @@
 @reference "../../styles/index.css";
 
 .tabsRoot {
-  @apply grid max-w-full;
+  @apply grid
+    max-w-full;
 
   .tabsList {
     @apply font-open-sans

--- a/packages/ui-components/Common/Tabs/index.module.css
+++ b/packages/ui-components/Common/Tabs/index.module.css
@@ -1,7 +1,7 @@
 @reference "../../styles/index.css";
 
 .tabsRoot {
-  @apply max-w-full;
+  @apply grid max-w-full;
 
   .tabsList {
     @apply font-open-sans


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The Tabs component was overflowing on the page, causing a lot of unnecessary side effects on the page. Found this bug investigating the following issues and it should resolve both of them:
https://github.com/nodejs/nodejs.org/issues/7491
https://github.com/nodejs/nodejs.org/issues/7729

Previously:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/8cefdaec-24ae-41cf-ab8a-a4023eb411a7" />

Now:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/2da35b57-68bf-4b7d-b4ae-7206949cdecc" />



<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
https://github.com/nodejs/nodejs.org/issues/7491
https://github.com/nodejs/nodejs.org/issues/7729

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
