### PR TITLE
refactor: FunctionSignature return type container

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "exports": {
     "./*": {

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
@@ -12,7 +12,8 @@
 }
 
 .root {
-  @apply flex
+  @apply mb-1
+    flex
     flex-col
     gap-4
     rounded-sm

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
@@ -12,7 +12,7 @@
 }
 
 .root {
-  @apply mb-1
+  @apply mb-3
     flex
     flex-col
     gap-4

--- a/packages/ui-components/src/Containers/FunctionSignature/index.stories.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.stories.tsx
@@ -118,6 +118,17 @@ export const Nested: Story = {
           },
         ],
       },
+      {
+        name: 'Returns',
+        kind: 'return',
+        description: 'description',
+        type: (
+          <>
+            <a href="#">&lt;Promise&gt;</a>|
+            <a href="#">&lt;AsyncIterable&gt;</a>
+          </>
+        ),
+      },
     ],
   },
 };

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -41,13 +41,11 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
         <Signature title={title}>
           {attributes.map((param, i) => renderSignature(param, i))}
         </Signature>
-        {returnTypes.length > 0 && (
-          <Signature>
-            {returnTypes.map((param, i) =>
-              renderSignature(param, attributes.length + i)
-            )}
-          </Signature>
-        )}
+
+        {returnTypes.length > 0 &&
+          returnTypes.map((param, i) =>
+            renderSignature(param, attributes.length + i)
+          )}
       </>
     );
   }

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -33,7 +33,9 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
     const returnTypes: Array<SignatureDefinition> = [];
 
     for (const item of items) {
-      (item.kind === 'return' ? returnTypes : attributes).push(item);
+      const target = item.kind === 'return' ? returnTypes : attributes;
+
+      target.push(item);
     }
 
     return (

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -43,7 +43,9 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
         </Signature>
         {returnTypes.length > 0 && (
           <Signature>
-            {returnTypes.map((param, i) => renderSignature(param, i))}
+            {returnTypes.map((param, i) =>
+              renderSignature(param, attributes.length + i)
+            )}
           </Signature>
         )}
       </>

--- a/packages/ui-components/src/Containers/FunctionSignature/index.tsx
+++ b/packages/ui-components/src/Containers/FunctionSignature/index.tsx
@@ -29,10 +29,24 @@ const renderSignature = (param: SignatureDefinition, index: number) => (
 
 const FunctionSignature: FC<FunctionSignatureProps> = ({ title, items }) => {
   if (title) {
+    const attributes: Array<SignatureDefinition> = [];
+    const returnTypes: Array<SignatureDefinition> = [];
+
+    for (const item of items) {
+      (item.kind === 'return' ? returnTypes : attributes).push(item);
+    }
+
     return (
-      <Signature title={title}>
-        {items.map((param, i) => renderSignature(param, i))}
-      </Signature>
+      <>
+        <Signature title={title}>
+          {attributes.map((param, i) => renderSignature(param, i))}
+        </Signature>
+        {returnTypes.length > 0 && (
+          <Signature>
+            {returnTypes.map((param, i) => renderSignature(param, i))}
+          </Signature>
+        )}
+      </>
     );
   }
 


### PR DESCRIPTION
## Description
As discussed on [Slack](https://openjs-foundation.slack.com/archives/C09EXEEHFKP/p1772890087617509?thread_ts=1772889869.732879&cid=C09EXEEHFKP), this PR includes moving the first return in the `FunctionSignature` component outside of the container.

## Validation

<img width="1032" height="359" alt="image" src="https://github.com/user-attachments/assets/ce8704b1-4dd1-4b3d-8c88-6342fde69177" />
