### PR TITLE
fix(ui): badge + breadcrumbs color contrast

### DIFF
--- a/packages/ui-components/src/Common/Badge/index.module.css
+++ b/packages/ui-components/src/Common/Badge/index.module.css
@@ -35,6 +35,6 @@
   }
 
   &.neutral {
-    @apply bg-neutral-600;
+    @apply bg-neutral-800;
   }
 }

--- a/packages/ui-components/src/Common/Breadcrumbs/BreadcrumbLink/index.module.css
+++ b/packages/ui-components/src/Common/Breadcrumbs/BreadcrumbLink/index.module.css
@@ -6,7 +6,7 @@
 
   &.active {
     @apply rounded
-      bg-green-600
+      bg-green-800
       px-2
       py-1
       font-semibold


### PR DESCRIPTION
## Description

This PR addresses color contrast accessibility issues on Previous Releases Page.

## Validation

Axe Report:

Before:
<img width="1512" height="465" alt="Screenshot 2025-12-30 at 3 52 47 PM" src="https://github.com/user-attachments/assets/a2f8e193-a7f7-41d1-b261-6271a6d1133e" />


After:
<img width="1512" height="465" alt="Screenshot 2025-12-30 at 3 53 20 PM" src="https://github.com/user-attachments/assets/dab73fe2-2688-4384-8335-7325201a5da0" />

## Related Issues

Fixes https://github.com/nodejs/nodejs.org/issues/8464

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
