### PR TITLE
fix: redirect Linux x86 download links to x64 binaries

### DIFF
--- a/apps/site/util/url.ts
+++ b/apps/site/util/url.ts
@@ -68,7 +68,10 @@ export const getNodeDownloadUrl = (
       // Prepares a downloadable Node.js link for the ARM platforms such as
       // ARMv7 and ARMv8
       if (typeof platform === 'string') {
-        return `${baseURL}/node-${versionWithPrefix}-linux-${platform}.tar.xz`;
+        // For Linux, if platform is 'x86', default to 'x64'.
+        // Since x86 binaries are not available for recent Node.js versions
+        const linuxPlatform = platform === 'x86' ? 'x64' : platform;
+        return `${baseURL}/node-${versionWithPrefix}-linux-${linuxPlatform}.tar.xz`;
       }
 
       // Prepares a downloadable Node.js link for the x64 platform.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Fix broken Linux x86 download links by redirecting them to x64 binaries. The Node.js website was generating non-existent download URLs for Linux x86 architecture because Node.js v22+ no longer provides 32-bit Linux binaries. This fix ensures users on Android Chrome and other configurations that detect x86 architecture will receive working download links.
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

- Manual Testing: Verified that Linux x86 platform detection now generates URLs pointing to existing x64 binaries
- URL Verification: Confirmed generated URLs like https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz exist in the Node.js distribution
- Cross-platform Testing: Ensured Windows x86, macOS, and ARM platforms remain unaffected
- Reviewers should check: The Linux case in getNodeDownloadUrl() now includes fallback logic that converts x86 to x64 for Linux downloads only

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
Fixes #7589 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.