### PR TITLE
fix: remove misleading sentence from typescript natively

### DIFF
--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -45,8 +45,6 @@ enum MyEnum {
 console.log(MyEnum.A);
 ```
 
-Future versions of Node.js will include support for TypeScript without the need for a command line flag.
-
 ## Limitations
 
 At the time of writing, the experimental support for TypeScript in Node.js has some limitations.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/typescript/issues/46