### PR TITLE
fix(publish): don't use pnpm cache when not installing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -109,9 +109,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
+          # Don't use caching here as we never install dependencies in this workflow
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
 
       - name: Publish
         working-directory: packages/${{ matrix.package }}


### PR DESCRIPTION
## Description

Per discussion in https://github.com/nodejs/nodejs.org/pull/7824#issuecomment-3029888384, the publish matrix sometimes generates a failure in the post-step for actions/setup-node due to a cache issue. I suspect this is due to us enabling pnpm caching for actions/setup-node in this job when we never invoke `pnpm install`, resulting in the post-step being unable to find dependencies to cache if a cache hit didn't occur during actions/setup-node earlier in the job.

## Validation

~~Dispatch this workflow on this branch. May need to manually delete whatever cache entry is hit and re-dispatch.~~

Cannot publish arbitrary commits via the job, will need to merge and then test in main.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
