### PR TITLE
fix: update Devbox package name and fix Turkish snippet

### DIFF
--- a/apps/site/snippets/en/download/devbox.bash
+++ b/apps/site/snippets/en/download/devbox.bash
@@ -5,7 +5,7 @@ curl -fsSL https://get.jetify.com/devbox | bash
 devbox init
 
 # Download and install Node.js:
-devbox add node@${props.release.major}
+devbox add nodejs@${props.release.major}
 
 # Open a Devbox shell
 devbox shell


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR corrects the Devbox installation package name from node to nodejs across all localized download snippets. Currently, the download page provides instructions using `devbox add node@version`, but the official package name in the Nix/Devbox ecosystem is nodejs. Using node results in a package not found error.

```console
$ devbox add node@24 
Ensuring nixpkgs registry is downloaded.
error: getting status of '/Users/XXXX/Dev/nodejs.org/nixpkgs/677fbe97984e7af3175b6c121f3c39ee5c8d62c9': No such file or directory
Ensuring nixpkgs registry is downloaded: Fail
                                                                                                                                                                                                                                                                                                   
Error: Package node@24 not found                                                                                                                                                                                                                                                                                                  
```

Additionally, the Turkish instructions contained two problems:
- Typo in `devbox` command
- Missing comment hashes

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

The change was validated by cross-referencing the official Devbox package registry on Nixhub, which confirms that nodejs is the correct identifier for the runtime.

See: https://www.nixhub.io/packages/nodejs vs https://www.nixhub.io/packages/node

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

No related issue. This is a direct fix for incorrect installation instructions found on the /en/download page.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `pnpm format` to ensure the code follows the style guide.
- [X] I have run `pnpm test` to check if all tests are passing.
- [X] I have run `pnpm build` to check if the website builds without errors.
- [X] I've covered new added functionality with unit tests if necessary.
