### PR TITLE
ci: disable is-crawlable audit in Lighthouse

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -11,7 +11,8 @@
         "categories:performance": ["warn", { "minScore": 0.9 }],
         "categories:accessibility": ["warn", { "minScore": 0.9 }],
         "categories:best-practices": ["warn", { "minScore": 0.9 }],
-        "categories:seo": ["warn", { "minScore": 0.9 }]
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "is-crawlable": "off"
       }
     }
   }

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -3,7 +3,8 @@
     "collect": {
       "numberOfRuns": 1,
       "settings": {
-        "preset": "desktop"
+        "preset": "desktop",
+        "skipAudits": ["is-crawlable"]
       }
     },
     "assert": {
@@ -11,8 +12,7 @@
         "categories:performance": ["warn", { "minScore": 0.9 }],
         "categories:accessibility": ["warn", { "minScore": 0.9 }],
         "categories:best-practices": ["warn", { "minScore": 0.9 }],
-        "categories:seo": ["warn", { "minScore": 0.9 }],
-        "is-crawlable": "off"
+        "categories:seo": ["warn", { "minScore": 0.9 }]
       }
     }
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Disables the indexing audit for Lighthouse, as this always fails in our build previews.

## Validation

See if Lighthouse reports a better score w/o the indexing warning.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
