### PR TITLE
fix(learn): Adjust V8 RangeError message formatting

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -331,7 +331,7 @@ callback _after_ the rest of the user's code and _before_ the event loop
 is allowed to proceed. To achieve this, the JS call stack is allowed to
 unwind then immediately execute the provided callback which allows a
 person to make recursive calls to `process.nextTick()` without reaching a
-`RangeError: Maximum call stack size exceeded from v8`.
+`RangeError: Maximum call stack size exceeded` from v8.
 
 This philosophy can lead to some potentially problematic situations.
 Take this snippet for example:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adjusted the formatting of the "RangeError: Maximum call stack size exceeded" message in `event-loop-timers-and-nexttick.md`. This change ensures that "from v8" is no longer included within the code-style formatting (backticks), improving readability.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
