### PR TITLE
docs(code-style): commit messages should be in lowercase

### DIFF
--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -36,7 +36,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 ### Commit Message Format
 
 - Commit messages must include a "type" as described in Conventional Commits
-- Commit messages **must** start with a capital letter
+- Commit messages **must** be written in lowercase, except proper nouns
 - Commit messages **must not** end with a period `.`
 
 ### Commit Signing
@@ -48,9 +48,9 @@ Commits should be signed. You can read more about [Commit Signing](https://docs.
 ✅ **Good commit messages:**
 
 ```
-feat: Add new component for download statistics
-fix: Resolve navigation menu accessibility issue
-docs: Update contributing guidelines
+feat: add new component for download statistics
+fix: resolve navigation menu accessibility issue
+docs: update contributing guidelines
 ```
 
 ❌ **Bad commit messages:**


### PR DESCRIPTION
## Description

As I noticed in [my first PR](https://github.com/nodejs/nodejs.org/pull/8417#issuecomment-3651642156), the guidelines currently state that commit messages need to start with a capital letter. This guideline is not followed so let's change it. I went with @avivkeller 's recommendation, the convention most repos follow: only lowercase except for proper nouns.

## Validation

N/A

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
