### PR TITLE
fix: Text selection in code blocks

### DIFF
--- a/packages/rehype-shiki/src/transformers/twoslash/index.css
+++ b/packages/rehype-shiki/src/transformers/twoslash/index.css
@@ -9,6 +9,7 @@
   max-width: 600px;
   display: block;
   width: fit-content;
+  user-select: none;
 }
 
 .twoslash-popup-code:not(:has(div)) {

--- a/packages/rehype-shiki/src/transformers/twoslash/index.css
+++ b/packages/rehype-shiki/src/transformers/twoslash/index.css
@@ -2,6 +2,7 @@
 
 .twoslash-hover {
   cursor: text;
+  user-select: text;
 }
 
 .twoslash-popup-code {


### PR DESCRIPTION
## Description

With this PR aim to resolve the issue with code selection mentioned in #8292

## Validation

Double / Triple click on symbols with tooltip should work
Start selection into symbol with tooltip should work
Symbols with tooltip should be selected

## Related Issues

Fixes #8292

