### PR TITLE
meta: add next-env.d.ts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ package-lock.json
 apps/site/.next
 apps/site/build
 apps/site/public/blog-data.json
+apps/site/next-env.d.ts
 
 # Test Runner
 junit.xml

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts';
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -21,7 +21,7 @@
     "lint:js:fix": "node --run lint:js -- --fix",
     "lint:md": "eslint \"**/*.md?(x)\" --cache --cache-strategy=content --cache-location=.eslintmdcache",
     "lint:md:fix": "node --run lint:md -- --fix",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "next typegen && tsc --noEmit",
     "playwright": "playwright test",
     "scripts:release-post": "cross-env NODE_NO_WARNINGS=1 node scripts/release-post/index.mjs",
     "serve": "node --run dev",


### PR DESCRIPTION
## Description

Folks frequently run into diffs being generated on `next-env.d.ts` locally when they run the site, and we've flip-flopped on the checked-in values a few times. I think it is easier to just ensure this file is never checked in, so it can contain whatever Next.js needs to generate for a person's local setup.

Next.js itself also recommends that this value is not checked in: https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts + https://nextjs.org/docs/app/api-reference/cli/next#next-typegen-options

If you run `next typegen` or `next build`, you get this:
```ts
/// <reference types="next" />
/// <reference types="next/image-types/global" />
/// <reference types="next/navigation-types/compat/navigation" />
import "./.next/types/routes.d.ts";

// NOTE: This file should not be edited
// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
```

But if you run `next dev`, you get this:
```ts
/// <reference types="next" />
/// <reference types="next/image-types/global" />
/// <reference types="next/navigation-types/compat/navigation" />
import "./.next/dev/types/routes.d.ts";

// NOTE: This file should not be edited
// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
```

The `import` line changes...

## Validation

File no longer checked in. CI still passes for type-checking.

## Related Issues

N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
