### PR TITLE
fix(context): supply PR to `bundle-compare`

### DIFF
--- a/.github/workflows/bundle-compare.yml
+++ b/.github/workflows/bundle-compare.yml
@@ -67,3 +67,4 @@ jobs:
         with:
           comment-tag: 'compare_bundle_size'
           message: ${{ steps.compare-bundle-size.outputs.comment }}
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
Apparently this action does not read the PR from the context of a workflow run event correctly.