### PR TITLE
Add missing `WORKER_SELF_REFERENCE` service binding to wrangler configuation

### DIFF
--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -12,6 +12,12 @@
     "binding": "ASSETS",
     "run_worker_first": true,
   },
+  "services": [
+    {
+      "binding": "WORKER_SELF_REFERENCE",
+      "service": "nodejs-website",
+    },
+  ],
   "vars": {
     // Variables needed for skew protection
     // Also note that an appropriate CF_WORKERS_SCRIPTS_API_TOKEN secret


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

As per the open-next docs, in the wrangler configuration there should be a `WORKER_SELF_REFERENCE` service binding (that is used by open-next for caching): https://opennext.js.org/cloudflare/get-started#3-create-a-wrangler-configuration-file

This PR is adding this service binding to the wrangler configuration since it is currently missing

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
