### PR TITLE
docs: add monorepo considerations for TypeScript handling

### DIFF
--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -59,6 +59,29 @@ The Node.js TypeScript loader ([Amaro](https://github.com/nodejs/amaro)) does no
 
 We recommend configuring your editor and `tsc` to reflect Node.js behavior by creating a `tsconfig.json` using the `compilerOptions` listed [here](https://nodejs.org/api/typescript.html#type-stripping), as well as using TypeScript version **5.7 or higher**.
 
+### Monorepo
+
+When working with monorepos, you might need more direct control over how TypeScript files are handled, especially for linked packages. Node.js uses a tool called [Amaro](https://github.com/nodejs/amaro) internally for type stripping. For advanced monorepo setups, you can use the `amaro` package directly.
+
+First, install `amaro` as a dependency:
+
+```bash
+npm install amaro
+```
+
+To run TypeScript files within a monorepo structure, you can invoke Node.js with specific flags to use `amaro`.
+The command is:
+
+```bash
+node --experimental-strip-types --import="amaro/strip" --conditions=typescript ./src/index.ts
+```
+
+For Node.js v23 and later (where type stripping is enabled by default), you can omit the `--experimental-strip-types` flag.
+
+This approach allows Node.js to process linked packages within the monorepo without requiring an explicit, separate build step for each package.
+
+For further details and advanced configurations, refer to the [Amaro documentation](https://github.com/nodejs/amaro).
+
 ## Important notes
 
 Thanks to all the contributors who have made this feature possible. We hope that this feature will be stable and available in the LTS version of Node.js soon.


### PR DESCRIPTION
## Description

This adds a section for using the native typescript with monorepo using the [nodejs/amaro](https://github.com/nodejs/amaro) package as discussed in NodeJS [here](https://github.com/nodejs/node/issues/58429#issuecomment-2908825412) and [here](https://github.com/nodejs/node/issues/58429#issuecomment-2926536590)

## Validation

The reviewer needs to look into the `run-natively.md` file

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

This issue exists inside the node repo
Fixes [#58429](https://github.com/nodejs/node/issues/58429)

### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
