### PR TITLE
fix: use fetchWithRetry for nodevu fetch calls

### DIFF
--- a/apps/site/next-data/generators/majorNodeReleases.mjs
+++ b/apps/site/next-data/generators/majorNodeReleases.mjs
@@ -2,11 +2,13 @@
 
 import nodevu from '@nodevu/core';
 
+import { fetchWithRetry } from '#site/util/fetch';
+
 /**
  * Filters Node.js release data to return only major releases with documented support.
  */
 export default async function getMajorNodeReleases() {
-  const nodevuData = await nodevu({ fetch });
+  const nodevuData = await nodevu({ fetch: fetchWithRetry });
 
   return Object.entries(nodevuData).filter(([version, { support }]) => {
     // Filter out those without documented support

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises';
-
 type RetryOptions = RequestInit & {
   maxRetry?: number;
   delay?: number;
@@ -28,7 +26,7 @@ export const fetchWithRetry = async (
         throw e;
       }
 
-      await setTimeout(delay * i);
+      await new Promise(resolve => setTimeout(resolve, delay * i));
     }
   }
 };

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -15,7 +15,7 @@ export const fetchWithRetry = async (
 ) => {
   for (let i = 1; i <= maxRetry; i++) {
     try {
-      return fetch(url, options);
+      return await fetch(url, options);
     } catch (e) {
       console.debug(
         `fetch of ${url} failed at ${Date.now()}, attempt ${i}/${maxRetry}`,

--- a/apps/site/util/fetch.ts
+++ b/apps/site/util/fetch.ts
@@ -3,11 +3,12 @@ type RetryOptions = RequestInit & {
   delay?: number;
 };
 
-type FetchError = {
-  cause: {
-    code: string;
-  };
-};
+const isTimeoutError = (e: unknown): boolean =>
+  e instanceof Error &&
+  typeof e.cause === 'object' &&
+  e.cause !== null &&
+  'code' in e.cause &&
+  e.cause.code === 'ETIMEDOUT';
 
 export const fetchWithRetry = async (
   url: string,
@@ -22,7 +23,7 @@ export const fetchWithRetry = async (
         e
       );
 
-      if (i === maxRetry || (e as FetchError).cause.code !== 'ETIMEDOUT') {
+      if (i === maxRetry || !isTimeoutError(e)) {
         throw e;
       }
 


### PR DESCRIPTION
## Description

Uses our standard fetch wrapper for the nodevu fetch calls, to help with issues we've been seeing coming from this specifically. Will automatically retry if a fetch call fails, while also logging which fetch call is actually causing the problem.

## Validation

nodevu data continues to load.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
