### PR TITLE
fix(DataTag): add global

### DIFF
--- a/packages/ui-components/Common/DataTag/index.module.css
+++ b/packages/ui-components/Common/DataTag/index.module.css
@@ -49,4 +49,8 @@
   &.ctor {
     @apply bg-accent2-600;
   }
+
+  &.global {
+    @apply bg-amber-600;
+  }
 }

--- a/packages/ui-components/Common/DataTag/index.stories.tsx
+++ b/packages/ui-components/Common/DataTag/index.stories.tsx
@@ -8,7 +8,16 @@ type Meta = MetaObj<typeof DataTag>;
 export const DataTags: Story = {
   render: () => (
     <div className="grid grid-cols-3 gap-6 p-6">
-      {['event', 'method', 'property', 'class', 'module', 'classMethod', 'ctor']
+      {[
+        'event',
+        'method',
+        'property',
+        'class',
+        'module',
+        'classMethod',
+        'ctor',
+        'global',
+      ]
         .map(kind =>
           ['sm', 'md', 'lg'].map(size => (
             <div

--- a/packages/ui-components/Common/DataTag/index.tsx
+++ b/packages/ui-components/Common/DataTag/index.tsx
@@ -11,6 +11,7 @@ export type DataTagProps = {
     | 'class'
     | 'module'
     | 'classMethod'
+    | 'global'
     | 'ctor';
   size?: 'lg' | 'md' | 'sm';
 };
@@ -25,6 +26,7 @@ const symbolMap = {
   class: 'C',
   module: 'M',
   classMethod: 'S',
+  global: 'G',
   ctor: 'C',
 } as const;
 


### PR DESCRIPTION
This type was missing from `HeadingMetataEntry`, so I didn't know to add it.

See https://github.com/nodejs/api-docs-tooling/pull/289 for the fix PR.