### PR TITLE
feat(shiki): use wasm engine

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -95,6 +95,11 @@ const nextConfig = {
       'shiki',
     ],
   },
+
+  webpack: config => ({
+    ...config,
+    experiments: { ...config.experiments, asyncWebAssembly: true },
+  }),
 };
 
 const withNextIntl = createNextIntlPlugin('./i18n.tsx');

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -95,11 +95,6 @@ const nextConfig = {
       'shiki',
     ],
   },
-
-  webpack: config => ({
-    ...config,
-    experiments: { ...config.experiments, asyncWebAssembly: true },
-  }),
 };
 
 const withNextIntl = createNextIntlPlugin('./i18n.tsx');

--- a/packages/rehype-shiki/eslint.config.js
+++ b/packages/rehype-shiki/eslint.config.js
@@ -5,8 +5,12 @@ export default [
   {
     languageOptions: {
       parserOptions: {
-        // Allow nullish syntax (i.e. "?." or "??")
-        ecmaVersion: 2020,
+        // Allow nullish syntax (i.e. "?." or "??"),
+        // and top-level await
+        ecmaVersion: 'latest',
+      },
+      globals: {
+        globalThis: 'readonly',
       },
     },
     rules: {

--- a/packages/rehype-shiki/package.json
+++ b/packages/rehype-shiki/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@shikijs/core": "^3.4.2",
     "@shikijs/engine-javascript": "^3.4.2",
+    "@shikijs/engine-oniguruma": "^3.7.0",
     "classnames": "~2.5.1",
     "hast-util-to-string": "^3.0.1",
     "shiki": "~3.4.2",

--- a/packages/rehype-shiki/src/highlighter.mjs
+++ b/packages/rehype-shiki/src/highlighter.mjs
@@ -1,5 +1,4 @@
 import { createHighlighterCoreSync } from '@shikijs/core';
-import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
 import shikiNordTheme from 'shiki/themes/nord.mjs';
 
 const DEFAULT_THEME = {
@@ -17,7 +16,6 @@ const DEFAULT_THEME = {
 export const createHighlighter = options => {
   const shiki = createHighlighterCoreSync({
     themes: [DEFAULT_THEME],
-    engine: createJavaScriptRegexEngine(),
     ...options,
   });
 

--- a/packages/rehype-shiki/src/index.mjs
+++ b/packages/rehype-shiki/src/index.mjs
@@ -1,3 +1,5 @@
+import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
+import { createOnigurumaEngine } from '@shikijs/engine-oniguruma';
 import cLanguage from 'shiki/langs/c.mjs';
 import coffeeScriptLanguage from 'shiki/langs/coffeescript.mjs';
 import cPlusPlusLanguage from 'shiki/langs/cpp.mjs';
@@ -17,6 +19,21 @@ import { createHighlighter } from './highlighter.mjs';
 
 const { shiki, getLanguageDisplayName, highlightToHast, highlightToHtml } =
   createHighlighter({
+    // We use the faster WASM engine on the server instead of the web-optimized version.
+    //
+    // Currently we fall back to the JavaScript RegEx engine
+    // on Cloudflare workers because `shiki/wasm` requires loading via
+    // `WebAssembly.instantiate` with custom imports, which Cloudflare doesn't support
+    // for security reasons.
+    //
+    // TODO(@avivkeller): When available, use `OPEN_NEXT_CLOUDFLARE` environmen
+    // variable for detection instead of current method, which will enable better
+    // tree-shaking.
+    // Reference: https://github.com/nodejs/nodejs.org/pull/7896#issuecomment-3009480615
+    engine:
+      'Cloudflare' in globalThis
+        ? createJavaScriptRegexEngine()
+        : await createOnigurumaEngine(import('shiki/wasm')),
     langs: [
       ...cLanguage,
       ...coffeeScriptLanguage,

--- a/packages/rehype-shiki/src/minimal.mjs
+++ b/packages/rehype-shiki/src/minimal.mjs
@@ -1,3 +1,4 @@
+import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
 import powershellLanguage from 'shiki/langs/powershell.mjs';
 import shellScriptLanguage from 'shiki/langs/shellscript.mjs';
 
@@ -5,6 +6,9 @@ import { createHighlighter } from './highlighter.mjs';
 
 const { shiki, getLanguageDisplayName, highlightToHast, highlightToHtml } =
   createHighlighter({
+    // For the minimal (web) Shiki, we want to use the simpler,
+    // JavaScript based engine.
+    engine: createJavaScriptRegexEngine(),
     langs: [...powershellLanguage, ...shellScriptLanguage],
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@shikijs/engine-javascript':
         specifier: ^3.4.2
         version: 3.4.2
+      '@shikijs/engine-oniguruma':
+        specifier: ^3.7.0
+        version: 3.7.0
       classnames:
         specifier: ~2.5.1
         version: 2.5.1
@@ -2548,6 +2551,9 @@ packages:
   '@shikijs/engine-oniguruma@3.4.2':
     resolution: {integrity: sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==}
 
+  '@shikijs/engine-oniguruma@3.7.0':
+    resolution: {integrity: sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==}
+
   '@shikijs/langs@1.29.2':
     resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
 
@@ -2565,6 +2571,9 @@ packages:
 
   '@shikijs/types@3.4.2':
     resolution: {integrity: sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==}
+
+  '@shikijs/types@3.7.0':
+    resolution: {integrity: sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -10476,6 +10485,11 @@ snapshots:
       '@shikijs/types': 3.4.2
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/engine-oniguruma@3.7.0':
+    dependencies:
+      '@shikijs/types': 3.7.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
@@ -10498,6 +10512,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@3.4.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.7.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4


### PR DESCRIPTION
Using the WASM shiki on the server, and the JavaScript shiki on the client, should result in the best mix of speed and size for our use-case.

See https://github.com/nodejs/api-docs-tooling/pull/320.

Rouhgly a 50% speed improvement on the server, per my testing.