### PR TITLE
docs: Mention --disable-sigusr1 in getting started guide

### DIFF
--- a/apps/site/pages/en/learn/getting-started/debugging.md
+++ b/apps/site/pages/en/learn/getting-started/debugging.md
@@ -129,6 +129,7 @@ The following table lists the impact of various runtime flags on debugging:
 | --inspect-brk=[host:port]          | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Break before user code starts     |
 | --inspect-wait                     | Enable inspector agent; Listen on default address and port (127.0.0.1:9229); Wait for debugger to be attached.                                        |
 | --inspect-wait=[host:port]         | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Wait for debugger to be attached. |
+| --disable-sigusr1                  | Disable the ability of starting a debugging session by sending a SIGUSR1 signal to the process (since Node v23.7.0, v22.14.0).                        |
 | node inspect script.js             | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger.                                              |
 | node inspect --port=xxxx script.js | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger. Listen on port port (default: 9229)          |
 

--- a/apps/site/pages/en/learn/getting-started/debugging.md
+++ b/apps/site/pages/en/learn/getting-started/debugging.md
@@ -129,7 +129,7 @@ The following table lists the impact of various runtime flags on debugging:
 | --inspect-brk=[host:port]          | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Break before user code starts     |
 | --inspect-wait                     | Enable inspector agent; Listen on default address and port (127.0.0.1:9229); Wait for debugger to be attached.                                        |
 | --inspect-wait=[host:port]         | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Wait for debugger to be attached. |
-| --disable-sigusr1                  | Disable the ability of starting a debugging session by sending a SIGUSR1 signal to the process (since Node v23.7.0, v22.14.0).                        |
+| --disable-sigusr1                  | Disable the ability of starting a debugging session by sending a SIGUSR1 signal to the process.                        |
 | node inspect script.js             | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger.                                              |
 | node inspect --port=xxxx script.js | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger. Listen on port port (default: 9229)          |
 

--- a/apps/site/pages/en/learn/getting-started/debugging.md
+++ b/apps/site/pages/en/learn/getting-started/debugging.md
@@ -129,7 +129,7 @@ The following table lists the impact of various runtime flags on debugging:
 | --inspect-brk=[host:port]          | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Break before user code starts     |
 | --inspect-wait                     | Enable inspector agent; Listen on default address and port (127.0.0.1:9229); Wait for debugger to be attached.                                        |
 | --inspect-wait=[host:port]         | Enable inspector agent; Bind to address or hostname host (default: 127.0.0.1); Listen on port port (default: 9229); Wait for debugger to be attached. |
-| --disable-sigusr1                  | Disable the ability of starting a debugging session by sending a SIGUSR1 signal to the process.                        |
+| --disable-sigusr1                  | Disable the ability of starting a debugging session by sending a SIGUSR1 signal to the process.                                                       |
 | node inspect script.js             | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger.                                              |
 | node inspect --port=xxxx script.js | Spawn child process to run user's script under --inspect flag; and use main process to run CLI debugger. Listen on port port (default: 9229)          |
 


### PR DESCRIPTION
## Description

Mention --disable-sigusr1 in getting started guide

## Validation

I took it from the node.js documentation site (https://nodejs.org/api/cli.html#--disable-sigusr1)

## Related Issues
None so far
### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
