### PR TITLE
fix(a11y): wrap SidebarItem with <li> in SidebarGroup

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.tsx
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.tsx
@@ -25,7 +25,9 @@ const SidebarGroup: FC<SidebarGroupProps> = ({
     <label className={styles.groupName}>{groupName}</label>
     <ul className={styles.itemList}>
       {items.map(({ label, link }) => (
-        <SidebarItem key={link} label={label} link={link} {...props} />
+        <li key={link}>
+          <SidebarItem label={label} link={link} {...props} />
+        </li>
       ))}
     </ul>
   </section>

--- a/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.tsx
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarGroup/index.tsx
@@ -25,9 +25,7 @@ const SidebarGroup: FC<SidebarGroupProps> = ({
     <label className={styles.groupName}>{groupName}</label>
     <ul className={styles.itemList}>
       {items.map(({ label, link }) => (
-        <li key={link}>
-          <SidebarItem label={label} link={link} {...props} />
-        </li>
+        <SidebarItem key={link} label={label} link={link} {...props} />
       ))}
     </ul>
   </section>

--- a/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.tsx
+++ b/packages/ui-components/src/Containers/Sidebar/SidebarItem/index.tsx
@@ -15,18 +15,20 @@ type SidebarItemProps = {
 };
 
 const SidebarItem: FC<SidebarItemProps> = ({ label, link, ...props }) => (
-  <BaseActiveLink
-    className={styles.item}
-    href={link}
-    activeClassName={styles.active}
-    {...props}
-  >
-    <div className={styles.label}>
-      <span>{label}</span>
+  <li>
+    <BaseActiveLink
+      className={styles.item}
+      href={link}
+      activeClassName={styles.active}
+      {...props}
+    >
+      <div className={styles.label}>
+        <span>{label}</span>
 
-      {/^https?:/.test(link) && <ArrowUpRightIcon className={styles.icon} />}
-    </div>
-  </BaseActiveLink>
+        {/^https?:/.test(link) && <ArrowUpRightIcon className={styles.icon} />}
+      </div>
+    </BaseActiveLink>
+  </li>
 );
 
 export default SidebarItem;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes an accessibility issue in the `Sidebar` navigation.  
Currently, sidebar items are placed directly inside `<ul>` without `<li>` wrappers, which breaks HTML list rules and causes accessibility errors.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation
Before the fix (invalid – direct `<a>` inside `<ul>`):

<img width="787" height="148" alt="530712270-c5d9d7f8-f13a-4cfc-9225-26bd71b74e3e" src="https://github.com/user-attachments/assets/08fd1682-a899-4c4f-ae3f-8757a91ca65a" />

After the fix (correct – wrapped in `<li>`):

<img width="790" height="305" alt="Sidebar Accessibilty Issue" src="https://github.com/user-attachments/assets/3578f955-64fd-4efa-818c-a04ca2648079" />


<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->


## Related Issues
#8465 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
