### PR TITLE
chore(downloads): replace Docker alpine with slim

### DIFF
--- a/apps/site/snippets/en/download/docker.bash
+++ b/apps/site/snippets/en/download/docker.bash
@@ -2,7 +2,7 @@
 # Please refer to the official documentation at https://docker.com/get-started/
 
 # Pull the Node.js Docker image:
-docker pull node:${props.release.major}-${props.release.major >= 4 ? 'alpine' : 'slim'}
+docker pull node:${props.release.major}-slim
 
 # Create a Node.js container and start a Shell session:
-docker run -it --rm --entrypoint sh node:${props.release.major}-${props.release.major >= 4 ? 'alpine' : 'slim'}
+docker run -it --rm --entrypoint sh node:${props.release.major}-slim


### PR DESCRIPTION
## Description

Replace Docker `alpine` with `slim` displayed on https://nodejs.org/en/download

https://nodejs.org/en/download previously recommended an Alpine Docker image, for instance, selecting the LTS version on this page suggests:

```shell
docker pull node:24-alpine
```

On the [Platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list) Node.js classifies Linux `musl` platforms as "Experimental", including Alpine as an example. The [Strategy](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) classification states:

> Test failures on experimental platforms do not block releases.

On the [docker-node](https://github.com/nodejs/docker-node) repo, workflows are set up such that the non-availability of `musl` builds does not block the release of Node.js Docker images for security releases. For non-security releases, the strategy is currently undefined (see https://github.com/nodejs/docker-node/issues/2363). Typically, maintainers may manually release Debian-based Docker images if Alpine builds are significantly delayed.

This means that the "Experimental" status of the Alpine unofficial builds often causes their release to be delayed.

### Replacement assessment

Alpine Docker images have typically been preferred and recommended due to their smaller size. Due to less content, the risk of vulnerabilities is also reduced. On [Docker Hub](https://hub.docker.com/_/node), the image `node:alpine` for `linux/amd64` lists with 56.99 MB compressed size.

`node:slim`, as a Debian alternative to Alpine Linux, built from the base image `debian:*-slim`, lists with 75.37 MB.

Debian images use `glibc`. The Docker image `node:lts-slim` is published with the following architectures, none of which are "Experimental":

| Docker OS/architecture | Node.js category |
| ---------------------- | ---------------- |
| `linux/amd64`          | Tier 1           |
| `linux/arm64/v8`       | Tier 1           |
| `linux/ppc64le`        | Tier 2           |
| `linux/s390x`          | Tier 2           |

The trade-off when moving from `node:alpine` to `node:slim` is the advantage of faster and more reliable availability of new releases (Tier 1 or 2), compared to the disadvantage of ~30% size increase. This is disregarding other basic differences between Alpine and Debian, where Alpine is considered more of a restricted run-time environment, and Debian more of a flexible development / build environment.

## Validation

Go to https://nodejs.org/en/download and select using "Docker" for LTS release. Note the instructions:

```shell
# Docker has specific installation instructions for each operating system.
# Please refer to the official documentation at https://docker.com/get-started/

# Pull the Node.js Docker image:
docker pull node:24-slim

# Create a Node.js container and start a Shell session:
docker run -it --rm --entrypoint sh node:24-slim

# Verify the Node.js version:
node -v # Should print "v24.14.1".

# Verify npm version:
npm -v # Should print "11.11.0".
```

Copying-and-pasting the whole script in one go doesn't work correctly (not due to this PR).

Individually copying each command works fine:

```text
$ docker pull node:24-slim
24-slim: Pulling from library/node
Digest: sha256:06e5c9f86bfa0aaa7163cf37a5eaa8805f16b9acb48e3f85645b09d459fc2a9f
Status: Image is up to date for node:24-slim
docker.io/library/node:24-slim
$ docker run -it --rm --entrypoint sh node:24-slim
# node -v # Should print "v24.14.1".
v24.14.1
# npm -v # Should print "11.11.0".
11.11.0
# exit
```

## Related Issues

Resolves: https://github.com/nodejs/nodejs.org/issues/8690

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `pnpm format` to ensure the code follows the style guide.
- [X] I have run `pnpm test` to check if all tests are passing.
- [X] I have run `pnpm build` to check if the website builds without errors.
- [na] I've covered new added functionality with unit tests if necessary.
