### PR TITLE
chore: sitemap paths added into the robots.txt

### DIFF
--- a/apps/site/app/robots.ts
+++ b/apps/site/app/robots.ts
@@ -1,3 +1,5 @@
+import { BASE_URL } from '#site/next.constants.mjs';
+
 import type { MetadataRoute } from 'next';
 
 // This allows us to generate a `robots.txt` file dynamically based on the needs of the Node.js Website
@@ -10,6 +12,7 @@ const robots = (): MetadataRoute.Robots => ({
       allow: ['/dist/latest/', '/dist/latest/docs/api/', '/api/'],
     },
   ],
+  sitemap: [`${BASE_URL}/sitemap.xml`, `${BASE_URL}/learn/sitemap.xml`],
 });
 
 export default robots;


### PR DESCRIPTION
## Description

Since we now have multiple sitemap files, the sitemap paths have been added to robots.txt for the SEO.

## Validation

In preview environment the robots.txt should contains

```
Sitemap: https://nodejs.org/sitemap.xml
Sitemap: https://nodejs.org/learn/sitemap.xml
```

## Related Issues

Related with this comment; https://github.com/nodejs/learn/pull/47#pullrequestreview-4068761571

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
