### PR TITLE
fix(blog): apply proper route to metadata call

### DIFF
--- a/apps/site/app/[locale]/blog/[...path]/page.tsx
+++ b/apps/site/app/[locale]/blog/[...path]/page.tsx
@@ -15,7 +15,7 @@ export const generateViewport = basePage.generateViewport;
 
 // This generates each page's HTML Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
-export const generateMetadata = basePage.generateMetadata;
+export const generateMetadata = basePage.generateBlogMetadata;
 
 // Generates all possible static paths based on the locales and environment configuration
 // - Returns an empty array if static export is disabled (`ENABLE_STATIC_EXPORT` is false)

--- a/apps/site/app/[locale]/blog/[...path]/page.tsx
+++ b/apps/site/app/[locale]/blog/[...path]/page.tsx
@@ -17,9 +17,8 @@ export const generateViewport = basePage.generateViewport;
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
 export const generateMetadata = ({
   params,
-}: {
-  params: Promise<{ path: Array<string>; locale: string }>;
-}) => basePage.generateMetadata({ params, prefix: 'blog' });
+}: PageProps<'/[locale]/blog/[...path]'>) =>
+  basePage.generateMetadata({ params, prefix: 'blog' });
 
 // Generates all possible static paths based on the locales and environment configuration
 // - Returns an empty array if static export is disabled (`ENABLE_STATIC_EXPORT` is false)

--- a/apps/site/app/[locale]/blog/[...path]/page.tsx
+++ b/apps/site/app/[locale]/blog/[...path]/page.tsx
@@ -7,7 +7,7 @@ import * as basePage from '#site/next.dynamic.page.mjs';
 import { defaultLocale } from '#site/next.locales.mjs';
 import type { DynamicParams } from '#site/types';
 
-type PageParams = DynamicParams<{ path: Array<string>; locale: string }>;
+type PageParams = DynamicParams<{ path: Array<string> }>;
 
 // This is the default Viewport Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-viewport#generateviewport-function

--- a/apps/site/app/[locale]/blog/[...path]/page.tsx
+++ b/apps/site/app/[locale]/blog/[...path]/page.tsx
@@ -15,7 +15,11 @@ export const generateViewport = basePage.generateViewport;
 
 // This generates each page's HTML Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
-export const generateMetadata = basePage.generateBlogMetadata;
+export const generateMetadata = ({
+  params,
+}: {
+  params: Promise<{ path: Array<string>; locale: string }>;
+}) => basePage.generateMetadata({ params, prefix: 'blog' });
 
 // Generates all possible static paths based on the locales and environment configuration
 // - Returns an empty array if static export is disabled (`ENABLE_STATIC_EXPORT` is false)

--- a/apps/site/app/[locale]/blog/[...path]/page.tsx
+++ b/apps/site/app/[locale]/blog/[...path]/page.tsx
@@ -7,7 +7,7 @@ import * as basePage from '#site/next.dynamic.page.mjs';
 import { defaultLocale } from '#site/next.locales.mjs';
 import type { DynamicParams } from '#site/types';
 
-type PageParams = DynamicParams<{ path: Array<string> }>;
+type PageParams = DynamicParams<{ path: Array<string>; locale: string }>;
 
 // This is the default Viewport Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-viewport#generateviewport-function
@@ -15,9 +15,7 @@ export const generateViewport = basePage.generateViewport;
 
 // This generates each page's HTML Metadata
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
-export const generateMetadata = ({
-  params,
-}: PageProps<'/[locale]/blog/[...path]'>) =>
+export const generateMetadata = ({ params }: PageParams) =>
   basePage.generateMetadata({ params, prefix: 'blog' });
 
 // Generates all possible static paths based on the locales and environment configuration

--- a/apps/site/next.dynamic.page.mjs
+++ b/apps/site/next.dynamic.page.mjs
@@ -1,4 +1,4 @@
-import { sep } from 'node:path';
+import { join } from 'node:path';
 
 import { notFound, redirect } from 'next/navigation';
 import { setRequestLocale } from 'next-intl/server';
@@ -25,29 +25,19 @@ export const generateViewport = () => ({ ...PAGE_VIEWPORT });
  *
  * @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
  *
- * @param {{ params: Promise<{ path: Array<string>; locale: string }> }} props
+ * @param {{ params: Promise<{ path: Array<string>; locale: string }>, prefix?: string }} props
  * @returns {Promise<import('next').Metadata>} the metadata for the page
  */
-export const generateMetadata = async props => {
-  const { path = [], locale = defaultLocale.code } = await props.params;
+export const generateMetadata = async ({ params, prefix }) => {
+  const { path = [], locale = defaultLocale.code } = await params;
 
   const pathname = dynamicRouter.getPathname(path);
 
-  return dynamicRouter.getPageMetadata(locale, pathname);
-};
-
-/**
- * This generates each blog's HTML Metadata
- *
- * @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
- *
- * @param {{ params: Promise<{ path: Array<string>; locale: string }> }} props
- * @returns {Promise<import('next').Metadata>} the metadata for the page
- */
-export const generateBlogMetadata = async props => {
-  const { path = [], locale = defaultLocale.code } = await props.params;
-  const pathname = dynamicRouter.getPathname(path);
-  return dynamicRouter.getPageMetadata(locale, `blog${sep}${pathname}`);
+  return dynamicRouter.getPageMetadata(
+    locale,
+    // If there's a prefix, `join` it with the pathname
+    prefix ? join(prefix, pathname) : pathname
+  );
 };
 
 /**

--- a/apps/site/next.dynamic.page.mjs
+++ b/apps/site/next.dynamic.page.mjs
@@ -1,3 +1,5 @@
+import { sep } from 'node:path';
+
 import { notFound, redirect } from 'next/navigation';
 import { setRequestLocale } from 'next-intl/server';
 
@@ -32,6 +34,20 @@ export const generateMetadata = async props => {
   const pathname = dynamicRouter.getPathname(path);
 
   return dynamicRouter.getPageMetadata(locale, pathname);
+};
+
+/**
+ * This generates each blog's HTML Metadata
+ *
+ * @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata
+ *
+ * @param {{ params: Promise<{ path: Array<string>; locale: string }> }} props
+ * @returns {Promise<import('next').Metadata>} the metadata for the page
+ */
+export const generateBlogMetadata = async props => {
+  const { path = [], locale = defaultLocale.code } = await props.params;
+  const pathname = dynamicRouter.getPathname(path);
+  return dynamicRouter.getPageMetadata(locale, `blog${sep}${pathname}`);
 };
 
 /**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The base generateMetadata function is not taking `/blog` into account.
I don't quite understand this next convention and the params type and how it relates to our code - `/blog` is not coming in on the initial entrypoint.

This is also affecting [the download archive logic](https://github.com/nodejs/nodejs.org/blob/main/apps/site/app/%5Blocale%5D/download/archive/%5Bversion%5D/page.tsx#L19). Perhaps we can code-golf a solution that doesn't require duplication.
Live at https://nodejs.org/en/download/archive/v24.10.0


<!-- Write a brief description of the changes introduced by this PR -->

## Validation

View title at https://nodejs-org-git-8223-blog-title-openjs.vercel.app/en/blog/release/v24.10.0

<img width="804" height="302" alt="image" src="https://github.com/user-attachments/assets/9b7176f4-b711-4275-bcf3-f822c8d88430" />



<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
