### PR TITLE
fix: mobile dialog close icon

### DIFF
--- a/packages/ui-components/src/Common/Search/Input/index.module.css
+++ b/packages/ui-components/src/Common/Search/Input/index.module.css
@@ -22,10 +22,11 @@
     py-4
     pr-4
     pl-9
-    text-sm
+    text-base
     text-neutral-900
     placeholder:text-neutral-500
     focus:outline-none
+    md:text-sm
     dark:border-neutral-900
     dark:text-neutral-200
     dark:placeholder:text-neutral-600;

--- a/packages/ui-components/src/Common/Search/Modal/index.module.css
+++ b/packages/ui-components/src/Common/Search/Modal/index.module.css
@@ -117,3 +117,17 @@
     lg:border
     dark:border-neutral-900;
 }
+
+.modalCloseButton {
+  @apply absolute
+    top-2
+    right-4
+    z-10
+    cursor-pointer
+    bg-white
+    px-2
+    text-2xl
+    text-neutral-950
+    dark:bg-black
+    dark:text-neutral-200;
+}

--- a/packages/ui-components/src/Common/Search/Modal/index.module.css
+++ b/packages/ui-components/src/Common/Search/Modal/index.module.css
@@ -128,6 +128,7 @@
     px-2
     text-2xl
     text-neutral-950
+    md:hidden
     dark:bg-black
     dark:text-neutral-200;
 }

--- a/packages/ui-components/src/Common/Search/Modal/index.tsx
+++ b/packages/ui-components/src/Common/Search/Modal/index.tsx
@@ -46,6 +46,7 @@ const SearchModal: FC<PropsWithChildren<SearchModalProps>> = ({
                   placeholder={placeholder}
                   ariaLabel={placeholder}
                 />
+                <Modal.Close className={styles.modalCloseButton} />
                 {children}
               </Modal.Content>
             </Modal.Inner>


### PR DESCRIPTION
## Description

I didn’t get a chance to review #8443 in time, and when I checked it, I couldn’t exit the dialog once it was opened. With this PR, I added a simple close icon. Also, Safari tends to zoom in on inputs with font sizes below 16px, so I set the input font size to 16px for mobile resolutions

## Validation
### Before
<img width="430" height="381" alt="image" src="https://github.com/user-attachments/assets/2a4538e6-13c9-4f9a-be24-c35bbeb08416" />

### After
<img width="430" height="381" alt="image" src="https://github.com/user-attachments/assets/b9c63b51-c1bb-4293-9238-7d45c0131bb9" />
