### PR TITLE
feat(ui-components): add Signature and FunctionSignature components

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "exports": {
     "./*": {

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.module.css
@@ -1,0 +1,40 @@
+@reference "../../../styles/index.css";
+
+.header {
+  @apply flex
+    items-start
+    gap-1;
+}
+
+.attribute {
+  @apply font-ibm-plex-mono
+    inline-flex
+    flex-wrap
+    items-center
+    gap-1
+    text-sm
+    font-semibold
+    break-all;
+
+  &.return {
+    @apply font-open-sans;
+
+    svg {
+      @apply size-4;
+    }
+  }
+}
+
+.type {
+  @apply font-ibm-plex-mono
+    inline-flex
+    flex-wrap
+    gap-0.5
+    text-sm
+    break-all;
+
+  a {
+    @apply text-green-700
+      dark:text-green-400;
+  }
+}

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.module.css
@@ -13,11 +13,16 @@
     items-center
     gap-1
     text-sm
-    font-semibold
-    break-all;
+    font-semibold;
+
+  .longName {
+    @apply break-all
+      sm:break-keep;
+  }
 
   &.return {
-    @apply font-open-sans;
+    @apply font-open-sans
+      shrink-0;
 
     svg {
       @apply size-4;

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
@@ -1,0 +1,48 @@
+import { ArrowTurnDownLeftIcon } from '@heroicons/react/24/outline';
+import classNames from 'classnames';
+
+import type Signature from '#ui/Common/Signature';
+import type { ComponentProps, FC } from 'react';
+
+import styles from './index.module.css';
+
+type SignatureHeaderProps = { isReturn?: boolean } & Omit<
+  ComponentProps<typeof Signature>,
+  'title' | 'description'
+>;
+
+const SignatureHeader: FC<SignatureHeaderProps> = ({
+  name,
+  type,
+  optional,
+  isReturn = false,
+}) => (
+  <div className={styles.header}>
+    {name && (
+      <span
+        className={classNames(styles.attribute, {
+          [styles.return]: isReturn,
+        })}
+      >
+        {isReturn && <ArrowTurnDownLeftIcon />}
+        <span>
+          {name}:
+          {optional && (
+            <span
+              className={styles.optional}
+              role="img"
+              aria-label="Optional"
+              data-tooltip="Optional"
+              tabIndex={0}
+            >
+              ?
+            </span>
+          )}
+        </span>
+      </span>
+    )}
+    {type && <span className={styles.type}>{type}</span>}
+  </div>
+);
+
+export default SignatureHeader;

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
@@ -26,14 +26,13 @@ const SignatureHeader: FC<SignatureHeaderProps> = ({
       >
         {isReturn && <ArrowTurnDownLeftIcon />}
         <span
-          className={classNames(styles.name, {
+          className={classNames({
             [styles.longName]: name.length > 16,
           })}
         >
           {name}:
           {optional && (
             <span
-              className={styles.optional}
               role="img"
               aria-label="Optional"
               data-tooltip="Optional"

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
@@ -25,7 +25,11 @@ const SignatureHeader: FC<SignatureHeaderProps> = ({
         })}
       >
         {isReturn && <ArrowTurnDownLeftIcon />}
-        <span>
+        <span
+          className={classNames(styles.name, {
+            [styles.longName]: name.length > 16,
+          })}
+        >
           {name}:
           {optional && (
             <span

--- a/packages/ui-components/src/Common/Signature/SignatureItem/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureItem/index.module.css
@@ -1,0 +1,50 @@
+@reference "../../../styles/index.css";
+
+.item {
+  @apply flex
+    flex-col
+    gap-1;
+}
+
+.return {
+  @apply rounded-sm
+    bg-green-100
+    px-4
+    py-3
+    dark:bg-neutral-900/40;
+}
+
+.children {
+  @apply relative
+    flex
+    flex-col
+    rounded-sm
+    border
+    border-neutral-200
+    dark:border-neutral-900;
+
+  &:has(> .return:only-child) {
+    @apply border-0;
+  }
+
+  &:not(:has(.return:only-child)) .return {
+    @apply mx-4
+      mb-3;
+  }
+
+  .item:not(.return) {
+    @apply mx-4
+      py-3;
+  }
+
+  .item:not(:last-child, :has(+ .return)) {
+    @apply border-b
+      border-neutral-200
+      dark:border-neutral-900;
+  }
+}
+
+.description {
+  @apply text-sm
+    break-all;
+}

--- a/packages/ui-components/src/Common/Signature/SignatureItem/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureItem/index.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames';
+
+import SignatureHeader from '#ui/Common/Signature/SignatureHeader';
+
+import type Signature from '#ui/Common/Signature';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+
+import styles from './index.module.css';
+
+type SignatureItemProps = Omit<ComponentProps<typeof Signature>, 'title'>;
+
+const SignatureItem: FC<PropsWithChildren<SignatureItemProps>> = ({
+  kind = 'default',
+  name,
+  type,
+  description,
+  optional,
+  children,
+}) => (
+  <div
+    className={classNames(styles.item, {
+      [styles.return]: kind === 'return',
+    })}
+  >
+    <SignatureHeader
+      name={name}
+      type={type}
+      optional={optional}
+      isReturn={kind === 'return'}
+    />
+    {description && <div className={styles.description}>{description}</div>}
+    {children && <div className={styles.children}>{children}</div>}
+  </div>
+);
+
+export default SignatureItem;

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
@@ -1,0 +1,24 @@
+@reference "../../../styles/index.css";
+
+.container {
+  @apply flex
+    flex-col
+    gap-3;
+}
+
+.title {
+  @apply text-base
+    font-semibold;
+}
+
+.root {
+  @apply flex
+    flex-col
+    gap-4
+    rounded-sm
+    border
+    border-neutral-200
+    px-4
+    py-3
+    dark:border-neutral-900;
+}

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.tsx
@@ -15,9 +15,9 @@ const SignatureRoot: FC<PropsWithChildren<SignatureRootProps>> = ({
 
   return (
     <section className={styles.container} aria-labelledby={titleId}>
-      <h3 className={styles.title} id={titleId}>
+      <div className={styles.title} id={titleId}>
         {title}
-      </h3>
+      </div>
       <div className={styles.root}>{children}</div>
     </section>
   );

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.tsx
@@ -1,0 +1,26 @@
+import { useId } from 'react';
+
+import type Signature from '#ui/Common/Signature';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+
+import styles from './index.module.css';
+
+type SignatureRootProps = Pick<ComponentProps<typeof Signature>, 'title'>;
+
+const SignatureRoot: FC<PropsWithChildren<SignatureRootProps>> = ({
+  title,
+  children,
+}) => {
+  const titleId = useId();
+
+  return (
+    <section className={styles.container} aria-labelledby={titleId}>
+      <h3 className={styles.title} id={titleId}>
+        {title}
+      </h3>
+      <div className={styles.root}>{children}</div>
+    </section>
+  );
+};
+
+export default SignatureRoot;

--- a/packages/ui-components/src/Common/Signature/index.stories.tsx
+++ b/packages/ui-components/src/Common/Signature/index.stories.tsx
@@ -1,16 +1,16 @@
-import FunctionDefinition from '#ui/Common/Signature';
+import Signature from '#ui/Common/Signature';
 
 import type { Meta as MetaObj, StoryObj } from '@storybook/react-webpack5';
 
-type Story = StoryObj<typeof FunctionDefinition>;
-type Meta = MetaObj<typeof FunctionDefinition>;
+type Story = StoryObj<typeof Signature>;
+type Meta = MetaObj<typeof Signature>;
 
 export const Default: Story = {
   args: {
     title: 'Attributes',
     children: (
       <>
-        <FunctionDefinition
+        <Signature
           name="attribute1"
           type={
             <>
@@ -18,27 +18,21 @@ export const Default: Story = {
             </>
           }
         />
-        <FunctionDefinition
+        <Signature
           name="attribute2"
           optional
           type={<a href="#">&lt;Object&gt;</a>}
           description="An optional attribute."
         >
-          <FunctionDefinition
-            name="option1"
-            type={<a href="#">&lt;Type3&gt;</a>}
-          />
-          <FunctionDefinition
-            name="option2"
-            type={<a href="#">&lt;Type3&gt;</a>}
-          />
-          <FunctionDefinition
+          <Signature name="option1" type={<a href="#">&lt;Type3&gt;</a>} />
+          <Signature name="option2" type={<a href="#">&lt;Type3&gt;</a>} />
+          <Signature
             name="option3"
             type={<a href="#">&lt;Type3&gt;</a>}
             description="One of the available options."
           />
-        </FunctionDefinition>
-        <FunctionDefinition
+        </Signature>
+        <Signature
           name="Returns"
           type={<a href="#">&lt;Type4&gt;</a>}
           description="Returns the result of the function."
@@ -54,7 +48,7 @@ export const WithLongAttributeNames: Story = {
     title: 'Attributes',
     children: (
       <>
-        <FunctionDefinition
+        <Signature
           name="thisIsAnAttributeWithAnExcessivelyLongNameToTestTextWrapping"
           type={
             <>
@@ -72,7 +66,7 @@ export const WithLongTypeAndAttributeNames: Story = {
     title: 'Attributes',
     children: (
       <>
-        <FunctionDefinition
+        <Signature
           name="attribute1"
           type={
             <>
@@ -91,7 +85,7 @@ export const OptionalAttribute: Story = {
   args: {
     title: 'Attributes',
     children: (
-      <FunctionDefinition
+      <Signature
         name="optionalAttribute"
         optional
         type={<a href="#">&lt;Object&gt;</a>}
@@ -102,5 +96,5 @@ export const OptionalAttribute: Story = {
 };
 
 export default {
-  component: FunctionDefinition,
+  component: Signature,
 } as Meta;

--- a/packages/ui-components/src/Common/Signature/index.stories.tsx
+++ b/packages/ui-components/src/Common/Signature/index.stories.tsx
@@ -1,0 +1,106 @@
+import FunctionDefinition from '#ui/Common/Signature';
+
+import type { Meta as MetaObj, StoryObj } from '@storybook/react-webpack5';
+
+type Story = StoryObj<typeof FunctionDefinition>;
+type Meta = MetaObj<typeof FunctionDefinition>;
+
+export const Default: Story = {
+  args: {
+    title: 'Attributes',
+    children: (
+      <>
+        <FunctionDefinition
+          name="attribute1"
+          type={
+            <>
+              <a href="#">&lt;Type1&gt;</a>|<a href="#">&lt;Type2&gt;</a>
+            </>
+          }
+        />
+        <FunctionDefinition
+          name="attribute2"
+          optional
+          type={<a href="#">&lt;Object&gt;</a>}
+          description="An optional attribute."
+        >
+          <FunctionDefinition
+            name="option1"
+            type={<a href="#">&lt;Type3&gt;</a>}
+          />
+          <FunctionDefinition
+            name="option2"
+            type={<a href="#">&lt;Type3&gt;</a>}
+          />
+          <FunctionDefinition
+            name="option3"
+            type={<a href="#">&lt;Type3&gt;</a>}
+            description="One of the available options."
+          />
+        </FunctionDefinition>
+        <FunctionDefinition
+          name="Returns"
+          type={<a href="#">&lt;Type4&gt;</a>}
+          description="Returns the result of the function."
+          kind="return"
+        />
+      </>
+    ),
+  },
+};
+
+export const WithLongAttributeNames: Story = {
+  args: {
+    title: 'Attributes',
+    children: (
+      <>
+        <FunctionDefinition
+          name="thisIsAnAttributeWithAnExcessivelyLongNameToTestTextWrapping"
+          type={
+            <>
+              <a href="#">&lt;Type1&gt;</a>|<a href="#">&lt;Type2&gt;</a>
+            </>
+          }
+        />
+      </>
+    ),
+  },
+};
+
+export const WithLongTypeAndAttributeNames: Story = {
+  args: {
+    title: 'Attributes',
+    children: (
+      <>
+        <FunctionDefinition
+          name="attribute1"
+          type={
+            <>
+              <a href="#">
+                &lt;ThisIsATypeWithAnExcessivelyLongNameToTestTextWrapping&gt;
+              </a>
+            </>
+          }
+        />
+      </>
+    ),
+  },
+};
+
+export const OptionalAttribute: Story = {
+  args: {
+    title: 'Attributes',
+    children: (
+      <FunctionDefinition
+        name="optionalAttribute"
+        optional
+        type={<a href="#">&lt;Object&gt;</a>}
+        description="An optional attribute."
+      />
+    ),
+  },
+};
+
+export default {
+  component: FunctionDefinition,
+} as Meta;

--- a/packages/ui-components/src/Common/Signature/index.tsx
+++ b/packages/ui-components/src/Common/Signature/index.tsx
@@ -1,0 +1,41 @@
+import SignatureItem from '#ui/Common/Signature/SignatureItem';
+import SignatureRoot from '#ui/Common/Signature/SignatureRoot';
+
+import type { FC, PropsWithChildren, ReactNode } from 'react';
+
+export type SignatureProps = {
+  title?: string;
+  kind?: 'default' | 'return';
+  name?: string;
+  type?: ReactNode;
+  description?: ReactNode;
+  optional?: boolean;
+};
+
+const Signature: FC<PropsWithChildren<SignatureProps>> = ({
+  kind = 'default',
+  name,
+  type,
+  description,
+  optional,
+  title,
+  children,
+}) => {
+  if (title) {
+    return <SignatureRoot title={title}>{children}</SignatureRoot>;
+  }
+
+  return (
+    <SignatureItem
+      kind={kind}
+      name={name}
+      type={type}
+      description={description}
+      optional={optional}
+    >
+      {children}
+    </SignatureItem>
+  );
+};
+
+export default Signature;

--- a/packages/ui-components/src/Containers/FunctionSignature/index.stories.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.stories.tsx
@@ -1,0 +1,152 @@
+import FunctionSignature from '#ui/Containers/FunctionSignature';
+
+import type { Meta as MetaObj, StoryObj } from '@storybook/react-webpack5';
+
+type Story = StoryObj<typeof FunctionSignature>;
+type Meta = MetaObj<typeof FunctionSignature>;
+
+export const Default: Story = {
+  args: {
+    title: 'Attributes',
+    items: [
+      {
+        name: 'streams',
+        type: (
+          <>
+            <a href="#">&lt;Stream[]&gt;</a>|<a href="#">&lt;Iterable[]&gt;</a>|
+            <a href="#">&lt;AsyncIterable[]&gt;</a>|
+            <a href="#">&lt;Function[]&gt;</a>
+          </>
+        ),
+      },
+      {
+        name: 'options',
+        optional: true,
+        type: <a href="#">&lt;Object&gt;</a>,
+        children: [
+          {
+            name: 'Signal',
+            type: <a href="#">&lt;AbortSignal&gt;</a>,
+          },
+          {
+            name: 'end',
+            type: <a href="#">&lt;boolean&gt;</a>,
+            description: (
+              <>
+                End the destination stream when the source stream ends.
+                Transform streams are always ended, even if this value is&nbsp;
+                false.<strong>Default:</strong> true.
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        name: 'Returns',
+        type: <a href="#">&lt;Promise&gt;</a>,
+        description: 'Fulfills when the pipeline is complete.',
+        kind: 'return',
+      },
+    ],
+  },
+};
+
+export const Nested: Story = {
+  args: {
+    title: 'Attributes',
+    items: [
+      {
+        name: 'source',
+        type: (
+          <>
+            <a href="#">&lt;Stream&gt;</a>|<a href="#">&lt;Iterable&gt;</a>|
+            <a href="#">&lt;AsyncIterable&gt;</a>|
+            <a href="#">&lt;Function&gt;</a>
+          </>
+        ),
+        children: [
+          {
+            name: 'attribute1',
+            type: <a href="#">&lt;Attribute1&gt;</a>,
+          },
+          {
+            name: 'attribute2',
+            type: <a href="#">&lt;Attribute2&gt;</a>,
+          },
+          {
+            name: 'attribute3',
+            type: <a href="#">&lt;Attribute3&gt;</a>,
+          },
+          {
+            name: 'Returns',
+            kind: 'return',
+            description: 'description',
+            type: (
+              <>
+                <a href="#">&lt;Promise&gt;</a>|
+                <a href="#">&lt;AsyncIterable&gt;</a>
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        name: '...transforms',
+        type: (
+          <>
+            <a href="#">&lt;Stream&gt;</a>|<a href="#">&lt;Function&gt;</a>
+          </>
+        ),
+        children: [
+          {
+            name: 'source',
+            description: 'description',
+            type: <a href="#">&lt;AsyncIterable&gt;</a>,
+            children: [
+              {
+                name: 'Returns',
+                kind: 'return',
+                description: 'description',
+                type: (
+                  <>
+                    <a href="#">&lt;Promise&gt;</a>|
+                    <a href="#">&lt;AsyncIterable&gt;</a>
+                  </>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const ReturnType: Story = {
+  args: {
+    items: [
+      {
+        name: 'Returns',
+        type: <a href="#">&lt;Promise&gt;</a>,
+        description: 'Fulfills when the pipeline is complete.',
+        kind: 'return',
+      },
+    ],
+  },
+};
+
+export const HasOnlyTypeDefinition: Story = {
+  args: {
+    title: 'Type',
+    items: [
+      {
+        type: <a href="#">&lt;Promise&gt;</a>,
+        description: 'A simple type definition.',
+      },
+    ],
+  },
+};
+
+export default {
+  component: FunctionSignature,
+} as Meta;

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -1,0 +1,42 @@
+import Signature from '#ui/Common/Signature';
+
+import type { ComponentProps, FC } from 'react';
+
+type SignatureDefinition = Omit<
+  ComponentProps<typeof Signature>,
+  'children'
+> & {
+  children?: Array<SignatureDefinition>;
+};
+
+type FunctionSignatureProps = {
+  title?: string;
+  items: Array<SignatureDefinition>;
+};
+
+const renderSignature = (param: SignatureDefinition, index: number) => (
+  <Signature
+    key={`${param.name}-${index}`}
+    name={param.name}
+    type={param.type}
+    optional={param.optional}
+    description={param.description}
+    kind={param.kind}
+  >
+    {param.children?.map((child, i) => renderSignature(child, i))}
+  </Signature>
+);
+
+const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
+  if (title) {
+    return (
+      <Signature title={title}>
+        {items.map((param, i) => renderSignature(param, i))}
+      </Signature>
+    );
+  }
+
+  return <>{items.map((param, i) => renderSignature(param, i))}</>;
+};
+
+export default FunctionSignature;

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -36,7 +36,7 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
     );
   }
 
-  return <>{items.map((param, i) => renderSignature(param, i))}</>;
+  return items.map((param, i) => renderSignature(param, i));
 };
 
 export default FunctionSignature;


### PR DESCRIPTION
## Description

Adds new `Signature` and  `FunctionSignature` components for rendering API function signatures with support for nested parameters, return types, and optional attributes.

Ref: https://github.com/nodejs/doc-kit/issues/587
Figma: https://www.figma.com/design/a10cjjw3MzvRQMPT9FP3xz/Node.js?node-id=6382-1517&t=T63PRMdf9tzlCrww-0

## Validation

<img width="837" height="386" alt="image" src="https://github.com/user-attachments/assets/cdf7be27-542e-4e5e-b867-a0cc28d0baef" />
<img width="837" height="386" alt="image" src="https://github.com/user-attachments/assets/dbb077d1-6de9-43fc-bc18-3e4a103978dc" />

## Related Issues

Related to https://github.com/nodejs/doc-kit/issues/587

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
