### PR TITLE
fix: download page mobile layout spacing

### DIFF
--- a/apps/site/layouts/layouts.module.css
+++ b/apps/site/layouts/layouts.module.css
@@ -114,7 +114,7 @@
 }
 
 .downloadLayout {
-  section:nth-last-child(1) {
+  section:nth-last-child(3) {
     @apply flex
       flex-col
       gap-2;
@@ -124,7 +124,7 @@
     }
   }
 
-  section:nth-last-child(2) p {
+  section:nth-last-child(4) p {
     @apply flex
       flex-row
       flex-wrap

--- a/apps/site/layouts/layouts.module.css
+++ b/apps/site/layouts/layouts.module.css
@@ -68,8 +68,8 @@
 
     &:nth-of-type(2) {
       @apply flex
-        min-w-0
         max-w-full
+        min-w-0
         flex-[1_1]
         flex-col
         items-center
@@ -190,8 +190,8 @@
     }
 
     > div:nth-of-type(1) {
-      @apply mb-4
-        mt-2;
+      @apply mt-2
+        mb-4;
     }
   }
 }


### PR DESCRIPTION
## Description

With the addition of sponsors on the download page, the order of the sections has changed, which caused the selects to appear too close to each other on mobile viewports. This PR aims to fix that visual issue.

Adding ids to the sections would probably be a better long-term solution, but instead of resetting all existing translations(mdx files), it would make more sense to introduce those ids after a major structural update

## Validation

### Before

<img width="421" height="865" alt="image" src="https://github.com/user-attachments/assets/8eb7404b-e112-4fae-b103-1f4a77b35cad" />

#### After
<img width="421" height="888" alt="image" src="https://github.com/user-attachments/assets/9d0624a2-a751-4fb1-8aa0-33b9a3d19436" />

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
