### PR TITLE
feat(ui): improve partner grid layout on download page

### DIFF
--- a/apps/site/components/Common/Partners/index.module.css
+++ b/apps/site/components/Common/Partners/index.module.css
@@ -12,6 +12,9 @@
   @apply grid
     w-full
     gap-6
+    sm:grid-cols-[repeat(auto-fill,minmax(240px,1fr))]
+    sm:gap-4
     lg:grid-cols-[repeat(auto-fit,minmax(240px,260px))]
-    lg:justify-center;
+    lg:justify-center
+    lg:gap-6;
 }

--- a/apps/site/components/Common/Partners/index.module.css
+++ b/apps/site/components/Common/Partners/index.module.css
@@ -11,7 +11,7 @@
 .large {
   @apply grid
     w-full
-    grid-cols-[repeat(auto-fit,minmax(240px,260px))]
-    justify-center
-    gap-6;
+    gap-6
+    lg:grid-cols-[repeat(auto-fit,minmax(240px,260px))]
+    lg:justify-center;
 }

--- a/apps/site/components/Common/Partners/index.module.css
+++ b/apps/site/components/Common/Partners/index.module.css
@@ -11,6 +11,7 @@
 .large {
   @apply grid
     w-full
-    grid-cols-[repeat(auto-fill,minmax(240px,1fr))]
-    gap-4;
+    grid-cols-[repeat(auto-fit,minmax(240px,260px))]
+    justify-center
+    gap-6;
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Centered the partner logos in the download page’s partner section by adjusting the grid layout for improved visual alignment and consistency.

## Validation

- Verified that partner logos are centered across different screen sizes
- Checked consistent spacing and alignment of all items
- No UI breakages observed

## Related Issues

Fixes #8749

## Before changes:

<img width="1919" height="1073" alt="Screenshot 2026-03-21 055018" src="https://github.com/user-attachments/assets/cf6c6df2-54f2-443b-981c-32d54ac01283" />

## After changes:

<img width="1919" height="1076" alt="Screenshot 2026-03-21 053611" src="https://github.com/user-attachments/assets/6384b692-df5e-4fdd-9cd8-3b697ef0498a" />

## Files Changed

- nodejs.org\apps\site\components\Common\Partners\index.module.css

## Code Changed

```
@reference "../../../styles/index.css";

.small {
  @apply flex
    flex-row
    flex-wrap
    items-center
    gap-2;
}

.large {
  @apply grid
    w-full
    grid-cols-[repeat(auto-fit,minmax(240px,260px))]
    justify-center
    gap-6;
}
```

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
