### PR TITLE
fix(blog): Fix homepage link in RSS feed

### DIFF
--- a/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
+++ b/apps/site/next-data/generators/__tests__/websiteFeeds.test.mjs
@@ -30,8 +30,8 @@ describe('generateWebsiteFeeds', () => {
       id: siteConfig.rssFeeds[0].file,
       title: siteConfig.rssFeeds[0].title,
       language: 'en',
-      link: `${base}/feed/${siteConfig.rssFeeds[0].file}`,
-      description: siteConfig.rssFeeds[0].description,
+      link: base,
+      description: siteConfig.rssFeeds[0].description || '',
     });
 
     const date = new Date(blogData.posts[0].date);

--- a/apps/site/next-data/generators/websiteFeeds.mjs
+++ b/apps/site/next-data/generators/websiteFeeds.mjs
@@ -32,8 +32,8 @@ const generateWebsiteFeeds = ({ posts }) => {
         id: file,
         title: title,
         language: 'en',
-        link: `${canonicalUrl}/feed/${file}`,
-        description: description,
+        link: canonicalUrl,
+        description: description || '',
       });
 
       const blogFeedEntries = posts


### PR DESCRIPTION
## Description

When following the Node.js Blog at https://nodejs.org/en/blog in a feed reader like NetNewsWire, or when sharing a blog roll via OPML ([example](https://gist.github.com/Krinkle/e0d13f84b91e829afffa7b27822482be)), the homepage link gets broken.

Instead of navigating the browser to the website, one gets a blank page and an unexpected RSS feed download in the background.

The `<link>` tag in RSS 2.0 is for the HTML website. The "self" link for the RSS file itself is already generated by [jpmonette/feed](https://github.com/jpmonette/feed) package.

While at it, fix the broken `<description>undefined</defined>` element. This is often left empty and fine not to pass in `/apps/site/site.json`. However, the upstream Feed class has a bug where it takes the undefined and outputs the string "undefined" as the blog's description instead of a sensible default like empty string.

## Validation

```diff
  <?xml version="1.0" encoding="utf-8"?>
  <rss version="2.0">
    <channel>
      <title>Node.js Blog</title>
-     <link>https://nodejs.org/en/feed/blog.xml</link>
-     <description>undefined</description>
+     <link>https://nodejs.org/en/</link>
+     <description></description>
```

## Related Issues

* https://github.com/jpmonette/feed/issues/222
* https://github.com/nodejs/nodejs.org/pull/6215

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
