### PR TITLE
fix: run-id reference in bundle-compare workflow

### DIFF
--- a/.github/workflows/bundle-compare.yml
+++ b/.github/workflows/bundle-compare.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           name: webpack-stats
           path: head-stats
-          run-id: ${{ github.event.workflow_run.workflow_id }}
+          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Run ID from BASE

--- a/.github/workflows/bundle-compare.yml
+++ b/.github/workflows/bundle-compare.yml
@@ -15,6 +15,7 @@ jobs:
   compare:
     name: Compare Bundle Stats
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
`workflow_id` refers to the workflow, `id` refers to the run