### PR TITLE
fix(sidebar): use RegExp for outgoing link detection

### DIFF
--- a/apps/site/components/Link.tsx
+++ b/apps/site/components/Link.tsx
@@ -7,7 +7,7 @@ const Link: FC<HTMLProps<HTMLAnchorElement>> = ({
   href,
   ...props
 }) => {
-  if (!href || href.toString().startsWith('http')) {
+  if (!href || /^https?:/.test(href.toString())) {
     return (
       <a href={href} {...props}>
         {children}

--- a/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/Containers/Sidebar/SidebarItem/index.tsx
@@ -36,7 +36,7 @@ const SidebarItem: FC<SidebarItemProps> = ({
     )}
     <span className={styles.label}>{label}</span>
 
-    {link.startsWith('http') && <ArrowUpRightIcon className={styles.icon} />}
+    {/^https?:/.test(link) && <ArrowUpRightIcon className={styles.icon} />}
   </BaseActiveLink>
 );
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4bb27ea4-7914-4a68-8a4f-3b9220cd8d4b)

For `api-docs-tooling`, `HTTP` documentations are being mis-interpreted as outgoing links. We should instead check the full protocol.