### PR TITLE
feat: enhance footer layout with powered by Alignment

### DIFF
--- a/apps/site/components/Common/Searchbox/Footer/index.module.css
+++ b/apps/site/components/Common/Searchbox/Footer/index.module.css
@@ -3,6 +3,7 @@
 .footer {
   @apply flex
     justify-center
+    gap-4
     border-t
     border-neutral-200
     bg-neutral-100
@@ -12,6 +13,11 @@
     lg:rounded-b-xl
     dark:border-neutral-900
     dark:bg-neutral-950;
+}
+
+.poweredByContainer {
+  @apply flex
+    justify-center;
 }
 
 .poweredByLink {

--- a/apps/site/components/Common/Searchbox/Footer/index.tsx
+++ b/apps/site/components/Common/Searchbox/Footer/index.tsx
@@ -46,7 +46,7 @@ export const Footer = () => {
           </span>
         </div>
       </div>
-      <div>
+      <div className={styles.poweredByContainer}>
         <a
           href="https://www.orama.com/?utm_source=nodejs.org&utm_medium=powered-by"
           target="_blank"


### PR DESCRIPTION
## Description
Fixes a visual alignment issue in the search dropdown footer where the “Orama” logo/text were not vertically aligned, making the footer look off in the search UI.
This change adjusts the footer layout/styles to keep the logo + text aligned consistently across browsers and screen sizes.

## Validation

- Click the search box to open the search dropdown.
- Check the footer section of the dropdown: the Orama logo and “Orama” text should be vertically aligned and evenly spaced.

Before : 
<img width="515" height="383" alt="Screenshot 2026-01-28 212247" src="https://github.com/user-attachments/assets/98e5f3ae-7e75-444a-bb23-1d3ab1e52f18" />

After : 
<img width="517" height="382" alt="Screenshot 2026-01-28 222119" src="https://github.com/user-attachments/assets/8de3b019-e355-4071-9e4b-a0d3bd29f4d2" />

## Related Issues
Fixes #8570 

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
