### PR TITLE
fix: remove mastodon from footer

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -81,11 +81,6 @@
       "alt": "Discord"
     },
     {
-      "icon": "mastodon",
-      "link": "https://social.lfx.dev/@nodejs",
-      "alt": "Mastodon"
-    },
-    {
       "icon": "bluesky",
       "link": "https://bsky.app/profile/nodejs.org",
       "alt": "Bluesky"


### PR DESCRIPTION
Fixes #7873

Removes the Mastodon social link from the footer navigation.
The hidden rel="me" verification link remains unchanged.