### PR TITLE
fix(ci): use `##` instead of `#` when comparing

### DIFF
--- a/apps/site/scripts/compare-size/index.mjs
+++ b/apps/site/scripts/compare-size/index.mjs
@@ -82,7 +82,7 @@ function reportDiff({ assets: oldAssets }, { assets: newAssets }) {
   const totalDelta = newTotal - oldTotal;
 
   // Summary table
-  let report = `## 📦 Build Size Comparison\n\n## Summary\n\n| Metric | Value |\n|--------|-------|\n`;
+  let report = `## 📦 Build Size Comparison\n\n### Summary\n\n| Metric | Value |\n|--------|-------|\n`;
   report += `| Old Total Size | ${formatBytes(oldTotal)} |\n`;
   report += `| New Total Size | ${formatBytes(newTotal)} |\n`;
   report += `| Delta | ${formatBytes(totalDelta)} (${formatPercent(

--- a/apps/site/scripts/compare-size/index.mjs
+++ b/apps/site/scripts/compare-size/index.mjs
@@ -82,7 +82,7 @@ function reportDiff({ assets: oldAssets }, { assets: newAssets }) {
   const totalDelta = newTotal - oldTotal;
 
   // Summary table
-  let report = `# 📦 Build Size Comparison\n\n## Summary\n\n| Metric | Value |\n|--------|-------|\n`;
+  let report = `## 📦 Build Size Comparison\n\n## Summary\n\n| Metric | Value |\n|--------|-------|\n`;
   report += `| Old Total Size | ${formatBytes(oldTotal)} |\n`;
   report += `| New Total Size | ${formatBytes(newTotal)} |\n`;
   report += `| Delta | ${formatBytes(totalDelta)} (${formatPercent(


### PR DESCRIPTION
cc @ovflowd 

> Completely unrelated thing, but can we decrease the heading size of this comment? It is gigantic compared to the other ones 😭

---

# This is a `#`

## This is a `##`

### This is a `###`