### PR TITLE
fix: fallback to Maintenance LTS if no Active LTS found

### DIFF
--- a/apps/site/components/withDownloadSection.tsx
+++ b/apps/site/components/withDownloadSection.tsx
@@ -38,7 +38,7 @@ const WithDownloadSection: FC<WithDownloadSectionProps> = ({
   // Decides which initial release to use based on the current pathname
   const initialRelease = pathname.endsWith('/current')
     ? 'Current'
-    : 'Active LTS';
+    : ['Active LTS' as const, 'Maintenance LTS' as const];
 
   return (
     <WithNodeRelease status={initialRelease}>

--- a/apps/site/components/withFooter.tsx
+++ b/apps/site/components/withFooter.tsx
@@ -22,7 +22,7 @@ const WithFooter: FC = () => {
 
   const primary = (
     <div className="flex flex-row gap-2">
-      <WithNodeRelease status="Active LTS">
+      <WithNodeRelease status={['Active LTS', 'Maintenance LTS']}>
         {({ release }) => (
           <BadgeGroup
             size="small"

--- a/apps/site/components/withNodeRelease.tsx
+++ b/apps/site/components/withNodeRelease.tsx
@@ -19,12 +19,18 @@ const WithNodeRelease: FC<WithNodeReleaseProps> = async ({
 }) => {
   const releaseData = await provideReleaseData();
 
-  const matchingRelease = releaseData.find(release =>
-    [status].flat().includes(release.status)
-  );
+  let matchingRelease: NodeRelease | undefined;
+  for (const statusItem of Array.isArray(status) ? status : [status]) {
+    matchingRelease = releaseData.find(
+      release => release.status === statusItem
+    );
+    if (matchingRelease) {
+      break;
+    }
+  }
 
-  if (matchingRelease !== undefined) {
-    return <Component release={matchingRelease!} />;
+  if (matchingRelease) {
+    return <Component release={matchingRelease} />;
   }
 
   return null;


### PR DESCRIPTION
## Description

There is no Active LTS release currently, just Current + Maintenance LTS releases, causing the main download page to render no content as it cannot find an Active LTS release. This updates the logic to allow an array of release statues to be passed in, with the provider trying to find a release with a matching status in the order they're provided in (e.g. it'll pick an Active LTS release even if it is after a Maintenance LTS release).

## Validation

`/en/download` and `/en/download/current` load.

## Related Issues

Resolves #8248

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
