### PR TITLE
fix(ui): avatar overlap

### DIFF
--- a/packages/ui-components/Common/AvatarGroup/index.module.css
+++ b/packages/ui-components/Common/AvatarGroup/index.module.css
@@ -4,22 +4,18 @@
   @apply flex
     flex-wrap
     items-center;
-
-  &:not(.expandable) {
-    > span {
-      @apply ml-0;
-    }
-  }
 }
 
 .small {
   > span {
-    @apply -ml-2;
+    @apply -ml-2
+      first:ml-0;
   }
 }
 
 .medium {
   > span {
-    @apply -ml-2.5;
+    @apply -ml-2.5
+      first:ml-0;
   }
 }

--- a/packages/ui-components/Common/AvatarGroup/index.tsx
+++ b/packages/ui-components/Common/AvatarGroup/index.tsx
@@ -42,11 +42,7 @@ const AvatarGroup: FC<AvatarGroupProps> = ({
     : undefined;
 
   return (
-    <div
-      className={classNames(styles.avatarGroup, styles[size], {
-        [styles.expandable]: avatars.length > limit,
-      })}
-    >
+    <div className={classNames(styles.avatarGroup, styles[size])}>
       {renderAvatars.map(avatar => (
         <Tooltip
           key={avatar.nickname}


### PR DESCRIPTION
## Description

As discussed in the [Slack thread](https://openjs-foundation.slack.com/archives/CVAMEJ4UV/p1748206305954349);

When there are fewer avatars or when viewed on the blog listing or blog pages, the avatars were not overlapping. With this PR, the issue where the first avatar was getting cut off has been fixed, and now the avatars properly overlap regardless of the number of items


## Validation

### Before
<img width="443" alt="image" src="https://github.com/user-attachments/assets/006a0d0d-cf4b-4b7a-aa8d-531965c37ec2" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/f0e3da9c-2bed-4bd7-ab57-12da4f8d6322" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/4d951dae-1e3c-4056-bb00-922b4c9dac23" />

<img width="443" alt="image" src="https://github.com/user-attachments/assets/df7bdf46-747b-4cd8-a173-3d80f3adc6ae" />

### After
<img width="443" alt="image" src="https://github.com/user-attachments/assets/a735e199-20af-4078-83da-4be612c8fe23" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/74313ebd-6131-4a2e-8fe8-ce7953424532" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/719e2521-4ea5-4b8b-9711-df8e8bf11c06" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/00402c0f-5a0d-40ca-aa39-ece981ed9a04" />