### PR TITLE
chore(ci): ping releasers on blog post PR

### DIFF
--- a/.github/workflows/create-release-post.yml
+++ b/.github/workflows/create-release-post.yml
@@ -35,6 +35,7 @@ jobs:
 
       - run: node --run scripts:release-post -- "$VERSION"
         working-directory: apps/site
+        id: release-post
         env:
           VERSION: ${{ inputs.version }}
 
@@ -54,4 +55,5 @@ jobs:
           commit-message: 'feat(blog): create post for ${{ inputs.version }}'
           labels: fast-track
           title: 'feat(blog): create post for ${{ inputs.version }}'
+          assignees: ${{ steps.release-post.outputs.author }}
           draft: true


### PR DESCRIPTION
The @nodejs/releasers team isn't pinged to the release blog post PR _until_ it's ready for review. By cc-ing them in the description, they will be pinged on creation.

@targos does this resolve the concerns you brought up?