### PR TITLE
fix(blog): remove duplicate blog title for jan 2026

### DIFF
--- a/apps/site/pages/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks.md
+++ b/apps/site/pages/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks.md
@@ -7,8 +7,6 @@ layout: blog-post
 author: Matteo Collina and Joyee Cheung
 ---
 
-# Mitigating Denial-of-Service Vulnerability from Unrecoverable Stack Space Exhaustion for React, Next.js, and APM Users
-
 ## TL;DR
 
 Node.js/V8 makes a best-effort attempt to recover from stack space exhaustion with a catchable error, which frameworks have come to rely on for service availability. A bug that only reproduces when `async_hooks` are used would break this attempt, causing Node.js to exit with 7 directly without throwing a catchable error when recursions in user code exhaust the stack space. This makes applications whose recursion depth is controlled by unsanitized input vulnerable to Denial-of-Service attacks. This silently affects countless applications because:


### PR DESCRIPTION

## Description

Removes duplicate blog title for January 2026 dos-mitigation-async-hooks

## Validation

Before:
<img width="1314" height="856" alt="Screenshot 2026-01-13 at 5 52 59 PM" src="https://github.com/user-attachments/assets/c63eb856-2510-4919-bec9-9d40851334ee" />


After:
<img width="1314" height="856" alt="Screenshot 2026-01-13 at 5 52 34 PM" src="https://github.com/user-attachments/assets/cc11c448-b81d-4c37-804a-b892b3770763" />


