### PR TITLE
fix(turbo): add root prettier:fix task to format command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cloudflare:preview": "turbo cloudflare:preview",
     "deploy": "turbo deploy",
     "dev": "turbo dev",
-    "format": "turbo prettier:fix lint:fix",
+    "format": "turbo //#prettier:fix prettier:fix lint:fix",
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
     "lint:staged": "lint-staged",

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,9 @@
     "//#prettier": {
       "outputs": [".prettiercache"]
     },
+    "//#prettier:fix": {
+      "outputs": [".prettiercache"]
+    },
     "build": {
       "dependsOn": ["^topo"]
     },


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The `format` script was not properly calling `prettier:fix` to format files in the root directory. The issue was that `turbo prettier:fix` only looked for `prettier:fix` scripts in workspace packages, but the root-level script wasn't being executed.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
1. Create test files with unformatted code in the root directory.
2. Verify that `pnpm run format` now properly formats root files.

## Related Issues
Fixes #8108 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.