### PR TITLE
chore(release-blogs): fix a few issues

### DIFF
--- a/.github/workflows/create-release-post.yml
+++ b/.github/workflows/create-release-post.yml
@@ -21,6 +21,7 @@ defaults:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   create-post:
@@ -33,6 +34,7 @@ jobs:
           use-version-file: true
 
       - run: node --run scripts:release-post "$VERSION"
+        working-directory: apps/site
         env:
           VERSION: ${{ inputs.version }}
 
@@ -40,6 +42,8 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b # v1.10.1
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           update-pull-request-title-and-body: true
           branch: release-${{ inputs.version }}

--- a/apps/site/scripts/release-post/index.mjs
+++ b/apps/site/scripts/release-post/index.mjs
@@ -23,6 +23,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
 
 import handlebars from 'handlebars';
 import { format } from 'prettier';
@@ -58,10 +59,20 @@ const ERRORS = {
     new Error(`Failed to write Release post: Reason: ${reason}`),
 };
 
+const parsedArgs = parseArgs({
+  options: {
+    force: {
+      type: 'boolean',
+      short: 'f',
+    },
+  },
+  allowPositionals: true,
+});
+
 const ARGS = {
   CURRENT_PATH: process.argv[1],
-  SPECIFIC_VERSION: process.argv[2] && process.argv[2].replace('--force', ''),
-  SHOULD_FORCE: (process.argv[3] || process.argv[2]) === '--force',
+  SPECIFIC_VERSION: parsedArgs.positionals[0]?.replace(/^v/, ''),
+  SHOULD_FORCE: Boolean(parsedArgs.values.force),
 };
 
 // this allows us to get the current module working directory
@@ -262,9 +273,6 @@ if (import.meta.url.startsWith('file:')) {
       .then(renderPost)
       .then(formatPost)
       .then(writeToFile)
-      .then(
-        filepath => console.log('Release post created:', filepath),
-        error => console.error('Some error occurred here!', error.stack)
-      );
+      .then(filepath => console.log('Release post created:', filepath));
   }
 }


### PR DESCRIPTION
Fixes the following with the release blog post generator:

1. Set the working directory, as otherwise it'll use turbo (and not correctly pass the `$VERSION` argument
2. Apparently, we need to pass `GITHUB_TOKEN` explicitly to this action (https://github.com/gr2m/create-or-update-pull-request-action/blob/master/index.js#L15), and it needs a bit more permissions
3. In nodejs/node, the version will be passed as `vX.Y.Z` format, and the script is currently only equipped to handle `X.Y.Z` format
4. We want the script to throw an error when it fails, as to disrupt the workflow run.

Sorry that this ended up being two PRs! You can't test a `workflow_dispatch` trigger before it's merged into the `main` branch.

Successful Run: https://github.com/nodejs/nodejs.org/actions/runs/18730461924
Example PR: https://github.com/nodejs/nodejs.org/pull/8260 (The content of this PR looks like it doesn't do anything, but it generated a release post identical to that of `main`, hence why the file diff didn't incldue it)