### PR TITLE
chore: explicitly skip the Vercel OTEL when running open-next

### DIFF
--- a/apps/site/instrumentation.ts
+++ b/apps/site/instrumentation.ts
@@ -1,5 +1,7 @@
-import { registerOTel } from '@vercel/otel';
-
-export function register() {
-  registerOTel({ serviceName: 'nodejs-org' });
+export async function register() {
+  if (!('Cloudflare' in globalThis)) {
+    // Note: we don't need to set up the Vercel OTEL if the application is running on Cloudflare
+    const { registerOTel } = await import('@vercel/otel');
+    registerOTel({ serviceName: 'nodejs-org' });
+  }
 }


### PR DESCRIPTION
## Description

The Vercel OTEL implementation doesn't work on the open-next build (I haven't investigated why), but it doesn't seem to cause issues either. However it produces some error in the terminal on previews.

In any case for the open-next build Vercel OTEL couldn't be used anyways (since the app wouldn't be hosted on Vercel).

In order to remove the terminal error and also to make the code more clear/explicit this PR is making the Vercel OTEL setup conditional based on whether the application is being run by Cloudflare or not.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

I've validated that the open-next preview now does not present the telemetry error anymore.

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
