### PR TITLE
feat: improve username sanitization in profiling example

### DIFF
--- a/apps/site/pages/en/learn/getting-started/profiling.md
+++ b/apps/site/pages/en/learn/getting-started/profiling.md
@@ -41,7 +41,7 @@ app.get('/newUser', (req, res) => {
   let username = req.query.username || '';
   const password = req.query.password || '';
 
-  username = username.replace(/[!@#$%^&*]/g, '');
+  username = username.replace(/[^a-zA-Z0-9]/g, '');
 
   if (!username || !password || users[username]) {
     return res.sendStatus(400);
@@ -63,7 +63,7 @@ app.get('/auth', (req, res) => {
   let username = req.query.username || '';
   const password = req.query.password || '';
 
-  username = username.replace(/[!@#$%^&*]/g, '');
+  username = username.replace(/[^a-zA-Z0-9]/g, '');
 
   if (!username || !password || !users[username]) {
     return res.sendStatus(400);
@@ -228,7 +228,7 @@ app.get('/auth', (req, res) => {
   let username = req.query.username || '';
   const password = req.query.password || '';
 
-  username = username.replace(/[!@#$%^&*]/g, '');
+  username = username.replace(/[^a-zA-Z0-9]/g, '');
 
   if (!username || !password || !users[username]) {
     return res.sendStatus(400);


### PR DESCRIPTION
Hello,

This commit updates the username sanitization logic in the profiling
example code to allow only alphanumeric characters. The original
pattern (/[!@#$%^&*]/g) was limited and could lead to inconsistent
behavior depending on input.

Changed:
- From: username = username.replace(/[!@#$%^&*]/g, '');
- To:   username = username.replace(/[^a-zA-Z0-9]/g, '');

This change makes the input handling cleaner and more appropriate
for educational purposes, aligning better with common sanitization
practices.

Note: This change was initially merged into my forked repository by mistake during development. This PR now reflects the correct version intended for the original repository.

Relates to: #7867

Thank you for reviewing.