### PR TITLE
remove userland migration image

### DIFF
--- a/apps/site/pages/en/learn/getting-started/userland-migrations.md
+++ b/apps/site/pages/en/learn/getting-started/userland-migrations.md
@@ -4,8 +4,6 @@ layout: learn
 authors: JakobJingleheimer, AugustinMauroy
 ---
 
-![Node.js Userland Migrations](https://raw.githubusercontent.com/nodejs/userland-migrations/8fd9c141a118c4b64cc37eed8e663005cbc819ac/.github/assets/Userland-Migration-Tagline.png)
-
 # Userland Migrations
 
 Node.js offers migrations for "userland" code (anything outside the node executable) to help adopt new features and handle breaking changes. These are built in collaboration with [Codemod](https://codemod.com), a platform focused on making it easy to build, share, and run codemods.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removed the image altogether. 

- The source file is 1.3 MB, which is a lot to add to the repo. Smaller when converted by Next.js, but still causes CLS on load.
- No other learn content has a top-level image like that, so it's an outlier
- As placed, it takes precedent over the heading, which is odd too.
- I think it is nice to have on the userland repo content or README, but not on the site.

With resolution: 

<img width="1858" height="993" alt="image" src="https://github.com/user-attachments/assets/10c3fe58-3663-42c1-874c-6db97e1dbe85" />


Without at all

<img width="1858" height="993" alt="image" src="https://github.com/user-attachments/assets/3c7d1a73-16a9-48a9-a062-25eadf413a6e" />




## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

resolves #8333

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
