### PR TITLE
chore: re-enable open-next build check

### DIFF
--- a/.github/workflows/playwright-cloudflare-open-next.yml
+++ b/.github/workflows/playwright-cloudflare-open-next.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Install packages
         run: pnpm install --frozen-lockfile
 
+      - name: Downgrade Next.js
+        # Open-next does not yet support next@15.4, so temporarily in order to have
+        # this workflow working we force install the latest Next.js 15.3 version instead
+        run: pnpm i next@15.3.2
+        working-directory: apps/site
+
       - name: Get Playwright version
         id: playwright-version
         working-directory: apps/site

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@eslint/compat": "~1.3.1",
     "@eslint/eslintrc": "~3.3.1",
-    "@flarelabs-net/wrangler-build-time-fs-assets-polyfilling": "^0.0.0",
+    "@flarelabs-net/wrangler-build-time-fs-assets-polyfilling": "^0.0.1",
     "@next/eslint-plugin-next": "15.4.4",
     "@opennextjs/cloudflare": "^1.6.0",
     "@playwright/test": "^1.54.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ~3.3.1
         version: 3.3.1
       '@flarelabs-net/wrangler-build-time-fs-assets-polyfilling':
-        specifier: ^0.0.0
-        version: 0.0.0
+        specifier: ^0.0.1
+        version: 0.0.1
       '@next/eslint-plugin-next':
         specifier: 15.4.4
         version: 15.4.4
@@ -1534,8 +1534,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@flarelabs-net/wrangler-build-time-fs-assets-polyfilling@0.0.0':
-    resolution: {integrity: sha512-8Nq96CtZD+NHRbHl9yooHIclCDhQx3Ayg+H6P4OlapdcalZq7NQ7YRN7BIF+UVNX/uFHZiE+IZwdKVr2gR+8mA==}
+  '@flarelabs-net/wrangler-build-time-fs-assets-polyfilling@0.0.1':
+    resolution: {integrity: sha512-uT7N77TaKZqGeb3c/KR+UlUs7xR36iU/g3uPaDflpJsXGRk8XwL2Ol2IpCNmv7ok57teModokqcbb6JT8a018Q==}
     hasBin: true
 
   '@floating-ui/core@1.7.1':
@@ -9733,7 +9733,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@flarelabs-net/wrangler-build-time-fs-assets-polyfilling@0.0.0': {}
+  '@flarelabs-net/wrangler-build-time-fs-assets-polyfilling@0.0.1': {}
 
   '@floating-ui/core@1.7.1':
     dependencies:


### PR DESCRIPTION
## Description

The open-next playwright build check is currently not functional and the open-next build is also not working, my PR is addressing these issues by:
 - updating the github workflow to downgrade the Next.js version being used
   (necessary workaround since https://github.com/nodejs/nodejs.org/pull/8019 didn't land)
   (note: even if not on the same Next.js version I think it's still important to keep the CI check functioning so that we make sure that the open-next compatibility doesn't unknowingly break for some unrelated reasons)
 - bumping the `@flarelabs-net/wrangler-build-time-fs-assets-polyfilling`
    (this is needed because since https://github.com/nodejs/nodejs.org/pull/7999 the site uses `glob` from `node:fs/promises`) which wasn't polyfilled by the package
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

I run the workflow on my for of the repository and it seems to be working as expected: https://github.com/dario-piotrowicz/nodejs.org/actions/runs/16576981245/job/46884037779

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

> [!Important]
> The workflow has been manually disable on GitHub
> <img width="865" height="195" alt="Screenshot 2025-07-28 at 19 41 30" src="https://github.com/user-attachments/assets/c423d4b1-47a4-4a8f-9b17-7f875cb7a8d8" />
> Can it be re-enabled?
> Could I know what the cause for disabling it was? 
> I assume it was due to its flakiness but haven't had anyone directly confirming that
> If it was flakiness I am definitely happy to look into addressing that next, although on my fork I cannot seem
> to be able to repro the flakiness right now:
> <img width="407" height="480" alt="Screenshot 2025-07-28 at 19 55 46" src="https://github.com/user-attachments/assets/5a4cb079-230f-431a-b67a-bc9532998f1e" />
> (could it just have gone away by itself? 😕)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
