### PR TITLE
fix(styles): improve hover visibility for right-sidebar links in dark & light mode (#7894)

### DIFF
--- a/packages/ui-components/src/Containers/MetaBar/index.module.css
+++ b/packages/ui-components/src/Containers/MetaBar/index.module.css
@@ -51,11 +51,13 @@
         font-semibold
         text-neutral-900
         underline
+        transition-colors
+        duration-200
         dark:text-white;
 
       &:hover {
-        @apply text-neutral-800
-          dark:text-neutral-200;
+        @apply text-neutral-700
+            dark:text-neutral-600;
       }
     }
 
@@ -66,6 +68,22 @@
         flex-col
         gap-1.5
         p-0;
+
+      li {
+        a {
+          @apply font-semibold
+            text-neutral-900
+            underline
+            transition-colors
+            duration-200
+            dark:text-white;
+
+          &:hover {
+            @apply text-neutral-700
+              dark:text-neutral-600;
+          }
+        }
+      }
     }
 
     svg {

--- a/packages/ui-components/src/Containers/MetaBar/index.module.css
+++ b/packages/ui-components/src/Containers/MetaBar/index.module.css
@@ -57,7 +57,7 @@
 
       &:hover {
         @apply text-neutral-700
-            dark:text-neutral-600;
+          dark:text-neutral-500;
       }
     }
 
@@ -68,22 +68,6 @@
         flex-col
         gap-1.5
         p-0;
-
-      li {
-        a {
-          @apply font-semibold
-            text-neutral-900
-            underline
-            transition-colors
-            duration-200
-            dark:text-white;
-
-          &:hover {
-            @apply text-neutral-700
-              dark:text-neutral-600;
-          }
-        }
-      }
     }
 
     svg {

--- a/packages/ui-components/src/Containers/MetaBar/index.module.css
+++ b/packages/ui-components/src/Containers/MetaBar/index.module.css
@@ -51,8 +51,6 @@
         font-semibold
         text-neutral-900
         underline
-        transition-colors
-        duration-200
         dark:text-white;
 
       &:hover {


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR improves the hover state styling for links in the site's right sidebar.

Previously, the color difference between normal and hover states was too subtle, especially in `dark mode`, making it difficult for users to see when a link was being hovered. This created a `poor user experience and reduced accessibility`.



## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

### Current Situation

https://github.com/user-attachments/assets/af8edd2d-7813-4247-97f9-4457fd028ee5



### Expected Situation


https://github.com/user-attachments/assets/8158fd0a-b785-4efc-a00e-70d77f9811f4


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes [#7894](https://github.com/nodejs/nodejs.org/issues/7894)

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [✅] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [✅] I have run `pnpm format` to ensure the code follows the style guide.
- [✅] I have run `pnpm test` to check if all tests are passing.
- [✅] I have run `pnpm build` to check if the website builds without errors.
- [✅] I've covered new added functionality with unit tests if necessary.
