### PR TITLE
fix(release): fix issues with maintenance and active lts

### DIFF
--- a/apps/site/app/[locale]/next-data/api-data/route.ts
+++ b/apps/site/app/[locale]/next-data/api-data/route.ts
@@ -23,7 +23,9 @@ const getPathnameForApiFile = (name: string, version: string) =>
 export const GET = async () => {
   const releases = provideReleaseData();
 
-  const { versionWithPrefix } = releases.find(release => release.status === 'Active LTS')!;
+  const { versionWithPrefix } = releases.find(
+    release => release.status === 'Active LTS'
+  )!;
 
   const gitHubApiResponse = await fetch(
     getGitHubApiDocsUrl(versionWithPrefix),

--- a/apps/site/app/[locale]/next-data/api-data/route.ts
+++ b/apps/site/app/[locale]/next-data/api-data/route.ts
@@ -23,7 +23,7 @@ const getPathnameForApiFile = (name: string, version: string) =>
 export const GET = async () => {
   const releases = provideReleaseData();
 
-  const { versionWithPrefix } = releases.find(release => release.isLts)!;
+  const { versionWithPrefix } = releases.find(release => release.status === 'Active LTS')!;
 
   const gitHubApiResponse = await fetch(
     getGitHubApiDocsUrl(versionWithPrefix),

--- a/apps/site/app/[locale]/next-data/api-data/route.ts
+++ b/apps/site/app/[locale]/next-data/api-data/route.ts
@@ -23,9 +23,7 @@ const getPathnameForApiFile = (name: string, version: string) =>
 export const GET = async () => {
   const releases = provideReleaseData();
 
-  const { versionWithPrefix } = releases.find(
-    release => release.status === 'LTS'
-  )!;
+  const { versionWithPrefix } = releases.find(release => release.isLts)!;
 
   const gitHubApiResponse = await fetch(
     getGitHubApiDocsUrl(versionWithPrefix),

--- a/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
+++ b/apps/site/components/Downloads/DownloadReleasesTable/index.tsx
@@ -8,18 +8,10 @@ import getReleaseData from '#site/next-data/releaseData';
 
 const BADGE_KIND_MAP = {
   'End-of-life': 'warning',
-  Maintenance: 'neutral',
-  LTS: 'info',
+  'Maintenance LTS': 'neutral',
+  'Active LTS': 'info',
   Current: 'default',
   Pending: 'default',
-} as const;
-
-const BADGE_TEXT_MAP = {
-  'End-of-life': 'End-of-Life (EOL)',
-  Maintenance: 'Maintenance LTS',
-  LTS: 'Active LTS',
-  Current: 'Current',
-  Pending: 'Pending',
 } as const;
 
 const DownloadReleasesTable: FC = async () => {
@@ -52,7 +44,8 @@ const DownloadReleasesTable: FC = async () => {
             </td>
             <td data-label="Status">
               <Badge kind={BADGE_KIND_MAP[release.status]} size="small">
-                {BADGE_TEXT_MAP[release.status]}
+                {release.status}
+                {release.status === 'End-of-life' ? ' (EoL)' : ''}
               </Badge>
             </td>
             <td className="download-table-last">

--- a/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
+++ b/apps/site/components/Downloads/Release/ReleaseCodeBox.tsx
@@ -127,7 +127,7 @@ const ReleaseCodeBox: FC = () => {
         </AlertBox>
       )}
 
-      {release.status === 'LTS' && (
+      {release.isLts && (
         <AlertBox
           title={t('components.common.alertBox.info')}
           level="info"

--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from '#site/providers/releaseProvider';
 
 const getDropDownStatus = (version: string, status: string) => {
-  if (status === 'LTS') {
+  if (status.endsWith('LTS')) {
     return `${version} (LTS)`;
   }
 
@@ -37,7 +37,7 @@ const VersionDropdown: FC = () => {
       ({ versionWithPrefix }) => versionWithPrefix === version
     );
 
-    if (release?.status === 'LTS' && pathname.includes('current')) {
+    if (release?.isLts && pathname.includes('current')) {
       redirect({ href: '/download', locale: locale });
       return;
     }

--- a/apps/site/components/Downloads/ReleaseModal/index.tsx
+++ b/apps/site/components/Downloads/ReleaseModal/index.tsx
@@ -54,7 +54,7 @@ const ReleaseModal: FC<ReleaseModalProps> = ({
         </div>
       )}
 
-      {release.status === 'LTS' && (
+      {release.isLts && (
         <div className="mb-4">
           <AlertBox
             title={t('components.common.alertBox.info')}

--- a/apps/site/components/withDownloadSection.tsx
+++ b/apps/site/components/withDownloadSection.tsx
@@ -28,7 +28,9 @@ const WithDownloadSection: FC<PropsWithChildren> = async ({ children }) => {
     .concat(snippets);
 
   // Decides which initial release to use based on the current pathname
-  const initialRelease = pathname.endsWith('/current') ? 'Current' : 'LTS';
+  const initialRelease = pathname.endsWith('/current')
+    ? 'Current'
+    : 'Active LTS';
 
   return (
     <WithNodeRelease status={initialRelease}>

--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -12,11 +12,11 @@ const getNodeReleaseStatus = (now, support) => {
   }
 
   if (maintenanceStart && now >= new Date(maintenanceStart)) {
-    return 'Maintenance';
+    return 'Maintainence LTS';
   }
 
   if (ltsStart && now >= new Date(ltsStart)) {
-    return 'LTS';
+    return 'Active LTS';
   }
 
   if (currentStart && now >= new Date(currentStart)) {
@@ -96,7 +96,7 @@ const generateReleaseData = async () => {
       version: latestVersion.semver.raw,
       versionWithPrefix: `v${latestVersion.semver.raw}`,
       codename: major.support.codename || '',
-      isLts: status === 'LTS',
+      isLts: status.endsWith('LTS'),
       npm: latestVersion.dependencies.npm || '',
       v8: latestVersion.dependencies.v8,
       releaseDate: latestVersion.releaseDate,

--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -12,7 +12,7 @@ const getNodeReleaseStatus = (now, support) => {
   }
 
   if (maintenanceStart && now >= new Date(maintenanceStart)) {
-    return 'Maintainence LTS';
+    return 'Maintenance LTS';
   }
 
   if (ltsStart && now >= new Date(ltsStart)) {

--- a/apps/site/pages/en/index.mdx
+++ b/apps/site/pages/en/index.mdx
@@ -28,7 +28,7 @@ layout: home
       </Button>
 
       <div className="flex flex-col xs:flex-row gap-2 justify-center xs:mt-6">
-        <WithNodeRelease status="LTS">
+        <WithNodeRelease status="Active LTS">
           {({ release }) =>
             <BadgeGroup size="small" kind="info" badgeText={release.versionWithPrefix} href={`/blog/release/${release.versionWithPrefix}`}>
               Node.js LTS

--- a/apps/site/types/releases.ts
+++ b/apps/site/types/releases.ts
@@ -1,6 +1,6 @@
 export type NodeReleaseStatus =
-  | 'LTS'
-  | 'Maintenance'
+  | 'Active LTS'
+  | 'Maintenance LTS'
   | 'Current'
   | 'End-of-life'
   | 'Pending';

--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -142,7 +142,7 @@
       "name": "Brew",
       "compatibility": {
         "os": ["MAC", "LINUX"],
-        "releases": ["Current", "LTS"]
+        "releases": ["Current", "Active LTS", "Maintenance LTS"]
       },
       "url": "https://brew.sh/",
       "info": "layouts.download.codeBox.platformInfo.brew"


### PR DESCRIPTION
There are many times where we reference the `'LTS'` status in an attempt to get an Long-Term Support version. However, the `'LTS'` status actually refers to the Active Long-Term Support version.

This PR makes the Maintenance vs Active LTS labels more distinct (as to not cause confusion), and replaces instances of checking `'LTS'` with `isLts`.