### PR TITLE
feat(shiki): allow custom highlighters, avoid async rehype

### DIFF
--- a/packages/rehype-shiki/package.json
+++ b/packages/rehype-shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/rehype-shiki",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "exports": {
     ".": "./src/index.mjs",

--- a/packages/rehype-shiki/src/__tests__/plugin.test.mjs
+++ b/packages/rehype-shiki/src/__tests__/plugin.test.mjs
@@ -25,7 +25,7 @@ describe('rehypeShikiji', async () => {
 
   it('calls visit twice', async () => {
     mockVisit.mock.resetCalls();
-    await rehypeShikiji()(mockTree);
+    (await rehypeShikiji())(mockTree);
     assert.strictEqual(mockVisit.mock.calls.length, 2);
   });
 
@@ -61,7 +61,7 @@ describe('rehypeShikiji', async () => {
       }
     });
 
-    await rehypeShikiji()(mockTree);
+    (await rehypeShikiji())(mockTree);
     assert.ok(parent.children.some(child => child.tagName === 'CodeTabs'));
   });
 });

--- a/packages/rehype-shiki/src/highlighter.mjs
+++ b/packages/rehype-shiki/src/highlighter.mjs
@@ -19,11 +19,19 @@ export const getLanguageByName = (language, langs) => {
 };
 
 /**
+ * @typedef {Object} SyntaxHighlighter
+ * @property {import('@shikijs/core').HighlighterCoreSync} shiki - The underlying shiki core instance.
+ * @property {(code: string, lang: string, meta?: Record<string, any>) => string} highlightToHtml - Highlights code and returns inner HTML of the <code> tag.
+ * @property {(code: string, lang: string, meta?: Record<string, any>) => any} highlightToHast - Highlights code and returns a HAST tree.
+ */
+
+/**
  * Factory function to create a syntax highlighter instance with utility methods.
  *
  * @param {Object} params - Parameters for highlighter creation.
  * @param {import('@shikijs/core').HighlighterCoreOptions} [params.coreOptions] - Core options for the highlighter.
  * @param {import('@shikijs/core').CodeToHastOptions} [params.highlighterOptions] - Additional options for highlighting.
+ * @returns {SyntaxHighlighter}
  */
 const createHighlighter = ({ coreOptions = {}, highlighterOptions = {} }) => {
   const options = {

--- a/packages/rehype-shiki/src/index.mjs
+++ b/packages/rehype-shiki/src/index.mjs
@@ -21,8 +21,8 @@ import createHighlighter, { getLanguageByName } from './highlighter.mjs';
  * @property {boolean} [wasm=false] - Enable WebAssembly for the regex engine
  * @property {boolean} [twoslash=false] - Enable twoslash
  * @property {import('@shikijs/twoslash').TransformerTwoslashIndexOptions} [twoslashOptions] - Twoslash configuration options
- * @param {import('@shikijs/core').HighlighterCoreOptions} [coreOptions] - Core options for the highlighter.
- * @param {import('@shikijs/core').CodeToHastOptions} [highlighterOptions] - Additional options for highlighting.
+ * @property {import('@shikijs/core').HighlighterCoreOptions} [coreOptions] - Core options for the highlighter.
+ * @property {import('@shikijs/core').CodeToHastOptions} [highlighterOptions] - Additional options for highlighting.
  */
 
 /**

--- a/packages/rehype-shiki/src/plugin.mjs
+++ b/packages/rehype-shiki/src/plugin.mjs
@@ -54,14 +54,13 @@ function isCodeBlock(node) {
 }
 
 /**
- * @param {import('./index.mjs').HighlighterOptions} options
+ * @param {import('./index.mjs').HighlighterOptions & { highlighter: import('./highlighter.mjs').SyntaxHighlighter }} options
  */
-export default function rehypeShikiji(options) {
-  let highlighter;
+export default async function rehypeShikiji(options) {
+  const highlighter =
+    options?.highlighter ?? (await createHighlighter(options));
 
-  return async function (tree) {
-    highlighter ??= await createHighlighter(options);
-
+  return function (tree) {
     visit(tree, 'element', (_, index, parent) => {
       const languages = [];
       const displayNames = [];


### PR DESCRIPTION
This'll make it possible to define a custom Shiki singleton for `rehype-shiki` to use (ie if you want to define your Shiki instance elsewhere).

It also makes Shiki a non-async rehype plugin