### PR TITLE
fix: ensure last sidebar item is visible when scrolling

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/index.module.css
@@ -10,7 +10,10 @@
     bg-white
     px-4
     py-6
-    sm:overflow-auto
+    sm:sticky
+    sm:top-16
+    sm:max-h-[calc(100vh-6.5rem)]
+    sm:overflow-y-auto
     sm:border-r
     md:max-w-xs
     lg:px-6


### PR DESCRIPTION
## Description

Fixed the sidebar scrolling issue where the last item ("Collecting code coverage in Node.js") was not visible unless the entire page was scrolled down. 

The sidebar now uses sticky positioning with a proper max-height calculation that accounts for the navbar height, allowing users to scroll within the sidebar independently of the page content and see all items.

**Changes made:**
- Added `sm:sticky` positioning to keep sidebar in viewport
- Added `sm:top-16` to position below navbar
- Set `sm:max-h-[calc(100vh-6.5rem)]` to constrain height accounting for navbar
- Changed to `sm:overflow-y-auto` for vertical scrolling

## Validation

**Before:** Last sidebar items were cut off when scrolling within the sidebar. Users had to scroll the entire page content to reveal them.

**After:** All sidebar items are now visible when scrolling within the sidebar itself, independent of page scroll position.

**Testing performed:**
- ✅ Verified last item "Collecting code coverage in Node.js" is now visible when scrolling sidebar to bottom
- ✅ Tested on Firefox 146.0.1 (where issue was originally reported)
- ✅ Tested on Chrome
- ✅ Verified with security banner present (as mentioned in original issue)

**File changed:** `packages/ui-components/src/Containers/Sidebar/index.module.css`

## Related Issues

Fixes #8521

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.