### PR TITLE
fix: download options alignment

### DIFF
--- a/packages/ui-components/src/Common/Select/index.module.css
+++ b/packages/ui-components/src/Common/Select/index.module.css
@@ -3,7 +3,8 @@
 .select {
   @apply inline-flex
     flex-col
-    gap-1.5;
+    gap-1.5
+    align-middle;
 
   .label {
     @apply block

--- a/packages/ui-components/src/Common/Skeleton/index.module.css
+++ b/packages/ui-components/src/Common/Skeleton/index.module.css
@@ -4,12 +4,14 @@
   @apply outline-hidden
     dark:animate-pulse-dark
     pointer-events-none
+    inline-flex
     animate-pulse
     cursor-default
     select-none
     rounded-md
     border-none
     bg-clip-border
+    align-middle
     text-transparent
     shadow-none;
 }


### PR DESCRIPTION
## Description

This PR aims to fix the height of the Skeleton used with Select and to adjust the alignment of the select on the download page

## Validation

Download select must be aligned

## Related Issues

Fixes #8208