### PR TITLE
feat(meta): use OpenJS Figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ These are maintained in different repositories and we urge users to open **issue
 [content vs code]: https://github.com/nodejs/nodejs.org/blob/main/docs/content-vs-code.md
 [dependency pinning]: https://github.com/nodejs/nodejs.org/blob/main/docs/dependency-pinning.md
 [collaborator guide]: https://github.com/nodejs/nodejs.org/blob/main/docs/collaborator-guide.md
-[figma design]: https://www.figma.com/file/8fG0oWFQArJ7C9WbC9n2wa
+[figma design]: https://www.figma.com/file/a10cjjw3MzvRQMPT9FP3xz
 [translation guidelines]: https://github.com/nodejs/nodejs.org/blob/main/docs/translation.md


### PR DESCRIPTION
It was a pleasure to host the Figma for all of 5 minutes, but the OpenJS Foundation is now hosting the Figma.  