### PR TITLE
chore: pipe the webServer output for cloudflare playwright runs

### DIFF
--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -41,6 +41,7 @@ function getWebServerConfig(): Pick<Config, 'webServer'> {
   if (process.env.PLAYWRIGHT_RUN_CLOUDFLARE_PREVIEW) {
     return {
       webServer: {
+        stdout: 'pipe',
         command: '../../node_modules/.bin/turbo cloudflare:preview',
         url: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
         timeout: 60_000 * 3,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

As I've mentioned here: https://github.com/nodejs/nodejs.org/pull/7947#issuecomment-3035053420 I'm updating the playwright config to expose the stdout for Cloudflare runs.

This can be a bit noisy but I think the extra info that we can get out of the stdout in case of issues will definitely make it worth it (since as you can see from this run: [Cloudflare Playwright CI run](https://github.com/nodejs/nodejs.org/actions/runs/16062567733/job/45331245226#step:11:17) we are not getting much info when actual issues occur during the build process).

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

Validated in this PR, I've purposely broken the open-next preview: https://github.com/nodejs/nodejs.org/pull/7951/commits/89388720d108c34515d9bffc9ae6100dc0d626f8 and then run the playwright e2es:
 - with stdout piping: https://github.com/nodejs/nodejs.org/actions/runs/16078376467/job/45378516249
 - without stdout piping: https://github.com/nodejs/nodejs.org/actions/runs/16078442484/job/45378702367
 
 As you can see with the output with stdout piping the error is visible in the CI run while without piping it is not.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
