### PR TITLE
Update description of process.nextTick() behavior

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-processnexttick.md
@@ -9,7 +9,7 @@ authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais, ovflowd, marksist300
 As you try to understand the Node.js event loop, one important part of it is `process.nextTick()`.
 Every time the runtime calls back into JavaScript for an event, we call it a tick.
 
-When we pass a function to `process.nextTick()`, we instruct the engine to invoke this function immediately after the current operation completes, before moving to the next phase in the event loop:
+When we pass a function to `process.nextTick()`, we schedule it to run immediately after the current call stack completes, before the event loop continues and before any other queued tasks or phases are processed:
 
 ```js
 process.nextTick(() => {


### PR DESCRIPTION
Clarify the explanation of process.nextTick() in relation to the event loop: The phrase “before moving to the next phase” may be misleading, as it can imply that process.nextTick() waits for the current event-loop phase to complete. In reality, process.nextTick() callbacks run immediately after the current call stack empties, it doesn't wait for the current phase to end.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I changed the explanation a little bit about the process.nextTick(). The old version could cause misunderstanding.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
