### PR TITLE
chore: UX improvements

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "type": "module",
   "exports": {
     "./*": [

--- a/packages/ui-components/src/Common/AlertBox/index.module.css
+++ b/packages/ui-components/src/Common/AlertBox/index.module.css
@@ -50,6 +50,10 @@
       size-5;
   }
 
+  .content {
+    @apply wrap-anywhere;
+  }
+
   &.info {
     @apply bg-info-600;
 

--- a/packages/ui-components/src/Common/AlertBox/index.stories.tsx
+++ b/packages/ui-components/src/Common/AlertBox/index.stories.tsx
@@ -111,16 +111,6 @@ export const NoTitle: Story = {
   },
 };
 
-export default {
-  component: AlertBox,
-  argTypes: {
-    size: {
-      options: ['default', 'small'],
-      control: { type: 'radio' },
-    },
-  },
-} as Meta;
-
 export const SmallContainer: Story = {
   render: args => (
     <div className="w-200">
@@ -141,3 +131,58 @@ export const SmallContainer: Story = {
     size: 'default',
   },
 };
+
+export const WithLongContent: Story = {
+  args: {
+    level: 'warning',
+    title: 'Stability: 1',
+    children: (
+      <span>
+        Experimental. Please migrate away from this API, if you can. We do not
+        recommend using the{' '}
+        <a href="#async_hookscreatehookcallbacks">
+          <code>createHook</code>
+        </a>
+        ,{' '}
+        <a href="#class-asynchook">
+          <code>AsyncHook</code>
+        </a>
+        , and
+        <a href="#async_hooksexecutionasyncresource">
+          <code>executionAsyncResource</code>
+        </a>{' '}
+        APIs as they have usability issues, safety risks, and performance
+        implications. Async context tracking use cases are better served by the
+        stable{' '}
+        <a href="async_context.html#class-asynclocalstorage">
+          <code>AsyncLocalStorage</code>
+        </a>{' '}
+        API. If you have a use case for
+        <code>createHook</code>, <code>AsyncHook</code>, or{' '}
+        <code>executionAsyncResource</code> beyond the context tracking need
+        solved by{' '}
+        <a href="async_context.html#class-asynclocalstorage">
+          <code>AsyncLocalStorage</code>
+        </a>{' '}
+        or diagnostics data currently provided by{' '}
+        <a href="diagnostics_channel.html">Diagnostics Channel</a>, please open
+        an issue at{' '}
+        <a href="https://github.com/nodejs/node/issues">
+          https://github.com/nodejs/node/issues
+        </a>{' '}
+        describing your use case so we can create a more purpose-focused API.
+      </span>
+    ),
+    size: 'default',
+  },
+};
+
+export default {
+  component: AlertBox,
+  argTypes: {
+    size: {
+      options: ['default', 'small'],
+      control: { type: 'radio' },
+    },
+  },
+} as Meta;

--- a/packages/ui-components/src/Common/AlertBox/index.tsx
+++ b/packages/ui-components/src/Common/AlertBox/index.tsx
@@ -18,7 +18,7 @@ const AlertBox: FC<AlertBoxProps> = ({
 }) => (
   <div className={classNames(styles.alertBox, styles[level], styles[size])}>
     <span className={styles.title}>{title}</span>
-    <span>{children}</span>
+    <span className={styles.content}>{children}</span>
   </div>
 );
 

--- a/packages/ui-components/src/Common/Badge/index.module.css
+++ b/packages/ui-components/src/Common/Badge/index.module.css
@@ -37,4 +37,20 @@
   &.neutral {
     @apply bg-neutral-800;
   }
+
+  &.circular {
+    @apply font-ibm-plex-mono
+      inline-flex
+      items-center
+      justify-center
+      p-0;
+
+    &.small {
+      @apply size-5;
+    }
+
+    &.medium {
+      @apply size-7;
+    }
+  }
 }

--- a/packages/ui-components/src/Common/Badge/index.stories.tsx
+++ b/packages/ui-components/src/Common/Badge/index.stories.tsx
@@ -47,4 +47,21 @@ export const Medium: Story = {
   },
 };
 
+export const Circular: Story = {
+  args: {
+    circular: true,
+    children: 'D',
+    size: 'small',
+    kind: 'error',
+  },
+};
+
+export const MediumCircular: Story = {
+  args: {
+    circular: true,
+    children: 'E',
+    kind: 'warning',
+  },
+};
+
 export default { component: Badge, args: { children: 'Badge' } } as Meta;

--- a/packages/ui-components/src/Common/Badge/index.tsx
+++ b/packages/ui-components/src/Common/Badge/index.tsx
@@ -10,17 +10,25 @@ type BadgeSize = 'small' | 'medium';
 type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
   size?: BadgeSize;
   kind?: BadgeKind;
+  circular?: boolean;
 };
 
 const Badge: FC<PropsWithChildren<BadgeProps>> = ({
   kind = 'default',
   size = 'medium',
+  circular = false,
   className,
   children,
   ...props
 }) => (
   <span
-    className={classNames(styles.badge, styles[kind], styles[size], className)}
+    className={classNames(
+      styles.badge,
+      styles[kind],
+      styles[size],
+      { [styles.circular]: circular },
+      className
+    )}
     {...props}
   >
     {children}

--- a/packages/ui-components/src/Common/DataTag/index.module.css
+++ b/packages/ui-components/src/Common/DataTag/index.module.css
@@ -1,7 +1,8 @@
 @reference "../../styles/index.css";
 
 .dataTag {
-  @apply flex
+  @apply font-ibm-plex-mono
+    flex
     items-center
     justify-center
     rounded-full

--- a/packages/ui-components/src/Common/TableOfContents/index.module.css
+++ b/packages/ui-components/src/Common/TableOfContents/index.module.css
@@ -8,19 +8,39 @@
     lg:hidden
     dark:bg-neutral-900;
 
+  &[open] {
+    .icon {
+      @apply rotate-90;
+    }
+  }
+
   .summary {
-    @apply px-4
-      py-2;
+    @apply flex
+      list-none
+      items-center
+      gap-1
+      px-3.5
+      py-2.5;
+
+    &::-webkit-details-marker {
+      @apply hidden;
+    }
+
+    .icon {
+      @apply size-5;
+    }
   }
 
   .list {
     @apply space-y-1
       px-4
-      pb-2;
+      pb-2
+      wrap-anywhere;
   }
 
   .link {
-    @apply text-sm
+    @apply inline-block
+      text-sm
       font-semibold
       text-neutral-900
       underline

--- a/packages/ui-components/src/Common/TableOfContents/index.stories.tsx
+++ b/packages/ui-components/src/Common/TableOfContents/index.stories.tsx
@@ -60,6 +60,11 @@ export default {
         depth: 5, // h5s do not get shown
         data: { id: 'node-website' },
       },
+      {
+        value: 'ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION',
+        depth: 3,
+        data: { id: 'err_duplicate_startup_snapshot_main_function' },
+      },
     ],
   },
 } as Meta;

--- a/packages/ui-components/src/Common/TableOfContents/index.tsx
+++ b/packages/ui-components/src/Common/TableOfContents/index.tsx
@@ -1,3 +1,4 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 
 import { LinkLike } from '#ui/types';
@@ -35,7 +36,9 @@ const TableOfContents: FC<TableOfContentsProps> = ({
 
   return (
     <details className={classNames(styles.details, className)} {...props}>
-      <summary className={styles.summary}>{summaryTitle}</summary>
+      <summary className={styles.summary}>
+        <ChevronRightIcon className={styles.icon} /> {summaryTitle}
+      </summary>
       <ul className={styles.list}>
         {filteredHeadings.map((head, index) => (
           <li key={head.data?.id ?? index}>


### PR DESCRIPTION
## Description

With this PR, aiming to make some small UX improvements that I noticed while using the new `doc-kit` (some of them might be nitpicks 🙈 )

### AlerBox
<img width="389" height="683" alt="image" src="https://github.com/user-attachments/assets/dd9468ba-784d-4308-8563-0c6248c3293e" />

Links added inside the `AlertBox` can cause the content to overflow outside of the `AlertBox`

### Badge
<img width="355" height="91" alt="image" src="https://github.com/user-attachments/assets/3cfc3a89-ceab-4027-aba0-f6896bb895ce" />

The Badge component we use in the Sidebar isn’t circular, and its width changes depending on the text inside. I added a prop for single-character badges that makes the text monospace (also did on `DataTag`) and fixes the width and height, ensuring all badges are consistent with each other

### TableOfContents

<img width="391" height="462" alt="image" src="https://github.com/user-attachments/assets/ac697bb8-62ea-40dd-b5ba-fbc5ed19c06e" />

<img width="391" height="462" alt="image" src="https://github.com/user-attachments/assets/0c6af756-41e4-44fd-8404-998abbabeb5b" />

Because there’s no line break, some texts can overflow. In addition, when a line break is applied to lines with indents, ignores the indent.

And replaced the marker icon since it was causing issues on iOS and didn’t align with the design system

## Validation

The changes made in Storybook/Chromatic should appear without any issues

Example screenshots;
<img width="430" height="444" alt="image" src="https://github.com/user-attachments/assets/4ed2de8e-f780-420d-a5bc-d55e06caed6f" />

<img width="430" height="66" alt="image" src="https://github.com/user-attachments/assets/0d22eeb6-3d12-4d53-86cc-6e6704f2b81c" />

<img width="430" height="339" alt="image" src="https://github.com/user-attachments/assets/b5246938-c248-48c4-9427-67f467271db1" />

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
