### PR TITLE
Feat 9(pt.json)  corrections in portuguese json file

### DIFF
--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -185,6 +185,41 @@
       "unsupportedVersionWarning": "Esta versão está fora de manutenção. Por favor, use uma versão com suporte. <link>Entender o Suporte EOL.</link>",
       "ltsVersionFeaturesNotice": "Quer novos recursos mais cedo? Obtenha a <link>versão mais recente do Node.js</link> e experimente as últimas melhorias!"
     },
+    "eolAlert": {
+      "message": "Suporte comercial para versões após a fase de LTS de Manutenção está disponível através dos nossos <link>parceiros do Programa de Sustentabilidade do Ecossistema OpenJS</link>"
+    },
+    "eolChip": {
+      "severity": {
+        "unknown": "Desconhecida",
+        "low": "Baixa",
+        "medium": "Média",
+        "high": "Alta",
+        "critical": "Crítica"
+      }
+    },
+    "eolModal": {
+      "title": "Node.js v{version} ({codename}) atingiu EOL",
+      "titleWithoutCodename": "Node.js v{version} atingiu EOL",
+      "vulnerabilitiesMessage": "Existem {count}+ problemas de segurança conhecidos (Common Vulnerabilities and Exposures ou CVEs) associados a esta versão do Node.js. CVEs são identificadores para falhas de segurança relatadas publicamente. Clicar num link CVE levará a detalhes mais técnicos, como o funcionamento da vulnerabilidade.",
+      "noVulnerabilitiesMessage": "Atualmente não há CVEs (Common Vulnerabilities and Exposures) conhecidas associadas a esta versão do Node.js. No entanto, isso não significa que seja completamente segura - algumas vulnerabilidades podem ainda não ter sido descobertas ou divulgadas publicamente. Se esta versão estiver desatualizada ou sem suporte, ainda é uma boa ideia considerar a atualização para garantir que se beneficia das últimas correções e melhorias de segurança.",
+      "blogLinkText": "Blogue",
+      "showUnknownSeverities": "Mostrar vulnerabilidades de gravidade desconhecida",
+      "table": {
+        "cves": "CVE(s)",
+        "severity": "Severidade",
+        "overview": "Visão geral",
+        "details": "Detalhes"
+      }
+    },
+    "eolTable": {
+      "version": "Versão",
+      "codename": "Nome de código",
+      "releaseDate": "Lançado em",
+      "lastUpdated": "Última atualização",
+      "vulnerabilities": "Vulnerabilidades",
+      "details": "Detalhes",
+      "hideNonLts": "Esconder versões que não são LTS"
+    },
     "pagination": {
       "next": "Próxima",
       "previous": "Anterior"

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -405,6 +405,7 @@
       },
       "codeBox": {
         "unsupportedVersionWarning": "Esta versão está fora de manutenção. Usar uma versão suportada atualmente. <link>Entender o Suporte do Fim da Vida.</link>",
+        "ltsVersionFeaturesNotice": "Quer novos recursos mais cedo? Obtenha a <link>versão mais recente do Node.js</link> e experimente as últimas melhorias!",
         "communityPlatformInfo": "Os métodos de instalação que envolvem software da comunidade são apoiados pelas equipas que mantêm esse software.",
         "externalSupportInfo": "Se encontrarmos quaisquer problemas, podemos visitar o <link>sítio da {platform}</link>",
         "noScriptDetected": "Esta página requer JavaScript. Nós podemos descarregar a Node.js sem JavaScript ao visitar diretamente a <link>página de lançamentos</link>.",

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -10,12 +10,21 @@
     },
     "containers": {
       "footer": {
+        "legal": "Copyright <foundationName>OpenJS Foundation</foundationName> e colaboradores do Node.js. Todos os direitos reservados. A <foundationName>OpenJS Foundation</foundationName> possui e utiliza marcas registadas. Para consultar a lista de marcas registadas da <foundationName>OpenJS Foundation</foundationName>, aceda à nossa <trademarkPolicy>Política de Marcas Registadas</trademarkPolicy> e à <trademarkList>Lista de Marcas Registadas</trademarkList>. Marcas registadas e logótipos não indicados na <trademarkList>lista de marcas registadas da OpenJS Foundation</trademarkList> são marcas comerciais™ ou marcas registadas® dos respetivos titulares. O uso dessas marcas não implica qualquer vínculo ou endosso por parte dos respetivos titulares.",
         "links": {
-          "trademarkPolicy": "Política da Marca Comercial",
+          "foundationName": "OpenJS Foundation",
+          "termsOfUse": "Termos de Uso",
           "privacyPolicy": "Política de Privacidade",
-          "versionSupport": "Suporte da Versão",
+          "bylaws": "Estatutos",
           "codeOfConduct": "Código de Conduta",
+          "trademarkPolicy": "Política de Marca Registada",
+          "trademarkList": "Lista de Marcas Registadas",
+          "cookiePolicy": "Política de Cookies",
           "security": "Política de Segurança"
+        },
+        "releasePills": {
+          "latestLTS": "LTS Mais Recente",
+          "latestRelease": "Versão Mais Recente"
         }
       },
       "navBar": {

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -276,8 +276,10 @@
         "label": "Selecionar o idioma"
       },
       "themeToggle": {
-        "label": "Alternar Modo Escuro"
-      }
+        "light": "Mudar para Modo Claro",
+        "dark": "Mudar para Modo Escuro"
+      },
+      "skipToContent": "Saltar para o conteúdo"
     },
     "metabar": {
       "lastUpdated": "Última Atualização",

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -171,6 +171,20 @@
       "status": "Estado",
       "details": "Detalhes"
     },
+    "downloadsTable": {
+      "fileName": "Nome do Ficheiro",
+      "operatingSystem": "SO",
+      "architecture": "Arquitetura"
+    },
+    "releaseModal": {
+      "title": "Node.js v{version} ({codename})",
+      "titleWithoutCodename": "Node.js v{version}",
+      "overview": "Visão Geral",
+      "minorVersions": "Versões menores",
+      "releaseAnnouncement": "Anúncio do Lançamento",
+      "unsupportedVersionWarning": "Esta versão está fora de manutenção. Por favor, use uma versão com suporte. <link>Entender o Suporte EOL.</link>",
+      "ltsVersionFeaturesNotice": "Quer novos recursos mais cedo? Obtenha a <link>versão mais recente do Node.js</link> e experimente as últimas melhorias!"
+    },
     "pagination": {
       "next": "Próxima",
       "previous": "Anterior"

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -220,6 +220,26 @@
       "details": "Detalhes",
       "hideNonLts": "Esconder versões que não são LTS"
     },
+    "minorReleasesTable": {
+      "version": "Versão",
+      "links": "Links",
+      "nApiVersion": "Versão N-API",
+      "npmVersion": "Versão npm",
+      "v8Version": "Versão V8",
+      "actions": {
+        "release": "Lançamento",
+        "changelog": "Registo de alterações",
+        "docs": "Documentação"
+      }
+    },
+    "releaseOverview": {
+      "firstReleased": "Primeiro lançamento",
+      "lastUpdated": "Última atualização",
+      "minorVersions": "Versões menores",
+      "nApiVersion": "Versão N-API",
+      "npmVersion": "Versão npm",
+      "v8Version": "Versão V8"
+    },
     "pagination": {
       "next": "Próxima",
       "previous": "Anterior"

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -290,7 +290,13 @@
       "contribute": "Colaborar",
       "contributeText": "Editar esta página",
       "viewAs": "Ver como",
-      "tableOfContents": "Índice"
+      "tableOfContents": "Índice",
+      "metadata": "Metadados do Artigo"
+    },
+    "banner": {
+      "default": "Anúncio",
+      "warning": "Alerta",
+      "error": "Erro"
     },
     "search": {
       "searchBox": {

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -416,6 +416,7 @@
           "brew": "Homebrew é um gestor de pacote para macOS e Linux.",
           "choco": "Chocolatey é um gestor de pacote para Windows.",
           "docker": "Docker é uma plataforma de contentorização.",
+          "n": "\"n\" é um gestor de versão de Node.js multiplataforma.",
           "volta": "\"Volta\" é um gestor de versão de Node.js multiplataforma."
         }
       }

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -299,8 +299,30 @@
       "error": "Erro"
     },
     "search": {
-      "searchBox": {
-        "placeholder": "Pesquisar..."
+      "searchPlaceholder": "Comece a digitar...",
+      "chatPlaceholder": "Pergunte-me qualquer coisa",
+      "noResultsFoundFor": "Nenhum resultado encontrado para",
+      "suggestions": "Sugestões",
+      "seeAll": "Ver tudo",
+      "addMore": "Adicionar mais",
+      "clearChat": "Limpar chat",
+      "errorMessage": "Ocorreu um erro ao tentar pesquisar. Por favor, tente novamente.",
+      "disclaimer": "Resumos de IA podem cometer erros. Por favor, verifique as informações.",
+      "startYourSearch": "Inicie a sua pesquisa",
+      "initErrorSearch": "Não foi possível inicializar o serviço de pesquisa",
+      "initErrorChat": "Não foi possível inicializar o serviço de chat",
+      "chatButtonLabel": "Obter um resumo de IA",
+      "searchButtonLabel": "Pesquisar",
+      "poweredBy": "Fornecido por",
+      "suggestionOne": "Como instalar Node.js?",
+      "suggestionTwo": "Como criar um servidor HTTP?",
+      "suggestionThree": "Atualizar a versão do Node.js",
+      "scrollToBottom": "Rolar para o final",
+      "closeChat": "Fechar chat",
+      "keyboardShortcuts": {
+        "select": "para selecionar",
+        "navigate": "para navegar",
+        "close": "para fechar"
       }
     },
     "blog": {

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -1,5 +1,13 @@
 {
   "components": {
+    "header": {
+      "buttons": {
+        "theme": "Selecionar tema",
+        "themeSystem": "Sistema",
+        "themeLightMode": "Claro",
+        "themeDarkMode": "Escuro"
+      }
+    },
     "containers": {
       "footer": {
         "links": {

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -158,7 +158,9 @@
           "branding": "Marca da Node.js",
           "governance": "Gestão do Projeto",
           "releases": "Lançamentos da Node.js",
-          "security": "Relatórios de Segurança"
+          "security": "Relatórios de Segurança",
+          "partners": "Parceiros e Apoiadores",
+          "eol": "Fim de Vida Útil (EOL)"
         }
       },
       "getInvolved": {
@@ -369,6 +371,7 @@
         "video": "Vídeo",
         "weekly": "Atualizações Semanais",
         "wg": "Grupos de Trabalho",
+        "migrations": "Guias de Migração",
         "events": "Eventos"
       }
     },

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -61,7 +61,8 @@
             "profiling": "Definição de Perfis de Aplicações de Node.js",
             "fetch": "Obter dados com a Node.js",
             "websocket": "Cliente de WebSocket com a Node.js",
-            "securityBestPractices": "Boas Práticas de Segurança"
+            "securityBestPractices": "Boas Práticas de Segurança",
+            "userlandMigrations": "Introdução às Migrações Userland"
           }
         },
         "typescript": {
@@ -77,10 +78,11 @@
         "asynchronousWork": {
           "links": {
             "asynchronousWork": "Trabalho Assíncrono",
-            "asynchronousFlowControl": "Controlo do Fluxo Assíncrono",
-            "overviewOfBlockingVsNonBlocking": "Visão Geral de Bloqueante vs Não Bloqueante",
             "javascriptAsynchronousProgrammingAndCallbacks": "Programação Assíncrona de JavaScript e Funções de Resposta",
+            "asynchronousFlowControl": "Controlo do Fluxo Assíncrono",
+            "discoverPromisesInNodejs": "Descobrir Promises no Node.js",
             "discoverJavascriptTimers": "Descobrir os Temporizadores da JavaScript",
+            "overviewOfBlockingVsNonBlocking": "Visão Geral de Bloqueante vs Não Bloqueante",
             "eventLoopTimersAndNexttick": "O Ciclo de Evento da Node.js",
             "theNodejsEventEmitter": "O Emissor de Evento da Node.js",
             "understandingProcessnexttick": "Entendendo o process.nextTick()",
@@ -104,10 +106,17 @@
           "links": {
             "commandLine": "Linha de Comando",
             "runNodejsScriptsFromTheCommandLine": "Execute scripts de Node.js através da linha de comandos",
-            "howToReadEnvironmentVariablesFromNodejs": "Como Ler Variáveis de Ambiente no Node.js",
             "howToUseTheNodejsRepl": "Como Usar o REPL do Node.js",
             "outputToTheCommandLineUsingNodejs": "Saída para a linha de comando usando o Node.js",
-            "acceptInputFromTheCommandLineInNodejs": "Aceitar entrada na linha de comando no Node.js"
+            "acceptInputFromTheCommandLineInNodejs": "Aceitar entrada na linha de comando no Node.js",
+            "howToReadEnvironmentVariablesFromNodejs": "Como Ler Variáveis de Ambiente no Node.js"
+          }
+        },
+        "http": {
+          "links": {
+            "http": "HTTP",
+            "anatomyOfAnHttpTransaction": "Anatomia de uma Transação HTTP",
+            "enterpriseNetworkConfiguration": "Configuração de Rede para Ambientes Empresariais"
           }
         },
         "modules": {
@@ -126,6 +135,7 @@
             "diagnostics": "Diagnósticos",
             "userJourney": "Jornada do Utilizador",
             "memory": "Memória",
+            "understandingAndTuningMemory": "Compreender e Ajustar Memória",
             "liveDebugging": "Depuração em Direto",
             "poorPerformance": "Desempenho Deficiente",
             "flameGraphs": "Gráficos de Chamas"
@@ -136,7 +146,8 @@
             "testRunner": "Executor de Teste",
             "introduction": "Descobrir o executor de teste da Node.js",
             "usingTestRunner": "Usar o executor de teste da Node.js",
-            "mocking": "Simulação em Testes"
+            "mocking": "Simulação em Testes",
+            "collectingCodeCoverage": "Recolher cobertura de código no Node.js"
           }
         }
       },

--- a/packages/i18n/src/locales/pt.json
+++ b/packages/i18n/src/locales/pt.json
@@ -166,11 +166,10 @@
       "npmVersion": "npm",
       "codename": "Nome de código",
       "releaseDate": "Lançado em",
-      "actions": {
-        "changelog": "Registo de alterações",
-        "releases": "Lançamentos",
-        "docs": "Documentação"
-      }
+      "firstReleased": "Primeiro lançamento",
+      "lastUpdated": "Última atualização",
+      "status": "Estado",
+      "details": "Detalhes"
     },
     "pagination": {
       "next": "Próxima",


### PR DESCRIPTION
## Description

As a Brazilian, I noticed some problems related to the website's Portuguese translation; the pt.json file is extremely incomplete regarding other language settings.

This PR completes and corrects the European Portuguese (`pt`) locale by aligning `packages/i18n/src/locales/pt.json` with the existing `en` and `pt-br` locales. It adds missing navigation labels (including “Partners” and “EOL”), the `migrations` blog category, and fills gaps in the downloads page strings such as the LTS notice and the `n` platform description.

## Validation

- Confirmed that `packages/i18n/src/locales/pt.json` is valid JSON.
- Verified that the About navigation renders the new “Partners” and “EOL” links in Portuguese.
- Verified that the blog category filter shows the “Migrations” category in Portuguese.
- Verified that the downloads page renders the new LTS notice and `n` platform description for the `pt` locale without runtime errors.

## Related Issues

- N/A  
  <!-- Or: Fixes #1234 / Addresses #1234 if there is a tracking issue -->

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.