### PR TITLE
fix: remove volta from install options

### DIFF
--- a/apps/site/snippets/en/download/volta.bash
+++ b/apps/site/snippets/en/download/volta.bash
@@ -1,8 +1,0 @@
-# On most Unix systems including macOS, you can install with a single command:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Download and install Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/es/download/volta.bash
+++ b/apps/site/snippets/es/download/volta.bash
@@ -1,8 +1,0 @@
-# En la mayoría de los sistemas Unix, incluyendo macOS, puedes instalar con un solo comando:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Descarga e instala Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/fr/download/volta.bash
+++ b/apps/site/snippets/fr/download/volta.bash
@@ -1,8 +1,0 @@
-# Sur la plupart des systèmes Unix, y compris macOS, vous pouvez effectuer l'installation à l'aide d'une seule commande :
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Télécharger et installer Node.js :
-volta install node@${props.release.major}

--- a/apps/site/snippets/id/download/volta.bash
+++ b/apps/site/snippets/id/download/volta.bash
@@ -1,8 +1,0 @@
-# Di sebagian besar sistem Unix termasuk macOS, kamu dapat memasang dengan satu perintah:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Unduh dan pasang Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/ja/download/volta.bash
+++ b/apps/site/snippets/ja/download/volta.bash
@@ -1,8 +1,0 @@
-# macOSを含むほとんどのUnixシステムでは1つのコマンドでインストールできます：
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Node.jsをダウンロードしてインストールする：
-volta install node@${props.release.major}

--- a/apps/site/snippets/pt-br/download/volta.bash
+++ b/apps/site/snippets/pt-br/download/volta.bash
@@ -1,8 +1,0 @@
-# Na maioria dos sistemas de Unix, incluindo macOS, podemos instalar com um único comando:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Baixar e instalar a Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/pt/download/volta.bash
+++ b/apps/site/snippets/pt/download/volta.bash
@@ -1,8 +1,0 @@
-# Na maioria dos sistemas de Unix incluindo macOS, podemos instalar com um único comando:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Descarregar e instalar a Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/ro/download/volta.bash
+++ b/apps/site/snippets/ro/download/volta.bash
@@ -1,8 +1,0 @@
-# Pe cele mai multe sisteme de operare Unix, inclusiv macOS, poți instala cu o singură comandă:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Descarcă și instalează Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/tr/download/volta.bash
+++ b/apps/site/snippets/tr/download/volta.bash
@@ -1,8 +1,0 @@
-Çoğu Unix sistemi, macOS dahil, tek bir komutla kurulum yapabilirsiniz:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Node.js indirin ve kurun:
-volta install node@${props.release.major}

--- a/apps/site/snippets/uk/download/volta.bash
+++ b/apps/site/snippets/uk/download/volta.bash
@@ -1,8 +1,0 @@
-# На більшості системах Unix, включно з macOS, його можна встановити однією командою:
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# Завантажує й установлює Node.js:
-volta install node@${props.release.major}

--- a/apps/site/snippets/zh-cn/download/volta.bash
+++ b/apps/site/snippets/zh-cn/download/volta.bash
@@ -1,8 +1,0 @@
-# 在大多数包括 macOS 的 Unix 系统中，可以运行这个命令来安装：
-${props.os === 'WIN' ?
-  'winget install Volta.Volta' :
-  'curl https://get.volta.sh | bash'
-}
-
-# 下载并安装 Node.js：
-volta install node@${props.release.major}

--- a/apps/site/types/release.ts
+++ b/apps/site/types/release.ts
@@ -5,7 +5,6 @@ import type { OperatingSystem, Platform } from '#site/types/userAgent';
 export type InstallationMethod =
   | 'NVM'
   | 'FNM'
-  | 'VOLTA'
   | 'BREW'
   | 'DEVBOX'
   | 'DOCKER'

--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -197,16 +197,6 @@
       },
       "url": "https://github.com/tj/n",
       "info": "layouts.download.codeBox.platformInfo.n"
-    },
-    {
-      "id": "VOLTA",
-      "icon": "Volta",
-      "name": "Volta",
-      "compatibility": {
-        "os": ["WIN", "MAC", "LINUX"]
-      },
-      "url": "https://docs.volta.sh/guide/getting-started",
-      "info": "layouts.download.codeBox.platformInfo.volta"
     }
   ],
   "packageManagers": [


### PR DESCRIPTION
## Description

After 8 years of faithful and reliable service, Volta is no longer maintained. Consequently, this PR removes Volta from the recommended installation methods. o7

## Validation

Check that Volta is not in the dropdown list anymore on the `/en/download`

## Related Issues
None

### Check List


- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
