### PR TITLE
chore: update running typescript natively documentation

### DIFF
--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -8,7 +8,7 @@ authors: AugustinMauroy, khaosdoctor, jakebailey, robpalme
 
 You can write code that's valid TypeScript directly in Node.js without the need to transpile it first.
 
-If you are using v22.18.0 or later and your source code contains only [erasable TypeScript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), can you just run directly without any flag.
+If you are using v22.18.0 or later and your source code contains only [erasable TypeScript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), you can just run directly without any flag.
 
 ```bash
 node example.ts

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -8,7 +8,7 @@ authors: AugustinMauroy, khaosdoctor, jakebailey, robpalme
 
 You can write code that's valid TypeScript directly in Node.js without the need to transpile it first.
 
-If you are using v22.18.0 or later and your source code contains only [erasable TypeScript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), you can just run directly without any flag.
+If you are using v22.18.0 or later and your source code contains only [erasable TypeScript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), you can execute TypeScript code without any flags.
 
 ```bash
 node example.ts

--- a/apps/site/pages/en/learn/typescript/run-natively.md
+++ b/apps/site/pages/en/learn/typescript/run-natively.md
@@ -6,13 +6,15 @@ authors: AugustinMauroy, khaosdoctor, jakebailey, robpalme
 
 # Running TypeScript Natively
 
-Since v22.18.0, Node.js enables "type stripping" by default. If you are using v22.18.0 or later and your source code contains only [erasable typescript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), you do not need this article.
+You can write code that's valid TypeScript directly in Node.js without the need to transpile it first.
 
-## Running TypeScript code with Node.js
+If you are using v22.18.0 or later and your source code contains only [erasable TypeScript syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), can you just run directly without any flag.
 
-Since V22.6.0, Node.js has experimental support for some TypeScript syntax via "type stripping". You can write code that's valid TypeScript directly in Node.js without the need to transpile it first.
+```bash
+node example.ts
+```
 
-The [`--experimental-strip-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-strip-types) flag tells Node.js to strip the type annotations from the TypeScript code before running it.
+If you are using a version less than v22.18.0, you can use the `--experimental-strip-types` flag to run TypeScript files directly in Node.js.
 
 ```bash
 node --experimental-strip-types example.ts
@@ -20,34 +22,23 @@ node --experimental-strip-types example.ts
 
 And that's it! You can now run TypeScript code directly in Node.js without the need to transpile it first, and use TypeScript to catch type-related errors.
 
-In V22.7.0 this experimental support was extended to transform TypeScript-only syntax, like `enum`s and `namespace`, with the addition of the [`--experimental-transform-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-transform-types) flag. Enabling `--experimental-transform-types` automatically implies that `--experimental-strip-types` is enabled, so there's no need to use both flags in the same command:
+You can disable it via [`--no-experimental-strip-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--no-experimental-strip-types) flag if needed.
+
+```bash
+node --no-experimental-strip-types example.ts
+```
+
+In v22.7.0 the flag [`--experimental-transform-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-transform-types) was added to enable TypeScript-only syntax that requires transformation, like `enum`s and `namespace`. Enabling `--experimental-transform-types` automatically implies that `--experimental-strip-types` is enabled, so there's no need to use both flags in the same command:
 
 ```bash
 node --experimental-transform-types another-example.ts
 ```
 
-From v22.18.0 onwards, type stripping is enabled by default (you can disable it via [`--no-experimental-strip-types`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--no-experimental-strip-types)), enabling you to run any supported syntax, so running files like the one below with `node file.ts` is supported:
+This flag is opt-in, and you should only use it if your code requires it.
 
-```ts
-function foo(bar: number): string {
-  return 'hello';
-}
-```
+## Constraints
 
-However, running any code that requires transformations, like the code below still needs the use of `--experimental-transform-types`:
-
-```ts
-enum MyEnum {
-  A,
-  B,
-}
-
-console.log(MyEnum.A);
-```
-
-## Limitations
-
-At the time of writing, the experimental support for TypeScript in Node.js has some limitations.
+The support for TypeScript in Node.js has some constraints to keep in mind:
 
 You can get more information on the [API docs](https://nodejs.org/docs/latest-v22.x/api/typescript.html#typescript-features).
 
@@ -56,9 +47,3 @@ You can get more information on the [API docs](https://nodejs.org/docs/latest-v2
 The Node.js TypeScript loader ([Amaro](https://github.com/nodejs/amaro)) does not need or use `tsconfig.json` to run TypeScript code.
 
 We recommend configuring your editor and `tsc` to reflect Node.js behavior by creating a `tsconfig.json` using the `compilerOptions` listed [here](https://nodejs.org/api/typescript.html#type-stripping), as well as using TypeScript version **5.7 or higher**.
-
-## Important notes
-
-Thanks to all the contributors who have made this feature possible. We hope that this feature will be stable and available in the LTS version of Node.js soon.
-
-We can understand that this feature is experimental and has some limitations; if that doesn't suit your use-case, please use something else, or contribute a fix. Bug reports are also welcome, please keep in mind the project is run by volunteers, without warranty of any kind, so please be patient if you can't contribute the fix yourself.


### PR DESCRIPTION
updated the documentation since all node.js versions dont need `--experimental-strip-types` flag to work and the feature is no longer experimental in v25.2.0

@nodejs/typescript 