### PR TITLE
feat(remark-lint): improve validation

### DIFF
--- a/packages/remark-lint/package.json
+++ b/packages/remark-lint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@node-core/remark-lint",
   "type": "module",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "exports": {
     ".": "./src/index.mjs",
     "./api": "./src/api.mjs"
@@ -20,7 +20,7 @@
     "test:unit": "cross-env NODE_NO_WARNINGS=1 node --experimental-test-coverage --test \"**/*.test.mjs\""
   },
   "dependencies": {
-    "@node-core/doc-kit": "^1.0.0",
+    "@node-core/doc-kit": "^1.0.2",
     "remark-gfm": "^4.0.1",
     "remark-lint-blockquote-indentation": "^4.0.1",
     "remark-lint-checkbox-character-style": "^5.0.1",

--- a/packages/remark-lint/src/api.mjs
+++ b/packages/remark-lint/src/api.mjs
@@ -7,6 +7,7 @@ import remarkLintUnorderedListMarkerStyle from 'remark-lint-unordered-list-marke
 import basePreset from './index.mjs';
 import duplicateStabilityNodes from './rules/duplicate-stability-nodes.mjs';
 import hashedSelfReference from './rules/hashed-self-reference.mjs';
+import invalidDeprecations from './rules/invalid-deprecations.mjs';
 import invalidTypeReference from './rules/invalid-type-reference.mjs';
 import orderedReferences from './rules/ordered-references.mjs';
 import requiredMetadata from './rules/required-metadata.mjs';
@@ -37,6 +38,7 @@ export default (options = {}) => ({
       orderedReferences,
       requiredMetadata,
       invalidTypeReference,
+      invalidDeprecations,
     ].map(plugin => [plugin, options]),
 
     // External Rules

--- a/packages/remark-lint/src/rules/__tests__/invalid-deprecations.test.mjs
+++ b/packages/remark-lint/src/rules/__tests__/invalid-deprecations.test.mjs
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+
+import dedent from 'dedent';
+
+import { testRule } from './utils.mjs';
+import invalidDeprecations from '../invalid-deprecations.mjs';
+
+const TYPE = 'Type: [...]';
+const CHANGES = dedent`
+  <!-- YAML
+  changes:
+  -->
+  `;
+const BODY = TYPE + '\n' + CHANGES;
+
+const testCases = [
+  {
+    name: 'in order deprecations',
+    input: dedent`
+      ## DEP0001:
+      ${BODY}
+      ## DEP0002:
+      ${BODY}
+    `,
+    expected: [],
+  },
+  {
+    name: 'out of order deprecations',
+    input: dedent`
+      ## DEP0001:
+      ${BODY}
+      ## DEP0003:
+      ${BODY}
+    `,
+    expected: [
+      'Deprecation codes are out of order. Expected DEP0002, saw "DEP0003"',
+    ],
+  },
+  {
+    name: 'skipped deprecations',
+    input: dedent`
+      ## DEP0001:
+      ${BODY}
+      <!-- md-lint skip-deprecation DEP0002 -->
+      ## DEP0003:
+      ${BODY}
+    `,
+    expected: [],
+  },
+  {
+    name: 'out of order skipped deprecations',
+    input: dedent`
+      ## DEP0001:
+      ${BODY}
+      <!-- md-lint skip-deprecation DEP0004 -->
+      ## DEP0003:
+      ${BODY}
+    `,
+    expected: [
+      'Deprecation codes are out of order. Expected DEP0002, saw "DEP0004"',
+    ],
+  },
+  {
+    name: 'not enough skipped deprecations',
+    input: dedent`
+      ## DEP0001:
+      ${BODY}
+      <!-- md-lint skip-deprecation DEP0002 -->
+      ## DEP0004:
+      ${BODY}
+    `,
+    expected: [
+      'Deprecation codes are out of order. Expected DEP0003, saw "DEP0004"',
+    ],
+  },
+  {
+    name: 'no type',
+    input: dedent`
+      ## DEP0001:
+      some text
+      ${CHANGES}
+    `,
+    expected: ['Deprecation "DEP0001" is missing a "Type"'],
+  },
+  {
+    name: 'no changes',
+    input: dedent`
+      ## DEP0001:
+      ${TYPE}
+    `,
+    expected: ['Deprecation "DEP0001" is missing changes'],
+  },
+];
+
+describe('invalid-deprecations', () => {
+  for (const { name, input, expected, options } of testCases) {
+    it(name, () =>
+      testRule(
+        invalidDeprecations,
+        input,
+        expected,
+        { stem: 'deprecations' },
+        options
+      )
+    );
+  }
+});

--- a/packages/remark-lint/src/rules/__tests__/invalid-type-reference.test.mjs
+++ b/packages/remark-lint/src/rules/__tests__/invalid-type-reference.test.mjs
@@ -20,6 +20,11 @@ const testCases = [
     expected: ['Type reference must be wrapped in "{}"; saw "<number>"'],
   },
   {
+    name: 'miswrapped reference inside link',
+    input: '[<number>]()',
+    expected: ['Type reference must be wrapped in "{}"; saw "<number>"'],
+  },
+  {
     name: 'multiple references',
     input: 'Psst, are you a {string | boolean}',
     expected: [

--- a/packages/remark-lint/src/rules/duplicate-stability-nodes.mjs
+++ b/packages/remark-lint/src/rules/duplicate-stability-nodes.mjs
@@ -1,4 +1,4 @@
-import createQueries from '@node-core/doc-kit/src/utils/queries/index.mjs';
+import { QUERIES } from '@node-core/doc-kit/src/utils/queries/index.mjs';
 import { lintRule } from 'unified-lint-rule';
 import { visit } from 'unist-util-visit';
 
@@ -29,7 +29,7 @@ const duplicateStabilityNodes = (tree, vfile) => {
       return;
     }
 
-    const match = createQueries.QUERIES.stabilityIndexPrefix.exec(text); // Match "Stability: X"
+    const match = QUERIES.stabilityIndexPrefix.exec(text); // Match "Stability: X"
     if (!match) {
       return;
     }

--- a/packages/remark-lint/src/rules/invalid-deprecations.mjs
+++ b/packages/remark-lint/src/rules/invalid-deprecations.mjs
@@ -1,0 +1,69 @@
+import { lintRule } from 'unified-lint-rule';
+import { visit } from 'unist-util-visit';
+
+const DEPRECATION_COMMENT = /^<!-- md-lint skip-deprecation (DEP\d{4}) -->$/;
+const DEPRECATION_HEADING = /^(DEP\d{4}):/;
+const DEPRECATION_YAML = /^<!-- YAML\r?\nchanges:\r?\n/;
+
+const generateDeprecation = code => `DEP${code.toString().padStart(4, '0')}`;
+
+/**
+ * Ensures all needed metadata exists
+ * @type {import('unified-lint-rule').Rule}
+ */
+const invalidDeprecations = (tree, vfile) => {
+  if (vfile.stem !== 'deprecations') {
+    // Skip non-deprecation files
+    return;
+  }
+
+  let expectedDeprecationCode = 1;
+
+  visit(tree, ['heading', 'html'], (node, idx, parent) => {
+    // Get the current deprecation
+    const deprecationCode =
+      node.type === 'html'
+        ? node.value.match(DEPRECATION_COMMENT)?.[1]
+        : node.children[0].value.match(DEPRECATION_HEADING)?.[1];
+
+    if (node.type === 'heading') {
+      const typeNode = parent.children[idx + 1]?.children[0];
+
+      if (!typeNode?.value?.startsWith('Type:')) {
+        vfile.message(
+          `Deprecation "${deprecationCode}" is missing a "Type"`,
+          node
+        );
+      }
+
+      const changesNode = parent.children[idx + 2];
+
+      if (!DEPRECATION_YAML.test(changesNode?.value)) {
+        vfile.message(
+          `Deprecation "${deprecationCode}" is missing changes`,
+          node
+        );
+      }
+    }
+
+    // If not found, skip
+    if (!deprecationCode) {
+      return;
+    }
+
+    const generatedDeprecationCode = generateDeprecation(
+      expectedDeprecationCode
+    );
+
+    if (deprecationCode !== generatedDeprecationCode) {
+      vfile.message(
+        `Deprecation codes are out of order. Expected ${generatedDeprecationCode}, saw "${deprecationCode}"`,
+        node
+      );
+    }
+
+    expectedDeprecationCode++;
+  });
+};
+
+export default lintRule('node-core:invalid-deprecations', invalidDeprecations);

--- a/packages/remark-lint/src/rules/invalid-type-reference.mjs
+++ b/packages/remark-lint/src/rules/invalid-type-reference.mjs
@@ -1,5 +1,5 @@
-import { transformTypeToReferenceLink } from '@node-core/doc-kit/src/utils/parser/index.mjs';
-import createQueries from '@node-core/doc-kit/src/utils/queries/index.mjs';
+import { transformTypeToReferenceLink } from '@node-core/doc-kit/src/generators/metadata/utils/transformers.mjs';
+import { QUERIES } from '@node-core/doc-kit/src/utils/queries/index.mjs';
 import { lintRule } from 'unified-lint-rule';
 import { visit } from 'unist-util-visit';
 
@@ -11,36 +11,42 @@ const REPLACE_RE = /\s*\| */g;
  * @type {import('unified-lint-rule').Rule<, import('../api.mjs').Options>}
  */
 const invalidTypeReference = (tree, vfile, { typeMap = {} }) => {
-  visit(tree, createQueries.UNIST.isTextWithType, node => {
-    const types = node.value.match(createQueries.QUERIES.normalizeTypes);
+  visit(
+    tree,
+    ({ value }) => QUERIES.normalizeTypes.test(value),
+    node => {
+      const types = node.value.match(QUERIES.normalizeTypes);
 
-    types.forEach(type => {
-      // Ensure wrapped in {}
-      if (type[0] !== '{' || type[type.length - 1] !== '}') {
-        vfile.message(
-          `Type reference must be wrapped in "{}"; saw "${type}"`,
-          node
-        );
+      types.forEach(type => {
+        // Ensure wrapped in {}
+        if (type[0] !== '{' || type[type.length - 1] !== '}') {
+          vfile.message(
+            `Type reference must be wrapped in "{}"; saw "${type}"`,
+            node
+          );
 
-        node.value = node.value.replace(type, `{${type.slice(1, -1)}}`);
-      }
+          const newType = `{${type.slice(1, -1)}}`;
+          node.value = node.value.replace(type, newType);
+          type = newType;
+        }
 
-      // Fix spaces around |
-      if (MATCH_RE.test(type)) {
-        vfile.message(
-          `Type reference should be separated by "|", without spaces; saw "${type}"`,
-          node
-        );
+        // Fix spaces around |
+        if (MATCH_RE.test(type)) {
+          vfile.message(
+            `Type reference should be separated by "|", without spaces; saw "${type}"`,
+            node
+          );
 
-        const normalized = type.replace(REPLACE_RE, '|');
-        node.value = node.value.replace(type, normalized);
-      }
+          const normalized = type.replace(REPLACE_RE, '|');
+          node.value = node.value.replace(type, normalized);
+        }
 
-      if (transformTypeToReferenceLink(type, typeMap) === type) {
-        vfile.message(`Invalid type reference: ${type}`, node);
-      }
-    });
-  });
+        if (transformTypeToReferenceLink(type, typeMap) === type) {
+          vfile.message(`Invalid type reference: ${type}`, node);
+        }
+      });
+    }
+  );
 };
 
 export default lintRule(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,7 +255,7 @@ importers:
         version: 1.7.1
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-mdx:
         specifier: ~3.6.2
         version: 3.6.2(eslint@9.39.4(jiti@2.6.1))(remark-lint-file-extension@3.0.1)
@@ -351,8 +351,8 @@ importers:
   packages/remark-lint:
     dependencies:
       '@node-core/doc-kit':
-        specifier: ^1.0.0
-        version: 1.0.0(@orama/core@1.2.19)(@types/react@19.2.14)(jiti@2.6.1)(postcss@8.5.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.2
+        version: 1.0.2(@orama/core@1.2.19)(@types/react@19.2.14)(jiti@2.6.1)(postcss@8.5.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1976,8 +1976,8 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@node-core/doc-kit@1.0.0':
-    resolution: {integrity: sha512-IUqjEhwn5bQptyY1jrURJTZfQGXIWKoLFmb0pvZSe4H/PD6CNHqXhHF3551eIT0OppgeBpTk8YUodPp8GcQFRw==}
+  '@node-core/doc-kit@1.0.2':
+    resolution: {integrity: sha512-dYTh29FRH7Qcbz8M1WbAu1tg2YVcmCEdt514QcDqJWsRrYJfvzg10OyDODyEPJfKZ4+OUN/VPi3knGoGfOSNkQ==}
     hasBin: true
 
   '@node-core/rehype-shiki@1.4.1':
@@ -9978,7 +9978,7 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@node-core/doc-kit@1.0.0(@orama/core@1.2.19)(@types/react@19.2.14)(jiti@2.6.1)(postcss@8.5.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@node-core/doc-kit@1.0.2(@orama/core@1.2.19)(@types/react@19.2.14)(jiti@2.6.1)(postcss@8.5.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@actions/core': 3.0.0
       '@heroicons/react': 2.2.0(react@19.2.4)
@@ -11765,10 +11765,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -13029,13 +13029,13 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -13075,7 +13075,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
@@ -13091,7 +13091,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
@@ -13118,21 +13118,22 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
@@ -13177,7 +13178,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13188,7 +13189,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13200,13 +13201,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13217,7 +13218,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13228,6 +13229,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -17237,7 +17240,7 @@ snapshots:
 
   typescript-eslint@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/62090

---

Adds deprecation validation based on https://github.com/nodejs/node/blob/main/tools/doc/deprecationCodes.mjs, and allows type validation to work in links (i.e. `[<Type>]()`)