### PR TITLE
chore: require admin approval for `.github`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @nodejs/nodejs-website
 
 # Infrastructure
-.github @nodejs/web-infra
+.github @nodejs/web-infra @nodejs/web-admins
 .husky @nodejs/web-infra
 .nvmrc @nodejs/web-infra
 codecov.yml @nodejs/web-infra


### PR DESCRIPTION
Fixes https://github.com/nodejs/nodejs.org/issues/7986