### PR TITLE
fix(ui-components): guard ThemeToggle against invalid stored theme

### DIFF
--- a/packages/ui-components/src/Common/ThemeToggle/index.tsx
+++ b/packages/ui-components/src/Common/ThemeToggle/index.tsx
@@ -33,7 +33,9 @@ const ThemeToggle: FC<ThemeToggleProps> = ({
   ariaLabel,
   themeLabels = { system: 'System', light: 'Light', dark: 'Dark' },
 }) => {
-  const TriggerIcon = themeIcons[currentTheme];
+  const normalizedTheme: Theme =
+    currentTheme in themeIcons ? currentTheme : 'system';
+  const TriggerIcon = themeIcons[normalizedTheme];
 
   return (
     <DropdownMenu.Root>
@@ -60,7 +62,7 @@ const ThemeToggle: FC<ThemeToggleProps> = ({
                 key={theme}
                 onClick={() => onChange(theme)}
                 className={classNames(styles.dropDownItem, {
-                  [styles.activeItem]: theme === currentTheme,
+                  [styles.activeItem]: theme === normalizedTheme,
                 })}
               >
                 <Icon height="16" />


### PR DESCRIPTION
## Description

This PR fixes a runtime crash in `ThemeToggle` when `currentTheme` contains an unexpected value.

Previously, the component assumed `currentTheme` was always one of `system | light | dark`. If a stale or invalid value was persisted in `localStorage` (for example, `invalid-theme`), `themeIcons[currentTheme]` resolved to `undefined`, causing React to throw:

`Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`

The fix normalizes `currentTheme` to `system` when the value is not a known key, and uses the normalized value for both icon lookup and active item highlighting.

## Validation

I validated the fix with the following steps:

1. Run the site locally.
2. In browser console, execute:

```js
localStorage.setItem('theme', 'invalid-theme'); location.reload();
```

3. Before fix: app crashes in `ThemeToggle` with "Element type is invalid".
4. After fix: no crash; theme toggle renders and safely falls back to `system` behavior.

## Related Issues

Fixes #8729

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
