### PR TITLE
fix(InstallationMethodDropdown): increase height

### DIFF
--- a/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
+++ b/apps/site/components/Downloads/Release/InstallationMethodDropdown.tsx
@@ -80,6 +80,7 @@ const InstallationMethodDropdown: FC = () => {
       ariaLabel={t('layouts.download.dropdown.platform')}
       onChange={platform => platform && release.setInstallMethod(platform)}
       className="min-w-28"
+      dropdownClassName="!max-h-none"
       inline={true}
     />
   );

--- a/packages/ui-components/src/Common/Select/index.module.css
+++ b/packages/ui-components/src/Common/Select/index.module.css
@@ -61,7 +61,7 @@
 }
 
 .dropdown {
-  @apply max-h-56
+  @apply max-h-48
     max-w-xs
     overflow-hidden
     overflow-y-auto

--- a/packages/ui-components/src/Common/Select/index.module.css
+++ b/packages/ui-components/src/Common/Select/index.module.css
@@ -61,7 +61,7 @@
 }
 
 .dropdown {
-  @apply max-h-48
+  @apply max-h-56
     max-w-xs
     overflow-hidden
     overflow-y-auto

--- a/packages/ui-components/src/Common/Select/index.tsx
+++ b/packages/ui-components/src/Common/Select/index.tsx
@@ -39,6 +39,12 @@ type SelectProps<T extends string> = {
   inline?: boolean;
   onChange?: (value: T) => void;
   className?: string;
+  /**
+   * Allows passing custom CSS classes to the dropdown container element.
+   * This is useful for overriding default styles, such as adjusting `max-height`.
+   * The dropdown is rendered within a `Portal`.
+   */
+  dropdownClassName?: string;
   ariaLabel?: string;
   loading?: boolean;
   disabled?: boolean;
@@ -52,6 +58,7 @@ const Select = <T extends string>({
   inline,
   onChange,
   className,
+  dropdownClassName,
   ariaLabel,
   loading = false,
   disabled = false,
@@ -166,9 +173,11 @@ const Select = <T extends string>({
           <SelectPrimitive.Portal>
             <SelectPrimitive.Content
               position={inline ? 'popper' : 'item-aligned'}
-              className={classNames(styles.dropdown, {
-                [styles.inline]: inline,
-              })}
+              className={classNames(
+                styles.dropdown,
+                { [styles.inline]: inline },
+                dropdownClassName
+              )}
             >
               <SelectPrimitive.ScrollUpButton>
                 <ChevronUpIcon className={styles.scrollIcon} />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

 Adjust dropdown max-height from 48 to 56
https://github.com/nodejs/nodejs.org/issues/7969

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
