### PR TITLE
ci: set 3-day cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       - 'github_actions:pull-request'
     commit-message:
       prefix: meta
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
 
   - package-ecosystem: npm
@@ -19,6 +21,8 @@ updates:
       - 'github_actions:pull-request'
     commit-message:
       prefix: meta
+    cooldown:
+      default-days: 3
     groups:
       lint:
         patterns:


### PR DESCRIPTION
## Description

Reduces the risk from compromised dependency versions by requiring that they've been published for at least three days before Dependabot will update us to them, giving time for maintainers and the community to spot and resolve compromises.

## Validation
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

## Related Issues

https://github.com/nodejs/web-team/issues/25

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
