### PR TITLE
fix(CodeTabs): name overrides, duplicate name titles

### DIFF
--- a/packages/ui-components/src/MDX/CodeTabs.tsx
+++ b/packages/ui-components/src/MDX/CodeTabs.tsx
@@ -10,6 +10,10 @@ type MDXCodeTabsProps = {
   defaultTab?: string;
 };
 
+const NAME_OVERRIDES: Record<string, string | undefined> = {
+  mjs: 'ESM',
+};
+
 const MDXCodeTabs: FC<MDXCodeTabsProps> = ({
   languages: rawLanguages,
   displayNames: rawDisplayNames,
@@ -20,12 +24,22 @@ const MDXCodeTabs: FC<MDXCodeTabsProps> = ({
   const languages = rawLanguages.split('|');
   const displayNames = rawDisplayNames?.split('|') ?? [];
 
+  const occurrences: Record<string, number> = {};
+
   const tabs = languages.map((language, index) => {
-    const displayName = displayNames[index];
+    const base =
+      displayNames[index]?.trim() ||
+      NAME_OVERRIDES[language] ||
+      language.toUpperCase();
+
+    const count = occurrences[base] ?? 0;
+    occurrences[base] = count + 1;
+
+    const label = count === 0 ? base : `${base} (${count})`;
 
     return {
       key: `${language}-${index}`,
-      label: displayName?.length ? displayName : language.toUpperCase(),
+      label: label,
     };
   });
 

--- a/packages/ui-components/src/MDX/CodeTabs.tsx
+++ b/packages/ui-components/src/MDX/CodeTabs.tsx
@@ -35,7 +35,7 @@ const MDXCodeTabs: FC<MDXCodeTabsProps> = ({
     const count = occurrences[base] ?? 0;
     occurrences[base] = count + 1;
 
-    const label = count === 0 ? base : `${base} (${count})`;
+    const label = count > 0 ? `${base} (${count + 1})` : base;
 
     return {
       key: `${language}-${index}`,


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/52343#issuecomment-3092432939
Ref: https://github.com/nodejs/node/issues/52343#issuecomment-3092438900

This PR renames `MJS` to `ESM`, and adds a `(1)` (etc) when multiple identically titled codetabs are used.
<img width="117" height="49" alt="image" src="https://github.com/user-attachments/assets/0dbe003f-6557-47ba-8aa1-4556831d0454" />
