### PR TITLE
fix(blog): use redirect for Discord link

### DIFF
--- a/apps/site/pages/en/blog/community/2025-pride.md
+++ b/apps/site/pages/en/blog/community/2025-pride.md
@@ -62,4 +62,4 @@ Happy Pride.
 
 As part of Pride Month, the Node.js Project is launching a series of blog posts highlighting the voices and work of LGBTQ technologists. If you identify as part of the community and want to share your journey, your projects, or how your identity has shaped your perspective and contributions, we’d love to hear from you, and we invite you to [submit a PR](https://github.com/nodejs/nodejs.org/tree/main/apps/site/pages/en/blog/community) with your answer to the prompt, "how did you come to understand who you are, and what contributions have you made to open source?"
 
-_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer comunity leader for [the official Node.js Discord server](https://discord.gg/vUsrbjd)._
+_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer comunity leader for [the official Node.js Discord server](/discord)._

--- a/apps/site/pages/en/blog/community/2025-pride.md
+++ b/apps/site/pages/en/blog/community/2025-pride.md
@@ -62,4 +62,4 @@ Happy Pride.
 
 As part of Pride Month, the Node.js Project is launching a series of blog posts highlighting the voices and work of LGBTQ technologists. If you identify as part of the community and want to share your journey, your projects, or how your identity has shaped your perspective and contributions, we’d love to hear from you, and we invite you to [submit a PR](https://github.com/nodejs/nodejs.org/tree/main/apps/site/pages/en/blog/community) with your answer to the prompt, "how did you come to understand who you are, and what contributions have you made to open source?"
 
-_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer comunity leader for [the official Node.js Discord server](/discord)._
+_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer community leader for [the official Node.js Discord server](/discord)._


### PR DESCRIPTION
## Description

Quick fix for #7888 to use the Discord redirect that we have, so that we have a single source of truth for the Discord invite code should it need to be changed.

## Validation

Discord link at end of pride blog post still works.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
