### PR TITLE
chore: remove Active/Maintenance LTS distinction

### DIFF
--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -5,36 +5,13 @@ import { useLocale, useTranslations } from 'next-intl';
 import { use } from 'react';
 
 import { redirect, usePathname } from '#site/navigation';
+import { STATUS_KIND_MAP } from '#site/next.constants.mjs';
 import {
   ReleaseContext,
   ReleasesContext,
 } from '#site/providers/releaseProvider';
 
-import type { NodeReleaseStatus } from '#site/types/releases.js';
 import type { FC } from 'react';
-
-const getDropDownStatus = (status: NodeReleaseStatus) => {
-  if (status === 'LTS') {
-    return {
-      label: 'LTS',
-      kind: 'info' as const,
-    };
-  }
-
-  if (status === 'Current') {
-    return {
-      label: 'Current',
-      kind: 'default' as const,
-    };
-  }
-
-  if (status === 'End-of-life') {
-    return {
-      label: 'EoL',
-      kind: 'warning' as const,
-    };
-  }
-};
 
 const VersionDropdown: FC = () => {
   const { releases } = use(ReleasesContext);
@@ -69,7 +46,7 @@ const VersionDropdown: FC = () => {
       values={releases.map(({ status, versionWithPrefix }) => ({
         value: versionWithPrefix,
         label: versionWithPrefix,
-        badge: getDropDownStatus(status),
+        badge: { label: status, kind: STATUS_KIND_MAP[status] },
       }))}
       defaultValue={release.versionWithPrefix}
       onChange={setVersionOrNavigate}

--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -13,20 +13,27 @@ import {
 import type { NodeReleaseStatus } from '#site/types/releases.js';
 import type { FC } from 'react';
 
-const getDropDownStatus = (version: string, status: NodeReleaseStatus) => {
+const getDropDownStatus = (status: NodeReleaseStatus) => {
   if (status === 'LTS') {
-    return `${version} (LTS)`;
+    return {
+      label: 'LTS',
+      kind: 'info' as const,
+    };
   }
 
   if (status === 'Current') {
-    return `${version} (Current)`;
+    return {
+      label: 'Current',
+      kind: 'default' as const,
+    };
   }
 
   if (status === 'End-of-life') {
-    return `${version} (EoL)`;
+    return {
+      label: 'EoL',
+      kind: 'warning' as const,
+    };
   }
-
-  return version;
 };
 
 const VersionDropdown: FC = () => {
@@ -61,7 +68,8 @@ const VersionDropdown: FC = () => {
       ariaLabel={t('layouts.download.dropdown.version')}
       values={releases.map(({ status, versionWithPrefix }) => ({
         value: versionWithPrefix,
-        label: getDropDownStatus(versionWithPrefix, status),
+        label: versionWithPrefix,
+        badge: getDropDownStatus(status),
       }))}
       defaultValue={release.versionWithPrefix}
       onChange={setVersionOrNavigate}

--- a/apps/site/components/Downloads/Release/VersionDropdown.tsx
+++ b/apps/site/components/Downloads/Release/VersionDropdown.tsx
@@ -10,15 +10,20 @@ import {
   ReleasesContext,
 } from '#site/providers/releaseProvider';
 
+import type { NodeReleaseStatus } from '#site/types/releases.js';
 import type { FC } from 'react';
 
-const getDropDownStatus = (version: string, status: string) => {
-  if (status.endsWith('LTS')) {
+const getDropDownStatus = (version: string, status: NodeReleaseStatus) => {
+  if (status === 'LTS') {
     return `${version} (LTS)`;
   }
 
   if (status === 'Current') {
     return `${version} (Current)`;
+  }
+
+  if (status === 'End-of-life') {
+    return `${version} (EoL)`;
   }
 
   return version;
@@ -38,7 +43,7 @@ const VersionDropdown: FC = () => {
       ({ versionWithPrefix }) => versionWithPrefix === version
     );
 
-    if (release?.isLts && pathname.includes('current')) {
+    if (release?.status === 'LTS' && pathname.includes('current')) {
       redirect({ href: '/download', locale });
       return;
     }

--- a/apps/site/components/EOL/EOLReleaseTable/TableBody.tsx
+++ b/apps/site/components/EOL/EOLReleaseTable/TableBody.tsx
@@ -34,7 +34,7 @@ const EOLReleaseTableBody: FC<EOLReleaseTableBodyProps> = ({
             </td>
 
             <td data-label="Date">
-              <FormattedTime date={release.releaseDate} />
+              <FormattedTime date={release.latestReleaseDate} />
             </td>
 
             <td>

--- a/apps/site/components/EOL/EOLReleaseTable/index.tsx
+++ b/apps/site/components/EOL/EOLReleaseTable/index.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from 'next-intl/server';
 
 import provideReleaseData from '#site/next-data/providers/releaseData';
 import provideVulnerabilities from '#site/next-data/providers/vulnerabilities';
-import { EOL_VERSION_IDENTIFIER } from '#site/next.constants.mjs';
 
 import type { FC } from 'react';
 
@@ -15,9 +14,7 @@ const EOLReleaseTable: FC = async () => {
   const releaseData = await provideReleaseData();
   const vulnerabilities = await provideVulnerabilities();
 
-  const eolReleases = releaseData.filter(
-    release => release.status === EOL_VERSION_IDENTIFIER
-  );
+  const eolReleases = releaseData.filter(release => release.status === 'EOL');
 
   const t = await getTranslations();
 

--- a/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
+++ b/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
@@ -15,10 +15,8 @@ import ReleaseModal from '../ReleaseModal';
 
 const BADGE_KIND_MAP = {
   'End-of-life': 'warning',
-  'Maintenance LTS': 'neutral',
-  'Active LTS': 'info',
+  LTS: 'info',
   Current: 'default',
-  Pending: 'default',
 } as const;
 
 type PreviousReleasesTableBodyProps = {
@@ -50,7 +48,7 @@ const PreviousReleasesTableBody: FC<PreviousReleasesTableBodyProps> = ({
             <td
               data-label={t('components.downloadReleasesTable.firstReleased')}
             >
-              <FormattedTime date={release.currentStart} />
+              <FormattedTime date={release.initialDate} />
             </td>
 
             <td data-label={t('components.downloadReleasesTable.lastUpdated')}>

--- a/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
+++ b/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
@@ -7,17 +7,12 @@ import { Fragment, useState } from 'react';
 import FormattedTime from '#site/components/Common/FormattedTime';
 import LinkWithArrow from '#site/components/Common/LinkWithArrow';
 import Link from '#site/components/Link';
+import { STATUS_KIND_MAP } from '#site/next.constants.mjs';
 
 import type { NodeRelease } from '#site/types';
 import type { FC } from 'react';
 
 import ReleaseModal from '../ReleaseModal';
-
-const BADGE_KIND_MAP = {
-  'End-of-life': 'warning',
-  LTS: 'info',
-  Current: 'default',
-} as const;
 
 type PreviousReleasesTableBodyProps = {
   releaseData: Array<NodeRelease>;
@@ -56,9 +51,8 @@ const PreviousReleasesTableBody: FC<PreviousReleasesTableBodyProps> = ({
             </td>
 
             <td data-label={t('components.downloadReleasesTable.status')}>
-              <Badge kind={BADGE_KIND_MAP[release.status]} size="small">
+              <Badge kind={STATUS_KIND_MAP[release.status]} size="small">
                 {release.status}
-                {release.status === 'End-of-life' ? ' (EoL)' : ''}
               </Badge>
             </td>
 

--- a/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
+++ b/apps/site/components/Releases/PreviousReleasesTable/TableBody.tsx
@@ -43,11 +43,11 @@ const PreviousReleasesTableBody: FC<PreviousReleasesTableBodyProps> = ({
             <td
               data-label={t('components.downloadReleasesTable.firstReleased')}
             >
-              <FormattedTime date={release.initialDate} />
+              <FormattedTime date={release.initialReleaseDate} />
             </td>
 
             <td data-label={t('components.downloadReleasesTable.lastUpdated')}>
-              <FormattedTime date={release.releaseDate} />
+              <FormattedTime date={release.latestReleaseDate} />
             </td>
 
             <td data-label={t('components.downloadReleasesTable.status')}>

--- a/apps/site/components/Releases/ReleaseOverview/index.tsx
+++ b/apps/site/components/Releases/ReleaseOverview/index.tsx
@@ -28,7 +28,7 @@ const ReleaseOverview: FC<ReleaseOverviewProps> = ({ release }) => {
       <div className={styles.container}>
         <ReleaseOverviewItem
           Icon={CalendarIcon}
-          title={<FormattedTime date={release.currentStart} />}
+          title={<FormattedTime date={release.initialDate} />}
           subtitle={t('components.releaseOverview.firstReleased')}
         />
 

--- a/apps/site/components/Releases/ReleaseOverview/index.tsx
+++ b/apps/site/components/Releases/ReleaseOverview/index.tsx
@@ -28,13 +28,13 @@ const ReleaseOverview: FC<ReleaseOverviewProps> = ({ release }) => {
       <div className={styles.container}>
         <ReleaseOverviewItem
           Icon={CalendarIcon}
-          title={<FormattedTime date={release.initialDate} />}
+          title={<FormattedTime date={release.initialReleaseDate} />}
           subtitle={t('components.releaseOverview.firstReleased')}
         />
 
         <ReleaseOverviewItem
           Icon={ClockIcon}
-          title={<FormattedTime date={release.releaseDate} />}
+          title={<FormattedTime date={release.latestReleaseDate} />}
           subtitle={t('components.releaseOverview.lastUpdated')}
         />
 

--- a/apps/site/components/withDownloadSection.tsx
+++ b/apps/site/components/withDownloadSection.tsx
@@ -39,9 +39,7 @@ const WithDownloadSection: FC<WithDownloadSectionProps> = async ({
     .concat(localeSnippets);
 
   // Decides which initial release to use based on the current pathname
-  const initialRelease = pathname.endsWith('/current')
-    ? 'Current'
-    : ['Active LTS' as const, 'Maintenance LTS' as const];
+  const initialRelease = pathname.endsWith('/current') ? 'Current' : 'LTS';
 
   return (
     <WithNodeRelease status={initialRelease}>

--- a/apps/site/components/withFooter.tsx
+++ b/apps/site/components/withFooter.tsx
@@ -27,7 +27,7 @@ const WithFooter: FC = () => {
 
   const primary = (
     <div className="flex flex-row gap-2">
-      <WithNodeRelease status={['Active LTS', 'Maintenance LTS']}>
+      <WithNodeRelease status="LTS">
         {({ release }) => (
           <BadgeGroup
             size="small"

--- a/apps/site/components/withReleaseAlertBox.tsx
+++ b/apps/site/components/withReleaseAlertBox.tsx
@@ -14,7 +14,7 @@ const WithReleaseAlertBox: FC<WithReleaseAlertBoxProps> = ({ status }) => {
   const t = useTranslations();
 
   switch (status) {
-    case 'End-of-life':
+    case 'EOL':
       return (
         <AlertBox
           title={t('components.common.alertBox.warning')}

--- a/apps/site/components/withReleaseAlertBox.tsx
+++ b/apps/site/components/withReleaseAlertBox.tsx
@@ -26,8 +26,7 @@ const WithReleaseAlertBox: FC<WithReleaseAlertBoxProps> = ({ status }) => {
           })}
         </AlertBox>
       );
-    case 'Active LTS':
-    case 'Maintenance LTS':
+    case 'LTS':
       return (
         <AlertBox
           title={t('components.common.alertBox.info')}

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -43,19 +43,7 @@ describe('generateReleaseData', () => {
       },
     });
 
-    assert.equal(result.length, 1);
-    assert.partialDeepStrictEqual(result[0], {
-      major: 14,
-      version: '14.0.0',
-      versionWithPrefix: 'v14.0.0',
-      codename: '',
-      npm: '6.14.10',
-      v8: '8.0.276.20',
-      releaseDate: '2021-04-20',
-      initialDate: '2021-04-20',
-      modules: '83',
-      status: 'EOL',
-    });
+    assert.equal(result[0]?.status, 'EOL');
   });
 
   it('returns Current when release is not EOL and latest is not LTS', async t => {
@@ -142,7 +130,7 @@ describe('generateReleaseData', () => {
     assert.equal(result[0]?.status, 'Current');
   });
 
-  it('uses latest and earliest release dates for releaseDate and initialDate', async t => {
+  it('uses latest and earliest release dates for latestReleaseDate and initialReleaseDate', async t => {
     const result = await runWithNodevuData(t, '2026-04-14', {
       26: {
         releases: {
@@ -174,7 +162,7 @@ describe('generateReleaseData', () => {
       },
     });
 
-    assert.equal(result[0]?.releaseDate, '2026-04-01');
-    assert.equal(result[0]?.initialDate, '2025-10-21');
+    assert.equal(result[0]?.latestReleaseDate, '2026-04-01');
+    assert.equal(result[0]?.initialReleaseDate, '2025-10-21');
   });
 });

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -2,39 +2,46 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 describe('generateReleaseData', () => {
-  it('generates release data with correct status', async t => {
-    t.mock.timers.enable({ now: new Date('2024-10-18') });
+  let currentNodevuData = {};
+  const nodevuMock = () => Promise.resolve(currentNodevuData);
+
+  const runWithNodevuData = async (t, now, data) => {
+    currentNodevuData = data;
+    t.mock.timers.enable({ now: new Date(now) });
 
     t.mock.module('@nodevu/core', {
-      defaultExport: () =>
-        Promise.resolve({
-          14: {
-            releases: {
-              '14.0.0': {
-                semver: { major: 14, raw: '14.0.0' },
-                dependencies: { npm: '6.14.10', v8: '8.0.276.20' },
-                releaseDate: '2021-04-20',
-                modules: { version: '83' },
-              },
-            },
-            support: {
-              phases: {
-                dates: {
-                  start: '2021-10-26',
-                  lts: '2022-10-18',
-                  maintenance: '2023-10-18',
-                  end: '2024-10-18',
-                },
-              },
-            },
-          },
-        }),
+      defaultExport: nodevuMock,
     });
 
     const { default: generateReleaseData } =
       await import('#site/next-data/generators/releaseData.mjs');
 
-    const result = await generateReleaseData();
+    return generateReleaseData();
+  };
+
+  it('returns End-of-life when release is on or past EOL date', async t => {
+    const result = await runWithNodevuData(t, '2024-10-18', {
+      14: {
+        releases: {
+          '14.0.0': {
+            semver: { major: 14, raw: '14.0.0' },
+            dependencies: { npm: '6.14.10', v8: '8.0.276.20' },
+            releaseDate: '2021-04-20',
+            modules: { version: '83' },
+          },
+        },
+        support: {
+          phases: {
+            dates: {
+              start: '2021-10-26',
+              lts: '2022-10-18',
+              maintenance: '2023-10-18',
+              end: '2024-10-18',
+            },
+          },
+        },
+      },
+    });
 
     assert.equal(result.length, 1);
     assert.partialDeepStrictEqual(result[0], {
@@ -49,5 +56,125 @@ describe('generateReleaseData', () => {
       modules: '83',
       status: 'End-of-life',
     });
+  });
+
+  it('returns Current when release is not EOL and latest is not LTS', async t => {
+    const result = await runWithNodevuData(t, '2026-04-14', {
+      20: {
+        releases: {
+          '20.12.0': {
+            semver: { major: 20, raw: '20.12.0' },
+            dependencies: { npm: '10.8.2', v8: '11.3.244.8' },
+            lts: { isLts: false },
+            releaseDate: '2026-03-26',
+            modules: { version: '115' },
+          },
+        },
+        support: {
+          phases: {
+            dates: {
+              start: '2025-10-22',
+              lts: '2026-10-22',
+              maintenance: '2027-10-22',
+              end: '2028-04-30',
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(result[0]?.status, 'Current');
+  });
+
+  it('returns LTS when release is not EOL and latest is flagged as LTS', async t => {
+    const result = await runWithNodevuData(t, '2026-04-14', {
+      22: {
+        releases: {
+          '22.7.0': {
+            semver: { major: 22, raw: '22.7.0' },
+            dependencies: { npm: '10.9.0', v8: '12.4.254.10' },
+            lts: { isLts: true },
+            releaseDate: '2026-02-18',
+            modules: { version: '124' },
+          },
+        },
+        support: {
+          phases: {
+            dates: {
+              start: '2026-04-23',
+              lts: '2026-10-21',
+              maintenance: '2027-10-20',
+              end: '2029-04-30',
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(result[0]?.status, 'LTS');
+  });
+
+  it('returns Current when release is not EOL and LTS date has passed but latest is not LTS', async t => {
+    const result = await runWithNodevuData(t, '2026-04-14', {
+      24: {
+        releases: {
+          '24.1.0': {
+            semver: { major: 24, raw: '24.1.0' },
+            dependencies: { npm: '11.1.0', v8: '13.0.12.7' },
+            lts: { isLts: false },
+            releaseDate: '2026-03-10',
+            modules: { version: '130' },
+          },
+        },
+        support: {
+          phases: {
+            dates: {
+              start: '2025-10-10',
+              lts: '2026-01-01',
+              maintenance: '2027-01-01',
+              end: '2028-10-01',
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(result[0]?.status, 'Current');
+  });
+
+  it('uses latest and earliest release dates for releaseDate and initialDate', async t => {
+    const result = await runWithNodevuData(t, '2026-04-14', {
+      26: {
+        releases: {
+          '26.2.0': {
+            semver: { major: 26, raw: '26.2.0' },
+            dependencies: { npm: '11.3.1', v8: '13.2.20.1' },
+            lts: { isLts: false },
+            releaseDate: '2026-04-01',
+            modules: { version: '132' },
+          },
+          '26.0.0': {
+            semver: { major: 26, raw: '26.0.0' },
+            dependencies: { npm: '11.0.0', v8: '13.1.0.0' },
+            lts: { isLts: false },
+            releaseDate: '2025-10-21',
+            modules: { version: '131' },
+          },
+        },
+        support: {
+          phases: {
+            dates: {
+              start: '2025-10-21',
+              lts: '2026-10-20',
+              maintenance: '2027-10-19',
+              end: '2029-04-30',
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(result[0]?.releaseDate, '2026-04-01');
+    assert.equal(result[0]?.initialDate, '2025-10-21');
   });
 });

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -19,7 +19,7 @@ describe('generateReleaseData', () => {
     return generateReleaseData();
   };
 
-  it('returns End-of-life when release is on or past EOL date', async t => {
+  it('returns EOL when release is on or past EOL date', async t => {
     const result = await runWithNodevuData(t, '2024-10-18', {
       14: {
         releases: {
@@ -54,7 +54,7 @@ describe('generateReleaseData', () => {
       releaseDate: '2021-04-20',
       initialDate: '2021-04-20',
       modules: '83',
-      status: 'End-of-life',
+      status: 'EOL',
     });
   });
 

--- a/apps/site/next-data/generators/__tests__/releaseData.test.mjs
+++ b/apps/site/next-data/generators/__tests__/releaseData.test.mjs
@@ -42,10 +42,10 @@ describe('generateReleaseData', () => {
       version: '14.0.0',
       versionWithPrefix: 'v14.0.0',
       codename: '',
-      isLts: false,
       npm: '6.14.10',
       v8: '8.0.276.20',
       releaseDate: '2021-04-20',
+      initialDate: '2021-04-20',
       modules: '83',
       status: 'End-of-life',
     });

--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -3,31 +3,18 @@
 import getMajorNodeReleases from './majorNodeReleases.mjs';
 
 // Gets the appropriate release status for each major release
-const getNodeReleaseStatus = (latest, support) => {
+const getNodeReleaseStatus = (latest, eol) => {
   const now = new Date();
-  const { endOfLife, maintenanceStart, ltsStart, currentStart } = support;
 
-  if (endOfLife && now >= new Date(endOfLife)) {
+  if (eol && now >= new Date(eol)) {
     return 'End-of-life';
   }
 
-  if (
-    latest.lts.isLts &&
-    maintenanceStart &&
-    now >= new Date(maintenanceStart)
-  ) {
-    return 'Maintenance LTS';
+  if (latest.lts.isLts) {
+    return 'LTS';
   }
 
-  if (latest.lts.isLts && ltsStart && now >= new Date(ltsStart)) {
-    return 'Active LTS';
-  }
-
-  if (currentStart && now >= new Date(currentStart)) {
-    return 'Current';
-  }
-
-  return 'Pending';
+  return 'Current';
 };
 
 /**
@@ -40,17 +27,15 @@ const generateReleaseData = async () => {
   const majors = await getMajorNodeReleases();
 
   return majors.map(([, major]) => {
-    const [latestVersion] = Object.values(major.releases);
-
-    const support = {
-      currentStart: major.support.phases.dates.start,
-      ltsStart: major.support.phases.dates.lts,
-      maintenanceStart: major.support.phases.dates.maintenance,
-      endOfLife: major.support.phases.dates.end,
-    };
+    const versions = Object.values(major.releases);
+    const latestVersion = versions[0];
+    const initialVersion = versions[versions.length - 1];
 
     // Get the major release status based on our Release Schedule
-    const status = getNodeReleaseStatus(latestVersion, support);
+    const status = getNodeReleaseStatus(
+      latestVersion,
+      major.support.phases.dates.end
+    );
 
     const minorVersions = Object.entries(major.releases).map(([, release]) => ({
       modules: release.modules.version || '',
@@ -62,16 +47,15 @@ const generateReleaseData = async () => {
     }));
 
     return {
-      ...support,
       status,
       major: latestVersion.semver.major,
       version: latestVersion.semver.raw,
       versionWithPrefix: `v${latestVersion.semver.raw}`,
       codename: major.support.codename || '',
-      isLts: status.endsWith('LTS'),
       npm: latestVersion.dependencies.npm || '',
       v8: latestVersion.dependencies.v8,
       releaseDate: latestVersion.releaseDate,
+      initialDate: initialVersion.releaseDate,
       modules: latestVersion.modules.version || '',
       minorVersions,
     };

--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -7,7 +7,7 @@ const getNodeReleaseStatus = (latest, eol) => {
   const now = new Date();
 
   if (eol && now >= new Date(eol)) {
-    return 'End-of-life';
+    return 'EOL';
   }
 
   if (latest.lts.isLts) {

--- a/apps/site/next-data/generators/releaseData.mjs
+++ b/apps/site/next-data/generators/releaseData.mjs
@@ -54,8 +54,8 @@ const generateReleaseData = async () => {
       codename: major.support.codename || '',
       npm: latestVersion.dependencies.npm || '',
       v8: latestVersion.dependencies.v8,
-      releaseDate: latestVersion.releaseDate,
-      initialDate: initialVersion.releaseDate,
+      latestReleaseDate: latestVersion.releaseDate,
+      initialReleaseDate: initialVersion.releaseDate,
       modules: latestVersion.modules.version || '',
       minorVersions,
     };

--- a/apps/site/next.constants.mjs
+++ b/apps/site/next.constants.mjs
@@ -205,9 +205,15 @@ export const SEVERITY_KIND_MAP = {
 };
 
 /**
- * Which Node.js versions do we want to display vulnerabilities for?
+ * Maps Node.js version status to UI Badge kinds
+ *
+ * @type {Record<import('./types/releases').NodeReleaseStatus, import('@node-core/ui-components/Common/Badge').BadgeKind>}
  */
-export const EOL_VERSION_IDENTIFIER = 'End-of-life';
+export const STATUS_KIND_MAP = {
+  EOL: 'warning',
+  LTS: 'info',
+  Current: 'default',
+};
 
 /**
  * The location of the Node.js Security Working Group Vulnerabilities data.

--- a/apps/site/scripts/orama-search/get-documents.mjs
+++ b/apps/site/scripts/orama-search/get-documents.mjs
@@ -13,17 +13,15 @@ const fetchOptions = process.env.GITHUB_TOKEN
 
 /**
  * Fetch Node.js API documentation directly from GitHub
- * for the current Active LTS version.
+ * for the current LTS version.
  */
 export const getAPIDocs = async () => {
   // Find the current Active LTS version
   const releaseData = await generateReleaseData();
-  const ltsRelease =
-    releaseData.find(r => r.status === 'Active LTS') ||
-    releaseData.find(r => r.status === 'Maintenance LTS');
+  const ltsRelease = releaseData.find(r => r.status === 'LTS');
 
   if (!ltsRelease) {
-    throw new Error('No Active LTS or Maintenance LTS release found');
+    throw new Error('No LTS release found');
   }
 
   // Get list of API docs from the Node.js repo

--- a/apps/site/types/releases.ts
+++ b/apps/site/types/releases.ts
@@ -6,8 +6,8 @@ export type NodeReleaseSource = {
   codename?: string;
   npm?: string;
   v8: string;
-  releaseDate: string;
-  initialDate: string;
+  latestReleaseDate: string;
+  initialReleaseDate: string;
   modules?: string;
 };
 

--- a/apps/site/types/releases.ts
+++ b/apps/site/types/releases.ts
@@ -1,4 +1,4 @@
-export type NodeReleaseStatus = 'LTS' | 'Current' | 'End-of-life';
+export type NodeReleaseStatus = 'LTS' | 'Current' | 'EOL';
 
 export type NodeReleaseSource = {
   major: number;

--- a/apps/site/types/releases.ts
+++ b/apps/site/types/releases.ts
@@ -1,21 +1,13 @@
-export type NodeReleaseStatus =
-  | 'Active LTS'
-  | 'Maintenance LTS'
-  | 'Current'
-  | 'End-of-life'
-  | 'Pending';
+export type NodeReleaseStatus = 'LTS' | 'Current' | 'End-of-life';
 
 export type NodeReleaseSource = {
   major: number;
   version: string;
   codename?: string;
-  currentStart: string;
-  ltsStart?: string;
-  maintenanceStart?: string;
-  endOfLife: string;
   npm?: string;
   v8: string;
   releaseDate: string;
+  initialDate: string;
   modules?: string;
 };
 
@@ -30,7 +22,6 @@ export type MinorVersion = {
 
 export type NodeRelease = {
   versionWithPrefix: string;
-  isLts: boolean;
   status: NodeReleaseStatus;
   minorVersions: Array<MinorVersion>;
 } & NodeReleaseSource;

--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -152,7 +152,7 @@
       "name": "Brew",
       "compatibility": {
         "os": ["MAC", "LINUX"],
-        "releases": ["Current", "Active LTS", "Maintenance LTS"]
+        "releases": ["Current", "LTS"]
       },
       "url": "https://brew.sh/",
       "info": "layouts.download.codeBox.platformInfo.brew"
@@ -213,11 +213,5 @@
     "bitness": ["64", "32"],
     "architecture": ["arm", "x86"]
   },
-  "statusOrder": [
-    "Current",
-    "Active LTS",
-    "Maintenance LTS",
-    "End-of-life",
-    "Pending"
-  ]
+  "statusOrder": ["Current", "LTS", "End-of-life"]
 }

--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -213,5 +213,5 @@
     "bitness": ["64", "32"],
     "architecture": ["arm", "x86"]
   },
-  "statusOrder": ["Current", "LTS", "End-of-life"]
+  "statusOrder": ["Current", "LTS", "EOL"]
 }

--- a/packages/ui-components/src/Common/Select/StatelessSelect/index.tsx
+++ b/packages/ui-components/src/Common/Select/StatelessSelect/index.tsx
@@ -2,6 +2,8 @@ import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import classNames from 'classnames';
 import { useId, useMemo } from 'react';
 
+import Badge from '#ui/Common/Badge';
+
 import type { SelectGroup, SelectProps } from '#ui/Common/Select';
 import type { LinkLike } from '#ui/types';
 
@@ -66,6 +68,15 @@ const StatelessSelect = <T extends string>({
             <span className={styles.selectedValue}>
               {currentItem.iconImage}
               <span>{currentItem.label}</span>
+              {currentItem.badge && (
+                <Badge
+                  size="small"
+                  kind={currentItem.badge.kind}
+                  className={styles.badge}
+                >
+                  {currentItem.badge.label}
+                </Badge>
+              )}
             </span>
           )}
           {!currentItem && (
@@ -89,7 +100,13 @@ const StatelessSelect = <T extends string>({
               )}
 
               {items.map(
-                ({ value, label, iconImage, disabled: itemDisabled }) => (
+                ({
+                  value,
+                  label,
+                  iconImage,
+                  badge,
+                  disabled: itemDisabled,
+                }) => (
                   <Component
                     key={value}
                     href={value}
@@ -101,6 +118,15 @@ const StatelessSelect = <T extends string>({
                   >
                     {iconImage}
                     <span>{label}</span>
+                    {badge && (
+                      <Badge
+                        size="small"
+                        kind={badge.kind}
+                        className={styles.badge}
+                      >
+                        {badge.label}
+                      </Badge>
+                    )}
                   </Component>
                 )
               )}

--- a/packages/ui-components/src/Common/Select/index.module.css
+++ b/packages/ui-components/src/Common/Select/index.module.css
@@ -161,6 +161,10 @@
     dark:text-neutral-200;
 }
 
+.badge {
+  @apply ml-auto;
+}
+
 .noscript {
   @apply relative
     cursor-pointer;

--- a/packages/ui-components/src/Common/Select/index.tsx
+++ b/packages/ui-components/src/Common/Select/index.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from '@radix-ui/react-select';
 import classNames from 'classnames';
 import { useEffect, useId, useMemo, useState } from 'react';
 
+import Badge, { type BadgeKind } from '#ui/Common/Badge';
 import Skeleton from '#ui/Common/Skeleton';
 
 import type { FormattedMessage, LinkLike } from '#ui/types';
@@ -18,6 +19,10 @@ export type SelectValue<T extends string> = {
   label: FormattedMessage | string;
   value: T;
   iconImage?: ReactElement<SVGSVGElement>;
+  badge?: {
+    label: FormattedMessage | string;
+    kind?: BadgeKind;
+  };
   disabled?: boolean;
 };
 
@@ -91,7 +96,7 @@ const Select = <T extends string>({
           </SelectPrimitive.Label>
         )}
 
-        {items.map(({ value, label, iconImage, disabled }) => (
+        {items.map(({ value, label, iconImage, badge, disabled }) => (
           <SelectPrimitive.Item
             key={value}
             value={value}
@@ -101,6 +106,11 @@ const Select = <T extends string>({
             <SelectPrimitive.ItemText>
               {iconImage}
               <span>{label}</span>
+              {badge && (
+                <Badge size="small" kind={badge.kind} className={styles.badge}>
+                  {badge.label}
+                </Badge>
+              )}
             </SelectPrimitive.ItemText>
           </SelectPrimitive.Item>
         ))}
@@ -151,6 +161,15 @@ const Select = <T extends string>({
                 <>
                   {currentItem.iconImage}
                   <span>{currentItem.label}</span>
+                  {currentItem.badge && (
+                    <Badge
+                      size="small"
+                      kind={currentItem.badge.kind}
+                      className={styles.badge}
+                    >
+                      {currentItem.badge.label}
+                    </Badge>
+                  )}
                 </>
               )}
             </SelectPrimitive.Value>


### PR DESCRIPTION
## Description

In preparation for the change to how Node.js will be shipping releases, this removes the Active/Maintenance distinction for LTS release lines in the website's logic. This distinction was never shown to users; it was only used in internal logic and was always just reported as LTS to the user viewing the site.

Also, I've updated the version dropdown on the downloads page to make use of badges to make it clearer what status a given release has, as during the conversation around this change, it was flagged that it is odd we show EoL releases there and it isn't super obvious that they're EoL.

| Before | After |
|-|-|
| <img width="164" height="244" alt="image" src="https://github.com/user-attachments/assets/27d04221-d3e9-41c0-9554-3abde09b6ebf" /> | <img width="166" height="245" alt="image" src="https://github.com/user-attachments/assets/8bd99304-7319-4938-9837-efc1acf45415" /> |

## Validation

All release lines continue to report their correct statuses and dates on the site.

## Related Issues

I think we can say that this finally closes #8277.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
