### PR TITLE
fix: select defaultValue re-render issue

### DIFF
--- a/packages/ui-components/src/Common/Select/index.tsx
+++ b/packages/ui-components/src/Common/Select/index.tsx
@@ -3,7 +3,7 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import classNames from 'classnames';
-import { useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
 import Skeleton from '#ui/Common/Skeleton';
 
@@ -63,6 +63,8 @@ const Select = <T extends string>({
 }: SelectProps<T>): ReactNode => {
   const id = useId();
   const [value, setValue] = useState(defaultValue);
+
+  useEffect(() => setValue(defaultValue), [defaultValue]);
 
   const mappedValues = useMemo(() => mapValues(values), [values]) as Array<
     SelectGroup<T>


### PR DESCRIPTION
## Description

In our current `Select` component, even if the `defaultValue` changes, it wasn't being reflected in the UI because the effect we were using had been removed in #8672. With this PR, we're adding that effect back

## Validation

OS default value would work on preview

## Related Issues

Fixes: #8815

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
