### PR TITLE
chore: add x86 for Node.js <10 for Linux

### DIFF
--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -52,6 +52,13 @@
       "compatibility": {},
       "platforms": [
         {
+          "label": "x86",
+          "value": "x86",
+          "compatibility": {
+            "semver": ["< 10.0.0"]
+          }
+        },
+        {
           "label": "x64",
           "value": "x64"
         },


### PR DESCRIPTION
This PR adds x86 Platform/Bitness for Linux on Node.js <10