### PR TITLE
style(sidebar): make hover full-width and add clearer item spacing

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.module.css
@@ -6,6 +6,13 @@
     flex-col
     gap-2;
 
+  /* Default item list spacing for non-progression groups */
+  .itemList {
+    @apply flex
+      flex-col
+      gap-1;
+  }
+
   &:not(.progression) {
     .groupName {
       @apply px-2

--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
@@ -7,19 +7,21 @@
     flex
     w-full
     items-center
+    gap-1
     overflow-hidden
     rounded-md
     text-sm
     text-neutral-800
     dark:text-neutral-200;
 
-  &:hover {
-    &:not(.progression) .label {
-      /* @see https://github.com/nodejs/nodejs.org/blob/main/packages/ui-components/src/Containers/NavBar/NavItem/index.module.css#L24 */
-      @apply rounded-sm
-        bg-neutral-100
-        text-neutral-900
-        dark:bg-neutral-900
+  &:not(.active):hover {
+    /* Apply hover background to the full item width */
+    @apply bg-neutral-100
+      dark:bg-neutral-900;
+
+    /* Ensure text colors contrast with hover background */
+    .label {
+      @apply text-neutral-900
         dark:text-neutral-100;
     }
 
@@ -64,25 +66,38 @@
       @apply p-1;
     }
 
-    &:not(.active):hover .label {
-      @apply rounded-sm
-        bg-neutral-100
+    /* On hover, use full-width background on the item (set above) */
+    &:not(.active):hover {
+      @apply bg-neutral-100
         dark:bg-neutral-900;
+    }
+
+    /* Avoid extra pill background on the label when hovering */
+    &:not(.active):hover .label {
+      @apply rounded-none
+        bg-transparent;
     }
   }
 
   &.active {
-    @apply text-neutral-900
-      dark:text-white;
+    /* Full-width active background and readable text */
+    @apply bg-green-600
+      text-white;
 
     .progressionIcon {
       @apply fill-green-500;
     }
 
-    &:not(.progression) .label {
-      @apply rounded-sm
-        bg-green-600
+    /* Remove pill background on the label; keep full-width bg on the item */
+    .label {
+      @apply rounded-none
+        bg-transparent
         text-white;
+    }
+
+    /* Preserve active background on hover */
+    &:hover {
+      @apply bg-green-600;
     }
   }
 }


### PR DESCRIPTION
## Description

- Enhance sidebar UI to improve discoverability and readability.
- Make the hover state span the full row width for non-active items; add consistent spacing between items; avoid double “pill” highlights by removing label background when the row is highlighted.
- Includes minor contrast adjustments for hover/active states to maintain accessibility.

## Validation

- Built locally with pnpm build and verified no build errors.
- Ran pnpm test and confirmed tests pass.
- Manually verified on desktop and mobile breakpoints:
- Hover covers entire row for non-active items.
- Item spacing is consistent across groups.
- Active state keeps full-row background on hover.

Screenshots:
Before: 
<img width="370" height="293" alt="Screenshot 2025-09-09 182051" src="https://github.com/user-attachments/assets/d4a16aa2-a882-47f0-8512-508f9eeecf8d" />
After: 
<img width="339" height="336" alt="Screenshot 2025-09-09 182016" src="https://github.com/user-attachments/assets/970e8be2-5da0-41d9-84cc-41f29fcbd856" />
<img width="512" height="322" alt="Screenshot 2025-09-09 182142" src="https://github.com/user-attachments/assets/dd180329-966c-4568-9062-4506217f2cf7" />

## Related Issues
- N/A, small UI enhancement.

### Check List
- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
