### PR TITLE
fix(fetch): fixup generators and add error handling

### DIFF
--- a/apps/site/next-data/generators/supportersData.mjs
+++ b/apps/site/next-data/generators/supportersData.mjs
@@ -1,4 +1,5 @@
 import { OPENCOLLECTIVE_MEMBERS_URL } from '#site/next.constants.mjs';
+import { fetchWithRetry } from '#site/util/fetch';
 
 /**
  * Fetches supporters data from Open Collective API, filters active backers,
@@ -7,7 +8,7 @@ import { OPENCOLLECTIVE_MEMBERS_URL } from '#site/next.constants.mjs';
  * @returns {Promise<Array<import('#site/types/supporters').OpenCollectiveSupporter>>} Array of supporters
  */
 export default () =>
-  fetch(OPENCOLLECTIVE_MEMBERS_URL)
+  fetchWithRetry(OPENCOLLECTIVE_MEMBERS_URL)
     .then(response => response.json())
     .then(payload =>
       payload
@@ -20,5 +21,4 @@ export default () =>
           profile,
           source: 'opencollective',
         }))
-    )
-    .catch(() => []);
+    );

--- a/apps/site/next-data/generators/supportersData.mjs
+++ b/apps/site/next-data/generators/supportersData.mjs
@@ -1,28 +1,24 @@
+import { OPENCOLLECTIVE_MEMBERS_URL } from '#site/next.constants.mjs';
+
 /**
  * Fetches supporters data from Open Collective API, filters active backers,
  * and maps it to the Supporters type.
  *
- * @returns {Promise<Array<import('#site/types/supporters')>>} Array of supporters
+ * @returns {Promise<Array<import('#site/types/supporters').OpenCollectiveSupporter>>} Array of supporters
  */
-async function fetchOpenCollectiveData() {
-  const endpoint = 'https://opencollective.com/nodejs/members/all.json';
-
-  const response = await fetch(endpoint);
-
-  const payload = await response.json();
-
-  const members = payload
-    .filter(({ role, isActive }) => role === 'BACKER' && isActive)
-    .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated)
-    .map(({ name, website, image, profile }) => ({
-      name,
-      image,
-      url: website,
-      profile,
-      source: 'opencollective',
-    }));
-
-  return members;
-}
-
-export default fetchOpenCollectiveData;
+export default () =>
+  fetch(OPENCOLLECTIVE_MEMBERS_URL)
+    .then(response => response.json())
+    .then(payload =>
+      payload
+        .filter(({ role, isActive }) => role === 'BACKER' && isActive)
+        .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated)
+        .map(({ name, website, image, profile }) => ({
+          name,
+          image,
+          url: website,
+          profile,
+          source: 'opencollective',
+        }))
+    )
+    .catch(() => []);

--- a/apps/site/next-data/generators/supportersData.mjs
+++ b/apps/site/next-data/generators/supportersData.mjs
@@ -7,18 +7,23 @@ import { fetchWithRetry } from '#site/util/fetch';
  *
  * @returns {Promise<Array<import('#site/types/supporters').OpenCollectiveSupporter>>} Array of supporters
  */
-export default () =>
-  fetchWithRetry(OPENCOLLECTIVE_MEMBERS_URL)
-    .then(response => response.json())
-    .then(payload =>
-      payload
-        .filter(({ role, isActive }) => role === 'BACKER' && isActive)
-        .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated)
-        .map(({ name, website, image, profile }) => ({
-          name,
-          image,
-          url: website,
-          profile,
-          source: 'opencollective',
-        }))
-    );
+async function fetchOpenCollectiveData() {
+  const response = await fetchWithRetry(OPENCOLLECTIVE_MEMBERS_URL);
+
+  const payload = await response.json();
+
+  const members = payload
+    .filter(({ role, isActive }) => role === 'BACKER' && isActive)
+    .sort((a, b) => b.totalAmountDonated - a.totalAmountDonated)
+    .map(({ name, website, image, profile }) => ({
+      name,
+      image,
+      url: website,
+      profile,
+      source: 'opencollective',
+    }));
+
+  return members;
+}
+
+export default fetchOpenCollectiveData;

--- a/apps/site/next-data/generators/vulnerabilities.mjs
+++ b/apps/site/next-data/generators/vulnerabilities.mjs
@@ -8,86 +8,76 @@ const RANGE_REGEX = /([<>]=?)\s*(\d+)(?:\.(\d+))?/;
  *
  * @returns {Promise<import('#site/types/vulnerabilities').GroupedVulnerabilities>} Grouped vulnerabilities
  */
-export default async function generateVulnerabilityData() {
-  const response = await fetch(VULNERABILITIES_URL);
+export default () =>
+  fetch(VULNERABILITIES_URL)
+    .then(response => response.json())
+    .then(payload => {
+      /** @type {Array<import('#site/types/vulnerabilities').RawVulnerability>} */
+      const data = Object.values(payload);
 
-  /** @type {Array<import('#site/types/vulnerabilities').RawVulnerability>} */
-  const data = Object.values(await response.json());
+      /** @type {Promise<import('#site/types/vulnerabilities').GroupedVulnerabilities> */
+      const grouped = {};
 
-  /** @type {Promise<import('#site/types/vulnerabilities').GroupedVulnerabilities> */
-  const grouped = {};
+      // Helper function to add vulnerability to a major version group
+      const addToGroup = (majorVersion, vulnerability) => {
+        grouped[majorVersion] ??= [];
+        grouped[majorVersion].push(vulnerability);
+      };
 
-  // Helper function to add vulnerability to a major version group
-  const addToGroup = (majorVersion, vulnerability) => {
-    grouped[majorVersion] ??= [];
-    grouped[majorVersion].push(vulnerability);
-  };
+      // Helper function to process version patterns
+      const processVersion = (version, vulnerability) => {
+        // Handle 0.X versions (pre-semver)
+        if (/^0\.\d+(\.x)?$/.test(version)) {
+          addToGroup('0', vulnerability);
 
-  // Helper function to process version patterns
-  const processVersion = (version, vulnerability) => {
-    // Handle 0.X versions (pre-semver)
-    if (/^0\.\d+(\.x)?$/.test(version)) {
-      addToGroup('0', vulnerability);
+          return;
+        }
 
-      return;
-    }
+        // Handle simple major.x patterns (e.g., 12.x)
+        if (/^\d+\.x$/.test(version)) {
+          const majorVersion = version.split('.')[0];
 
-    // Handle simple major.x patterns (e.g., 12.x)
-    if (/^\d+\.x$/.test(version)) {
-      const majorVersion = version.split('.')[0];
-
-      addToGroup(majorVersion, vulnerability);
-
-      return;
-    }
-
-    // Handle version ranges (>, >=, <, <=)
-    const rangeMatch = RANGE_REGEX.exec(version);
-
-    if (rangeMatch) {
-      const [, operator, majorVersion] = rangeMatch;
-
-      const majorNum = parseInt(majorVersion, 10);
-
-      switch (operator) {
-        case '>=':
-        case '>':
-        case '<=':
           addToGroup(majorVersion, vulnerability);
 
-          break;
-        case '<':
-          // Add to all major versions below the specified version
-          for (let i = majorNum - 1; i >= 0; i--) {
-            addToGroup(i.toString(), vulnerability);
+          return;
+        }
+
+        // Handle version ranges (>, >=, <, <=)
+        const rangeMatch = RANGE_REGEX.exec(version);
+
+        if (rangeMatch) {
+          const [, operator, majorVersion] = rangeMatch;
+
+          const majorNum = parseInt(majorVersion, 10);
+
+          switch (operator) {
+            case '>=':
+            case '>':
+            case '<=':
+              addToGroup(majorVersion, vulnerability);
+
+              break;
+            case '<':
+              // Add to all major versions below the specified version
+              for (let i = majorNum - 1; i >= 0; i--) {
+                addToGroup(i.toString(), vulnerability);
+              }
+
+              break;
           }
+        }
+      };
 
-          break;
+      for (const { ref, ...vulnerability } of Object.values(data)) {
+        vulnerability.url = ref;
+        // Process all potential versions from the vulnerable field
+        const versions = vulnerability.vulnerable.split(' || ').filter(Boolean);
+
+        for (const version of versions) {
+          processVersion(version, vulnerability);
+        }
       }
-    }
-  };
 
-  for (const vulnerability of Object.values(data)) {
-    const parsedVulnerability = {
-      cve: vulnerability.cve,
-      url: vulnerability.ref,
-      vulnerable: vulnerability.vulnerable,
-      patched: vulnerability.patched,
-      description: vulnerability.description,
-      overview: vulnerability.overview,
-      affectedEnvironments: vulnerability.affectedEnvironments,
-      severity: vulnerability.severity,
-    };
-
-    // Process all potential versions from the vulnerable field
-    const versions = parsedVulnerability.vulnerable
-      .split(' || ')
-      .filter(Boolean);
-
-    for (const version of versions) {
-      processVersion(version, parsedVulnerability);
-    }
-  }
-
-  return grouped;
-}
+      return grouped;
+    })
+    .catch(() => ({}));

--- a/apps/site/next.calendar.mjs
+++ b/apps/site/next.calendar.mjs
@@ -4,6 +4,7 @@ import {
   BASE_CALENDAR_URL,
   SHARED_CALENDAR_KEY,
 } from './next.calendar.constants.mjs';
+import { fetchWithRetry } from './util/fetch';
 
 /**
  *
@@ -33,7 +34,7 @@ export const getCalendarEvents = async (calendarId = '', maxResults = 20) => {
     calendarQueryUrl.searchParams.append(key, value)
   );
 
-  return fetch(calendarQueryUrl)
+  return fetchWithRetry(calendarQueryUrl)
     .then(response => response.json())
     .then(calendar => calendar.items ?? []);
 };

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -213,3 +213,9 @@ export const EOL_VERSION_IDENTIFIER = 'End-of-life';
  */
 export const VULNERABILITIES_URL =
   'https://raw.githubusercontent.com/nodejs/security-wg/main/vuln/core/index.json';
+
+/**
+ * The location of the OpenCollective data
+ */
+export const OPENCOLLECTIVE_MEMBERS_URL =
+  'https://opencollective.com/nodejs/members/all.json';

--- a/apps/site/types/index.ts
+++ b/apps/site/types/index.ts
@@ -16,3 +16,4 @@ export * from './download';
 export * from './userAgent';
 export * from './vulnerabilities';
 export * from './page';
+export * from './supporters';

--- a/apps/site/types/supporters.ts
+++ b/apps/site/types/supporters.ts
@@ -1,0 +1,9 @@
+export type Supporter = {
+  name: string;
+  image: string;
+  url: string;
+  profile: string;
+  source: string;
+};
+
+export type OpenCollectiveSupporter = Supporter & { source: 'opencollective' };

--- a/apps/site/types/supporters.ts
+++ b/apps/site/types/supporters.ts
@@ -1,9 +1,9 @@
-export type Supporter = {
+export type Supporter<T extends string> = {
   name: string;
   image: string;
   url: string;
   profile: string;
-  source: string;
+  source: T;
 };
 
-export type OpenCollectiveSupporter = Supporter & { source: 'opencollective' };
+export type OpenCollectiveSupporter = Supporter<'opencollective'>;

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -28,8 +28,7 @@ export const fetchWithRetry = async (
         throw e;
       }
 
-      await setTimeout(delay);
-      continue;
+      await setTimeout(delay * i);
     }
   }
 };

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -1,0 +1,24 @@
+import { setTimeout } from 'node:timers/promises';
+
+type RetryOptions = RequestInit & {
+  maxRetry: number;
+  delay: number;
+};
+
+export const fetchWithRetry = async (
+  url: string,
+  { maxRetry = 3, delay = 100, ...options }: RetryOptions
+) => {
+  for (let i = 1; i <= maxRetry; i++) {
+    try {
+      return fetch(url, options);
+    } catch (e) {
+      if (i === maxRetry) {
+        throw e;
+      }
+
+      await setTimeout(delay);
+      continue;
+    }
+  }
+};

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -5,6 +5,12 @@ type RetryOptions = RequestInit & {
   delay?: number;
 };
 
+type FetchError = {
+  cause: {
+    code: string;
+  };
+};
+
 export const fetchWithRetry = async (
   url: string,
   { maxRetry = 3, delay = 100, ...options }: RetryOptions = {}
@@ -13,7 +19,12 @@ export const fetchWithRetry = async (
     try {
       return fetch(url, options);
     } catch (e) {
-      if (i === maxRetry) {
+      console.debug(
+        `fetch of ${url} failed at ${Date.now()}, attempt ${i}/${maxRetry}`,
+        e
+      );
+
+      if (i === maxRetry || (e as FetchError).cause.code !== 'ETIMEDOUT') {
         throw e;
       }
 

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -1,13 +1,13 @@
 import { setTimeout } from 'node:timers/promises';
 
 type RetryOptions = RequestInit & {
-  maxRetry: number;
-  delay: number;
+  maxRetry?: number;
+  delay?: number;
 };
 
 export const fetchWithRetry = async (
   url: string,
-  { maxRetry = 3, delay = 100, ...options }: RetryOptions
+  { maxRetry = 3, delay = 100, ...options }: RetryOptions = {}
 ) => {
   for (let i = 1; i <= maxRetry; i++) {
     try {


### PR DESCRIPTION
This PR:

- Fixes the nasty fetch failed issue on deployments by rewriting the fetch statements to `.then().catch()` format
- Adds a missing type file
- Moves a constant to the constants file
- Simplifies an object creation