### PR TITLE
doc: add minimal SECURITY md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@ LICENSE @nodejs/tsc
 GOVERNANCE.md @nodejs/tsc
 CONTRIBUTING.md @nodejs/nodejs-website @nodejs/web-infra
 docs @nodejs/nodejs-website @nodejs/web-infra
+SECURITY.md @nodejs/security-wg
 
 # Node.js Release Blog Posts
 apps/site/pages/en/blog/release @nodejs/releasers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability to Node.js Website
 
 Please report security issues **privately** using the **GitHub Security Advisory**
-workflow (Security → “Report a vulnerability”).
+workflow ([Security → “Report a vulnerability”](https://github.com/nodejs/nodejs.org/security/advisories/new)).
 
 Do **not** open a public GitHub issue for security problems.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security
+
+## Reporting a vulnerability to Node.js Website
+
+Please report security issues **privately** using the **GitHub Security Advisory**
+workflow (Security → “Report a vulnerability”).
+
+Do **not** open a public GitHub issue for security problems.
+
+We aim to acknowledge reports within **7 business days**.
+If you do **not** receive an acknowledgement within **7 business days**,
+forward your report to **[tsc@nodejs.org](mailto:tsc@nodejs.org)**.
+
+## Disclosure & advisories
+
+Confirmed vulnerabilities will be published as a **GitHub Security Advisory**
+(and assigned a CVE when applicable). Notices are also shared via:
+
+- Node.js blog advisories: [https://nodejs.org/blog/vulnerability/](https://nodejs.org/blog/vulnerability/)
+  when necessary.


### PR DESCRIPTION
As discussed in https://openjs-foundation.slack.com/archives/C09EXEEHFKP/p1757790176003369

I believe the SECURITY.md from nodejs/.github isn't really applicable to a Node.js website, so it might be better to refer to the minimal security md defined in OpenJS Projects: https://github.com/openjs-foundation/cross-project-council/pull/1588. 