### PR TITLE
fix/The toggle navigation menu button is not keyboard accessible

### DIFF
--- a/packages/ui-components/Containers/NavBar/index.tsx
+++ b/packages/ui-components/Containers/NavBar/index.tsx
@@ -55,7 +55,17 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
           className={style.sidebarItemTogglerLabel}
           htmlFor="sidebarItemToggler"
           role="button"
+          tabIndex={0}
           aria-label={sidebarItemTogglerAriaLabel}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              const input = document.getElementById(
+                'sidebarItemToggler'
+              ) as HTMLInputElement;
+              input?.click(); // Triggers input toggle
+            }
+          }}
         >
           {navInteractionIcons[isMenuOpen ? 'close' : 'show']}
         </Label.Root>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR improves accessibility by making the `mobile navigation toggle icon (navInteractionIcon) keyboard accessible.` 
Previously, the icon could only be toggled via mouse click. With this update, users can now navigate to the toggle using the `Tab key and activate it using Enter or Space.`

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

https://github.com/user-attachments/assets/896ad9af-ee22-46d3-960d-64780f823734


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
  
-->
Fixes #7895

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [✅] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [✅] I have run `pnpm format` to ensure the code follows the style guide.
- [✅] I have run `pnpm test` to check if all tests are passing.
- [✅] I have run `pnpm build` to check if the website builds without errors.
