### PR TITLE
docs(learn): correct another example code for the consumption of response body

### DIFF
--- a/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
+++ b/apps/site/pages/en/learn/manipulating-files/reading-files-with-nodejs.md
@@ -101,6 +101,8 @@ async function downloadFile(url, outputPath) {
   const response = await fetch(url);
 
   if (!response.ok || !response.body) {
+    // consuming the response body is mandatory: https://undici.nodejs.org/#/?id=garbage-collection
+    await response.body?.cancel();
     throw new Error(`Failed to fetch ${url}. Status: ${response.status}`);
   }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Docs, fix #8331.

Added `await response.body?.cancel();` to explicitly destroy the response body before throwing an error.

```diff
  if (!response.ok || !response.body) {
+    // consuming the response body is mandatory: https://undici.nodejs.org/#/?id=garbage-collection
+    await response.body?.cancel();
    throw new Error(`Failed to fetch ${url}. Status: ${response.status}`);
  }
```

## Validation

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
