### PR TITLE
hotfix(css): reference index in Turtle css

### DIFF
--- a/apps/site/components/Common/Turtle/index.module.css
+++ b/apps/site/components/Common/Turtle/index.module.css
@@ -1,3 +1,5 @@
+@reference "../../../styles/index.css";
+
 .turtle {
   @apply motion-safe:animate-surf
     animate-surf


### PR DESCRIPTION
When updating the lint group, I appear to have broken the turtle's CSS classes. Sorry, rocket turtle!

Before:
<img width="649" height="674" alt="image" src="https://github.com/user-attachments/assets/93e896a7-e7fc-4a7b-9d2c-ad072dcc0177" />

After:
<img width="605" height="675" alt="image" src="https://github.com/user-attachments/assets/f874f3bf-ce00-4548-8fce-6fd9d676c25c" />


Requesting fast-track, as this is a hotfix.