### PR TITLE
fix: fixed statically indexed path for turbopack

### DIFF
--- a/apps/site/next.dynamic.mjs
+++ b/apps/site/next.dynamic.mjs
@@ -105,7 +105,7 @@ const getDynamicRouter = async () => {
     // meaning that the route exists on the website and can be rendered
     if (pathnameToFilename.has(normalizedPathname)) {
       const filename = pathnameToFilename.get(normalizedPathname);
-      const filepath = `${pagesDirectory}/${locale}/${filename}`;
+      const filepath = normalize(`${pagesDirectory}/${locale}/${filename}`);
 
       // We verify if our Markdown cache already has a cache entry for a localized
       // version of this file, because if not, it means that either

--- a/apps/site/next.dynamic.mjs
+++ b/apps/site/next.dynamic.mjs
@@ -55,6 +55,10 @@ const getDynamicRouter = async () => {
   // Keeps the map of pathnames to filenames
   const pathnameToFilename = new Map();
 
+  // Pre-compute the pages directory path to avoid Turbopack's overly broad
+  // file pattern analysis when using path.join() with dynamic segments
+  const pagesDirectory = join(process.cwd(), 'pages');
+
   const websitePages = await getMarkdownFiles(
     process.cwd(),
     `pages/${defaultLocale.code}`
@@ -101,7 +105,7 @@ const getDynamicRouter = async () => {
     // meaning that the route exists on the website and can be rendered
     if (pathnameToFilename.has(normalizedPathname)) {
       const filename = pathnameToFilename.get(normalizedPathname);
-      const filepath = join(process.cwd(), 'pages', locale, filename);
+      const filepath = `${pagesDirectory}/${locale}/${filename}`;
 
       // We verify if our Markdown cache already has a cache entry for a localized
       // version of this file, because if not, it means that either


### PR DESCRIPTION
This PR is a hot-fix to Next.js complaining about Turbopack being unable to correctly statically analyze paths:

```
@node-core/website:build: ./apps/site/next.dynamic.mjs:104:24
@node-core/website:build: The file pattern ('/ROOT/apps/site/pages/' <dynamic> '/' <dynamic> | '/ROOT/apps/site/pages' <dynamic> '/' <dynamic> | '/ROOT/apps/site/pages/' <dynamic> | '/ROOT/apps/site/pages' <dynamic>) matches 10104 files in [project]/apps/site
@node-core/website:build:   102 |     if (pathnameToFilename.has(normalizedPathname)) {
@node-core/website:build:   103 |       const filename = pathnameToFilename.get(normalizedPathname);
@node-core/website:build: > 104 |       const filepath = join(process.cwd(), 'pages', locale, filename);
@node-core/website:build:       |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@node-core/website:build:   105 |
@node-core/website:build:   106 |       // We verify if our Markdown cache already has a cache entry for a localized
@node-core/website:build:   107 |       // version of this file, because if not, it means that either
@node-core/website:build: 
@node-core/website:build: Overly broad patterns can lead to build performance issues and over bundling.
@node-core/website:build: 
@node-core/website:build: Import traces:
@node-core/website:build:   Server Component:
@node-core/website:build:     ./apps/site/next.dynamic.mjs
@node-core/website:build:     ./apps/site/app/[locale]/[...path]/page.tsx
@node-core/website:build: 
@node-core/website:build:   App Route:
@node-core/website:build:     ./apps/site/next.dynamic.mjs
@node-core/website:build:     ./apps/site/app/sitemap.ts
@node-core/website:build:     ./apps/site/app/sitemap--route-entry.js
```