### PR TITLE
fix: correct outdated fedora/CentOs/RHEL install guide

### DIFF
--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -59,7 +59,7 @@ might differ between fedora and various RHEL releases).
 dnf install nodejs24
 ```
 
-for older CentOS/RHEL releases Node.js is available as a module called `nodejs`.
+For older CentOS/RHEL releases Node.js is available as a module called `nodejs`.
 
 ```bash
 dnf module install nodejs:<stream>

--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -52,7 +52,7 @@ LTS Node.js version.
 dnf install nodejs npm
 ```
 
-Or from a specific stream for alternative, maintained version (maintained versions
+Or from a specific stream for alternative, maintained versions (maintained versions
 might differ between fedora and various RHEL releases).
 
 ```bash

--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -53,7 +53,7 @@ dnf install nodejs npm
 ```
 
 Or from a specific stream for alternative, maintained versions (maintained versions
-might differ between fedora and various RHEL releases).
+might differ between Fedora and various RHEL releases).
 
 ```bash
 dnf install nodejs24

--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -43,7 +43,7 @@ pacman -S nodejs npm
 
 ## CentOS, Fedora and Red Hat Enterprise Linux
 
-Node.js and npm packages are availale in the main Repository for Fedora and RHEL 10.
+Node.js and npm packages are available in the main Repository for Fedora and RHEL 10.
 
 It can be installed from a default stream which contains the currently active
 LTS nodejs version.

--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -43,7 +43,23 @@ pacman -S nodejs npm
 
 ## CentOS, Fedora and Red Hat Enterprise Linux
 
-Node.js is available as a module called `nodejs` in CentOS/RHEL 8 and Fedora.
+Node.js and npm packages are availale in the main Repository for Fedora and RHEL 10.
+
+It can be installed from a default stream which contains the currently active
+LTS nodejs version.
+
+```bash
+dnf install nodejs npm
+```
+
+Or from a specific stream for alternative, maintained version (maintained versions
+might differ between fedora and various RHEL releases).
+
+```bash
+dnf install nodejs24
+```
+
+for older CentOS/RHEL releases Node.js is available as a module called `nodejs`.
 
 ```bash
 dnf module install nodejs:<stream>

--- a/apps/site/pages/en/download/package-manager/all.md
+++ b/apps/site/pages/en/download/package-manager/all.md
@@ -46,7 +46,7 @@ pacman -S nodejs npm
 Node.js and npm packages are available in the main Repository for Fedora and RHEL 10.
 
 It can be installed from a default stream which contains the currently active
-LTS nodejs version.
+LTS Node.js version.
 
 ```bash
 dnf install nodejs npm


### PR DESCRIPTION

## Description

Installation method in Fedora/CentOs/RHEL space has changed in the last few years, moving away from using modules to using traditional rpms for all maintained stream versions.

Quick [search](https://www.reddit.com/r/Fedora/comments/13huznq/how_do_i_install_nodejs_lts/) on google suggests that this created at-least some confusion with the conflicting content of the page modified in this PR.


## Related Issues
No related issues




### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [] I've covered new added functionality with unit tests if necessary.
