### PR TITLE
fix(AlertBox): override code styles in a markdown context

### DIFF
--- a/packages/ui-components/Common/AlertBox/index.module.css
+++ b/packages/ui-components/Common/AlertBox/index.module.css
@@ -73,4 +73,11 @@
       @apply bg-danger-700;
     }
   }
+
+  code {
+    /* Ignore the styles from `markdown.css` */
+    all: unset;
+
+    @apply font-mono;
+  }
 }

--- a/packages/ui-components/Common/AlertBox/index.module.css
+++ b/packages/ui-components/Common/AlertBox/index.module.css
@@ -78,6 +78,6 @@
     /* Ignore the styles from `markdown.css` */
     all: unset;
 
-    @apply font-mono;
+    @apply font-ibm-plex-mono;
   }
 }

--- a/packages/ui-components/Common/AlertBox/index.stories.tsx
+++ b/packages/ui-components/Common/AlertBox/index.stories.tsx
@@ -6,6 +6,12 @@ import AlertBox from '#ui/Common/AlertBox';
 type Story = StoryObj<typeof AlertBox>;
 type Meta = MetaObj<typeof AlertBox>;
 
+const withMain = (args: React.ComponentProps<typeof AlertBox>) => (
+  <main>
+    <AlertBox {...args} />
+  </main>
+);
+
 export const Info: Story = {
   args: {
     level: 'info',
@@ -44,6 +50,23 @@ export const Danger: Story = {
       'Deprecated. The feature may emit warnings. Backward compatibility is not guaranteed.',
     size: 'default',
   },
+};
+
+export const InMarkdown: Story = {
+  args: {
+    level: 'danger',
+    title: '0',
+    children: (
+      <>
+        In a markdown component, <code>Code renders correctly,</code>{' '}
+        <a href="#">
+          <code>even when in a link</code>
+        </a>
+      </>
+    ),
+    size: 'default',
+  },
+  render: withMain,
 };
 
 export const WithIcon: Story = {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When the inherited text is white, the `code` element does not have a readable contrast, as shown below:
![image](https://github.com/user-attachments/assets/16d51d51-30ab-4871-b85f-a02d0b931072)

## Validation

Everything on the website should look identical, but this should make a readable contrast on `api-docs-tooling`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
