### PR TITLE
fix: correct platform dropdown aria label key

### DIFF
--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -63,7 +63,7 @@ const PlatformDropdown: FC = () => {
       defaultValue={release.platform !== '' ? release.platform : undefined}
       loading={release.os === 'LOADING' || release.platform === ''}
       placeholder={t('layouts.download.dropdown.unknown')}
-      ariaLabel={t('layouts.download.dropdown.installMethod')}
+      ariaLabel={t('layouts.download.dropdown.platform')}
       onChange={platform => platform && release.setPlatform(platform)}
       className="min-w-28"
       inline={true}


### PR DESCRIPTION
## Description

Fixes the `ariaLabel` key used by the platform dropdown in downloads.

- changed `apps/site/components/Downloads/Release/PlatformDropdown.tsx` from `layouts.download.dropdown.installMethod` to `layouts.download.dropdown.platform`
- keeps the label aligned with the actual dropdown purpose (platform), improving accessibility semantics

## Validation

- reviewed the downloads dropdown components to confirm this key mismatch was isolated to `PlatformDropdown`
- attempted to run formatting checks, but local dependency setup was interrupted during `pnpm install --frozen-lockfile`, so `prettier` was unavailable locally
- CI should run the full lint/test/build checks on PR

## Related Issues

Related to accessibility consistency in downloads dropdown labeling

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
