### PR TITLE
fix: remove empty padding in mobile navbar when navItems is empty

### DIFF
--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -75,7 +75,7 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         />
 
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
-          {navItems && (
+          {navItems && navItems.length > 0 && (
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (
                 <NavItem


### PR DESCRIPTION
Description

This PR fixes the issue where the mobile navigation shows empty padding when the NavBar does not contain any children.

Solution

Added a conditional check before rendering the navbar so it only renders when navigation items exist.

navItems && navItems.length > 0

This prevents the navbar container from rendering when there are no items, removing the extra empty padding in the mobile navigation.

Fixes #8719
