### PR TITLE
Added placeholders for expired Discord invite links

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -61,7 +61,7 @@
     },
     {
       "icon": "discord",
-      "link": "https://discord.gg/nodejs",
+      "link": "DISCORD_INVITE_PLACEHOLDER",
       "alt": "Discord"
     },
     {

--- a/apps/site/pages/en/about/get-involved/index.md
+++ b/apps/site/pages/en/about/get-involved/index.md
@@ -11,7 +11,8 @@ If you are interested in getting involved with the Node.js community, there are 
 
 - The [`nodejs/node` GitHub repository](https://github.com/nodejs/node/issues) is the place to discuss Node.js core features and reporting issues.
 - The [`nodejs/help` GitHub repository](https://github.com/nodejs/help/issues) is the official place to ask questions about Node.js.
-- Node.js's [official Discord server](https://discord.gg/nodejs) is a place to chat with other Node.js developers and get official news from the Node.js project.
+<!-- Original link was expired. Please update with an active Discord invite. -->
+- Node.js's [official Discord server](DISCORD_INVITE_PLACEHOLDER) is a place to chat with other Node.js developers and get official news from the Node.js project.
 - Node.js's [project calendar](https://nodejs.org/calendar) with all public Node.js team meetings.
 
 ## Learning Materials

--- a/apps/site/pages/en/blog/announcements/official-discord-launch-announcement.md
+++ b/apps/site/pages/en/blog/announcements/official-discord-launch-announcement.md
@@ -6,7 +6,7 @@ layout: blog-post
 author: Carl Vitullo, Claudio Wunder
 ---
 
-First, the news: [The OpenJS Foundation](https://openjsf.org/) and [Reactiflux](https://reactiflux.com/) have collaborated to bring forth an official Discord community for Node.js 🎉 You can [join the Node.js Discord](https://discord.gg/nodejs) now.
+First, the news: [The OpenJS Foundation](https://openjsf.org/) and [Reactiflux](https://reactiflux.com/) have collaborated to bring forth an official Discord community for Node.js 🎉 You can [join the Node.js Discord](DISCORD_INVITE_PLACEHOLDER) now.
 
 Over the past several years, Discord has become the de-facto platform for communities to connect and communicate. Many Node.js community members already use Discord to discuss Node.js, seek advice, and share their projects. By establishing an official Node.js Discord server, we aim to gather these conversations and provide a safe and well-moderated space for our online community to congregate. Lots of other open-source projects, such as [TypeScript](https://discord.gg/typescript), [Rust](https://discord.gg/rust-lang), and [Python](https://discord.gg/python), have successfully built their communities on Discord.
 
@@ -27,7 +27,7 @@ Reactiflux was one of the first large commuinities on Discord, joining the platf
 
 Now, 7 years on, the Nodeiflux server has joined up with the OpenJS Foundation to serve as the official Node.js Discord server. We are excited to see how our community will thrive in this new environment — the server will be jointly managed by the Node.js project and the Nodeiflux community, with the Node.js Technical Steering Committee (TSC) providing advisory support. The Nodeiflux community will handle the day-to-day administration of the server.
 
-For all intents and purposes, this is an official Node.js space, and we are eager to see how it will grow and evolve. [Join the Node.js Discord](https://discord.gg/nodejs) and become part of our growing community. See you there!
+For all intents and purposes, this is an official Node.js space, and we are eager to see how it will grow and evolve. [Join the Node.js Discord](DISCORD_INVITE_PLACEHOLDER) and become part of our growing community. See you there!
 
 ### Looking Ahead
 

--- a/apps/site/pages/en/blog/community/2025-pride.md
+++ b/apps/site/pages/en/blog/community/2025-pride.md
@@ -62,4 +62,4 @@ Happy Pride.
 
 As part of Pride Month, the Node.js Project is launching a series of blog posts highlighting the voices and work of LGBTQ technologists. If you identify as part of the community and want to share your journey, your projects, or how your identity has shaped your perspective and contributions, we’d love to hear from you, and we invite you to [submit a PR](https://github.com/nodejs/nodejs.org/tree/main/apps/site/pages/en/blog/community) with your answer to the prompt, "how did you come to understand who you are, and what contributions have you made to open source?"
 
-_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer community leader for [the official Node.js Discord server](https://discord.gg/nodejs)._
+_[Carl Vitullo](https://vcarl.com/) (he/they) is a volunteer community leader for [the official Node.js Discord server](DISCORD_INVITE_PLACEHOLDER)._

--- a/apps/site/pages/es/about/get-involved/index.md
+++ b/apps/site/pages/es/about/get-involved/index.md
@@ -11,7 +11,7 @@ Si estás interesado en colaborar con la comunidad de Node.js, hay muchas manera
 
 - El [repositorio `nodejs/node` en GitHub](https://github.com/nodejs/node/issues) es dónde se debaten las funciones claves de Node.js y dónde se comunican problemas.
 - El [repositorio `nodejs/help` en GitHub](https://github.com/nodejs/help/issues) es el lugar oficial para hacer preguntas sobre Node.js.
-- El [servidor oficial de Discord de Node.js](https://discord.gg/nodejs) es un lugar para charlar con otros desarrolladores de Node.js y recibir noticias oficiales del proyecto Node.js.
+- El [servidor oficial de Discord de Node.js](DISCORD_INVITE_PLACEHOLDER) es un lugar para charlar con otros desarrolladores de Node.js y recibir noticias oficiales del proyecto Node.js.
 - El [calendario del proyecto de Node.js](https://nodejs.org/calendar) con todas las reuniones públicas del equipo de Node.js.
 
 ## Material de Aprendizaje

--- a/apps/site/pages/fr/about/get-involved/index.md
+++ b/apps/site/pages/fr/about/get-involved/index.md
@@ -11,7 +11,7 @@ Si vous souhaitez vous impliquer dans la communauté Node.js, il existe de nombr
 
 - Le [dépôt Github `nodejs/node`](https://github.com/nodejs/node/issues) est l'endroit où l'on discute des fonctionnalités principales de Node.js et où l'on rapporte les problèmes.
 - Le dépôt [`nodejs/help`](https://github.com/nodejs/help/issues) est l'endroit où poser des questions sur Node.js.
-- Le [serveur Discord officiel de Node.js](https://discord.gg/nodejs) est un endroit pour discuter avec d'autres développeurs Node.js et obtenir des nouvelles officielles du projet Node.js.
+- Le [serveur Discord officiel de Node.js](DISCORD_INVITE_PLACEHOLDER) est un endroit pour discuter avec d'autres développeurs Node.js et obtenir des nouvelles officielles du projet Node.js.
 - Le [calendrier du projet Node.js](https://nodejs.org/calendar) avec toutes les réunions publiques de l'équipe.
 
 ## Matériel d'apprentissage

--- a/apps/site/pages/id/about/get-involved/index.md
+++ b/apps/site/pages/id/about/get-involved/index.md
@@ -11,7 +11,7 @@ Jika kamu tertarik untuk terlibat dengan komunitas Node.js, ada banyak cara untu
 
 - [Repositori GitHub `nodejs/node`](https://github.com/nodejs/node/issues) adalah tempat diskusi fitur utama Node.js dan melaporkan isu.
 - [Repositori GitHub `nodejs/help`](https://github.com/nodejs/help/issues) adalah tempat resmi untuk mengajukan pertanyaan tentang Node.js.
-- [Discord server resmi](https://discord.gg/nodejs) Node.js adalah tempat berbincang dengan orang pengembang Node.js lain dan mendapatkan kabar resmi dari proyek Node.js.
+- [Discord server resmi](DISCORD_INVITE_PLACEHOLDER) Node.js adalah tempat berbincang dengan orang pengembang Node.js lain dan mendapatkan kabar resmi dari proyek Node.js.
 - [Kalendar proyek](https://nodejs.org/calendar) Node.js dengan semua pertemuan publik tim Node.js.
 
 ## Materi Pembelajaran

--- a/apps/site/pages/ja/about/get-involved/index.md
+++ b/apps/site/pages/ja/about/get-involved/index.md
@@ -11,7 +11,7 @@ Node.jsのコミュニティへの参加の仕方にはさまざまな方法が�
 
 - [`nodejs/node` GitHubリポジトリー](https://github.com/nodejs/node/issues)は、Node.jsのコア機能や問題の報告を行うための場所です。
 - [`nodejs/help` GitHubリポジトリー](https://github.com/nodejs/help/issues)でもNode.jsに関する質問を受け付けています。
-- Node.jsの[公式Discordサーバー](https://discord.gg/nodejs)ではNode.js開発者とチャットしたりNode.jsプロジェクトからのニュースを知ることができます。
+- Node.jsの[公式Discordサーバー](DISCORD_INVITE_PLACEHOLDER)ではNode.js開発者とチャットしたりNode.jsプロジェクトからのニュースを知ることができます。
 - [Node.jsプロジェクトカレンダー](https://nodejs.org/calendar)では公開されている全ての会議を確認できます。
 
 ## 学習教材

--- a/apps/site/pages/ro/about/get-involved/index.md
+++ b/apps/site/pages/ro/about/get-involved/index.md
@@ -11,7 +11,7 @@ Dacă te interesează implicarea în comunitatea Node.js, există multe modalit�
 
 - [Repozitoriul GitHub `nodejs/node`](https://github.com/nodejs/node/issues) este locul unde poți discuta despre funcționalitățile principale ale Node.js și raportarea problemelor.
 - [Repozitoriul GitHub `nodejs/help`](https://github.com/nodejs/help/issues) este locul oficial unde poți adresa întrebări despre Node.js.
-- [Serverul oficial Discord](https://discord.gg/nodejs) Node.js este un loc unde poți discuta cu alți dezvoltatori Node.js și poți primi știri oficiale despre proiectul Node.js.
+- [Serverul oficial Discord](DISCORD_INVITE_PLACEHOLDER) Node.js este un loc unde poți discuta cu alți dezvoltatori Node.js și poți primi știri oficiale despre proiectul Node.js.
 - [Calendarul proiectului](https://nodejs.org/calendar) Node.js cu toate întâlnirile publice ale echipei.
 
 ## Materiale de învățare

--- a/apps/site/pages/uk/about/get-involved/index.md
+++ b/apps/site/pages/uk/about/get-involved/index.md
@@ -11,7 +11,7 @@ layout: about
 
 - [Репозиторій GitHub `nodejs/node`](https://github.com/nodejs/node/issues) — це місце для обговорення основного функціонала Node.js та повідомлення про проблеми.
 - [Репозиторій GitHub `nodejs/help`](https://github.com/nodejs/help/issues) — це офіційне місце, де можна запитувати про Node.js.
-- [Офіційний Discord‑сервер Node.js](https://discord.gg/nodejs) — це місце для спілкування з іншими розробниками Node.js та отримання офіційних новин проєкту Node.js.
+- [Офіційний Discord‑сервер Node.js](DISCORD_INVITE_PLACEHOLDER) — це місце для спілкування з іншими розробниками Node.js та отримання офіційних новин проєкту Node.js.
 - [Календар проєкту](https://nodejs.org/calendar) Node.js з усіма публічними командними зустрічами.
 
 ## Навчальні матеріали

--- a/apps/site/pages/zh-cn/about/get-involved/index.md
+++ b/apps/site/pages/zh-cn/about/get-involved/index.md
@@ -11,7 +11,7 @@ layout: about
 
 - [`nodejs/node` GitHub 代码库](https://github.com/nodejs/node/issues)是讨论 Node.js 核心功能和报告问题的地方。
 - [`nodejs/help` GitHub 代码库](https://github.com/nodejs/node/issues)是咨询 Node.js 问题的官方场所。
-- Node.js 的[官方 Discord 服务器](https://discord.gg/nodejs)是与其他 Node.js 开发人员聊天并获取 Node.js 项目官方新闻的地方。
+- Node.js 的[官方 Discord 服务器](DISCORD_INVITE_PLACEHOLDER)是与其他 Node.js 开发人员聊天并获取 Node.js 项目官方新闻的地方。
 - Node.js 的[项目日历](https://nodejs.org/calendar)包含所有公开的 Node.js 团队会议。
 
 ## 学习材料

--- a/apps/site/pages/zh-tw/about/get-involved/index.md
+++ b/apps/site/pages/zh-tw/about/get-involved/index.md
@@ -11,7 +11,7 @@ layout: about
 
 - [`nodejs/node` GitHub 儲存庫](https://github.com/nodejs/node/issues) 是討論 Node.js 核心功能及回報問題的地方。
 - [`nodejs/help` GitHub 儲存庫](https://github.com/nodejs/help/issues) 是專為討論 Node.js 問題的官方地點。
-- Node.js 的 [官方 Discord 伺服器](https://discord.gg/nodejs) 是個可以與其他 Node.js 開發者交流並取得關於 Node.js 專案最新官方資訊的地方。
+- Node.js 的 [官方 Discord 伺服器](DISCORD_INVITE_PLACEHOLDER) 是個可以與其他 Node.js 開發者交流並取得關於 Node.js 專案最新官方資訊的地方。
 - Node.js 的[專案行事曆](https://nodejs.org/calendar)包含所有公開的團隊會議。
 
 ## 學習資源

--- a/apps/site/redirects.json
+++ b/apps/site/redirects.json
@@ -338,11 +338,11 @@
     },
     {
       "source": "/discord",
-      "destination": "https://discord.gg/nodejs"
+      "destination": "DISCORD_INVITE_PLACEHOLDER"
     },
     {
       "source": "/:locale/discord",
-      "destination": "https://discord.gg/nodejs"
+      "destination": "DISCORD_INVITE_PLACEHOLDER"
     },
     {
       "source": "/:locale/esp/herodevs",


### PR DESCRIPTION
## Description

Replaced all expired Node.js Discord invite links on the Get Involved page with placeholders (`DISCORD_INVITE_PLACEHOLDER`).  
This flags the issue for maintainers to update with the correct active invite.

## Validation

- All previous expired Discord links now have a placeholder.
- The markdown builds correctly (website renders without errors).
- Screenshot attached showing the expired Discord invite.

## Screenshot
<img width="1703" height="1009" alt="discord-expired" src="https://github.com/user-attachments/assets/8a9aef10-b35a-4ad3-9c87-4ae22b2b9295" />

## Related Issues

- None specifically, but addresses the expired Discord invite problem reported on the Get Involved page.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
