### PR TITLE
fix(navbar): don't show navitems if none provided

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "exports": {
     "./*": [

--- a/packages/ui-components/src/Containers/NavBar/index.stories.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.stories.tsx
@@ -5,14 +5,17 @@ import type { Meta as MetaObj, StoryObj } from '@storybook/react-webpack5';
 type Story = StoryObj<typeof NavBar>;
 type Meta = MetaObj<typeof NavBar>;
 
+const common = {
+  as: 'a',
+  Logo: 'a',
+  pathname: '/',
+
+  children: <a>Some other child</a>,
+} as const;
+
 export const Default: Story = {
   args: {
-    as: 'a',
-    Logo: 'a',
-    pathname: '/',
-
-    children: <a>Some other child</a>,
-
+    ...common,
     navItems: [
       {
         text: 'Learn',
@@ -41,5 +44,7 @@ export const Default: Story = {
     ],
   },
 };
+
+export const NoNavItems: Story = { args: common };
 
 export default { component: NavBar } as Meta;

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -22,7 +22,7 @@ const navInteractionIcons = {
 };
 
 type NavbarProps = {
-  navItems: Array<{
+  navItems?: Array<{
     text: FormattedMessage;
     link: string;
     target?: HTMLAttributeAnchorTarget | undefined;
@@ -61,7 +61,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
       </div>
 
       <input
-        className={classNames(['peer', style.sidebarItemToggler])}
+        className={classNames('peer', style.sidebarItemToggler)}
         id="sidebarItemToggler"
         type="checkbox"
         onChange={e => setIsMenuOpen(() => e.target.checked)}
@@ -69,21 +69,22 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         tabIndex={-1}
       />
 
-      <div className={`${style.main} hidden peer-checked:flex`}>
-        <div className={style.navItems}>
-          {navItems.map(({ text, link, target }) => (
-            <NavItem
-              pathname={pathname}
-              as={Component}
-              key={link}
-              href={link}
-              target={target}
-            >
-              {text}
-            </NavItem>
-          ))}
-        </div>
-
+      <div className={classNames(style.main, `hidden peer-checked:flex`)}>
+        {navItems && (
+          <div className={style.navItems}>
+            {navItems.map(({ text, link, target }) => (
+              <NavItem
+                pathname={pathname}
+                as={Component}
+                key={link}
+                href={link}
+                target={target}
+              >
+                {text}
+              </NavItem>
+            ))}
+          </div>
+        )}
         <div className={style.actionsWrapper}>{children}</div>
       </div>
     </nav>


### PR DESCRIPTION
Closes: #555
Fixes: #533

---

Hides the `navItems` if no `navItems` are provided.