### PR TITLE
chore(next): remove icons from `optimizedPackageImports`

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -91,7 +91,6 @@ const nextConfig = {
       '@radix-ui/react-avatar',
       '@orama/highlight',
       '@orama/react-components',
-      '@heroicons/react',
       'tailwindcss',
       'shiki',
     ],


### PR DESCRIPTION
Next.js already optimizes this import internally:
https://github.com/vercel/next.js/blob/12e888126ccf968193e7570a68db1bc35f90d52d/packages/next/src/server/config.ts#L715-L717