### PR TITLE
fix(lint): use `--fix` in `.lintstagedrc`

### DIFF
--- a/apps/site/.lintstagedrc.json
+++ b/apps/site/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "**/*.{js,mjs,ts,tsx,md,mdx}": ["prettier --check --write", "eslint --fix"],
-  "**/*.css": ["stylelint --allow-empty-input", "prettier --write"],
+  "**/*.css": ["stylelint --allow-empty-input --fix", "prettier --write"],
   "**/*.{json,yml}": ["prettier --check --write"]
 }

--- a/packages/ui-components/.lintstagedrc.json
+++ b/packages/ui-components/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "**/*.{js,mjs,ts,tsx,md,mdx}": ["prettier --check --write", "eslint --fix"],
-  "**/*.css": ["stylelint --allow-empty-input", "prettier --write"],
+  "**/*.css": ["stylelint --allow-empty-input --fix", "prettier --write"],
   "**/*.{json,yml}": ["prettier --check --write"]
 }


### PR DESCRIPTION
While doing #7937, I realized that our `.lintstagedrc.json` files were not performing automatic stylelint fixes when possible