### PR TITLE
chore(docs): Update codemod command for fs-truncate-fd-deprecation

### DIFF
--- a/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
+++ b/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
@@ -157,7 +157,7 @@ The [`fs.truncate`](https://nodejs.org/api/fs.html#fs_fs_truncate_path_len_callb
 
 The source code for this codemod can be found in the [fs-truncate-fd-deprecation directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/fs-truncate-fd-deprecation).
 
-You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/fs-truncate-to-ftruncate).
+You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/fs-truncate-fd-deprecation).
 
 ```bash
 npx codemod run @nodejs/fs-truncate-fd-deprecation

--- a/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
+++ b/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
@@ -160,7 +160,7 @@ The source code for this codemod can be found in the [fs-truncate-fd-deprecation
 You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/fs-truncate-to-ftruncate).
 
 ```bash
-npx codemod run @nodejs/fs-truncate-to-ftruncate
+npx codemod run @nodejs/fs-truncate-fd-deprecation
 ```
 
 #### Example:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When I started migrating my project to the new LTS version, I encountered an error when executing this codemod.

## Validation


```bash
> npx codemod run @nodejs/fs-truncate-to-ftruncate
[1/2] 🔍 Resolving package from registry: https://app.codemod.com ...
Error: Registry error: Package not found: @nodejs/fs-truncate-to-ftruncate
```

## Related Issues

No

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
