### PR TITLE
fix(meta): downgrade pnpm to 10.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     "prettier": "3.5.3",
     "prettier-plugin-tailwindcss": "0.6.11"
   },
-  "packageManager": "pnpm@10.10.0",
+  "packageManager": "pnpm@10.8.1",
   "engines": {
     "node": "v22"
   },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "10.10.0"
+      "version": "10.8.1"
     }
   }
 }


### PR DESCRIPTION
## Description

Dependabot is currently updating _all_ dependencies in the lockfile in each PR it opens: https://github.com/nodejs/nodejs.org/pull/7820/commits/e52dea5ec78c92d77a14fcbb02d7ba423d616859

This appears to be due to a bug in pnpm since 10.9.0, so this downgrades us to the last pnpm release prior to that.

## Validation

Managing dependencies continues to work. We'll need to merge and then ask Dependabot to update its PRs to fully validate if this works.

## Related Issues

https://github.com/pnpm/pnpm/issues/9519

(As an aside, https://github.com/dependabot/dependabot-core/issues/11246 + https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories does suggest that Dependabot doesn't officially support pnpm 10 at all)

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.