### PR TITLE
Fix link for Single Executable Applications in v25.5.0 release post

### DIFF
--- a/apps/site/pages/en/blog/release/v25.5.0.md
+++ b/apps/site/pages/en/blog/release/v25.5.0.md
@@ -12,7 +12,7 @@ author: Antoine du Hamel
 
 #### Streamlined building process of Single Executable Applications (SEA)
 
-This release introduces a new `--build-sea` command-line flag that simplifies the process of building [Single Executable Applications (SEA)](https://nodejs.org/api/single-executable-application.html) using Node.js.
+This release introduces a new `--build-sea` command-line flag that simplifies the process of building [Single Executable Applications (SEA)](https://nodejs.org/api/single-executable-applications.html) using Node.js.
 
 Previously, SEA generation involved copying the executable, generating the preparation blob with `--experimental-sea-config`, and injecting the blob into the copy using [nodejs/postject](https://github.com/nodejs/postject). With the new `--build-sea` flag, these steps are now consolidated into a single step available from Node.js core.
 


### PR DESCRIPTION
Hello, found a broken link in the recent [release notes](https://nodejs.org/en/blog/release/v25.5.0). This fixes it.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Updates link to SEA docs in the recent blog post.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
