### PR TITLE
docs: fix docker guide command line in TR translation

### DIFF
--- a/apps/site/snippets/tr/download/docker.bash
+++ b/apps/site/snippets/tr/download/docker.bash
@@ -1,7 +1,7 @@
 # Docker her işletim sistemi için özelleştirilmiş kurulum kılavuzu sunar.
 # Lütfen https://docker.com/get-started/ adresinde bulunan resmi belgelere göz atın.
 
-Node.js Docker imajını (kalıbını) çekin:
+# Node.js Docker imajını (kalıbını) çekin:
 docker pull node:${props.release.major}-${props.release.major >= 4 ? 'alpine' : 'slim'}
 
 # Bir Node.js konteyneri oluşturun ve bir Shell oturumu başlatın:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In Turkish translation, in Docker pulling the image guide, there is a command line that should be a comment line.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
