### PR TITLE
fix: broken script in example package.json

### DIFF
--- a/apps/site/pages/en/learn/command-line/run-nodejs-scripts-from-the-command-line.md
+++ b/apps/site/pages/en/learn/command-line/run-nodejs-scripts-from-the-command-line.md
@@ -71,7 +71,7 @@ The [`--run`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--run) flag allo
   "type": "module",
   "scripts": {
     "start": "node app.js",
-    "dev": "node --run -- --watch",
+    "dev": "node --run start -- --watch",
     "test": "node --test"
   }
 }


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The script for run is supposed to eventually run `node app.js --watch` by running `node --run start` with the `--watch` parameter - but the name of the script was missing resulting in a syntax error.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

It's a textual change; I've gone ahead and copied the example package.json to an actual file anyway to see that after the fix the script runs successfully.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
