### PR TITLE
docs: correct 'undefined' to 'null' in callback example

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -347,7 +347,7 @@ function someAsyncApiCall(callback) {
 // the callback is called before `someAsyncApiCall` completes.
 someAsyncApiCall(() => {
   // since someAsyncApiCall hasn't completed, bar hasn't been assigned any value
-  console.log('bar', bar); // undefined
+  console.log('bar', bar); // null
 });
 
 bar = 1;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The example comment shows `undefined` but logs `null` due to sync execution.

## Validation

The original example claimed `console.log('bar', bar)` outputs `undefined`, but this is incorrect because:  
1. `bar` is explicitly initialized to `null` (`let bar = null`).  
2. The callback runs *synchronously*, so `bar` is still `null` when logged (the `bar = 1` assignment happens later). 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
