### PR TITLE
feat(navigation): don't render `navItems` when no children

### DIFF
--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -74,7 +74,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
           tabIndex={-1}
         />
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
-          {navItems && navItems.length > 0 &&(
+          {navItems && navItems.length > 0 && (
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (
                 <NavItem

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -73,9 +73,9 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
           aria-label={sidebarItemTogglerAriaLabel}
           tabIndex={-1}
         />
-
+        
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
-          {navItems?.length > 0 && (
+          {navItems && navItems.length > 0 &&(
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (
                 <NavItem

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -73,7 +73,6 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
           aria-label={sidebarItemTogglerAriaLabel}
           tabIndex={-1}
         />
-        
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
           {navItems && navItems.length > 0 &&(
             <div className={styles.navItems}>

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -75,7 +75,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         />
 
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
-          {navItems && (
+          {!!navItems?.length && (
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (
                 <NavItem

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -75,7 +75,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         />
 
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
-          {!!navItems?.length && (
+          {navItems?.length > 0 && (
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (
                 <NavItem


### PR DESCRIPTION

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes an issue where an unwanted empty space was rendered in the mobile navigation menu when the navigation bar did not contain any child elements. It resolves this by ensuring the `navItems` container is only rendered when the `navItems` array has a length greater than zero.

## Validation

To verify this change, visually inspect the mobile navigation menu on a page or configuration where `navItems` is empty or not provided. The menu should no longer contain an empty padded area at the bottom. 

## Related Issues

Fixes #8719

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
