### PR TITLE
feat(ui): lessen padding of side bars

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "type": "module",
   "exports": {
     "./*": [

--- a/packages/ui-components/src/Containers/Article/index.module.css
+++ b/packages/ui-components/src/Containers/Article/index.module.css
@@ -1,8 +1,7 @@
 @reference "../../styles/index.css";
 
 .articleLayout {
-  @apply max-w-8xl
-    mx-auto
+  @apply mx-auto
     block
     w-full
     sm:grid


### PR DESCRIPTION
Alternate #8596.

This PR greatly reduces the padding of the side bars, giving the content more visibility on the page.

---
After:
<img width="1904" height="906" alt="image" src="https://github.com/user-attachments/assets/ecc00745-94f9-4fc6-a25b-21a7553998de" />
