### PR TITLE
fix(a11y): add correct `aria-label` on `ThemeToggle` button 

### DIFF
--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -11,6 +11,7 @@ import type { SimpleLocaleConfig } from '@node-core/ui-components/types';
 import dynamic from 'next/dynamic';
 import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
+import { useState, useEffect } from 'react';
 import type { FC } from 'react';
 
 import Link from '#site/components/Link';
@@ -35,12 +36,16 @@ const WithNavBar: FC = () => {
   const t = useTranslations();
 
   const locale = useLocale();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
 
   const toggleCurrentTheme = () =>
     setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
 
-  const themeToggleAriaLabel =
-    resolvedTheme === 'dark'
+  const themeToggleAriaLabel = !mounted
+    ? t('components.common.themeToggle.loading')
+    : resolvedTheme === 'dark'
       ? t('components.common.themeToggle.light')
       : t('components.common.themeToggle.dark');
 

--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -41,8 +41,8 @@ const WithNavBar: FC = () => {
 
   const themeToggleAriaLabel =
     resolvedTheme === 'dark'
-      ? t('components.common.themeToggle.label.light')
-      : t('components.common.themeToggle.label.dark');
+      ? t('components.common.themeToggle.light')
+      : t('components.common.themeToggle.dark');
 
   const changeLanguage = (locale: SimpleLocaleConfig) =>
     replace(pathname!, { locale: locale.code });

--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -39,6 +39,11 @@ const WithNavBar: FC = () => {
   const toggleCurrentTheme = () =>
     setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
 
+  const themeToggleAriaLabel =
+    resolvedTheme === 'dark'
+      ? t('components.common.themeToggle.label.light')
+      : t('components.common.themeToggle.label.dark');
+
   const changeLanguage = (locale: SimpleLocaleConfig) =>
     replace(pathname!, { locale: locale.code });
 
@@ -63,7 +68,7 @@ const WithNavBar: FC = () => {
 
         <ThemeToggle
           onClick={toggleCurrentTheme}
-          aria-label={t('components.common.themeToggle.label')}
+          aria-label={themeToggleAriaLabel}
         />
 
         <LanguageDropdown

--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -2,7 +2,6 @@
 
 import LanguageDropdown from '@node-core/ui-components/Common/LanguageDropDown';
 import Skeleton from '@node-core/ui-components/Common/Skeleton';
-import ThemeToggle from '@node-core/ui-components/Common/ThemeToggle';
 import NavBar from '@node-core/ui-components/Containers/NavBar';
 // TODO(@AvivKeller): I don't like that we are importing styles from another module
 import styles from '@node-core/ui-components/Containers/NavBar/index.module.css';
@@ -11,7 +10,6 @@ import type { SimpleLocaleConfig } from '@node-core/ui-components/types';
 import dynamic from 'next/dynamic';
 import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useState, useEffect } from 'react';
 import type { FC } from 'react';
 
 import Link from '#site/components/Link';
@@ -28,6 +26,16 @@ const SearchButton = dynamic(() => import('#site/components/Common/Search'), {
   ),
 });
 
+const ThemeToggle = dynamic(
+  () => import('@node-core/ui-components/Common/ThemeToggle'),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton className={styles.themeToggleSkeleton} loading={true} />
+    ),
+  }
+);
+
 const WithNavBar: FC = () => {
   const { navigationItems } = useSiteNavigation();
   const { resolvedTheme, setTheme } = useTheme();
@@ -36,16 +44,12 @@ const WithNavBar: FC = () => {
   const t = useTranslations();
 
   const locale = useLocale();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
 
   const toggleCurrentTheme = () =>
     setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
 
-  const themeToggleAriaLabel = !mounted
-    ? t('components.common.themeToggle.loading')
-    : resolvedTheme === 'dark'
+  const themeToggleAriaLabel =
+    resolvedTheme === 'dark'
       ? t('components.common.themeToggle.light')
       : t('components.common.themeToggle.dark');
 

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -13,7 +13,8 @@ const locators = {
   navLinksLocator: `[aria-label="${englishLocale.components.containers.navBar.controls.toggle}"] + div`,
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
-  themeToggleName: englishLocale.components.common.themeToggle.label,
+  // default light theme
+  themeToggleName: englishLocale.components.common.themeToggle.label.light,
 
   // Search components (from Orama library)
   searchButtonTag: 'orama-button',

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -14,7 +14,7 @@ const locators = {
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
   // Initially, the themeToggle's name will be the light mode i18n.
-  themeToggleName: englishLocale.components.common.themeToggle.light,
+  themeToggleName: englishLocale.components.common.themeToggle.loading,
   themeToggleAriaLabels: {
     light: englishLocale.components.common.themeToggle.light,
     dark: englishLocale.components.common.themeToggle.dark,

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -14,7 +14,7 @@ const locators = {
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
   // default light theme
-  themeToggleName: englishLocale.components.common.themeToggle.label.light,
+  themeToggleName: englishLocale.components.common.themeToggle.light,
 
   // Search components (from Orama library)
   searchButtonTag: 'orama-button',
@@ -75,7 +75,7 @@ test.describe('Node.js Website', () => {
       const initialTheme = await getTheme(page);
       const initialAriaLabel = await themeToggle.getAttribute('aria-label');
       expect(initialAriaLabel).toBe(
-        englishLocale.components.common.themeToggle.label[initialTheme]
+        englishLocale.components.common.themeToggle[initialTheme]
       );
 
       await themeToggle.click();
@@ -87,7 +87,7 @@ test.describe('Node.js Website', () => {
       expect(['light', 'dark']).toContain(newTheme);
 
       expect(newAriaLabel).toBe(
-        englishLocale.components.common.themeToggle.label[newTheme]
+        englishLocale.components.common.themeToggle[newTheme]
       );
     });
 

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -13,9 +13,12 @@ const locators = {
   navLinksLocator: `[aria-label="${englishLocale.components.containers.navBar.controls.toggle}"] + div`,
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
-  // default light theme
+  // Initially, the themeToggle's name will be the light mode i18n.
   themeToggleName: englishLocale.components.common.themeToggle.light,
-
+  themeToggleAriaLabels: {
+    light: englishLocale.components.common.themeToggle.light,
+    dark: englishLocale.components.common.themeToggle.dark,
+  },
   // Search components (from Orama library)
   searchButtonTag: 'orama-button',
   searchInputTag: 'orama-input',
@@ -75,7 +78,7 @@ test.describe('Node.js Website', () => {
       const initialTheme = await getTheme(page);
       const initialAriaLabel = await themeToggle.getAttribute('aria-label');
       expect(initialAriaLabel).toBe(
-        englishLocale.components.common.themeToggle[initialTheme]
+        locators.themeToggleAriaLabels[initialTheme]
       );
 
       await themeToggle.click();
@@ -86,9 +89,7 @@ test.describe('Node.js Website', () => {
       expect(newTheme).not.toBe(initialTheme);
       expect(['light', 'dark']).toContain(newTheme);
 
-      expect(newAriaLabel).toBe(
-        englishLocale.components.common.themeToggle[newTheme]
-      );
+      expect(newAriaLabel).toBe(locators.themeToggleAriaLabels[newTheme]);
     });
 
     test('should persist theme across page navigation', async ({ page }) => {

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -23,7 +23,9 @@ const locators = {
 };
 
 const getTheme = (page: Page) =>
-  page.evaluate(() => document.documentElement.dataset.theme);
+  page.evaluate(
+    () => document.documentElement.dataset.theme as 'light' | 'dark'
+  );
 
 const openLanguageMenu = async (page: Page) => {
   const button = page.getByRole('button', {
@@ -71,11 +73,22 @@ test.describe('Node.js Website', () => {
       await expect(themeToggle).toBeVisible();
 
       const initialTheme = await getTheme(page);
+      const initialAriaLabel = await themeToggle.getAttribute('aria-label');
+      expect(initialAriaLabel).toBe(
+        englishLocale.components.common.themeToggle.label[initialTheme]
+      );
+
       await themeToggle.click();
 
       const newTheme = await getTheme(page);
-      expect(newTheme).not.toEqual(initialTheme);
+      const newAriaLabel = await themeToggle.getAttribute('aria-label');
+
+      expect(newTheme).not.toBe(initialTheme);
       expect(['light', 'dark']).toContain(newTheme);
+
+      expect(newAriaLabel).toBe(
+        englishLocale.components.common.themeToggle.label[newTheme]
+      );
     });
 
     test('should persist theme across page navigation', async ({ page }) => {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -229,6 +229,7 @@
         "label": "Choose Language"
       },
       "themeToggle": {
+        "loading": "Loading theme label...",
         "light": "Switch to Light Mode",
         "dark": "Switch to Dark Mode"
       }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -230,8 +230,8 @@
       },
       "themeToggle": {
         "label": {
-          "light": "Activate Light Mode",
-          "dark": "Activate Dark Mode"
+          "light": "Toggle Light Mode",
+          "dark": "Toggle Dark Mode"
         }
       }
     },

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -229,7 +229,6 @@
         "label": "Choose Language"
       },
       "themeToggle": {
-        "loading": "Loading theme label...",
         "light": "Switch to Light Mode",
         "dark": "Switch to Dark Mode"
       }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -229,7 +229,10 @@
         "label": "Choose Language"
       },
       "themeToggle": {
-        "label": "Toggle Dark Mode"
+        "label": {
+          "light": "Activate Light Mode",
+          "dark": "Activate Dark Mode"
+        }
       }
     },
     "metabar": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -229,10 +229,8 @@
         "label": "Choose Language"
       },
       "themeToggle": {
-        "label": {
-          "light": "Toggle Light Mode",
-          "dark": "Toggle Dark Mode"
-        }
+        "light": "Switch to Light Mode",
+        "dark": "Switch to Dark Mode"
       }
     },
     "metabar": {

--- a/packages/ui-components/src/Containers/NavBar/index.module.css
+++ b/packages/ui-components/src/Containers/NavBar/index.module.css
@@ -108,6 +108,12 @@ span.searchButtonSkeleton {
   }
 }
 
+span.themeToggleSkeleton {
+  @apply size-9
+    rounded-md
+    py-4;
+}
+
 .ghIconWrapper {
   @apply size-9
     rounded-md


### PR DESCRIPTION
Added a11y test for `aria-label` in https://github.com/nodejs/nodejs.org/pull/8045/commits/d47d496f865300eb7cab801f0a22a68baf6fdfbc.

Hydration mismatch:- Initially `resolvedTheme` is undefined which is rendering wrong aria-label. Fixed in https://github.com/nodejs/nodejs.org/pull/8045/commits/61e8ea3105cd41114c7daf8e8c23affa566a212c by excluding from SSR. And technically, theme component should be rendered on the client.

closes #8044

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [X] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
