### PR TITLE
chore(navigation): re-order

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -102,14 +102,6 @@
           "link": "/about",
           "label": "components.navigation.about.links.aboutSide"
         },
-        "branding": {
-          "link": "/about/branding",
-          "label": "components.navigation.about.links.branding"
-        },
-        "governance": {
-          "link": "/about/governance",
-          "label": "components.navigation.about.links.governance"
-        },
         "previousReleases": {
           "link": "/about/previous-releases",
           "label": "components.navigation.about.links.releases"
@@ -117,6 +109,14 @@
         "securityReporting": {
           "link": "/about/security-reporting",
           "label": "components.navigation.about.links.security"
+        },
+        "governance": {
+          "link": "/about/governance",
+          "label": "components.navigation.about.links.governance"
+        },
+        "branding": {
+          "link": "/about/branding",
+          "label": "components.navigation.about.links.branding"
         }
       }
     },


### PR DESCRIPTION
## Description

IMO previous order of the navigation doesn't make sense.

The logic behind this is that
- About comes first because it is the theme of the section
- Node versions because this impacts many users
- Security reports are important for the project
- Then governance to understand how the project works
- And finally branding, which is just there for some users

## Related Issues

No related issue.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
