### PR TITLE
feat(blog): external canonical for syndicated posts

### DIFF
--- a/apps/site/next.dynamic.mjs
+++ b/apps/site/next.dynamic.mjs
@@ -230,7 +230,8 @@ const getDynamicRouter = async () => {
     ];
 
     // Default canonical URL for the page
-    pageMetadata.alternates.canonical = getUrlForPathname(locale, path);
+    pageMetadata.alternates.canonical =
+      data.canonical ?? getUrlForPathname(locale, path);
 
     // Default alternate URL for the page in the default locale
     pageMetadata.alternates.languages['x-default'] = getUrlForPathname(

--- a/apps/site/pages/en/blog/announcements/mikeal.md
+++ b/apps/site/pages/en/blog/announcements/mikeal.md
@@ -4,6 +4,7 @@ category: announcements
 title: 'In Memory of Mikeal Rogers: A Builder of Communities'
 layout: blog-post
 author: Robin Bender Ginn
+canonical: https://openjsf.org/blog/in-memory-of-mikeal-rogers
 ---
 
 ![][mikeal-rogers-image]

--- a/docs/adding-pages.md
+++ b/docs/adding-pages.md
@@ -63,6 +63,10 @@ The frontmatter (YAML block at the top) configures page metadata:
 - `description`: Optional meta description for SEO
 - `authors`: For learn pages, list of GitHub usernames
 
+Where content has been syndicated from another source, you can also include:
+
+- `canonical`: The original URL of the content
+
 ### 3. Choose the Appropriate Layout
 
 Available layouts are defined in `apps/site/layouts/`, and mapped in `components/withLayout`.

--- a/docs/adding-pages.md
+++ b/docs/adding-pages.md
@@ -63,7 +63,7 @@ The frontmatter (YAML block at the top) configures page metadata:
 - `description`: Optional meta description for SEO
 - `authors`: For learn pages, list of GitHub usernames
 
-Where content has been syndicated from another source, you can also include:
+In cases where content has been syndicated from another source, you should also include:
 
 - `canonical`: The original URL of the content
 


### PR DESCRIPTION
## Description

To follow SEO best practices, when a blog post is syndicated to our blog from elsewhere, we should set the meta canonical to point to the original post, so that indexing crawlers know this is a syndicated version of the original, rather than competing (near-)identical content.

## Validation

On the blog post for Mikeal, the canonical is set to the OpenJSF blog post. On all other blog posts, and all other pages, the canonicals remain as in production.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
