### PR TITLE
chore(remark-lint): better invalid type regex

### DIFF
--- a/packages/remark-lint/package.json
+++ b/packages/remark-lint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@node-core/remark-lint",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "exports": {
     ".": "./src/index.mjs",
     "./api": "./src/api.mjs"

--- a/packages/remark-lint/src/rules/__tests__/invalid-type-reference.test.mjs
+++ b/packages/remark-lint/src/rules/__tests__/invalid-type-reference.test.mjs
@@ -27,6 +27,11 @@ const testCases = [
     ],
   },
   {
+    name: 'newline, multiple references',
+    input: 'Psst, are you a {string|\nboolean}',
+    expected: [],
+  },
+  {
     name: 'invalid references',
     input: 'This is {invalid}.',
     expected: ['Invalid type reference: {invalid}'],

--- a/packages/remark-lint/src/rules/invalid-type-reference.mjs
+++ b/packages/remark-lint/src/rules/invalid-type-reference.mjs
@@ -3,8 +3,8 @@ import createQueries from '@nodejs/doc-kit/src/utils/queries/index.mjs';
 import { lintRule } from 'unified-lint-rule';
 import { visit } from 'unist-util-visit';
 
-const MATCH_RE = /\s\||\|\s/g;
-const REPLACE_RE = /\s*\|\s*/g;
+const MATCH_RE = /\s\||\| /g;
+const REPLACE_RE = /\s*\| */g;
 
 /**
  * Ensures that all type references are valid


### PR DESCRIPTION
In some cases in node core, a type can not fit on a single line, due to the length of the type. Thus, we should allow newlines to separate types, while still disallowing regular spaces.