### PR TITLE
fix(doc-kit): 'property' to the code like array

### DIFF
--- a/packages/ui-components/src/constants.ts
+++ b/packages/ui-components/src/constants.ts
@@ -3,4 +3,5 @@ export const CODE_LIKE_TYPES = new Set([
   'classMethod',
   'function',
   'ctor',
+  'property',
 ]);


### PR DESCRIPTION
Fixes partially code-like text, i.e.:
<img width="236" height="357" alt="image" src="https://github.com/user-attachments/assets/20160756-54e0-46b1-a76e-e4ebe096feec" />
