### PR TITLE
fix(css): `!` in `md:hidden`

### DIFF
--- a/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
@@ -2,13 +2,13 @@
 
 .tabsList {
   @apply font-open-sans
-    max-xs:hidden
     mb-6
     mt-10
     flex
     gap-2
     border-b
     border-b-neutral-200
+    max-md:hidden
     dark:border-b-neutral-800;
 
   .tabsTrigger {

--- a/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
@@ -38,5 +38,5 @@
 }
 
 .tabsSelect {
-  @apply md:hidden;
+  @apply !md:hidden;
 }

--- a/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.module.css
@@ -38,5 +38,5 @@
 }
 
 .tabsSelect {
-  @apply !md:hidden;
+  @apply md:hidden!;
 }

--- a/packages/ui-components/src/Common/BaseLinkTabs/index.stories.tsx
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.stories.tsx
@@ -27,7 +27,6 @@ export const Default: Story = {
     ],
     activeTab: 'prebuilt',
     children: <p>Tab content goes here</p>,
-    onSelect: console.log,
   },
 };
 


### PR DESCRIPTION
Fixes #8271.

Oddly, CSS behaves differently on the dev site than the prod site, so while `display: none` was respected on all preview sites, `display: inline-flex` took precedence on the production site.

(Note: A little type fix in the storybook was also added, but it's not needed for this)