### PR TITLE
fix: improve color contrast in AlertBox info variant

### DIFF
--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -16,7 +16,7 @@
     text-white;
 
   p {
-    color: white !important;
+    @apply text-white;
   }
 
   a {
@@ -51,7 +51,7 @@
   }
 
   &.info {
-    @apply bg-info-400;
+    @apply bg-info-600;
 
     .title {
       @apply bg-info-700;

--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -15,9 +15,7 @@
     text-sm
     text-white;
 
-  p,
-  span,
-  div {
+  * {
     @apply text-white;
   }
 

--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -15,7 +15,9 @@
     text-sm
     text-white;
 
-  p {
+  p,
+  span,
+  div {
     @apply text-white;
   }
 

--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -47,7 +47,7 @@
   }
 
   &.info {
-    @apply bg-info-600;
+    @apply bg-info-400;
 
     .title {
       @apply bg-info-700;

--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -15,6 +15,10 @@
     text-sm
     text-white;
 
+  p {
+    color: white !important;
+  }
+
   a {
     @apply font-bold
       text-white


### PR DESCRIPTION
Fixes #8290

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixed CSS specificity conflict between AlertBox and markdown content styles.

The issue was not with the AlertBox background color, but with paragraph (`<p>`) tags inside AlertBox inheriting black text color from markdown styles instead of maintaining white text. Added `!important` to override markdown paragraph styles and ensure text remains white.

## Changes

- Added `* { color: white !important; }` to AlertBox styles
- Kept background at `bg-info-600` as per design system
- Resolved CSS conflict between AlertBox component and markdown content

## Validation

### How to test:
1. Run `pnpm dev`
2. Navigate to any blog page with AlertBox in markdown content (e.g., `/blog/migrations`)
3. Verify the AlertBox text is white, not black

**Before:**

<img width="893" height="215" alt="image" src="https://github.com/user-attachments/assets/baeb1e5b-aa85-430e-98c7-3d3939655b65" />

**After:**

<img width="778" height="226" alt="image" src="https://github.com/user-attachments/assets/dd1993e8-d1b9-49f4-80ee-bdda4cdc7ff9" />


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
