### PR TITLE
fix: The "optional" label in the signature component is incorrectly positioned

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "exports": {
     "./*": {

--- a/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureHeader/index.tsx
@@ -30,7 +30,7 @@ const SignatureHeader: FC<SignatureHeaderProps> = ({
             [styles.longName]: name.length > 16,
           })}
         >
-          {name}:
+          {name}
           {optional && (
             <span
               role="img"
@@ -41,6 +41,7 @@ const SignatureHeader: FC<SignatureHeaderProps> = ({
               ?
             </span>
           )}
+          :
         </span>
       </span>
     )}


### PR DESCRIPTION
## Description

The "optional"(?) label in the signature component is incorrectly positioned.

Ref: https://github.com/nodejs/doc-kit/pull/637

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

Related to https://github.com/nodejs/doc-kit/pull/637