### PR TITLE
fix(cicd): add `--` before passing an argument

### DIFF
--- a/.github/workflows/create-release-post.yml
+++ b/.github/workflows/create-release-post.yml
@@ -33,7 +33,7 @@ jobs:
           pnpm: true
           use-version-file: true
 
-      - run: node --run scripts:release-post "$VERSION"
+      - run: node --run scripts:release-post -- "$VERSION"
         working-directory: apps/site
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Fixes #8281 
cc @richardlau

While the actions logs don't show it, the actual error that occured here was that the workflow did not correctly pass `v24.11.0` as an argument.