### PR TITLE
chore: migrate from middleware.ts to proxy.ts for Next.js 16 compatib…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ pnpm-lock.yaml @nodejs/web-infra
 # Framework
 apps/site/next.config.mjs @nodejs/web-infra
 apps/site/next.dynamic.mjs @nodejs/web-infra
-apps/site/middleware.ts @nodejs/web-infra
+apps/site/proxy.ts @nodejs/web-infra
 apps/site/navigation.mjs @nodejs/web-infra
 apps/site/playwright.config.ts @nodejs/web-infra
 

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -2,7 +2,11 @@ import createMiddleware from 'next-intl/middleware';
 
 import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
-export default createMiddleware({
+// Migrated from middleware.ts to proxy.ts as per Next.js 16 deprecation
+// The middleware file convention is deprecated and has been renamed to proxy
+// See: https://nextjs.org/docs/messages/middleware-to-proxy
+
+export const proxy = createMiddleware({
   // A list of all locales that are supported
   locales: availableLocaleCodes,
 
@@ -17,6 +21,6 @@ export default createMiddleware({
   alternateLinks: false,
 });
 
-// We only want the middleware to run on the `/` route
+// We only want the proxy to run on the `/` route
 // to redirect users to their preferred locale
 export const config = { matcher: ['/'] };

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -2,9 +2,6 @@ import createMiddleware from 'next-intl/middleware';
 
 import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
-// The middleware file convention is deprecated and has been renamed to proxy
-// See: https://nextjs.org/docs/messages/middleware-to-proxy
-
 export const proxy = createMiddleware({
   // A list of all locales that are supported
   locales: availableLocaleCodes,

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -2,7 +2,6 @@ import createMiddleware from 'next-intl/middleware';
 
 import { availableLocaleCodes, defaultLocale } from '#site/next.locales.mjs';
 
-// Migrated from middleware.ts to proxy.ts as per Next.js 16 deprecation
 // The middleware file convention is deprecated and has been renamed to proxy
 // See: https://nextjs.org/docs/messages/middleware-to-proxy
 

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -17,7 +17,6 @@ export const proxy = createMiddleware({
   alternateLinks: false,
 });
 
-// Export as proxy function (required by Next.js 16+)
 export default proxy;
 // We only want the proxy to run on the `/` route
 // to redirect users to their preferred locale

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -17,6 +17,8 @@ export const proxy = createMiddleware({
   alternateLinks: false,
 });
 
+// Export as proxy function (required by Next.js 16+)
+export default proxy;
 // We only want the proxy to run on the `/` route
 // to redirect users to their preferred locale
 export const config = { matcher: ['/'] };


### PR DESCRIPTION
…ility

Migrate from the deprecated middleware.ts file convention to the new proxy.ts convention as required by Next.js 16.0.10.

The middleware file convention has been deprecated and renamed to 'proxy' to better clarify its purpose as a network boundary in front of the app, and to avoid confusion with Express.js middleware.

Changes:
- Rename apps/site/middleware.ts to apps/site/proxy.ts
- Add named export const proxy = createMiddleware({
- Maintain full compatibility with next-intl internationalization
- Update comments to reflect proxy terminology

This resolves the deprecation warning:
'The middleware file convention is deprecated. Please use proxy instead.'

Refs: https://nextjs.org/docs/messages/middleware-to-proxy

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Fixed #8418  

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
