### PR TITLE
fix(ui): empty space on search

### DIFF
--- a/packages/ui-components/src/Common/Search/Results/Tabs/index.module.css
+++ b/packages/ui-components/src/Common/Search/Results/Tabs/index.module.css
@@ -2,7 +2,8 @@
 
 .facetTabsWrapper {
   @apply mb-2
-    overflow-x-auto;
+    overflow-x-auto
+    pt-2;
 
   &::-webkit-scrollbar {
     @apply hidden;

--- a/packages/ui-components/src/Common/Search/Results/index.module.css
+++ b/packages/ui-components/src/Common/Search/Results/index.module.css
@@ -4,7 +4,6 @@
   @apply grow-0
     overflow-y-auto
     px-5
-    pt-3
     text-neutral-900
     dark:text-neutral-200;
 

--- a/packages/ui-components/src/Common/Search/Suggestions/index.module.css
+++ b/packages/ui-components/src/Common/Search/Suggestions/index.module.css
@@ -6,6 +6,7 @@
     flex-1
     flex-col
     overflow-y-auto
+    pt-2
     pb-4
     text-neutral-900
     dark:text-neutral-200;


### PR DESCRIPTION
Fixes https://github.com/nodejs/doc-kit/issues/670

Supersedes https://github.com/nodejs/doc-kit/pull/678
Supersedes https://github.com/nodejs/nodejs.org/pull/8724

<img width="541" height="141" alt="image" src="https://github.com/user-attachments/assets/433436a1-f68a-43c0-a29a-e6f859812133" />