### PR TITLE
ci: add auto-merge label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: monthly
     labels:
+      - 'dependencies'
+      - 'github_actions'
       - 'github_actions:pull-request'
       - 'auto-merge'
     commit-message:
@@ -19,6 +21,8 @@ updates:
     schedule:
       interval: monthly
     labels:
+      - 'dependencies'
+      - 'javascript'
       - 'github_actions:pull-request'
       - 'auto-merge'
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: monthly
     labels:
       - 'github_actions:pull-request'
+      - 'auto-merge'
     commit-message:
       prefix: meta
     cooldown:
@@ -19,6 +20,7 @@ updates:
       interval: monthly
     labels:
       - 'github_actions:pull-request'
+      - 'auto-merge'
     commit-message:
       prefix: meta
     cooldown:


### PR DESCRIPTION
## Description

Automatically adds the `auto-merge` label to all Dependabot-created PRs, so that we only need to approve them in an initial review, and automation will handle landing them with no further interaction needed from maintainers.

_Also, restores the standard labels applied to Dependabot PRs that we were missing._

## Validation

Config valid.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
