### PR TITLE
feat(docs): add dual ESM/CJS tabs to fetch documentation

### DIFF
--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -173,23 +173,21 @@ async function fetchGitHubRepos() {
       return new Writable({
         write(chunk, encoding, callback) {
           buffer += chunk.toString();
-
+          callback();
+        },
+        final(callback) {
           try {
             const json = JSON.parse(buffer);
             console.log(
               'Repository Names:',
               json.map(repo => repo.name)
             );
-            buffer = '';
           } catch (error) {
             console.error('Error parsing JSON:', error);
+          } finally {
+            console.log('Stream processing completed.');
+            callback();
           }
-
-          callback();
-        },
-        final(callback) {
-          console.log('Stream processing completed.');
-          callback();
         },
       });
     }

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -21,6 +21,7 @@ async function main() {
   const data = await response.json();
   console.log(data);
   // returns something like:
+  // [
   //   {
   //   userId: 1,
   //   id: 1,
@@ -30,6 +31,7 @@ async function main() {
   //     'reprehenderit molestiae ut ut quas totam\n' +
   //     'nostrum rerum est autem sunt rem eveniet architecto'
   // }
+  // ]
 }
 
 main().catch(console.error);

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -81,7 +81,7 @@ This will download the `mistral` model and run it on your local machine.
 
 With a pool, you can reuse connections to the same server, which can improve performance. Here is an example of how you can use a pool with Undici:
 
-```js
+```mjs
 import { Pool } from 'undici';
 
 const ollamaPool = new Pool('http://localhost:11434', {
@@ -131,13 +131,113 @@ try {
 }
 ```
 
+```cjs
+const { Pool } = require('undici');
+
+const ollamaPool = new Pool('http://localhost:11434', {
+  connections: 10,
+});
+
+/**
+ * Stream the completion of a prompt using the Ollama API.
+ * @param {string} prompt - The prompt to complete.
+ * @link https://github.com/ollama/ollama/blob/main/docs/api.md
+ **/
+async function streamOllamaCompletion(prompt) {
+  const { statusCode, body } = await ollamaPool.request({
+    path: '/api/generate',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt: prompt, model: 'mistral' }),
+  });
+
+  // You can read about HTTP status codes here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+  // 200 means the request was successful.
+  if (statusCode !== 200) {
+    throw new Error(`Ollama request failed with status ${statusCode}`);
+  }
+
+  let partial = '';
+  const decoder = new TextDecoder();
+
+  for await (const chunk of body) {
+    partial += decoder.decode(chunk, { stream: true });
+    // Note: decoder.decode() with { stream: true } may buffer incomplete UTF-8 chunks.
+    console.log(partial);
+  }
+
+  console.log('Streaming complete.');
+}
+
+(async () => {
+  try {
+    await streamOllamaCompletion('What is recursion?');
+  } catch (error) {
+    console.error('Error calling Ollama:', error);
+  } finally {
+    console.log('Closing Ollama pool.');
+    ollamaPool.close();
+  }
+})();
+```
+
 ## Streaming Responses with Undici
 
 [Streams](https://nodejs.org/docs/v22.14.0/api/stream.html#stream) is a feature in Node.js that allows you to read and write chunks of data.
 
-```js
+```mjs
 import { Writable } from 'stream';
 import { stream } from 'undici';
+
+async function fetchGitHubRepos() {
+  const url = 'https://api.github.com/users/nodejs/repos';
+
+  const { statusCode } = await stream(
+    url,
+    {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'undici-stream-example',
+        Accept: 'application/json',
+      },
+    },
+    () => {
+      let buffer = '';
+
+      return new Writable({
+        write(chunk, encoding, callback) {
+          buffer += chunk.toString();
+          callback();
+        },
+        final(callback) {
+          try {
+            const json = JSON.parse(buffer);
+            console.log(
+              'Repository Names:',
+              json.map(repo => repo.name)
+            );
+          } catch (error) {
+            console.error('Error parsing JSON:', error);
+          } finally {
+            console.log('Stream processing completed.');
+            callback();
+          }
+        },
+      });
+    }
+  );
+
+  console.log(`Response status: ${statusCode}`);
+}
+
+fetchGitHubRepos().catch(console.error);
+```
+
+```cjs
+const { Writable } = require('stream');
+const { stream } = require('undici');
 
 async function fetchGitHubRepos() {
   const url = 'https://api.github.com/users/nodejs/repos';

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -120,6 +120,8 @@ async function streamOllamaCompletion(prompt) {
   console.log('Streaming complete.');
 }
 
+// Note: top-level await requires ES modules (".mjs" or "type": "module")
+// Using it outside of an ES module will result in a SyntaxError.
 try {
   await streamOllamaCompletion('What is recursion?');
 } catch (error) {
@@ -128,6 +130,20 @@ try {
   console.log('Closing Ollama pool.');
   ollamaPool.close();
 }
+
+// If you cannot use ES modules, wrap your asynchronous operations in an async IIFE:
+/*
+(async () => {
+  try {
+    await streamOllamaCompletion('What is recursion?');
+  } catch (error) {
+    console.error('Error calling Ollama:', error);
+  } finally {
+    console.log('Closing Ollama pool.');
+    ollamaPool.close();
+  }
+})();
+*/
 ```
 
 ## Streaming Responses with Undici

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -23,14 +23,14 @@ async function main() {
   // returns something like:
   // [
   //   {
-  //   userId: 1,
-  //   id: 1,
-  //   title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
-  //   body: 'quia et suscipit\n' +
-  //     'suscipit recusandae consequuntur expedita et cum\n' +
-  //     'reprehenderit molestiae ut ut quas totam\n' +
-  //     'nostrum rerum est autem sunt rem eveniet architecto'
-  // }
+  //     userId: 1,
+  //     id: 1,
+  //     title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
+  //     body: 'quia et suscipit\n' +
+  //       'suscipit recusandae consequuntur expedita et cum\n' +
+  //       'reprehenderit molestiae ut ut quas totam\n' +
+  //       'nostrum rerum est autem sunt rem eveniet architecto'
+  //   }
   // ]
 }
 

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -114,6 +114,7 @@ async function streamOllamaCompletion(prompt) {
   const decoder = new TextDecoder();
   for await (const chunk of body) {
     partial += decoder.decode(chunk, { stream: true });
+    // Note: decoder.decode() with { stream: true } may buffer incomplete UTF-8 chunks.
     console.log(partial);
   }
 

--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -81,7 +81,7 @@ This will download the `mistral` model and run it on your local machine.
 
 With a pool, you can reuse connections to the same server, which can improve performance. Here is an example of how you can use a pool with Undici:
 
-```mjs
+```js
 import { Pool } from 'undici';
 
 const ollamaPool = new Pool('http://localhost:11434', {
@@ -131,63 +131,11 @@ try {
 }
 ```
 
-```cjs
-const { Pool } = require('undici');
-
-const ollamaPool = new Pool('http://localhost:11434', {
-  connections: 10,
-});
-
-/**
- * Stream the completion of a prompt using the Ollama API.
- * @param {string} prompt - The prompt to complete.
- * @link https://github.com/ollama/ollama/blob/main/docs/api.md
- **/
-async function streamOllamaCompletion(prompt) {
-  const { statusCode, body } = await ollamaPool.request({
-    path: '/api/generate',
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ prompt: prompt, model: 'mistral' }),
-  });
-
-  // You can read about HTTP status codes here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-  // 200 means the request was successful.
-  if (statusCode !== 200) {
-    throw new Error(`Ollama request failed with status ${statusCode}`);
-  }
-
-  let partial = '';
-  const decoder = new TextDecoder();
-
-  for await (const chunk of body) {
-    partial += decoder.decode(chunk, { stream: true });
-    // Note: decoder.decode() with { stream: true } may buffer incomplete UTF-8 chunks.
-    console.log(partial);
-  }
-
-  console.log('Streaming complete.');
-}
-
-(async () => {
-  try {
-    await streamOllamaCompletion('What is recursion?');
-  } catch (error) {
-    console.error('Error calling Ollama:', error);
-  } finally {
-    console.log('Closing Ollama pool.');
-    ollamaPool.close();
-  }
-})();
-```
-
 ## Streaming Responses with Undici
 
 [Streams](https://nodejs.org/docs/v22.14.0/api/stream.html#stream) is a feature in Node.js that allows you to read and write chunks of data.
 
-```mjs
+```js
 import { Writable } from 'stream';
 import { stream } from 'undici';
 
@@ -233,52 +181,4 @@ async function fetchGitHubRepos() {
 }
 
 fetchGitHubRepos().catch(console.error);
-```
-```cjs
-const { Writable } = require('stream');
-const { stream } = require('undici');
-
-async function fetchGitHubRepos() {
-  const url = 'https://api.github.com/users/nodejs/repos';
-
-  const { statusCode } = await stream(
-    url,
-    {
-      method: 'GET',
-      headers: {
-        'User-Agent': 'undici-stream-example',
-        Accept: 'application/json',
-      },
-    },
-    () => {
-      let buffer = '';
-
-      return new Writable({
-        write(chunk, encoding, callback) {
-          buffer += chunk.toString();
-          callback();
-        },
-        final(callback) {
-          try {
-            const json = JSON.parse(buffer);
-            console.log(
-              'Repository Names:',
-              json.map(repo => repo.name)
-            );
-          } catch (error) {
-            console.error('Error parsing JSON:', error);
-          } finally {
-            console.log('Stream processing completed.');
-            callback();
-          }
-        },
-      });
-    }
-  );
-
-  console.log(`Response status: ${statusCode}`);
-}
-
-fetchGitHubRepos().catch(console.error);
-
 ```


### PR DESCRIPTION
## Description

- Adds dual-tab support (ESM and CJS) to fetch streaming examples.
- Ensures consistency between both versions.

**Note**: This PR is based on top of #8021 (`fetch-fix`) and includes those changes. It should be merged after that PR is merged to avoid conflicts and duplicate code review. I'm happy to rebase this branch on top of `main` once the other PR is merged, in case any conflicts occur. Feel free to tag me when needed.

## Validation

[Live preview](https://nodejs-org-git-fork-nitin-is-me-fetch-tabs-openjs.vercel.app/en/learn/getting-started/fetch) of the changed documentation page.
<img width="1350" height="646" alt="image" src="https://github.com/user-attachments/assets/7ae36144-5ad9-4fe7-afba-5efcff776567" />



## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary. (N/A)
