### PR TITLE
fix: RSS button navigate to 404 page if not with en locale

### DIFF
--- a/apps/site/app/[locale]/feed/[feed]/route.ts
+++ b/apps/site/app/[locale]/feed/[feed]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 
 import provideWebsiteFeeds from '#site/next-data/providers/websiteFeeds';
 import { siteConfig } from '#site/next.json.mjs';
-import { availableLocaleCodes } from '#site/next.locales.mjs';
+import { defaultLocale } from '#site/next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string; feed: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };
@@ -26,12 +26,10 @@ export const GET = async (_: Request, props: StaticParams) => {
 // `[locale]/feeds/[feed]` and returns an array of all available static paths
 // This is used for ISR static validation and generation
 export const generateStaticParams = async () =>
-  availableLocaleCodes.flatMap(locale =>
-    siteConfig.rssFeeds.map(feed => ({
-      locale: locale,
-      feed: feed.file,
-    }))
-  );
+  siteConfig.rssFeeds.map(feed => ({
+    locale: defaultLocale.code,
+    feed: feed.file,
+  }));
 
 // Enforces that only the paths from `generateStaticParams` are allowed, giving 404 on the contrary
 // @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams

--- a/apps/site/app/[locale]/feed/[feed]/route.ts
+++ b/apps/site/app/[locale]/feed/[feed]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 
 import provideWebsiteFeeds from '#site/next-data/providers/websiteFeeds';
 import { siteConfig } from '#site/next.json.mjs';
-import { defaultLocale } from '#site/next.locales.mjs';
+import { availableLocaleCodes } from '#site/next.locales.mjs';
 
 type DynamicStaticPaths = { locale: string; feed: string };
 type StaticParams = { params: Promise<DynamicStaticPaths> };
@@ -26,10 +26,12 @@ export const GET = async (_: Request, props: StaticParams) => {
 // `[locale]/feeds/[feed]` and returns an array of all available static paths
 // This is used for ISR static validation and generation
 export const generateStaticParams = async () =>
-  siteConfig.rssFeeds.map(feed => ({
-    locale: defaultLocale.code,
-    feed: feed.file,
-  }));
+  availableLocaleCodes.flatMap(locale =>
+    siteConfig.rssFeeds.map(feed => ({
+      locale: locale,
+      feed: feed.file,
+    }))
+  );
 
 // Enforces that only the paths from `generateStaticParams` are allowed, giving 404 on the contrary
 // @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams

--- a/apps/site/components/Blog/BlogHeader/index.tsx
+++ b/apps/site/components/Blog/BlogHeader/index.tsx
@@ -21,7 +21,6 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
         {t('layouts.blog.title')}
         <Link
           href={`/feed/${currentFile}`}
-          {...{ locale: 'en' }} // RSS feeds only exist in English
           aria-label={t('components.blog.blogHeader.rssLink')}
         >
           <RssIcon />

--- a/apps/site/components/Blog/BlogHeader/index.tsx
+++ b/apps/site/components/Blog/BlogHeader/index.tsx
@@ -21,7 +21,7 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
         {t('layouts.blog.title')}
         <Link
           href={`/feed/${currentFile}`}
-          {...{ locale: 'en' }} // RSS feeds only exist in English
+          locale="en"
           aria-label={t('components.blog.blogHeader.rssLink')}
         >
           <RssIcon />

--- a/apps/site/components/Blog/BlogHeader/index.tsx
+++ b/apps/site/components/Blog/BlogHeader/index.tsx
@@ -21,6 +21,7 @@ const BlogHeader: FC<BlogHeaderProps> = ({ category }) => {
         {t('layouts.blog.title')}
         <Link
           href={`/feed/${currentFile}`}
+          {...{ locale: 'en' }} // RSS feeds only exist in English
           aria-label={t('components.blog.blogHeader.rssLink')}
         >
           <RssIcon />


### PR DESCRIPTION
## Description

close #8070 

RSS feed links on non-English pages redirect to English feeds because RSS feeds only exist in English.
It is more user friendly instead of showing 404 page without any explanation to the user.

## Validation

 To test this fix:
 1. Start development server: `pnpm dev`
 2. Navigate to a non-English blog page (e.g.,`/ja/blog`)
 3. Click the RSS icon in the blog header
 4. Verify it redirects to the English RSS feed (`/en/feed/blog.xml` or `/en/feed/${file}.xml` if you are in certain feed type) instead of 404 not found page

## Related Issues
### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
