### PR TITLE
refactor: CrossLink `Prev` to `Previous` and cleanup of `Pagination` keys

### DIFF
--- a/apps/site/components/Common/CrossLink.tsx
+++ b/apps/site/components/Common/CrossLink.tsx
@@ -10,7 +10,7 @@ const CrossLink: FC<Omit<CrossLinkProps, 'as' | 'label'>> = props => {
   const t = useTranslations();
   return (
     <BaseCrossLink
-      label={t(`components.common.crossLink.${props.type}`)}
+      label={t(`components.common.pagination.${props.type}`)}
       as={Link}
       {...props}
     />

--- a/apps/site/components/Common/Pagination.tsx
+++ b/apps/site/components/Common/Pagination.tsx
@@ -16,9 +16,9 @@ const Pagination: FC<
       labels={{
         aria: t('components.common.pagination.defaultLabel'),
         prevAria: t('components.common.pagination.prevAriaLabel'),
-        prev: t('components.pagination.previous'),
+        prev: t('components.common.pagination.prev'),
         nextAria: t('components.common.pagination.nextAriaLabel'),
-        next: t('components.pagination.next'),
+        next: t('components.common.pagination.next'),
       }}
       getPageLabel={pageNumber =>
         t('components.common.pagination.pageLabel', { pageNumber })

--- a/apps/site/components/Common/Pagination.tsx
+++ b/apps/site/components/Common/Pagination.tsx
@@ -15,9 +15,9 @@ const Pagination: FC<
       as={Link}
       labels={{
         aria: t('components.common.pagination.defaultLabel'),
-        prevAria: t('components.common.pagination.prevAriaLabel'),
-        prev: t('components.common.pagination.prev'),
-        nextAria: t('components.common.pagination.nextAriaLabel'),
+        previousAriaLabel: t('components.common.pagination.previousAriaLabel'),
+        previous: t('components.common.pagination.previous'),
+        nextAriaLabel: t('components.common.pagination.nextAriaLabel'),
         next: t('components.common.pagination.next'),
       }}
       getPageLabel={pageNumber =>

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -251,7 +251,7 @@
         "navigateToHome": "Navigate to Home"
       },
       "crossLink": {
-        "previous": "Prev",
+        "previous": "Previous",
         "next": "Next"
       },
       "codebox": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -246,17 +246,13 @@
       "breadcrumbs": {
         "navigateToHome": "Navigate to Home"
       },
-      "crossLink": {
-        "previous": "Previous",
-        "next": "Next"
-      },
       "codebox": {
         "copy": "Copy to clipboard",
         "copied": "Copied to clipboard!"
       },
       "pagination": {
-        "prev": "Previous",
-        "prevAriaLabel": "Previous page",
+        "previous": "Previous",
+        "previousAriaLabel": "Previous page",
         "next": "Next",
         "nextAriaLabel": "Next page",
         "defaultLabel": "Pagination",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -237,10 +237,6 @@
       "npmVersion": "npm version",
       "v8Version": "V8 version"
     },
-    "pagination": {
-      "next": "Next",
-      "previous": "Previous"
-    },
     "common": {
       "alertBox": {
         "info": "Info",

--- a/packages/ui-components/src/Common/BasePagination/__tests__/index.test.jsx
+++ b/packages/ui-components/src/Common/BasePagination/__tests__/index.test.jsx
@@ -11,9 +11,9 @@ import BasePagination from '#ui/Common/BasePagination';
 const getPageLabel = number => number.toString();
 const labels = {
   aria: 'Aria',
-  prevAria: 'Previous Aria',
-  prev: 'Previous',
-  nextAria: 'Next Aria',
+  previousAriaLabel: 'Previous Aria',
+  previous: 'Previous',
+  nextAriaLabel: 'Next Aria',
   next: 'Next',
 };
 
@@ -51,14 +51,14 @@ describe('Pagination', () => {
       assert.ok(
         isVisible(
           screen.getByRole('button', {
-            name: labels.prevAria,
+            name: labels.previousAriaLabel,
           })
         )
       );
       assert.ok(
         isVisible(
           screen.getByRole('button', {
-            name: labels.nextAria,
+            name: labels.nextAriaLabel,
           })
         )
       );
@@ -157,7 +157,7 @@ describe('Pagination', () => {
       assert.ok(
         screen
           .getByRole('button', {
-            name: labels.prevAria,
+            name: labels.previousAriaLabel,
           })
           .getAttribute('aria-disabled')
       );
@@ -172,7 +172,7 @@ describe('Pagination', () => {
       assert.ok(
         screen
           .getByRole('button', {
-            name: labels.nextAria,
+            name: labels.nextAriaLabel,
           })
           .getAttribute('aria-disabled')
       );

--- a/packages/ui-components/src/Common/BasePagination/index.stories.tsx
+++ b/packages/ui-components/src/Common/BasePagination/index.stories.tsx
@@ -13,9 +13,9 @@ export const Default: Story = {
     getPageLabel: value => `Page: ${value}`,
     labels: {
       aria: 'Aria',
-      prevAria: 'Previous Aria',
-      prev: 'Previous',
-      nextAria: 'Next Aria',
+      previousAriaLabel: 'Previous Aria',
+      previous: 'Previous',
+      nextAriaLabel: 'Next Aria',
       next: 'Next',
     },
   },

--- a/packages/ui-components/src/Common/BasePagination/index.tsx
+++ b/packages/ui-components/src/Common/BasePagination/index.tsx
@@ -21,9 +21,9 @@ export type PaginationProps = {
   getPageLabel: (pageNumber: number) => string;
   labels: {
     aria: string;
-    prevAria: string;
-    prev: string;
-    nextAria: string;
+    previousAriaLabel: string;
+    previous: string;
+    nextAriaLabel: string;
     next: string;
   };
 };
@@ -48,21 +48,21 @@ const BasePagination: FC<PaginationProps> = ({
     <nav aria-label={labels.aria} className={styles.pagination}>
       <Button
         as={as}
-        aria-label={labels.prevAria}
+        aria-label={labels.previousAriaLabel}
         disabled={currentPage === 1}
         kind="secondary"
         className={styles.previousButton}
         href={pages[currentPage - 2]?.url}
       >
         <ArrowLeftIcon className={styles.arrowIcon} />
-        <span>{labels.prev}</span>
+        <span>{labels.previous}</span>
       </Button>
 
       <ol className={styles.list}>{parsedPages}</ol>
 
       <Button
         as={as}
-        aria-label={labels.nextAria}
+        aria-label={labels.nextAriaLabel}
         disabled={currentPage === pages.length}
         kind="secondary"
         className={styles.nextButton}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

While browsing the site, I got bothered by the abbreviation `Prev` showing to users. We have the screen real estate to use the full word here. I was initially concerned about internationalization too, which made me look at `en.json` key composition. I then noticed we were defining `prev` and `next` in two places... and only using one, or worse, intermingling them. This PR unifies the keys under the more structured `common.pagination` ...now the text and the label draw from the same object.

I chose not to refactor `PaginationProps` or non-user-facing references at this time which still use things like `prev` and `prevAria`. I could be convinced to do so, but wanted to start here. This might also thrash Crowdin translations.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

<img width="793" height="430" alt="image" src="https://github.com/user-attachments/assets/e77dae9c-5e7e-4bff-be8f-5cc87e143758" />


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
