### PR TITLE
fix(table): only apply border to immediate `td` children

### DIFF
--- a/packages/ui-components/__design__/table.stories.tsx
+++ b/packages/ui-components/__design__/table.stories.tsx
@@ -6,7 +6,7 @@ const tableData = [
   ['Data 1', 'Data 2', 'Data 3'],
 ];
 
-export const TableWithSubTableRow: StoryObj = {
+export const Table: StoryObj = {
   render: () => (
     <main>
       <table>

--- a/packages/ui-components/__design__/table.stories.tsx
+++ b/packages/ui-components/__design__/table.stories.tsx
@@ -6,7 +6,7 @@ const tableData = [
   ['Data 1', 'Data 2', 'Data 3'],
 ];
 
-export const Table: StoryObj = {
+export const TableWithSubTableRow: StoryObj = {
   render: () => (
     <main>
       <table>
@@ -25,24 +25,28 @@ export const Table: StoryObj = {
               ))}
             </tr>
           ))}
-        </tbody>
-      </table>
-    </main>
-  ),
-};
-
-export const HeadlessTable: StoryObj = {
-  render: () => (
-    <main>
-      <table>
-        <tbody>
-          {tableData.map((row, rowIndex) => (
-            <tr key={rowIndex}>
-              {row.map((cell, cellIndex) => (
-                <td key={cellIndex}>{cell}</td>
-              ))}
-            </tr>
-          ))}
+          <tr>
+            <td colSpan={3}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Sub 1</th>
+                    <th>Sub 2</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Sub A</td>
+                    <td>Sub B</td>
+                  </tr>
+                  <tr>
+                    <td>Sub C</td>
+                    <td>Sub D</td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
         </tbody>
       </table>
     </main>

--- a/packages/ui-components/styles/markdown.css
+++ b/packages/ui-components/styles/markdown.css
@@ -157,7 +157,7 @@ main {
       @apply font-semibold;
     }
 
-    tr:last-child td {
+    tr:last-child > td {
       @apply sm:border-b-0;
 
       &:last-child {


### PR DESCRIPTION
Fixes a bug where tables-in-tables wouldn't have their borders applied correctly:

<img width="560" alt="Screenshot 2025-06-29 at 20 07 38" src="https://github.com/user-attachments/assets/27a3348f-defd-4779-855a-4585f355020b" />

CC @ovflowd