### PR TITLE
docs: add marketing team as code owners for partners and branding pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,3 +48,5 @@ apps/site/pages/en/learn/getting-started/security-best-practices.md @nodejs/secu
 apps/site/pages/en/learn/manipulating-files @nodejs/fs
 apps/site/pages/en/learn/test-runner @nodejs/test_runner
 apps/site/pages/en/learn/typescript @nodejs/typescript
+apps/site/pages/en/about/partners.md @nodejs/marketing
+apps/site/pages/en/about/branding.md @nodejs/marketing

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,5 +48,5 @@ apps/site/pages/en/learn/getting-started/security-best-practices.md @nodejs/secu
 apps/site/pages/en/learn/manipulating-files @nodejs/fs
 apps/site/pages/en/learn/test-runner @nodejs/test_runner
 apps/site/pages/en/learn/typescript @nodejs/typescript
-apps/site/pages/en/about/partners.md @nodejs/marketing
-apps/site/pages/en/about/branding.md @nodejs/marketing
+apps/site/pages/en/about/partners.mdx @nodejs/marketing
+apps/site/pages/en/about/branding.mdx @nodejs/marketing


### PR DESCRIPTION
I think adding it as codeowners is a good idea, so changes, at least to the partners page, need to be approved by that team 😊.