### PR TITLE
feat: add migration guide for chalk to util styletext codemod

### DIFF
--- a/apps/site/authors.json
+++ b/apps/site/authors.json
@@ -222,6 +222,11 @@
     "name": "Richard Lau",
     "website": "https://github.com/richardlau"
   },
+  "Richie McColl": {
+    "id": "richiemccoll",
+    "name": "Richie McColl",
+    "website": "https://github.com/richiemccoll"
+  },
   "Robin Bender Ginn": {
     "id": "rginn",
     "name": "Robin Bender Ginn",

--- a/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
+++ b/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
@@ -1,5 +1,5 @@
 ---
-date: '2026-01-19T00:00:00.000Z'
+date: '2026-01-23T00:00:00.000Z'
 category: migrations
 title: Chalk to Node.js util styleText
 layout: blog-post
@@ -21,7 +21,7 @@ This codemod aims to help you reduce external dependencies by transforming chalk
 - Style chaining via array syntax
 - Environment variable support (NO_COLOR, NODE_DISABLE_COLORS, FORCE_COLOR)
 
-### Non-Compatible Features:
+### Incompatible Features:
 
 - Custom RGB colors (chalk.rgb(), chalk.hex())
 - 256-color palette (chalk.ansi256())
@@ -35,7 +35,8 @@ This codemod aims to help you reduce external dependencies by transforming chalk
 - Node.js v20.12.0 or later (for util.styleText)
 - `util.styleText` became stable in Node.js v22.13.0 (and v23.5.0)
 
-> If your package supports a version earlier than 22, this creates a breaking change, which means you must bump the major version of your package.
+> If your package currently supports Node.js versions earlier than v20.12.0, you cannot migrate to util.styleText without dropping support for those versions.
+> This requires bumping the major version of your package AND updating the engines field in your package.json to require Node.js >= v20.12.0.
 
 ### Usage:
 

--- a/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
+++ b/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
@@ -1,0 +1,67 @@
+---
+date: '2025-12-19T00:00:00.000Z'
+category: migrations
+title: Chalk to Node.js util styleText
+layout: blog-post
+author: richiemccoll
+---
+
+# Migrate from Chalk to Node.js util styleText
+
+## `chalk-to-util-styletext`
+
+This codemod aims to help you reduce external dependencies by transforming chalk method calls to use the native Node.js styling functionality. It will also handle automatic removal of the `chalk` package from the package.json.
+
+### Compatible Features:
+
+- Basic colors (red, green, blue, yellow, etc.)
+- Bright colors (redBright, greenBright, etc.)
+- Background colors (bgRed, bgGreen, etc.)
+- Text modifiers (bold, dim, italic, underline, strikethrough, etc.)
+- Style chaining via array syntax
+- Environment variable support (NO_COLOR, NODE_DISABLE_COLORS, FORCE_COLOR)
+
+### Non-Compatible Features:
+
+- Custom RGB colors (chalk.rgb(), chalk.hex())
+- 256-color palette (chalk.ansi256())
+- Template literal syntax (chalk...``)
+  -Advanced modifiers with limited terminal support (overline, blink, etc.)
+
+The source code for this codemod can be found in the [chalk-to-util-styletext directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/chalk-to-util-styletext).
+
+You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/chalk-to-util-styletext).
+
+```bash
+npx codemod @nodejs/chalk-to-util-styletext
+```
+
+### Example:
+
+```js displayName="Before"
+import chalk from 'chalk';
+
+console.log(chalk.red('Error message'));
+
+console.log(chalk.red.bold('Important error'));
+
+const red = chalk.red;
+console.log(red('Error'));
+
+const boldBlue = chalk.blue.bold;
+console.log(boldBlue('Info'));
+```
+
+```js displayName="After"
+import { styleText } from 'node:util';
+
+console.log(styleText('red', 'Error message'));
+
+console.log(styleText(['red', 'bold'], 'Important error'));
+
+const red = text => styleText('red', text);
+console.log(red('Error'));
+
+const boldBlue = text => styleText(['blue', 'bold'], text);
+console.log(boldBlue('Info'));
+```

--- a/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
+++ b/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
@@ -28,6 +28,15 @@ This codemod aims to help you reduce external dependencies by transforming chalk
 - Template literal syntax (chalk...``)
 - Advanced modifiers with limited terminal support (overline, blink, etc.)
 
+### Prerequisites:
+
+#### Node.js Version Requirements
+
+- Node.js v20.12.0 or later (for util.styleText)
+- `util.styleText` became stable in Node.js v22.13.0 (and v23.5.0)
+
+### Usage:
+
 The source code for this codemod can be found in the [chalk-to-util-styletext directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/chalk-to-util-styletext).
 
 You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/chalk-to-util-styletext).

--- a/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
+++ b/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
@@ -26,7 +26,7 @@ This codemod aims to help you reduce external dependencies by transforming chalk
 - Custom RGB colors (chalk.rgb(), chalk.hex())
 - 256-color palette (chalk.ansi256())
 - Template literal syntax (chalk...``)
-  -Advanced modifiers with limited terminal support (overline, blink, etc.)
+- Advanced modifiers with limited terminal support (overline, blink, etc.)
 
 The source code for this codemod can be found in the [chalk-to-util-styletext directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/chalk-to-util-styletext).
 

--- a/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
+++ b/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx
@@ -1,5 +1,5 @@
 ---
-date: '2025-12-19T00:00:00.000Z'
+date: '2026-01-19T00:00:00.000Z'
 category: migrations
 title: Chalk to Node.js util styleText
 layout: blog-post
@@ -10,7 +10,7 @@ author: richiemccoll
 
 ## `chalk-to-util-styletext`
 
-This codemod aims to help you reduce external dependencies by transforming chalk method calls to use the native Node.js styling functionality. It will also handle automatic removal of the `chalk` package from the package.json.
+This codemod aims to help you reduce external dependencies by transforming chalk method calls to use the native Node.js styling functionality. It will also handle automatic removal of the [`chalk`](https://github.com/chalk/chalk) package from the package.json.
 
 ### Compatible Features:
 
@@ -34,6 +34,8 @@ This codemod aims to help you reduce external dependencies by transforming chalk
 
 - Node.js v20.12.0 or later (for util.styleText)
 - `util.styleText` became stable in Node.js v22.13.0 (and v23.5.0)
+
+> If your package supports a version earlier than 22, this creates a breaking change, which means you must bump the major version of your package.
 
 ### Usage:
 
@@ -74,3 +76,7 @@ console.log(red('Error'));
 const boldBlue = text => styleText(['blue', 'bold'], text);
 console.log(boldBlue('Info'));
 ```
+
+## Recognition
+
+We would like to thank the maintainers of [`chalk`](https://github.com/chalk/chalk) for their support of the package over time and for its contributions to the ecosystem.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR addresses the comment [here](https://github.com/nodejs/userland-migrations/pull/256#issuecomment-3645804047) by adding a new Codemod migration guide for the new [recipe](https://app.codemod.com/registry/@nodejs/chalk-to-util-styletext): `chalk-to-util-styletext`. 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
