### PR TITLE
fix(esp): add utm params, don't use prohibited strings

### DIFF
--- a/apps/site/pages/en/index.mdx
+++ b/apps/site/pages/en/index.mdx
@@ -21,7 +21,7 @@ layout: home
 
       <Button kind="primary" className="!block dark:!hidden" href="/download">Install Node.js</Button>
 
-      <Button kind="secondary" className="!block" href="https://www.herodevs.com/support/node-nes">
+      <Button kind="secondary" className="!block" href="https://www.herodevs.com/support/node-nes?utm_source=NodeJS+&utm_medium=Link&utm_campaign=Homepage_button">
         <span>Get security support</span>
         <br />
         <small className="!text-xs">for Node.js 18 and below</small>

--- a/packages/i18n/locales/en.json
+++ b/packages/i18n/locales/en.json
@@ -169,7 +169,7 @@
       "minorVersions": "Minor versions",
       "releaseAnnouncement": "Release Announcement",
       "unsupportedVersionWarning": "This version is out of maintenance. Please use a currently supported version. <link>Understand EOL support.</link>",
-      "ltsVersionFeaturesNotice": "Want new features sooner? Get the <link>latest Node.js version</link> instead and try the latest improvements on Node!"
+      "ltsVersionFeaturesNotice": "Want new features sooner? Get the <link>latest Node.js version</link> instead and try the latest improvements!"
     },
     "minorReleasesTable": {
       "version": "Version",
@@ -320,7 +320,7 @@
       },
       "codeBox": {
         "unsupportedVersionWarning": "This version is out of maintenance. Please use a currently supported version. <link>Understand EOL support.</link>",
-        "ltsVersionFeaturesNotice": "Want new features sooner? Get the <link>latest Node.js version</link> instead and try the latest improvements on Node!",
+        "ltsVersionFeaturesNotice": "Want new features sooner? Get the <link>latest Node.js version</link> instead and try the latest improvements!",
         "communityPlatformInfo": "Installation methods that involve community software are supported by the teams maintaining that software.",
         "externalSupportInfo": "If you encounter any issues please visit <link>{platform}'s website</link>",
         "noScriptDetected": "This page requires JavaScript. You can download Node.js without JavaScript by visiting the <link>releases page</link> directly.",


### PR DESCRIPTION
1. Unless instructed otherwise, we should assume that UTM parameters are required. See https://openjs-foundation.slack.com/archives/CVAMEJ4UV/p1750546862196709?thread_ts=1750198935.143539&cid=CVAMEJ4UV and onward.

2. The presence of prohibited strings on the main download page suggests that users should refer to Node.js as "Node," which is incorrect. Users should use "Node.js" when referring to the project, and "node" when referring to the executable.