### PR TITLE
fix(ui-components): reduce empty search state padding

### DIFF
--- a/packages/ui-components/src/Common/Search/Results/Empty/index.module.css
+++ b/packages/ui-components/src/Common/Search/Results/Empty/index.module.css
@@ -2,11 +2,10 @@
 
 .noResultsWrapper {
   @apply flex
-    h-full
     items-center
     justify-center
     pt-10
-    pb-31
+    pb-6
     text-sm
     text-neutral-800
     dark:text-neutral-500;


### PR DESCRIPTION
## Description

The search modal shows a large blank space below the "No results found" message when a search returns no results.

The root cause was in `.noResultsWrapper` inside `Search/Results/Empty`:

- `h-full` — stretched the wrapper to the full parent height, expanding the empty area
- `pb-31` (7.75rem / 124px) — excessive bottom padding originally used as a visual centering trick for full-screen mobile, but creates a large visible blank gap on desktop

**Fix:** Remove `h-full` and reduce `pb-31` → `pb-6` (1.5rem). The wrapper now sizes to its content and the modal stays compact.

## Validation

1. Open the search modal (`Ctrl+K`)
2. Type a query that returns no results
3. The "No results found for X" message appears without the large blank space below it
4. Modal still looks correct when results are present
5. Both light and dark mode unaffected

Related investigation and earlier fix attempts in nodejs/doc-kit#674.

## Related Issues

Addresses nodejs/doc-kit#670

### Check List

-  [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
