### PR TITLE
feat: Improve CodeTabs tab naming 

### DIFF
--- a/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
@@ -67,8 +67,8 @@ export default {
     children: <TabsContent />,
     defaultValue: 'mjs',
     tabs: [
-      { key: 'mjs', label: 'Example', secondaryLabel: 'MJS' },
-      { key: 'cjs', label: 'Example', secondaryLabel: 'CJS' },
+      { key: 'mjs', label: 'Example', extension: 'MJS' },
+      { key: 'cjs', label: 'Example', extension: 'CJS' },
     ],
   },
 } as Meta;

--- a/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
@@ -61,14 +61,23 @@ const TabsContent: FC = () => (
 
 export const Default: Story = {};
 
+export const WithExtension: Story = {
+  args: {
+    tabs: [
+      { key: 'mjs', label: 'Example', extension: 'MJS' },
+      { key: 'cjs', label: 'Example', extension: 'CJS' },
+    ],
+  },
+};
+
 export default {
   component: CodeTabs,
   args: {
     children: <TabsContent />,
     defaultValue: 'mjs',
     tabs: [
-      { key: 'mjs', label: 'Example', extension: 'MJS' },
-      { key: 'cjs', label: 'Example', extension: 'CJS' },
+      { key: 'mjs', label: 'Example' },
+      { key: 'cjs', label: 'Example' },
     ],
   },
 } as Meta;

--- a/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
@@ -67,8 +67,8 @@ export default {
     children: <TabsContent />,
     defaultValue: 'mjs',
     tabs: [
-      { key: 'mjs', label: 'MJS' },
-      { key: 'cjs', label: 'CJS' },
+      { key: 'mjs', label: 'Example', secondaryLabel: 'MJS' },
+      { key: 'cjs', label: 'Example', secondaryLabel: 'CJS' },
     ],
   },
 } as Meta;

--- a/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
+++ b/packages/ui-components/src/Common/CodeTabs/index.stories.tsx
@@ -76,8 +76,8 @@ export default {
     children: <TabsContent />,
     defaultValue: 'mjs',
     tabs: [
-      { key: 'mjs', label: 'Example' },
-      { key: 'cjs', label: 'Example' },
+      { key: 'mjs', label: 'MJS' },
+      { key: 'cjs', label: 'CJS' },
     ],
   },
 } as Meta;

--- a/packages/ui-components/src/Common/Tabs/index.module.css
+++ b/packages/ui-components/src/Common/Tabs/index.module.css
@@ -23,8 +23,15 @@
         dark:text-neutral-200;
 
       .tabSecondaryLabel {
-        @apply pl-1
+        @apply ml-1
+          rounded
+          border
+          border-neutral-500
+          px-1
+          py-0.5
+          text-xs
           text-neutral-500
+          dark:border-neutral-800
           dark:text-neutral-800;
       }
 
@@ -35,7 +42,9 @@
           dark:text-green-400;
 
         .tabSecondaryLabel {
-          @apply text-green-800
+          @apply border-green-800
+            text-green-800
+            dark:border-green-600
             dark:text-green-600;
         }
       }

--- a/packages/ui-components/src/Common/Tabs/index.module.css
+++ b/packages/ui-components/src/Common/Tabs/index.module.css
@@ -27,11 +27,11 @@
           rounded-xs
           border
           border-neutral-200
-          p-0.5
-          text-[10px]
+          px-1
+          py-0.5
+          text-xs
           font-normal
-          text-neutral-800
-          dark:text-neutral-200;
+          text-neutral-200;
       }
 
       .tabSecondaryLabel {
@@ -47,10 +47,8 @@
           dark:text-green-400;
 
         .tabExtension {
-          @apply border-green-600
-            text-green-600
-            dark:border-green-400
-            dark:text-green-400;
+          @apply border-green-400
+            text-green-400;
         }
 
         .tabSecondaryLabel {

--- a/packages/ui-components/src/Common/Tabs/index.module.css
+++ b/packages/ui-components/src/Common/Tabs/index.module.css
@@ -22,16 +22,21 @@
         text-neutral-800
         dark:text-neutral-200;
 
-      .tabSecondaryLabel {
+      .tabExtension {
         @apply ml-1
-          rounded
+          rounded-xs
           border
-          border-neutral-500
-          px-1
-          py-0.5
-          text-xs
+          border-neutral-200
+          p-0.5
+          text-[10px]
+          font-normal
+          text-neutral-800
+          dark:text-neutral-200;
+      }
+
+      .tabSecondaryLabel {
+        @apply pl-1
           text-neutral-500
-          dark:border-neutral-800
           dark:text-neutral-800;
       }
 
@@ -41,10 +46,15 @@
           dark:border-b-green-400
           dark:text-green-400;
 
+        .tabExtension {
+          @apply border-green-600
+            text-green-600
+            dark:border-green-400
+            dark:text-green-400;
+        }
+
         .tabSecondaryLabel {
-          @apply border-green-800
-            text-green-800
-            dark:border-green-600
+          @apply text-green-800
             dark:text-green-600;
         }
       }

--- a/packages/ui-components/src/Common/Tabs/index.tsx
+++ b/packages/ui-components/src/Common/Tabs/index.tsx
@@ -10,6 +10,7 @@ type Tab = {
   label: string;
   secondaryLabel?: string;
   value?: string;
+  extension?: string;
 };
 
 type TabsProps = TabsPrimitive.TabsProps & {
@@ -37,6 +38,9 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
           className={classNames(styles.tabsTrigger, triggerClassName)}
         >
           {tab.label}
+          {tab.extension ? (
+            <span className={styles.tabExtension}>{tab.extension}</span>
+          ) : null}
           {tab.secondaryLabel ? (
             <span className={styles.tabSecondaryLabel}>
               {tab.secondaryLabel}

--- a/packages/ui-components/src/Common/Tabs/index.tsx
+++ b/packages/ui-components/src/Common/Tabs/index.tsx
@@ -38,9 +38,9 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
           className={classNames(styles.tabsTrigger, triggerClassName)}
         >
           {tab.label}
-          {tab.extension ? (
+          {tab.extension && (
             <span className={styles.tabExtension}>{tab.extension}</span>
-          ) : null}
+          )}
           {tab.secondaryLabel ? (
             <span className={styles.tabSecondaryLabel}>
               {tab.secondaryLabel}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR updates the secondary label styling of the tab components to improve visual clarity and consistency. It also updates the Storybook examples to reflect the new design for easier reference and validation.
Relevant screenshots have been attached for comparison and review

#### Light mode:
<img width="1919" height="993" alt="image" src="https://github.com/user-attachments/assets/d289627b-e474-48b1-9b96-823bdfca0680" />


#### Dark mode :
<img width="1276" height="551" alt="image" src="https://github.com/user-attachments/assets/5bccb8b8-0dd5-477d-b529-5e913a678343" />




## Related Issues
Related to #8549 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
