### PR TITLE
feat(previous-releases): convert plaintext link to markdown

### DIFF
--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/pages/en/about/previous-releases.mdx
+++ b/apps/site/pages/en/about/previous-releases.mdx
@@ -41,7 +41,7 @@ Installation methods designated as “Official” must meet the following requir
 
 ### Community Installation Methods
 
-Community installation methods included on the self-service [download page](/download) must also adhere to a minimum set of criteria:
+Community installation methods included on the self-service (located at /download) must also adhere to a minimum set of criteria:
 
 - **Version Support:** Must support all currently supported, non-End-of-Life (EOL) Node.js versions.
 - **OS Compatibility:** Must function on at least one officially supported Operating System (OS).

--- a/apps/site/pages/en/about/previous-releases.mdx
+++ b/apps/site/pages/en/about/previous-releases.mdx
@@ -41,7 +41,7 @@ Installation methods designated as “Official” must meet the following requir
 
 ### Community Installation Methods
 
-Community installation methods included on the self-service (located at /download) must also adhere to a minimum set of criteria:
+Community installation methods included on the self-service download page (located at /download) must also adhere to a minimum set of criteria:
 
 - **Version Support:** Must support all currently supported, non-End-of-Life (EOL) Node.js versions.
 - **OS Compatibility:** Must function on at least one officially supported Operating System (OS).

--- a/apps/site/pages/en/about/previous-releases.mdx
+++ b/apps/site/pages/en/about/previous-releases.mdx
@@ -41,7 +41,7 @@ Installation methods designated as “Official” must meet the following requir
 
 ### Community Installation Methods
 
-Community installation methods included on the self-service download page (/download) must also adhere to a minimum set of criteria:
+Community installation methods included on the self-service [download page](/download) must also adhere to a minimum set of criteria:
 
 - **Version Support:** Must support all currently supported, non-End-of-Life (EOL) Node.js versions.
 - **OS Compatibility:** Must function on at least one officially supported Operating System (OS).


### PR DESCRIPTION
## Description

Fixes a broken markdown link on the Previous Releases documentation page where /download was rendered as plain text instead of a clickable link. This change updates the sentence to use proper markdown link syntax for improved usability and consistency across the site.

## Validation

- Navigated to ```/en/about/previous-releases```
- Verified that the Download page link is now clickable and correctly routes to ```/download```
- Screenshot attached
<img width="1010" height="414" alt="image" src="https://github.com/user-attachments/assets/27c23cdd-d6d4-43df-a558-a9edc7b6cc68" />



## Related Issues

Fixes #8451 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
