### PR TITLE
learn: fix net module import in server and client example

### DIFF
--- a/apps/site/pages/en/learn/modules/how-to-use-streams.md
+++ b/apps/site/pages/en/learn/modules/how-to-use-streams.md
@@ -302,7 +302,7 @@ server.listen(8080, () => {
 ```
 
 ```mjs
-import { net } from 'node:net';
+import net from 'node:net';
 
 // Create a TCP server
 const server = net.createServer(socket => {
@@ -345,7 +345,7 @@ client.on('end', () => {
 ```
 
 ```mjs
-import { net } from 'node:net';
+import net from 'node:net';
 
 // Connect to the server at localhost:8080
 const client = net.createConnection({ port: 8080 }, () => {


### PR DESCRIPTION
Replaced incorrect destructured import with default import for the 'net' module.

Old:
  import { net } from 'node:net'

Corrected to:
  import net from 'node:net'

This fix applies to the server and client example for mjs on this page :- 
https://nodejs.org/en/learn/modules/how-to-use-streams#key-methods-and-events-in-duplex-streams