### PR TITLE
fix: code scroll issue on small screen

### DIFF
--- a/packages/rehype-shiki/src/transformers/twoslash/index.css
+++ b/packages/rehype-shiki/src/transformers/twoslash/index.css
@@ -6,10 +6,11 @@
 }
 
 .twoslash-popup-code {
-  max-width: 600px;
+  max-width: min(600px, 90vw);
   display: block;
   width: fit-content;
   user-select: none;
+  overflow-wrap: break-word;
 }
 
 .twoslash-popup-code:not(:has(div)) {

--- a/packages/ui-components/src/Common/BaseCodeBox/index.module.css
+++ b/packages/ui-components/src/Common/BaseCodeBox/index.module.css
@@ -3,7 +3,7 @@
 .root {
   @apply w-full
     max-w-full
-    overflow-hidden
+    overflow-x-clip
     rounded-sm
     border
     border-neutral-900

--- a/packages/ui-components/src/Common/BaseCodeBox/index.module.css
+++ b/packages/ui-components/src/Common/BaseCodeBox/index.module.css
@@ -2,6 +2,8 @@
 
 .root {
   @apply w-full
+    max-w-full
+    overflow-hidden
     rounded-sm
     border
     border-neutral-900
@@ -9,6 +11,7 @@
 
   .content {
     @apply m-0
+      min-w-0
       p-4;
 
     & > code {
@@ -16,6 +19,7 @@
         font-regular
         scrollbar-thin
         grid
+        max-w-full
         overflow-x-auto
         bg-transparent
         p-0

--- a/packages/ui-components/src/Common/BaseCodeBox/index.module.css
+++ b/packages/ui-components/src/Common/BaseCodeBox/index.module.css
@@ -3,7 +3,7 @@
 .root {
   @apply w-full
     max-w-full
-    overflow-x-clip
+    overflow-x-hidden
     rounded-sm
     border
     border-neutral-900
@@ -20,6 +20,7 @@
         scrollbar-thin
         grid
         max-w-full
+        [grid-template-columns:minmax(0,1fr)]
         overflow-x-auto
         bg-transparent
         p-0
@@ -31,7 +32,8 @@
       & > [class='line'] {
         @apply relative
           min-w-0
-          pl-8;
+          pl-8
+          [overflow-wrap:anywhere];
 
         &:not(:empty:last-child)::before {
           @apply inline-block

--- a/packages/ui-components/src/Common/BaseCodeBox/index.module.css
+++ b/packages/ui-components/src/Common/BaseCodeBox/index.module.css
@@ -33,7 +33,7 @@
         @apply relative
           min-w-0
           pl-8
-          [overflow-wrap:anywhere];
+          [overflow-wrap:break-word];
 
         &:not(:empty:last-child)::before {
           @apply inline-block


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The PR fixes the horizontal scroll bar appearing for code section on smaller devices. https://github.com/nodejs/nodejs.org/issues/8437

## Validation
<img width="388" height="737" alt="Screenshot 2025-12-23 at 3 57 37 PM" src="https://github.com/user-attachments/assets/05c194f8-3eb9-41a2-a82d-67ec21413d3e" />

## Related Issues

Issue -  https://github.com/nodejs/nodejs.org/issues/8437

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
