### PR TITLE
chore: ensure npm@11 is installed for OIDC publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -108,15 +108,16 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - name: Set up Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # Don't use caching here as we never install dependencies in this workflow
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup npm
-        # OIDC requires npm >=11.5.1. pnpm will use the installed version of npm for publishing
+      - name: Re-install npm
+        # TODO: OIDC requires npm >=11.5.1.
+        # Until Node.js v24 is LTS (with npm 11 as the default), we need to bump.
         run: npm install -g npm@11
 
       - name: Publish

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -108,12 +108,16 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # Don't use caching here as we never install dependencies in this workflow
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup npm
+        # OIDC requires npm >=11.5.1. pnpm will use the installed version of npm for publishing
+        run: npm install -g npm@11
 
       - name: Publish
         working-directory: packages/${{ matrix.package }}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Update to `npm@11` in the `publish-packages` workflow to ensure that OIDC is supported.

This could also pin to a specific npm version instead of using the entire `v11` range.

## Validation

I can't confirm that is working without running the workflow but I did see that a similar change to #8085 failed in the node-gyp repo (https://github.com/nodejs/node-gyp/issues/3201). npm's docs say that npm >=11.5.1 is required to use OIDC. I've also run a similar workflow in a [work repo](https://github.com/vltpkg/vltpkg/commit/61cee939cfb4b02401f65b39da5e907598855386) that used `pnpm publish` and it worked to update npm in this way.

## Related Issues

#8085 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
