### PR TITLE
fix: Remove unnecessary margin from sidebar item

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.module.css
@@ -31,6 +31,7 @@
         -left-1
         flex
         flex-col
+        gap-px
         after:absolute
         after:left-[0.45rem]
         after:top-0

--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
@@ -4,7 +4,6 @@
   @apply font-regular
     relative
     z-20
-    mb-px
     flex
     w-full
     items-center


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Eliminated the "loose pixel" which was being shown between sidebar items.
<!-- Write a brief description of the changes introduced by this PR -->

## Validation
Before:
<img width="557" height="396" alt="image" src="https://github.com/user-attachments/assets/45c6238f-24f3-4d25-837f-b78e07b5c7d4" />
After:
<img width="1529" height="660" alt="image" src="https://github.com/user-attachments/assets/604da231-88a4-4e17-aba9-e028d2d2d2e2" />

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
Fixes #8082 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
