### PR TITLE
chore: remove version support link

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -41,10 +41,6 @@
       "text": "components.containers.footer.links.privacyPolicy"
     },
     {
-      "link": "/about/previous-releases",
-      "text": "components.containers.footer.links.versionSupport"
-    },
-    {
       "link": "https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md",
       "text": "components.containers.footer.links.codeOfConduct"
     },

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5,7 +5,6 @@
         "links": {
           "trademarkPolicy": "Trademark Policy",
           "privacyPolicy": "Privacy Policy",
-          "versionSupport": "Version Support",
           "codeOfConduct": "Code of Conduct",
           "security": "Security Policy"
         },


### PR DESCRIPTION
With the work on https://github.com/nodejs/nodejs.org/issues/7906 and our EOL and ESP program links becoming prominent in multiple pages (downloads, about, home, security blog posts, etc) the need for a dedicated "version support" (which isn't clear IMO) isn't needed anymore.