### PR TITLE
feat(BaseLinkTabs): add hover effect

### DIFF
--- a/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
@@ -21,6 +21,13 @@
       text-neutral-800
       dark:text-neutral-200;
 
+    &:not([data-state='active']):hover {
+      @apply border-b-neutral-900
+        text-neutral-900
+        dark:border-b-neutral-300
+        dark:text-neutral-300;
+    }
+
     &[data-state='active'] {
       @apply border-b-green-600
         text-green-600


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR adds a hover effect to the blog page menu links to improve the user experience and visual feedback when navigating the blog section. This PR resolves issue #7952 by introducing a hover effect for various categories both for dark-mode and light-mode.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

https://github.com/user-attachments/assets/b70f8346-f6fb-4d28-b5c5-9a657a9af7d1


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #7952 
### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [✅] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [✅] I have run `pnpm format` to ensure the code follows the style guide.
- [✅] I have run `pnpm test` to check if all tests are passing.
- [✅] I have run `pnpm build` to check if the website builds without errors.
- [✅] I've covered new added functionality with unit tests if necessary.
