### PR TITLE
chore: remove duplicate mdast-util-to-string in site package

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -98,7 +98,6 @@
     "handlebars": "4.7.8",
     "jsdom": "^27.0.0",
     "mdast-util-from-markdown": "^2.0.2",
-    "mdast-util-to-string": "^4.0.0",
     "nock": "^14.0.10",
     "remark-frontmatter": "^5.0.0",
     "stylelint": "16.24.0",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Remove duplicate `mdast-util-to-string`, it was present in devDependencies and dependencies.

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
