### PR TITLE
ci: use custom token for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,11 +16,6 @@ jobs:
     name: Auto-merge
     if: github.repository == 'nodejs/nodejs.org'
     runs-on: ubuntu-latest
-    permissions:
-      # Required to approve and merge pull requests
-      pull-requests: write
-      # Required to merge pull requests via merge queue
-      contents: write
 
     steps:
       - name: Harden Runner
@@ -31,3 +26,4 @@ jobs:
       - uses: nodejs/web-team/actions/auto-merge-prs@b087df186d25f8792fb85cc7794f68718726b8ee
         with:
           merge-method: queue
+          github-token: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }} # zizmor: ignore[secrets-outside-env]


### PR DESCRIPTION
## Description

We ran into an issue when using the auto-merge with the queue in #8747 where it would loop due to CI not running in the merge queue as GitHub Actions was the actor for adding the PR to the queue.

## Validation

Ensure the new secret exists in the repo settings.

## Related Issues

cc https://github.com/nodejs/admin/issues/1049

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
