### PR TITLE
fix: images for node 18 eol blog post

### DIFF
--- a/apps/site/pages/en/blog/announcements/node-18-eol-support.md
+++ b/apps/site/pages/en/blog/announcements/node-18-eol-support.md
@@ -90,5 +90,5 @@ The path forward is clear: **Node.js 22 offers the longest support window, best 
 
 Your applications, your users, and your future self will thank you for making the strategic move to Node.js v22 today.
 
-[image1]: /static/images/blog/announcements/2025-eol-node-graph.png
-[image2]: /static/images/blog/announcements/2025-release-schedule.svg
+[image1]: /static/images/blog/announcements/2025-release-schedule.svg
+[image2]: /static/images/blog/announcements/2025-eol-node-graph.png


### PR DESCRIPTION
## Description

The images are not accurate on [Node.js 18 EOL blog post](https://nodejs.org/en/blog/announcements/node-18-eol-support).
The release schedule image should appear first, followed by EOL Node.js graph.

## Validation

Check preview at https://nodejs-org-git-trivikr-patch-1-openjs.vercel.app/en/blog/announcements/node-18-eol-support

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
