### PR TITLE
meta: re-enable turbo prod/dev builds

### DIFF
--- a/apps/site/open-next.config.ts
+++ b/apps/site/open-next.config.ts
@@ -1,4 +1,6 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare';
 import incrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache';
 
-export default defineCloudflareConfig({ incrementalCache });
+const cloudflareConfig = defineCloudflareConfig({ incrementalCache });
+
+export default { ...cloudflareConfig, buildCommand: 'pnpm build:default' };

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "prebuild": "pnpm build-blog-data",
-    "build": "cross-env NODE_NO_WARNINGS=1 next build",
+    "build": "cross-env NODE_NO_WARNINGS=1 next build --turbo",
     "check-types": "tsc --noEmit",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true NODE_NO_WARNINGS=1 next build",
     "dev": "cross-env NODE_NO_WARNINGS=1 next dev",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,7 +6,7 @@
     "build": "cross-env NODE_NO_WARNINGS=1 next build --turbo",
     "check-types": "tsc --noEmit",
     "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true NODE_NO_WARNINGS=1 next build",
-    "dev": "cross-env NODE_NO_WARNINGS=1 next dev",
+    "dev": "cross-env NODE_NO_WARNINGS=1 next dev --turbo",
     "lint": "turbo run lint:md lint:js lint:css",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input --cache --cache-strategy=content --cache-location=.stylelintcache",
     "lint:fix": "turbo run lint:md lint:js lint:css --no-cache -- --fix",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -2,10 +2,13 @@
   "name": "@node-core/website",
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm build-blog-data",
-    "build": "cross-env NODE_NO_WARNINGS=1 next build --turbo",
+    "prebuild": "pnpm build:blog-data",
+    "build": "pnpm build:default --turbo",
+    "build:default": "cross-env NODE_NO_WARNINGS=1 next build",
+    "build:blog-data": "node ./scripts/blog-data/generate.mjs",
+    "build:blog-data:watch": "node --watch --watch-path=pages/en/blog ./scripts/blog-data/generate.mjs",
     "check-types": "tsc --noEmit",
-    "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true NODE_NO_WARNINGS=1 next build",
+    "deploy": "cross-env NEXT_PUBLIC_STATIC_EXPORT=true pnpm build:default",
     "dev": "cross-env NODE_NO_WARNINGS=1 next dev --turbo",
     "lint": "turbo run lint:md lint:js lint:css",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input --cache --cache-strategy=content --cache-location=.stylelintcache",
@@ -20,11 +23,9 @@
     "test": "turbo test:unit",
     "test:unit": "cross-env NODE_NO_WARNINGS=1 node --experimental-test-coverage --test-coverage-exclude=**/*.test.* --experimental-test-module-mocks --enable-source-maps --import=global-jsdom/register --import=tsx --import=tests/setup.jsx --test **/*.test.*",
     "test:unit:watch": "cross-env NODE_OPTIONS=\"--watch\" pnpm test:unit",
-    "build-blog-data": "node ./scripts/blog-data/generate.mjs",
-    "build-blog-data:watch": "node --watch --watch-path=pages/en/blog ./scripts/blog-data/generate.mjs",
     "cloudflare:build:worker": "opennextjs-cloudflare build",
-    "cloudflare:preview": "wrangler dev",
-    "cloudflare:deploy": "wrangler deploy"
+    "cloudflare:deploy": "wrangler deploy",
+    "cloudflare:preview": "wrangler dev"
   },
   "dependencies": {
     "@heroicons/react": "~2.2.0",

--- a/apps/site/turbo.json
+++ b/apps/site/turbo.json
@@ -4,7 +4,7 @@
   "globalEnv": ["NODE_ENV"],
   "tasks": {
     "dev": {
-      "dependsOn": ["build-blog-data"],
+      "dependsOn": ["build:blog-data"],
       "cache": false,
       "persistent": true,
       "env": [
@@ -25,7 +25,7 @@
       ]
     },
     "build": {
-      "dependsOn": ["build-blog-data", "^build"],
+      "dependsOn": ["build:blog-data", "^build"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -120,7 +120,7 @@
       "cache": false
     },
     "test:unit": {
-      "dependsOn": ["build-blog-data"],
+      "dependsOn": ["build:blog-data"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx,mjs}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -130,12 +130,12 @@
       ],
       "outputs": ["coverage/**", "junit.xml"]
     },
-    "build-blog-data": {
+    "build:blog-data": {
       "inputs": ["{pages}/**/*.{mdx,md}"],
       "outputs": ["public/blog-data.json"]
     },
     "cloudflare:build:worker": {
-      "dependsOn": ["build-blog-data"],
+      "dependsOn": ["build:blog-data"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",


### PR DESCRIPTION
This PR re-enables `--turbo` for ISR-based builds. It is experimental, but we're pilot testing this feature.