### PR TITLE
fix: Add 'twoslash' to Dependabot Shiki group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,7 @@ updates:
           - vfile
           - vfile-*
           - reading-time
+          - twoslash
       orama:
         patterns:
           - '@orama/*'


### PR DESCRIPTION
Ref: https://github.com/nodejs/nodejs.org/pull/8479#pullrequestreview-3617234327