### PR TITLE
fix(a11y): add lang attribute to language selector for better SR accessibility

### DIFF
--- a/packages/ui-components/src/Common/LanguageDropDown/index.stories.tsx
+++ b/packages/ui-components/src/Common/LanguageDropDown/index.stories.tsx
@@ -8,11 +8,31 @@ type Meta = MetaObj<typeof LanguageDropDown>;
 export const Default: Story = {
   args: {
     availableLanguages: [
-      { name: 'English', code: 'en', localName: 'English' },
-      { name: 'French', code: 'fr', localName: 'Français' },
-      { name: 'Spanish', code: 'es', localName: 'Español' },
+      { name: 'English', code: 'en', localName: 'English', hrefLang: 'en-GB' },
+      { name: 'French', code: 'fr', localName: 'Français', hrefLang: 'fr' },
+      { name: 'Spanish', code: 'es', localName: 'Español', hrefLang: 'es-ES' },
+      { name: 'Japanese', code: 'ja', localName: '日本語', hrefLang: 'ja' },
+      {
+        name: 'Simplified Chinese',
+        code: 'zh-cn',
+        localName: '简体中文',
+        hrefLang: 'zh-Hans',
+      },
+      {
+        name: 'Traditional Chinese',
+        code: 'zh-tw',
+        localName: '繁體中文',
+        hrefLang: 'zh-Hant',
+      },
     ],
     currentLanguage: 'en',
+  },
+};
+
+export const Japanese: Story = {
+  args: {
+    ...Default.args,
+    currentLanguage: 'ja',
   },
 };
 

--- a/packages/ui-components/src/Common/LanguageDropDown/index.tsx
+++ b/packages/ui-components/src/Common/LanguageDropDown/index.tsx
@@ -35,10 +35,11 @@ const LanguageDropdown: FC<LanguageDropDownProps> = ({
           sideOffset={5}
         >
           <div>
-            {availableLanguages.map(({ name, code, localName }) => (
+            {availableLanguages.map(({ name, code, localName, hrefLang }) => (
               <DropdownMenu.Item
                 key={code}
-                onClick={() => onChange({ name, code, localName })}
+                lang={hrefLang}
+                onClick={() => onChange({ name, code, localName, hrefLang })}
                 className={classNames(styles.dropDownItem, {
                   [styles.currentDropDown]: code === currentLanguage,
                 })}

--- a/packages/ui-components/src/Common/LanguageDropDown/index.tsx
+++ b/packages/ui-components/src/Common/LanguageDropDown/index.tsx
@@ -38,13 +38,15 @@ const LanguageDropdown: FC<LanguageDropDownProps> = ({
             {availableLanguages.map(({ name, code, localName, hrefLang }) => (
               <DropdownMenu.Item
                 key={code}
-                lang={hrefLang}
+                aria-label={name}
                 onClick={() => onChange({ name, code, localName, hrefLang })}
                 className={classNames(styles.dropDownItem, {
                   [styles.currentDropDown]: code === currentLanguage,
                 })}
               >
-                {localName}
+                <span lang={hrefLang} aria-hidden="true">
+                  {localName}
+                </span>
               </DropdownMenu.Item>
             ))}
           </div>

--- a/packages/ui-components/src/types.ts
+++ b/packages/ui-components/src/types.ts
@@ -22,4 +22,5 @@ export type SimpleLocaleConfig = {
   code: string;
   localName: string;
   name: string;
+  hrefLang: string;
 };


### PR DESCRIPTION
## Description
This PR fixes an accessibility issue where screen readers (like Windows Narrator, android Talk back) were unable to correctly announce language names in the language selector.

### Changes:
- Added `hrefLang` to the `SimpleLocaleConfig` type.
- Implemented the `lang` attribute on `DropdownMenu.Item` using the `hrefLang` property.
- Updated Storybook mock data and added localized examples (Japanese/Chinese) for verification.

### Manual Testing Recordings:
- English Language Selection (Narrator): [Watch chrome testing Video](https://www.awesomescreenshot.com/video/50054078?key=702d39acd857ca3b831ca4c364992fcd), [watch FF test](https://www.awesomescreenshot.com/video/50051862?key=7dea5e78f480ca43aee2e76ae5e91d9b)
- Japanese Language Selection (Narrator): [Watch chrome testing Video](https://www.awesomescreenshot.com/video/50054023?key=46e5fd7613ef4fc3a56a5e95eaaa18cc), [watch FF test](https://www.awesomescreenshot.com/video/50054244?key=54f92794ddece4c6eac88200c12d1e3d)
- TalkBack (Android): [chrome testing video](https://youtube.com/shorts/MzKT30cJczg?si=zjn7gcJYAcpzPePa)

> [!IMPORTANT]
> I have used the `hrefLang` property for the `lang` attribute instead of the internal `code` property.
> In this project, `code` is often used for internal routing and directory structures (e.g. zh-cn), whereas `hrefLang` contains best current practice language tags (e.g. zh-Hans). Using hrefLang ensures that screen readers receive the most accurate language hint for pronunciation.

closes #8668 

> [!NOTE]
> **Additional Testing Welcome**
> These changes have not been tested on macOS (VoiceOver). If any maintainer or contributor has access to a Mac, verification on VoiceOver would be very helpful to ensure consistent multilingual accessibility across all platforms.

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `pnpm format` to ensure the code follows the style guide.
- [X] I have run `pnpm test` to check if all tests are passing.
- [X] I have run `pnpm build` to check if the website builds without errors.
- [X] I've covered new added functionality with unit tests if necessary.
