### PR TITLE
chore: Refine Progression Sidebar hover and active states

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
@@ -30,6 +30,15 @@
   }
 
   &.progression {
+    &.active {
+      @apply text-neutral-900
+        dark:text-white;
+
+      .hexagonIcon {
+        @apply fill-green-500;
+      }
+    }
+
     .label {
       @apply p-1;
     }
@@ -42,10 +51,6 @@
         dark:fill-neutral-800
         dark:stroke-neutral-950;
     }
-  }
-
-  &.active .hexagonIcon {
-    @apply fill-green-500;
   }
 
   &:not(.active):not(.progression):hover {

--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.module.css
@@ -14,7 +14,41 @@
     text-neutral-800
     dark:text-neutral-200;
 
-  &:not(.active):hover {
+  .label {
+    @apply font-regular
+      flex
+      items-center
+      gap-1.5
+      p-2
+      text-sm;
+  }
+
+  .icon {
+    @apply size-3
+      text-neutral-500
+      dark:text-neutral-200;
+  }
+
+  &.progression {
+    .label {
+      @apply p-1;
+    }
+
+    .hexagonIcon {
+      @apply shrink-0
+        fill-neutral-200
+        stroke-white
+        stroke-[4]
+        dark:fill-neutral-800
+        dark:stroke-neutral-950;
+    }
+  }
+
+  &.active .hexagonIcon {
+    @apply fill-green-500;
+  }
+
+  &:not(.active):not(.progression):hover {
     /* Apply hover background to the full item width */
     @apply bg-neutral-100
       dark:bg-neutral-900;
@@ -30,63 +64,12 @@
         text-green-600
         dark:text-green-400;
     }
-
-    .progressionIcon {
-      @apply fill-green-200
-        dark:fill-green-300;
-    }
   }
 
-  .label {
-    @apply font-regular
-      flex
-      items-center
-      gap-1.5
-      p-2
-      text-sm;
-  }
-
-  .progressionIcon {
-    @apply shrink-0
-      fill-neutral-200
-      stroke-white
-      stroke-[4]
-      dark:fill-neutral-800
-      dark:stroke-neutral-950;
-  }
-
-  .icon {
-    @apply size-3
-      text-neutral-500
-      dark:text-neutral-200;
-  }
-
-  &.progression {
-    .label {
-      @apply p-1;
-    }
-
-    /* On hover, use full-width background on the item (set above) */
-    &:not(.active):hover {
-      @apply bg-neutral-100
-        dark:bg-neutral-900;
-    }
-
-    /* Avoid extra pill background on the label when hovering */
-    &:not(.active):hover .label {
-      @apply rounded-none
-        bg-transparent;
-    }
-  }
-
-  &.active {
+  &.active:not(.progression) {
     /* Full-width active background and readable text */
     @apply bg-green-600
       text-white;
-
-    .progressionIcon {
-      @apply fill-green-500;
-    }
 
     /* Remove pill background on the label; keep full-width bg on the item */
     .label {

--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.tsx
@@ -31,9 +31,7 @@ const SidebarItem: FC<SidebarItemProps> = ({
     activeClassName={styles.active}
     {...props}
   >
-    {showProgressionIcons && (
-      <ProgressionIcon className={styles.progressionIcon} />
-    )}
+    {showProgressionIcons && <ProgressionIcon className={styles.hexagonIcon} />}
 
     <div className={styles.label}>
       <span>{label}</span>


### PR DESCRIPTION
## Description

As mentioned in this comment https://github.com/nodejs/nodejs.org/pull/8166#issuecomment-3308155155 this PR aims to use the styles defined in Figma for the Progression Sidebar instead of the custom hover and active styles that were previously added

## Validation

The Progression Sidebar and Sidebar should appear correctly in both the preview and Chromatic

## Related Issues

Related to #8166, Fixes #8179
