### PR TITLE
chore(ui): use compiled exports by default

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -114,8 +114,8 @@ jobs:
         working-directory: packages/${{ matrix.package }}
         run: |
           # Check if a custom publish script exists in package.json
-          if jq -e '.scripts.release' package.json > /dev/null; then
-            pnpm run release
+          if jq -e '.scripts.compile' package.json > /dev/null; then
+            pnpm run compile
           fi
 
           # Then publish the package to npm

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "Bundler",
-    "customConditions": ["default"],
+    "customConditions": ["uncompiled"],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "exports": {
     "./*": {
-      "rolldown": [
+      "default": [
         "./dist/*",
         "./dist/*.js",
         "./dist/*/index.js"
       ],
-      "default": [
+      "uncompiled": [
         "./src/*",
         "./src/*.tsx",
         "./src/*/index.tsx",
@@ -28,7 +28,6 @@
     "compile:css": "postcss --dir dist --base src \"src/**/*.module.css\" src/styles/index.css",
     "compile": "node --run compile:ts && node --run compile:css",
     "compile:watch": "concurrently -k \"node --run compile:ts -- --watch\" \"node --run compile:css -- --watch\"",
-    "release": "node --run compile",
     "lint": "node --run lint:js && node --run lint:css",
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input --cache --cache-strategy=content --cache-location=.stylelintcache",
     "lint:css:fix": "node --run lint:css -- --fix",
@@ -90,12 +89,12 @@
   },
   "imports": {
     "#ui/*": {
-      "rolldown": [
+      "default": [
         "./dist/*",
         "./dist/*.js",
         "./dist/*/index.js"
       ],
-      "default": [
+      "uncompiled": [
         "./src/*",
         "./src/*.tsx",
         "./src/*/index.tsx",

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "customConditions": ["default"],
+    "customConditions": ["uncompiled"],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
It makes little sense to me why the version _not_ published to npm is the default. It should be the other way around.