### PR TITLE
fix: Mobile navigation issue on blog pages

### DIFF
--- a/packages/ui-components/src/Common/BaseLinkTabs/index.tsx
+++ b/packages/ui-components/src/Common/BaseLinkTabs/index.tsx
@@ -40,6 +40,7 @@ const BaseLinkTabs: FC<LinkTabsProps> = ({
       className={styles.tabsSelect}
       defaultValue={tabs.find(tab => tab.key === activeTab)?.link}
       values={tabs.map(tab => ({ label: tab.label, value: tab.link }))}
+      as={Component}
     />
 
     {children}


### PR DESCRIPTION
## Description

Fixes the mobile navigation issue on blog pages

## Validation

When a user selects a category from the dropdown on the blog pages, they should be redirected to the corresponding category page

## Related Issues

Fixes #8296

