### PR TITLE
feat: add AI Coding Assistants Policy to footer

### DIFF
--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -1,8 +1,10 @@
 import { availableLocaleCodes, defaultLocale } from '@node-core/website-i18n';
 
-import { BASE_PATH } from '#site/next.constants.mjs';
-import { BASE_URL } from '#site/next.constants.mjs';
-import { EXTERNAL_LINKS_SITEMAP } from '#site/next.constants.mjs';
+import {
+  BASE_PATH,
+  BASE_URL,
+  EXTERNAL_LINKS_SITEMAP,
+} from '#site/next.constants.mjs';
 import { BLOG_DYNAMIC_ROUTES } from '#site/next.dynamic.constants.mjs';
 import { dynamicRouter } from '#site/next.dynamic.mjs';
 
@@ -16,8 +18,11 @@ const nonDefaultLocales = availableLocaleCodes.filter(
   l => l !== defaultLocale.code
 );
 
-const getAlternatePath = (r: string, locales: Array<string>) =>
-  Object.fromEntries(locales.map(l => [l, `${baseUrlAndPath}/${l}/${r}`]));
+const getFullPath = (r: string, l: string) =>
+  /^https?:\/\//.test(r) ? r : `${baseUrlAndPath}/${l}/${r}`;
+
+const getAlternatePaths = (r: string, locales: Array<string>) =>
+  Object.fromEntries(locales.map(l => [l, getFullPath(r, l)]));
 
 // This allows us to generate a `sitemap.xml` file dynamically based on the needs of the Node.js Website
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
@@ -27,10 +32,10 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const currentDate = new Date().toISOString();
 
   const getSitemapEntry = (r: string, locales: Array<string> = []) => ({
-    url: `${baseUrlAndPath}/${defaultLocale.code}/${r}`,
+    url: getFullPath(r, defaultLocale.code),
     lastModified: currentDate,
     changeFrequency: 'always' as const,
-    alternates: { languages: getAlternatePath(r, locales) },
+    alternates: { languages: getAlternatePaths(r, locales) },
   });
 
   const staticPaths = routes.map(r => getSitemapEntry(r, nonDefaultLocales));

--- a/apps/site/components/withLegal.tsx
+++ b/apps/site/components/withLegal.tsx
@@ -23,6 +23,7 @@ const RICH_TRANSLATION_KEYS = [
   'foundationName',
   'trademarkPolicy',
   'trademarkList',
+  'aiCodingAssistantsPolicy',
   'termsOfUse',
   'privacyPolicy',
   'bylaws',

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -37,6 +37,10 @@
       "text": "components.containers.footer.links.foundationName"
     },
     {
+      "link": "https://ai-coding-assistants-policy.openjsf.org/",
+      "text": "components.containers.footer.links.aiCodingAssistantsPolicy"
+    },
+    {
       "link": "https://terms-of-use.openjsf.org/",
       "text": "components.containers.footer.links.termsOfUse"
     },

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -41,36 +41,36 @@
       "text": "components.containers.footer.links.aiCodingAssistantsPolicy"
     },
     {
-      "link": "https://terms-of-use.openjsf.org/",
-      "text": "components.containers.footer.links.termsOfUse"
-    },
-    {
-      "link": "https://privacy-policy.openjsf.org/",
-      "text": "components.containers.footer.links.privacyPolicy"
-    },
-    {
       "link": "https://bylaws.openjsf.org/",
       "text": "components.containers.footer.links.bylaws"
     },
     {
-      "link": "https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md",
+      "link": "https://code-of-conduct.openjsf.org/",
       "text": "components.containers.footer.links.codeOfConduct"
-    },
-    {
-      "link": "https://trademark-policy.openjsf.org/",
-      "text": "components.containers.footer.links.trademarkPolicy"
-    },
-    {
-      "link": "https://trademark-list.openjsf.org/",
-      "text": "components.containers.footer.links.trademarkList"
     },
     {
       "link": "https://www.linuxfoundation.org/cookies/",
       "text": "components.containers.footer.links.cookiePolicy"
     },
     {
+      "link": "https://privacy-policy.openjsf.org/",
+      "text": "components.containers.footer.links.privacyPolicy"
+    },
+    {
       "link": "https://github.com/nodejs/node/security/policy",
       "text": "components.containers.footer.links.security"
+    },
+    {
+      "link": "https://terms-of-use.openjsf.org/",
+      "text": "components.containers.footer.links.termsOfUse"
+    },
+    {
+      "link": "https://trademark-list.openjsf.org/",
+      "text": "components.containers.footer.links.trademarkList"
+    },
+    {
+      "link": "https://trademark-policy.openjsf.org/",
+      "text": "components.containers.footer.links.trademarkPolicy"
     }
   ],
   "socialLinks": [

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -107,6 +107,7 @@ export const THEME_STORAGE_KEY = 'theme';
  * @see https://github.com/nodejs/nodejs.org/issues/5813 for more context
  */
 export const EXTERNAL_LINKS_SITEMAP = [
+  'https://ai-coding-assistants-policy.openjsf.org/',
   'https://terms-of-use.openjsf.org/',
   'https://privacy-policy.openjsf.org/',
   'https://bylaws.openjsf.org/',

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -13,6 +13,7 @@
         "legal": "Copyright <foundationName>OpenJS Foundation</foundationName> and Node.js contributors. All rights reserved. The <foundationName>OpenJS Foundation</foundationName> has registered trademarks and uses trademarks.  For a list of trademarks of the <foundationName>OpenJS Foundation</foundationName>, please see our <trademarkPolicy>Trademark Policy</trademarkPolicy> and <trademarkList>Trademark List</trademarkList>.  Trademarks and logos not indicated on the <trademarkList>list of OpenJS Foundation trademarks</trademarkList> are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.",
         "links": {
           "foundationName": "OpenJS Foundation",
+          "aiCodingAssistantsPolicy": "AI Coding Assistants Policy",
           "termsOfUse": "Terms of Use",
           "privacyPolicy": "Privacy Policy",
           "bylaws": "Bylaws",


### PR DESCRIPTION
## Description

Adds the new AI Coding Assistants Policy link to the footer, and also updates the ordering of the links in the footer based on the foundation's recommendation. The security policy is not in the foundation's regular set of links, but I have also updated the ordering of that to match the others, alphabetical. Also, this updates the code of conduct link to use the hostname redirect for consistency, matching the foundation's recommendation.

Also addresses an issue that Copilot spotted -- we include some external links in the sitemap, the ones from the footer, but these were being incorrectly prefixed with `https://nodejs.org/en`.

## Validation

Footer links match https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers

Sitemap contains valid external URLs for the footer links.

## Related Issues

cc https://github.com/openjs-foundation/artwork/pull/27 https://github.com/nodejs/node/pull/62105

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
