### PR TITLE
fix(redirects): don't prefix `/docs`

### DIFF
--- a/apps/site/redirects.json
+++ b/apps/site/redirects.json
@@ -106,7 +106,7 @@
     },
     {
       "source": "/documentation/:path*",
-      "destination": "/en/docs/:path*"
+      "destination": "/docs/:path*"
     },
     {
       "source": "/blog/:path*",

--- a/apps/site/redirects.json
+++ b/apps/site/redirects.json
@@ -126,7 +126,7 @@
     },
     {
       "source": "/:locale/documentation/:path*",
-      "destination": "/:locale/docs/:path*"
+      "destination": "/docs/:path*"
     },
     {
       "source": "/(atom|feed|rss).xml",


### PR DESCRIPTION
I doubt this was an intentional design choice