### PR TITLE
fix(ui): Learn Page Landmark Accessibility issues

### DIFF
--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -1,5 +1,6 @@
 import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import Banner from '@node-core/ui-components/Common/Banner';
+import { useTranslations } from 'next-intl';
 
 import Link from '#site/components/Link';
 import { siteConfig } from '#site/next.json.mjs';
@@ -9,10 +10,20 @@ import type { FC } from 'react';
 
 const WithBanner: FC<{ section: string }> = ({ section }) => {
   const banner = siteConfig.websiteBanners[section];
+  const t = useTranslations();
 
   if (banner && dateIsBetween(banner.startDate, banner.endDate)) {
+    const ariaLabels = {
+      default: t('components.banner.announcement'),
+      warning: t('components.banner.warning'),
+      error: t('components.banner.error'),
+    } as const;
+
+    // Fallback to 'default' if no type is specified
+    const bannerType = banner.type || 'default';
+
     return (
-      <Banner type={banner.type}>
+      <Banner type={banner.type} aria-label={ariaLabels[bannerType]}>
         {banner.link ? (
           <Link href={banner.link}>{banner.text}</Link>
         ) : (

--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -13,17 +13,13 @@ const WithBanner: FC<{ section: string }> = ({ section }) => {
   const t = useTranslations();
 
   if (banner && dateIsBetween(banner.startDate, banner.endDate)) {
-    const ariaLabels = {
-      default: t('components.banner.announcement'),
-      warning: t('components.banner.warning'),
-      error: t('components.banner.error'),
-    } as const;
-
-    // Fallback to 'default' if no type is specified
     const bannerType = banner.type || 'default';
 
     return (
-      <Banner type={banner.type} aria-label={ariaLabels[bannerType]}>
+      <Banner
+        type={banner.type}
+        aria-label={t(`components.banner.${bannerType}`)}
+      >
         {banner.link ? (
           <Link href={banner.link}>{banner.text}</Link>
         ) : (

--- a/apps/site/components/withMetaBar.tsx
+++ b/apps/site/components/withMetaBar.tsx
@@ -44,6 +44,7 @@ const WithMetaBar: FC = () => {
     <MetaBar
       heading={t('components.metabar.tableOfContents')}
       as={Link}
+      aria-label={t('components.metabar.metadata')}
       items={{
         [t('components.metabar.lastUpdated')]: lastUpdated,
         [t('components.metabar.readingTime')]: readingTimeText,

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -280,7 +280,13 @@
       "contribute": "Contribute",
       "contributeText": "Edit this page",
       "viewAs": "View as",
-      "tableOfContents": "Table of Contents"
+      "tableOfContents": "Table of Contents",
+      "metadata": "Article metadata"
+    },
+    "banner": {
+      "announcement": "Announcement",
+      "warning": "Warning notification",
+      "error": "Error notification"
     },
     "search": {
       "searchPlaceholder": "Start typing...",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -284,7 +284,7 @@
       "metadata": "Article metadata"
     },
     "banner": {
-      "announcement": "Announcement",
+      "default": "Announcement",
       "warning": "Warning notification",
       "error": "Error notification"
     },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "exports": {
     "./*": [

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -12,7 +12,6 @@ const Banner: FC<PropsWithChildren<BannerProps>> = ({
 }) => (
   <section
     className={`${styles.banner} ${styles[type] || styles.default}`}
-    role="region"
     aria-label="Announcement"
   >
     {children}

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -1,18 +1,19 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, HTMLAttributes, PropsWithChildren } from 'react';
 
 import styles from './index.module.css';
 
 export type BannerProps = {
   type?: 'default' | 'warning' | 'error';
-};
+} & HTMLAttributes<HTMLElement>;
 
 const Banner: FC<PropsWithChildren<BannerProps>> = ({
   type = 'default',
   children,
+  ...props
 }) => (
   <section
     className={`${styles.banner} ${styles[type] || styles.default}`}
-    aria-label="Announcement"
+    {...props}
   >
     {children}
   </section>

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -10,9 +10,13 @@ const Banner: FC<PropsWithChildren<BannerProps>> = ({
   type = 'default',
   children,
 }) => (
-  <div className={`${styles.banner} ${styles[type] || styles.default}`}>
+  <section
+    className={`${styles.banner} ${styles[type] || styles.default}`}
+    role="region"
+    aria-label="Announcement"
+  >
     {children}
-  </div>
+  </section>
 );
 
 export default Banner;

--- a/packages/ui-components/src/Containers/MetaBar/index.tsx
+++ b/packages/ui-components/src/Containers/MetaBar/index.tsx
@@ -31,7 +31,7 @@ const MetaBar: FC<MetaBarProps> = ({
   );
 
   return (
-    <div className={styles.wrapper}>
+    <aside className={styles.wrapper} aria-label="Article metadata">
       <dl>
         {Object.entries(items)
           .filter(([, value]) => !!value)
@@ -65,7 +65,7 @@ const MetaBar: FC<MetaBarProps> = ({
           </>
         )}
       </dl>
-    </div>
+    </aside>
   );
 };
 

--- a/packages/ui-components/src/Containers/MetaBar/index.tsx
+++ b/packages/ui-components/src/Containers/MetaBar/index.tsx
@@ -2,7 +2,7 @@ import { Fragment, useMemo } from 'react';
 
 import type { LinkLike } from '#ui/types';
 import type { Heading } from '@vcarl/remark-headings';
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import styles from './index.module.css';
 
@@ -14,13 +14,14 @@ type MetaBarProps = {
   };
   as?: LinkLike;
   heading: string;
-};
+} & HTMLAttributes<HTMLElement>;
 
 const MetaBar: FC<MetaBarProps> = ({
   items,
   headings,
   as: Component = 'a',
   heading,
+  ...props
 }) => {
   // The default depth of headings to display in the table of contents.
   const { minDepth = 2, items: headingItems = [] } = headings || {};
@@ -31,7 +32,7 @@ const MetaBar: FC<MetaBarProps> = ({
   );
 
   return (
-    <aside className={styles.wrapper} aria-label="Article metadata">
+    <aside className={styles.wrapper} {...props}>
       <dl>
         {Object.entries(items)
           .filter(([, value]) => !!value)


### PR DESCRIPTION
## Description

Fixes Axe accessibility violations where Learn page content was not contained within semantic HTML landmarks.

## Changes Made
1. **MetaBar component** - Changed wrapper from `<div>` to `<aside>` element with `aria-label="Article metadata"`.
2. **Banner component** - Changed from `<div>` to `<section>` element with `role="region"` and `aria-label="Announcement"`.
3. As changes are in `ui-packages` directory, ran command: `pnpm version patch`


## Validation (Axe Report)

Before:
<img width="1510" height="589" alt="Screenshot 2026-01-14 at 11 33 18 PM" src="https://github.com/user-attachments/assets/e94f1826-dd12-4db9-ba4e-50b153d4ee8a" />


After:
<img width="1510" height="589" alt="Screenshot 2026-01-14 at 11 33 46 PM" src="https://github.com/user-attachments/assets/6d1be84d-e209-40e7-b2d9-a8885171e823" />


### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
