### PR TITLE
fix: PartnerIcon Accessibility

### DIFF
--- a/apps/site/components/Common/Partners/index.tsx
+++ b/apps/site/components/Common/Partners/index.tsx
@@ -38,9 +38,11 @@ const renderSmallPartner = (partner: Partner) => {
   return (
     <Tooltip
       key={partner.id}
+      asChild
+      aria-label={partner.name}
       content={<div className={style.tooltip}>{partner.name}</div>}
     >
-      <PartnerButton size="small" href={partner.href}>
+      <PartnerButton aria-label={partner.name} size="small" href={partner.href}>
         <Logo.Favicon />
       </PartnerButton>
     </Tooltip>
@@ -51,7 +53,12 @@ const renderLargePartner = (partner: Partner) => {
   const Logo = PartnerLogos[partner.id];
 
   return (
-    <PartnerButton key={partner.id} size="large" href={partner.href}>
+    <PartnerButton
+      aria-label={partner.name}
+      key={partner.id}
+      size="large"
+      href={partner.href}
+    >
       <Logo.Logo />
     </PartnerButton>
   );

--- a/apps/site/components/Common/Partners/index.tsx
+++ b/apps/site/components/Common/Partners/index.tsx
@@ -39,7 +39,6 @@ const renderSmallPartner = (partner: Partner) => {
     <Tooltip
       key={partner.id}
       asChild
-      aria-label={partner.name}
       content={<div className={style.tooltip}>{partner.name}</div>}
     >
       <PartnerButton aria-label={partner.name} size="small" href={partner.href}>


### PR DESCRIPTION
## Description

This PR fixes accessibility issue in the `PartnerIcon` component.

## Validation

Before - Axe accessibility report:

<img width="1907" height="974" alt="Screenshot 2025-12-29 at 4 52 54 PM" src="https://github.com/user-attachments/assets/ad12c435-a4e3-4597-88a2-dc9c081f1841" />

After - Axe accessibility report:

<img width="1907" height="974" alt="Screenshot 2025-12-29 at 4 52 33 PM" src="https://github.com/user-attachments/assets/afd2056a-6dc5-4c83-a8c4-d36401cfb5f2" />

## Related Issues

fixes - https://github.com/nodejs/nodejs.org/issues/8466

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
