### PR TITLE
chore(publishing): version packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -81,17 +81,10 @@ jobs:
 
               # Determine if the package has changed (or include all on manual trigger)
               if [ "$EVENT_NAME" == "workflow_dispatch" ] || ! git diff --quiet $COMMIT_SHA~1 $COMMIT_SHA -- "$pkg/"; then
-                HAS_VERSION=$(jq 'has("version")' "$PKG_JSON")
-                if [ "$HAS_VERSION" == "false" ]; then
-                  # Include packages without version field
+                OLD_VERSION=$(git show $COMMIT_SHA~1:$PKG_JSON | jq -r '.version')
+                NEW_VERSION=$(jq -r '.version' "$PKG_JSON")
+                if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
                   CHANGED_PACKAGES+=("$PKG_NAME")
-                else
-                  # For packages with version field, include only if version changed
-                  OLD_VERSION=$(git show $COMMIT_SHA~1:$PKG_JSON | jq -r '.version')
-                  NEW_VERSION=$(jq -r '.version' "$PKG_JSON")
-                  if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-                    CHANGED_PACKAGES+=("$PKG_NAME")
-                  fi
                 fi
               fi
             done
@@ -137,12 +130,6 @@ jobs:
         run: |
           # Install deps
           pnpm install --frozen-lockfile
-
-          HAS_VERSION=$(jq 'has("version")' package.json)
-          if [ "$HAS_VERSION" == "false" ]; then
-            # Only bump version if package has no version field
-            npm version --no-git-tag-version 1.0.1-$COMMIT_SHA
-          fi
 
           # Check if a custom publish script exists in package.json
           if jq -e '.scripts.publish' package.json > /dev/null; then

--- a/.github/workflows/translations-sync.yml
+++ b/.github/workflows/translations-sync.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH_NAME }}
           token: ${{ secrets.CROWDIN_GITHUB_BOT_TOKEN }}
+          fetch-depth: 2
 
       - name: Restore Lint Cache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -111,6 +112,14 @@ jobs:
 
       - name: Run Prettier
         run: node --run prettier:fix
+
+      - name: Patch version if the files changed
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/main HEAD -- packages/website-i18n)
+          if [ -n "$CHANGED_FILES" ]; then
+            cd packages/website-i18n
+            pnpm version patch --no-git-tag-version
+          else
 
       - name: Push Changes back to Pull Request
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@node-core/website-i18n",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     "./*": [

--- a/packages/rehype-shiki/package.json
+++ b/packages/rehype-shiki/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@node-core/rehype-shiki",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     ".": "./src/index.mjs",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@node-core/ui-components",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     "./*": [


### PR DESCRIPTION
Fixes #7777 by adding a `"version"` field to all current `package.json` files. A new version will be released whenever a commit is pushed that bumps this field.

On crowdin syncs, the `@node-core/website-i18n` versions is bumped automatically