### PR TITLE
docs: Clarify that console.error appears in console but uses stderr

### DIFF
--- a/apps/site/pages/en/learn/command-line/output-to-the-command-line-using-nodejs.md
+++ b/apps/site/pages/en/learn/command-line/output-to-the-command-line-using-nodejs.md
@@ -165,7 +165,7 @@ As we saw console.log is great for printing messages in the Console. This is wha
 
 `console.error` prints to the `stderr` stream.
 
-It will not appear in the console, but it will appear in the error log.
+It will appear in the console, but can be handled separately from regular output.
 
 ### Color the output
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Clarified misleading description of `console.error` behavior in the stdout/stderr documentation. The previous text incorrectly stated that `console.error` "will not appear in the console" when it actually does appear in the console but uses the stderr stream.

## Validation

The change is a simple text clarification in documentation. Reviewers should verify that the new wording accurately describes `console.error` behavior - that it appears in the console like normal output but uses stderr instead of stdout.

## Related Issues

None - this is a standalone documentation improvement.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
