### PR TITLE
fix: add missing ESM/CJS tabs with their examples in Learn section

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/apps/site/pages/en/learn/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -110,8 +110,35 @@ For example, say you schedule a timeout to execute after a 100 ms
 threshold, then your script starts asynchronously reading a file which
 takes 95 ms:
 
-```js
+```cjs
 const fs = require('node:fs');
+
+function someAsyncOperation(callback) {
+  // Assume this takes 95ms to complete
+  fs.readFile('/path/to/file', callback);
+}
+
+const timeoutScheduled = Date.now();
+
+setTimeout(() => {
+  const delay = Date.now() - timeoutScheduled;
+
+  console.log(`${delay}ms have passed since I was scheduled`);
+}, 100);
+
+// do someAsyncOperation which takes 95 ms to complete
+someAsyncOperation(() => {
+  const startCallback = Date.now();
+
+  // do something that will take 10ms...
+  while (Date.now() - startCallback < 10) {
+    // do nothing
+  }
+});
+```
+
+```mjs
+import fs from 'node:fs';
 
 function someAsyncOperation(callback) {
   // Assume this takes 95ms to complete
@@ -259,11 +286,25 @@ timeout
 However, if you move the two calls within an I/O cycle, the immediate
 callback is always executed first:
 
-```js
+```cjs
 // timeout_vs_immediate.js
 const fs = require('node:fs');
 
 fs.readFile(__filename, () => {
+  setTimeout(() => {
+    console.log('timeout');
+  }, 0);
+  setImmediate(() => {
+    console.log('immediate');
+  });
+});
+```
+
+```mjs
+// timeout_vs_immediate.js
+import fs from 'node:fs';
+
+fs.readFile(import.meta.filename, () => {
   setTimeout(() => {
     console.log('timeout');
   }, 0);
@@ -453,7 +494,7 @@ allowing the connection event to be fired before the listening event.
 Another example is extending an `EventEmitter` and emitting an
 event from within the constructor:
 
-```js
+```cjs
 const EventEmitter = require('node:events');
 
 class MyEmitter extends EventEmitter {
@@ -469,14 +510,51 @@ myEmitter.on('event', () => {
 });
 ```
 
+```mjs
+import EventEmitter from 'node:events';
+
+class MyEmitter extends EventEmitter {
+  constructor() {
+    super();
+    this.emit('event');
+  }
+}
+
+const myEmitter = new MyEmitter();
+myEmitter.on('event', () => {
+  console.log('an event occurred!');
+});
+```
+
 You can't emit an event from the constructor immediately
+
 because the script will not have processed to the point where the user
 assigns a callback to that event. So, within the constructor itself,
 you can use `process.nextTick()` to set a callback to emit the event
 after the constructor has finished, which provides the expected results:
 
-```js
+```cjs
 const EventEmitter = require('node:events');
+
+class MyEmitter extends EventEmitter {
+  constructor() {
+    super();
+
+    // use nextTick to emit the event once a handler is assigned
+    process.nextTick(() => {
+      this.emit('event');
+    });
+  }
+}
+
+const myEmitter = new MyEmitter();
+myEmitter.on('event', () => {
+  console.log('an event occurred!');
+});
+```
+
+```mjs
+import EventEmitter from 'node:events';
 
 class MyEmitter extends EventEmitter {
   constructor() {

--- a/apps/site/pages/en/learn/asynchronous-work/javascript-asynchronous-programming-and-callbacks.md
+++ b/apps/site/pages/en/learn/asynchronous-work/javascript-asynchronous-programming-and-callbacks.md
@@ -96,8 +96,23 @@ How do you handle errors with callbacks? One very common strategy is to use what
 
 If there is no error, the object is `null`. If there is an error, it contains some description of the error and other information.
 
-```js
+```cjs
 const fs = require('node:fs');
+
+fs.readFile('/file.json', (err, data) => {
+  if (err) {
+    // handle error
+    console.log(err);
+    return;
+  }
+
+  // no errors, process data
+  console.log(data);
+});
+```
+
+```mjs
+import fs from 'node:fs';
 
 fs.readFile('/file.json', (err, data) => {
   if (err) {

--- a/apps/site/pages/en/learn/command-line/how-to-read-environment-variables-from-nodejs.md
+++ b/apps/site/pages/en/learn/command-line/how-to-read-environment-variables-from-nodejs.md
@@ -80,8 +80,17 @@ Because this method is invoked post-initialization, the setting of startup-relat
 PORT=1234
 ```
 
-```js
+```cjs
 const { loadEnvFile } = require('node:process');
+
+// Loads environment variables from the default .env file
+loadEnvFile();
+
+console.log(process.env.PORT); // Logs '1234'
+```
+
+```mjs
+import { loadEnvFile } from 'node:process';
 
 // Loads environment variables from the default .env file
 loadEnvFile();
@@ -91,7 +100,12 @@ console.log(process.env.PORT); // Logs '1234'
 
 You can also specify a custom path:
 
-```js
+```cjs
 const { loadEnvFile } = require('node:process');
+loadEnvFile('./config/.env');
+```
+
+```mjs
+import { loadEnvFile } from 'node:process';
 loadEnvFile('./config/.env');
 ```

--- a/apps/site/pages/en/learn/diagnostics/memory/understanding-and-tuning-memory.md
+++ b/apps/site/pages/en/learn/diagnostics/memory/understanding-and-tuning-memory.md
@@ -36,6 +36,14 @@ const heapSizeInGB = heap_size_limit / (1024 * 1024 * 1024);
 console.log(`${heapSizeInGB} GB`);
 ```
 
+```mjs
+import v8 from 'node:v8';
+const { heap_size_limit } = v8.getHeapStatistics();
+const heapSizeInGB = heap_size_limit / (1024 * 1024 * 1024);
+
+console.log(`${heapSizeInGB} GB`);
+```
+
 This will output the maximum heap size in gigabytes, which is based on your system's available memory.
 
 ### The Stack

--- a/apps/site/pages/en/learn/diagnostics/memory/using-gc-traces.md
+++ b/apps/site/pages/en/learn/diagnostics/memory/using-gc-traces.md
@@ -359,6 +359,33 @@ obs.observe({ entryTypes: ['gc'] });
 obs.disconnect();
 ```
 
+```mjs
+import { PerformanceObserver } from 'node:perf_hooks';
+
+// Create a performance observer
+const obs = new PerformanceObserver(list => {
+  const entry = list.getEntries()[0];
+  /*
+  The entry is an instance of PerformanceEntry containing
+  metrics of a single garbage collection event.
+  For example:
+  PerformanceEntry {
+    name: 'gc',
+    entryType: 'gc',
+    startTime: 2820.567669,
+    duration: 1.315709,
+    kind: 1
+  }
+  */
+});
+
+// Subscribe to notifications of GCs
+obs.observe({ entryTypes: ['gc'] });
+
+// Stop subscription
+obs.disconnect();
+```
+
 ### Examining a trace with performance hooks
 
 You can get GC statistics as [PerformanceEntry][] from the callback in

--- a/apps/site/pages/en/learn/diagnostics/memory/using-heap-snapshot.md
+++ b/apps/site/pages/en/learn/diagnostics/memory/using-heap-snapshot.md
@@ -73,8 +73,13 @@ For details, see the latest documentation of [heapsnapshot-signal flag][].
 If you need a snapshot from a working process, like an application running on a
 server, you can implement getting it using:
 
-```js
-require('v8').writeHeapSnapshot();
+```cjs
+require('node:v8').writeHeapSnapshot();
+```
+
+```mjs
+import { writeHeapSnapshot } from 'node:v8';
+writeHeapSnapshot();
 ```
 
 Check [`writeHeapSnapshot` docs][] for file name options.

--- a/apps/site/pages/en/learn/manipulating-files/writing-files-with-nodejs.md
+++ b/apps/site/pages/en/learn/manipulating-files/writing-files-with-nodejs.md
@@ -10,8 +10,22 @@ authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, clean99, ovf
 
 The easiest way to write to files in Node.js is to use the `fs.writeFile()` API.
 
-```js
+```cjs
 const fs = require('node:fs');
+
+const content = 'Some content!';
+
+fs.writeFile('/Users/joe/test.txt', content, err => {
+  if (err) {
+    console.error(err);
+  } else {
+    // file written successfully
+  }
+});
+```
+
+```mjs
+import fs from 'node:fs';
 
 const content = 'Some content!';
 
@@ -28,8 +42,21 @@ fs.writeFile('/Users/joe/test.txt', content, err => {
 
 Alternatively, you can use the synchronous version `fs.writeFileSync()`:
 
-```js
+```cjs
 const fs = require('node:fs');
+
+const content = 'Some content!';
+
+try {
+  fs.writeFileSync('/Users/joe/test.txt', content);
+  // file written successfully
+} catch (err) {
+  console.error(err);
+}
+```
+
+```mjs
+import fs from 'node:fs';
 
 const content = 'Some content!';
 
@@ -43,7 +70,7 @@ try {
 
 You can also use the promise-based `fsPromises.writeFile()` method offered by the `fs/promises` module:
 
-```js
+```cjs
 const fs = require('node:fs/promises');
 
 async function example() {
@@ -56,6 +83,17 @@ async function example() {
 }
 
 example();
+```
+
+```mjs
+import fs from 'node:fs/promises';
+
+try {
+  const content = 'Some content!';
+  await fs.writeFile('/Users/joe/test.txt', content);
+} catch (err) {
+  console.log(err);
+}
 ```
 
 By default, this API will **replace the contents of the file** if it does already exist.
@@ -85,8 +123,22 @@ Appending to files is handy when you don't want to overwrite a file with new con
 
 A handy method to append content to the end of a file is `fs.appendFile()` (and its `fs.appendFileSync()` counterpart):
 
-```js
+```cjs
 const fs = require('node:fs');
+
+const content = 'Some content!';
+
+fs.appendFile('file.log', content, err => {
+  if (err) {
+    console.error(err);
+  } else {
+    // done!
+  }
+});
+```
+
+```mjs
+import fs from 'node:fs';
 
 const content = 'Some content!';
 
@@ -103,7 +155,7 @@ fs.appendFile('file.log', content, err => {
 
 Here is a `fsPromises.appendFile()` example:
 
-```js
+```cjs
 const fs = require('node:fs/promises');
 
 async function example() {
@@ -116,4 +168,15 @@ async function example() {
 }
 
 example();
+```
+
+```mjs
+import fs from 'node:fs/promises';
+
+try {
+  const content = 'Some content!';
+  await fs.appendFile('/Users/joe/test.txt', content);
+} catch (err) {
+  console.log(err);
+}
 ```


### PR DESCRIPTION
## Description

This PR standardizes the code examples in en/learn section of the documentation to add the missing tabs for switching between ESM/CJS. I'd like to fix the other language docs as well whenever I get free time. Please do tell me if I missed any page in en/learn section.

## Validation

Manually verified that cjs and mjs code blocks are strictly adjacent in the markdown, which is the requirement for rehype-shiki to render the tabs correctly. Here is the visual change (visible in all changes pages):

### Original site: 
<img width="1366" height="680" alt="image" src="https://github.com/user-attachments/assets/bd62b8f9-b913-445d-b7fe-9cac6ec0d6a3" />

### [Deployed preview site](https://nodejs-ddxh3o32k-openjs.vercel.app/en/learn):
<img width="1366" height="690" alt="image" src="https://github.com/user-attachments/assets/0e5e1866-e6e6-4bb2-965f-20d94523ca3c" />


### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary. (N/A)
