### PR TITLE
docs: update explanation of setImmediate vs setTimeout

### DIFF
--- a/apps/site/pages/en/learn/asynchronous-work/understanding-setimmediate.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-setimmediate.md
@@ -20,7 +20,7 @@ How is `setImmediate()` different from `setTimeout(() => {}, 0)` (passing a 0ms 
 
 A function passed to `process.nextTick()` is going to be executed on the current iteration of the event loop, after the current operation ends. This means it will always execute before `setTimeout` and `setImmediate`.
 
-A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration of the event loop.
+A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration (the first one) of the event loop when called from the main module. When scheduled inside an I/O callback, setImmediate is guaranteed to run in the current iteration's Check phase, while setTimeout must wait for the Timers phase of the subsequent iteration.
 
 A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`. A `setTimeout`, `setImmediate` callback is added to `macrotask queue`.
 

--- a/apps/site/pages/en/learn/asynchronous-work/understanding-setimmediate.md
+++ b/apps/site/pages/en/learn/asynchronous-work/understanding-setimmediate.md
@@ -20,7 +20,7 @@ How is `setImmediate()` different from `setTimeout(() => {}, 0)` (passing a 0ms 
 
 A function passed to `process.nextTick()` is going to be executed on the current iteration of the event loop, after the current operation ends. This means it will always execute before `setTimeout` and `setImmediate`.
 
-A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration (the first one) of the event loop when called from the main module. When scheduled inside an I/O callback, setImmediate is guaranteed to run in the current iteration's Check phase, while setTimeout must wait for the Timers phase of the subsequent iteration.
+A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration (the first one) of the event loop when called from the main module. When scheduled inside an I/O callback, setImmediate is guaranteed to run in the current iteration's **check** phase, while setTimeout must wait for the **timers** phase of the subsequent iteration.
 
 A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`. A `setTimeout`, `setImmediate` callback is added to `macrotask queue`.
 


### PR DESCRIPTION
## Description

Clarifies the execution order of setTimeout and setImmediate when called from the main module and inside an I/O callback.

The current `they will be both run in the next iteration of the event loop` phrasing is confusing without the explicit context of where the code is run (main module vs I/O callback).

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
