### PR TITLE
docs(learn): correct the example code for the consumption of response…

### DIFF
--- a/apps/site/pages/en/learn/getting-started/fetch.md
+++ b/apps/site/pages/en/learn/getting-started/fetch.md
@@ -104,6 +104,8 @@ async function streamOllamaCompletion(prompt) {
   // You can read about HTTP status codes here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
   // 200 means the request was successful.
   if (statusCode !== 200) {
+    // consuming the response body is mandatory: https://undici.nodejs.org/#/?id=garbage-collection
+    await body.dump();
     throw new Error(`Ollama request failed with status ${statusCode}`);
   }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Docs, fix #8321

Added `await body.dump();` to explicitly destroy the response body before throwing an error.

```diff
  if (statusCode !== 200) {
+    // consuming the response body is mandatory: https://undici.nodejs.org/#/?id=garbage-collection
+    await body.dump();
    throw new Error(`Ollama request failed with status ${statusCode}`);
  }
```


### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
