### PR TITLE
chore(gov): refine Content vs. Code guidelines

### DIFF
--- a/docs/content-vs-code.md
+++ b/docs/content-vs-code.md
@@ -4,12 +4,25 @@ The **Website Team** (@nodejs/nodejs-website) is primarily concerned with the co
 
 The content of the website comes from Node.js core collaborators, in particular, from a variety of teams and [working groups](https://github.com/nodejs/TSC/blob/main/WORKING_GROUPS.md#current-working-groups).
 
-The Website team defers to these teams and WGs on matters of content. In other words, the Website team is not an **editorial** team except when no team or Working Group has taken responsibility for a content area, meaning we are the default editors for that content. In this case, the Website team will suggest editorial decisions. It is important to mention that there is no current formal process for ownership of content areas. Hence, generally speaking any core collaborator is invited to contribute content to the website.
+### Editorial Responsibilities
+
+The Website Team has **editorial responsibility** for content quality, structure, and presentation across the website, while **technical accuracy** remains the domain of relevant Working Groups and subject matter experts.
+
+Specifically:
+
+- **Working Groups and teams** retain final authority over technical content within their areas of expertise
+- **The Website Team** can make editorial decisions regarding content structure, clarity, formatting, and presentation
+- **The Website Team** serves as the default editorial team for content areas with no assigned Working Group ownership
+- **The Website Team** can proactively improve content that appears outdated, unclear, or inactive, while deferring to appropriate experts for technical validation
+
+### Content Ownership and Collaboration
 
 Some sections are implicitly assigned to teams based on a general consensus of what certain sections are about. An example of this policy playing out is Node.js releases blog posts. The Release WG has ownership of such content and it is free to publish it on the website. Some WGs might also have direct write access to this repository, meaning that (by using good judgement) they can approve their own Pull Requests.
 
-Note that The Website team may only review content for correct usage of this repository's tooling and structure and will not make editorial decisions (except in the case of content areas that have no team or WG ownership).
+When Working Groups are not actively maintaining content within their domain, the Website Team is encouraged to step in and help improve it, seeking input from the relevant experts as needed.
+
+The Website Team may review all content for correct usage of this repository's tooling and structure, and can make editorial decisions to improve content quality and user experience. For technical accuracy, the Website Team will collaborate with or defer to the appropriate Working Groups and subject matter experts.
 
 #### Summary
 
-The Website Team is responsible for creating, crafting and maintaining the Node.js Website, but we delegate the content creation to the Node.js Core Collaborators. The Website Team might suggest or add content, but it is not responsible for the content itself.
+The Website Team is responsible for creating, crafting and maintaining the Node.js Website. We have editorial authority to ensure content quality and presentation, while collaborating with Node.js Core Collaborators and Working Groups who maintain technical authority in their respective domains. The Website Team actively contributes content and takes editorial responsibility for improving the overall quality and user experience of the website.


### PR DESCRIPTION
Ref: https://github.com/nodejs/nodejs.org/issues/7974#issuecomment-3070405155

---

This PR updates the Content vs. Code guidelines to give the Node.js Website Team editorial authority to review/block/approve on the basis of "content quality, structure, and presentation across the website", while delegating "technical accuracy" to the working groups.

@ovflowd Hopefully this is worded in a way that "protects" the Website Team, as you mentioned prior.