### PR TITLE
chore(homepage): link to our blog, rather than HeroDevs

### DIFF
--- a/apps/site/pages/en/index.mdx
+++ b/apps/site/pages/en/index.mdx
@@ -21,7 +21,7 @@ layout: home
 
       <Button kind="primary" className="!block dark:!hidden" href="/download">Install Node.js</Button>
 
-      <Button kind="secondary" className="!block" href="https://nodejs.org/en/blog/announcements/node-18-eol-support">
+      <Button kind="secondary" className="!block" href="/blog/announcements/node-18-eol-support">
         <span>Get security support</span>
         <br />
         <small className="!text-xs">for Node.js 18 and below</small>

--- a/apps/site/pages/en/index.mdx
+++ b/apps/site/pages/en/index.mdx
@@ -21,7 +21,7 @@ layout: home
 
       <Button kind="primary" className="!block dark:!hidden" href="/download">Install Node.js</Button>
 
-      <Button kind="secondary" className="!block" href="https://www.herodevs.com/support/node-nes?utm_source=NodeJS+&utm_medium=Link&utm_campaign=Homepage_button">
+      <Button kind="secondary" className="!block" href="https://nodejs.org/en/blog/announcements/node-18-eol-support">
         <span>Get security support</span>
         <br />
         <small className="!text-xs">for Node.js 18 and below</small>


### PR DESCRIPTION
This PR proposes a quick improvement to the current homepage button that directly links to HeroDev's website.

It’s based on a suggestion by @joyeecheung to provide a clearer, more official announcement link.

cc @nodejs/tsc

Relates to https://github.com/nodejs/nodejs.org/issues/7773