### PR TITLE
fix(tw): use v3 button styling

### DIFF
--- a/packages/ui-components/src/styles/index.css
+++ b/packages/ui-components/src/styles/index.css
@@ -13,18 +13,18 @@
 @import './base.css' layer(utilities);
 @import './markdown.css' layer(utilities);
 
-/*
-  See https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor
-  See https://tailwindcss.com/docs/upgrade-guide#default-border-color
-*/
 @layer base {
-  :root {
-    --header-height: calc(var(--spacing, 0.25rem) * 16);
+  /* See https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor */
+  button,
+  [role='button'] {
+    &:not(:disabled) {
+      cursor: pointer;
+    }
   }
 
-  button:not(:disabled),
-  [role="button"]:not(:disabled) {
-    cursor: pointer;
+  /* See https://tailwindcss.com/docs/upgrade-guide#default-border-color */
+  :root {
+    --header-height: calc(var(--spacing, 0.25rem) * 16);
   }
 
   *,

--- a/packages/ui-components/src/styles/index.css
+++ b/packages/ui-components/src/styles/index.css
@@ -14,16 +14,17 @@
 @import './markdown.css' layer(utilities);
 
 /*
-  The default border color has changed to `currentColor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
+  See https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor
+  See https://tailwindcss.com/docs/upgrade-guide#default-border-color
 */
 @layer base {
   :root {
     --header-height: calc(var(--spacing, 0.25rem) * 16);
+  }
+
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
   }
 
   *,

--- a/packages/ui-components/src/styles/index.css
+++ b/packages/ui-components/src/styles/index.css
@@ -14,25 +14,25 @@
 @import './markdown.css' layer(utilities);
 
 @layer base {
-  /* See https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor */
-  button,
-  [role='button'] {
-    &:not(:disabled) {
-      cursor: pointer;
-    }
-  }
-
-  /* See https://tailwindcss.com/docs/upgrade-guide#default-border-color */
   :root {
     --header-height: calc(var(--spacing, 0.25rem) * 16);
   }
 
+  /* See https://tailwindcss.com/docs/upgrade-guide#default-border-color */
   *,
   ::after,
   ::before,
   ::backdrop,
   ::file-selector-button {
     border-color: var(--color-gray-200, currentColor);
+  }
+
+  /* See https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor */
+  button,
+  [role='button'] {
+    &:not(:disabled) {
+      @apply cursor-pointer;
+    }
   }
 }
 


### PR DESCRIPTION
In Tailwind v4, buttons use the `default` cursor, rather than the `pointer` cursor, see https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor.