### PR TITLE
fix(learn): Correct unclear example of passing arguments using the task runner

### DIFF
--- a/apps/site/pages/en/learn/command-line/run-nodejs-scripts-from-the-command-line.md
+++ b/apps/site/pages/en/learn/command-line/run-nodejs-scripts-from-the-command-line.md
@@ -71,8 +71,8 @@ The [`--run`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--run) flag allo
   "type": "module",
   "scripts": {
     "start": "node app.js",
-    "dev": "node --run start -- --watch",
-    "test": "node --test"
+    "test": "node --test",
+    "test:junit": "node --run test -- --test-reporter=\"junit\""
   }
 }
 ```
@@ -85,12 +85,13 @@ node --run test
 
 ### Passing arguments to the command
 
-Let's explain the `dev` key in the `scripts` object of the `package.json` file.
+Let's explain the `test:junit` key in the `scripts` object of the `package.json` file.
 
-The syntax `-- --another-argument` is used to pass arguments to the command. In this case, the `--watch` argument is passed to the `dev` script.
+The syntax `-- --another-argument` is used to pass arguments to the command. In this case, the `--test-reporter` argument is passed to the `node --test` command defined by the `test` script.
 
 ```bash
-node --run dev
+# Executes: node --test --test-reporter="junit"
+node --run test:junit
 ```
 
 ### Environment variables


### PR DESCRIPTION
## Description

Alters the phrasing used in the `Passing arguments to the command` section of the `Run Node.js scripts from the command line` page as it is incorrect:

Also, changes the example as current one can confuse the reader into thinking it's a good example of enabling the Node.js watch option even though it's just passing an '--watch' argument to the app.js script (`node app.js --watch`).

Current docs:
```
{
  "type": "module",
  "scripts": {
    "start": "node app.js",
    "dev": "node --run start -- --watch",
    "test": "node --test"
  }
}
[...]
In this case, the --watch argument is passed to the dev script.
```

Updated docs:
```
{
  "type": "module",
  "scripts": {
    "start": "node app.js",
    "test": "node --test",
    "test:junit": "node --run test -- --test-reporter=\"junit\"",
  }
}
[...]
In this case, the `--test-reporter` argument is passed to the `node --test` command defined by the `test` script.
```

## Validation

- Run the example scripts locally

## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
