### PR TITLE
feat: enable Twoslash on Cloudflare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ apps/site/build
 apps/site/public/blog-data.json
 apps/site/next-env.d.ts
 
+# Generated Build Artifacts
+apps/site/generated
+
 # Test Runner
 junit.xml
 lcov.info

--- a/apps/site/mdx/create-vfs-twoslasher.mjs
+++ b/apps/site/mdx/create-vfs-twoslasher.mjs
@@ -8,13 +8,11 @@
  * generated at build time by `scripts/twoslash-fsmap/index.mjs`.
  */
 export async function createVfsTwoslasher() {
-  const [{ createTwoslasher }, ts, fsMapJson] = await Promise.all([
-    import('twoslash/core'),
-    import('typescript').then(m => m.default),
-    import('../generated/twoslash-fsmap.json', { with: { type: 'json' } }).then(
-      m => m.default
-    ),
-  ]);
+  const { createTwoslasher } = await import('twoslash/core');
+  const ts = (await import('typescript')).default;
+  const fsMapJson = (
+    await import('../generated/twoslash-fsmap.json', { with: { type: 'json' } })
+  ).default;
 
   const fsMap = new Map(Object.entries(fsMapJson));
 

--- a/apps/site/mdx/create-vfs-twoslasher.mjs
+++ b/apps/site/mdx/create-vfs-twoslasher.mjs
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Creates a Twoslash instance backed by a virtual filesystem for environments
+ * without real filesystem access (e.g. Cloudflare Workers).
+ *
+ * Uses a pre-built JSON map of TypeScript lib declarations and @types/node
+ * generated at build time by `scripts/twoslash-fsmap/index.mjs`.
+ */
+export async function createVfsTwoslasher() {
+  const [{ createTwoslasher }, ts, fsMapJson] = await Promise.all([
+    import('twoslash/core'),
+    import('typescript').then(m => m.default),
+    import('../generated/twoslash-fsmap.json', { with: { type: 'json' } }).then(
+      m => m.default
+    ),
+  ]);
+
+  const fsMap = new Map(Object.entries(fsMapJson));
+
+  return createTwoslasher({
+    fsMap,
+    tsModule: ts,
+    vfsRoot: '/',
+    compilerOptions: {
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      // Explicitly include @types/node so that the VFS resolves Node.js
+      // globals and `node:*` module imports from the bundled declarations.
+      types: ['node'],
+    },
+  });
+}

--- a/apps/site/mdx/plugins.mjs
+++ b/apps/site/mdx/plugins.mjs
@@ -15,6 +15,37 @@ import remarkTableTitles from '../util/table';
 // Reference: https://github.com/nodejs/nodejs.org/pull/7896#issuecomment-3009480615
 const OPEN_NEXT_CLOUDFLARE = 'Cloudflare' in global;
 
+/**
+ * Creates a Twoslash instance backed by a virtual filesystem for environments
+ * without real filesystem access (e.g. Cloudflare Workers).
+ *
+ * Uses a pre-built JSON map of TypeScript lib declarations and @types/node
+ * generated at build time by `scripts/twoslash-fsmap/index.mjs`.
+ */
+async function createVfsTwoslasher() {
+  const [{ createTwoslasher }, ts, fsMapJson] = await Promise.all([
+    import('twoslash/core'),
+    import('typescript').then(m => m.default),
+    import('../generated/twoslash-fsmap.json', { with: { type: 'json' } }).then(
+      m => m.default
+    ),
+  ]);
+
+  const fsMap = new Map(Object.entries(fsMapJson));
+
+  return createTwoslasher({
+    fsMap,
+    tsModule: ts,
+    vfsRoot: '/',
+    compilerOptions: {
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      // Explicitly include @types/node so that the VFS resolves Node.js
+      // globals and `node:*` module imports from the bundled declarations.
+      types: ['node'],
+    },
+  });
+}
+
 // Shiki is created out here to avoid an async rehype plugin
 const singletonShiki = await rehypeShikiji({
   // We use the faster WASM engine on the server instead of the web-optimized version.
@@ -25,8 +56,15 @@ const singletonShiki = await rehypeShikiji({
   // for security reasons.
   wasm: !OPEN_NEXT_CLOUDFLARE,
 
-  // TODO(@avivkeller): Find a way to enable Twoslash w/ a VFS on Cloudflare
-  twoslash: !OPEN_NEXT_CLOUDFLARE,
+  twoslash: true,
+
+  // On Cloudflare Workers, the default filesystem-backed Twoslash cannot work
+  // because there is no real filesystem. Instead, we provide a custom twoslasher
+  // backed by an in-memory VFS pre-populated at build time with TypeScript
+  // lib declarations and @types/node.
+  twoslashOptions: OPEN_NEXT_CLOUDFLARE
+    ? { twoslasher: await createVfsTwoslasher() }
+    : undefined,
 });
 
 /**

--- a/apps/site/mdx/plugins.mjs
+++ b/apps/site/mdx/plugins.mjs
@@ -7,6 +7,7 @@ import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
 import readingTime from 'remark-reading-time';
 
+import { createVfsTwoslasher } from './create-vfs-twoslasher.mjs';
 import remarkTableTitles from '../util/table';
 
 // TODO(@avivkeller): When available, use `OPEN_NEXT_CLOUDFLARE` environment
@@ -14,37 +15,6 @@ import remarkTableTitles from '../util/table';
 // tree-shaking.
 // Reference: https://github.com/nodejs/nodejs.org/pull/7896#issuecomment-3009480615
 const OPEN_NEXT_CLOUDFLARE = 'Cloudflare' in global;
-
-/**
- * Creates a Twoslash instance backed by a virtual filesystem for environments
- * without real filesystem access (e.g. Cloudflare Workers).
- *
- * Uses a pre-built JSON map of TypeScript lib declarations and @types/node
- * generated at build time by `scripts/twoslash-fsmap/index.mjs`.
- */
-async function createVfsTwoslasher() {
-  const [{ createTwoslasher }, ts, fsMapJson] = await Promise.all([
-    import('twoslash/core'),
-    import('typescript').then(m => m.default),
-    import('../generated/twoslash-fsmap.json', { with: { type: 'json' } }).then(
-      m => m.default
-    ),
-  ]);
-
-  const fsMap = new Map(Object.entries(fsMapJson));
-
-  return createTwoslasher({
-    fsMap,
-    tsModule: ts,
-    vfsRoot: '/',
-    compilerOptions: {
-      moduleResolution: ts.ModuleResolutionKind.Bundler,
-      // Explicitly include @types/node so that the VFS resolves Node.js
-      // globals and `node:*` module imports from the bundled declarations.
-      types: ['node'],
-    },
-  });
-}
 
 // Shiki is created out here to avoid an async rehype plugin
 const singletonShiki = await rehypeShikiji({

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -2,10 +2,11 @@
   "name": "@node-core/website",
   "type": "module",
   "scripts": {
-    "prebuild": "node --run build:blog-data",
+    "prebuild": "node --run build:blog-data && node --run build:twoslash-fsmap",
     "build": "cross-env NODE_NO_WARNINGS=1 next build",
     "build:blog-data": "cross-env NODE_NO_WARNINGS=1 node ./scripts/blog-data/index.mjs",
     "build:blog-data:watch": "node --watch --watch-path=pages/en/blog ./scripts/blog-data/index.mjs",
+    "build:twoslash-fsmap": "node ./scripts/twoslash-fsmap/index.mjs",
     "cloudflare:build:worker": "OPEN_NEXT_CLOUDFLARE=true opennextjs-cloudflare build",
     "cloudflare:deploy": "opennextjs-cloudflare deploy",
     "cloudflare:preview": "wrangler dev",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -48,6 +48,7 @@
     "@tailwindcss/postcss": "~4.3.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "@typescript/vfs": "^1.6.4",
     "@vcarl/remark-headings": "~0.1.0",
     "@vercel/analytics": "~2.0.1",
     "@vercel/otel": "~2.1.2",

--- a/apps/site/scripts/twoslash-fsmap/generate.mjs
+++ b/apps/site/scripts/twoslash-fsmap/generate.mjs
@@ -1,0 +1,73 @@
+'use strict';
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Recursively collects all `.d.ts` files from a directory into the fsMap.
+ *
+ * @param {Record<string, string>} fsMap The map to populate
+ * @param {string} dir The directory to walk
+ * @param {string} virtualPrefix The virtual path prefix (e.g., "/node_modules/@types/node")
+ * @param {string} baseDir The base directory for computing relative paths
+ */
+function collectDtsFiles(fsMap, dir, virtualPrefix, baseDir) {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      collectDtsFiles(fsMap, fullPath, virtualPrefix, baseDir);
+    } else if (entry.isFile() && /\.d\.([^.]+\.)?[cm]?ts$/i.test(entry.name)) {
+      const relativePath = fullPath.slice(baseDir.length).replace(/\\/g, '/');
+      const virtualPath = `${virtualPrefix}${relativePath}`;
+
+      fsMap[virtualPath] = readFileSync(fullPath, 'utf8');
+    }
+  }
+}
+
+/**
+ * Generates a virtual filesystem map containing all TypeScript library
+ * declaration files and `@types/node` declarations needed for Twoslash
+ * to run without real filesystem access (e.g., on Cloudflare Workers).
+ *
+ * @returns {Record<string, string>} A map of virtual paths to file contents
+ */
+export default function generateTwoslashFsMap() {
+  const fsMap = {};
+
+  // 1. Collect TypeScript lib .d.ts files
+  //    These are keyed as "/lib.es5.d.ts", "/lib.dom.d.ts", etc.
+  //    (matching the convention used by @typescript/vfs)
+  const tsLibDir = dirname(require.resolve('typescript/lib/lib.d.ts'));
+  const tsLibFiles = readdirSync(tsLibDir)
+    .filter(f => f.startsWith('lib.') && /\.d\.([^.]+\.)?[cm]?ts$/i.test(f))
+    .sort();
+
+  for (const file of tsLibFiles) {
+    fsMap[`/${file}`] = readFileSync(join(tsLibDir, file), 'utf8');
+  }
+
+  // 2. Collect @types/node .d.ts files
+  //    These are keyed as "/node_modules/@types/node/index.d.ts", etc.
+  const typesNodeDir = resolve(
+    require.resolve('@types/node/package.json'),
+    '..'
+  );
+
+  collectDtsFiles(
+    fsMap,
+    typesNodeDir,
+    '/node_modules/@types/node',
+    typesNodeDir
+  );
+
+  return fsMap;
+}

--- a/apps/site/scripts/twoslash-fsmap/generate.mjs
+++ b/apps/site/scripts/twoslash-fsmap/generate.mjs
@@ -2,14 +2,17 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+
+import { createDefaultMapFromNodeModules } from '@typescript/vfs';
+import ts from 'typescript';
 
 const require = createRequire(import.meta.url);
 
 /**
  * Recursively collects all `.d.ts` files from a directory into the fsMap.
  *
- * @param {Record<string, string>} fsMap The map to populate
+ * @param {Map<string, string>} fsMap The map to populate
  * @param {string} dir The directory to walk
  * @param {string} virtualPrefix The virtual path prefix (e.g., "/node_modules/@types/node")
  * @param {string} baseDir The base directory for computing relative paths
@@ -28,7 +31,7 @@ function collectDtsFiles(fsMap, dir, virtualPrefix, baseDir) {
       const relativePath = fullPath.slice(baseDir.length).replace(/\\/g, '/');
       const virtualPath = `${virtualPrefix}${relativePath}`;
 
-      fsMap[virtualPath] = readFileSync(fullPath, 'utf8');
+      fsMap.set(virtualPath, readFileSync(fullPath, 'utf8'));
     }
   }
 }
@@ -38,22 +41,12 @@ function collectDtsFiles(fsMap, dir, virtualPrefix, baseDir) {
  * declaration files and `@types/node` declarations needed for Twoslash
  * to run without real filesystem access (e.g., on Cloudflare Workers).
  *
- * @returns {Record<string, string>} A map of virtual paths to file contents
+ * @returns {Map<string, string>} A map of virtual paths to file contents
  */
 export default function generateTwoslashFsMap() {
-  const fsMap = {};
-
-  // 1. Collect TypeScript lib .d.ts files
-  //    These are keyed as "/lib.es5.d.ts", "/lib.dom.d.ts", etc.
-  //    (matching the convention used by @typescript/vfs)
-  const tsLibDir = dirname(require.resolve('typescript/lib/lib.d.ts'));
-  const tsLibFiles = readdirSync(tsLibDir)
-    .filter(f => f.startsWith('lib.') && /\.d\.([^.]+\.)?[cm]?ts$/i.test(f))
-    .sort();
-
-  for (const file of tsLibFiles) {
-    fsMap[`/${file}`] = readFileSync(join(tsLibDir, file), 'utf8');
-  }
+  // 1. Collect TypeScript lib .d.ts files using @typescript/vfs
+  //    This returns a Map keyed as "/lib.es5.d.ts", "/lib.dom.d.ts", etc.
+  const fsMap = createDefaultMapFromNodeModules({}, ts);
 
   // 2. Collect @types/node .d.ts files
   //    These are keyed as "/node_modules/@types/node/index.d.ts", etc.

--- a/apps/site/scripts/twoslash-fsmap/index.mjs
+++ b/apps/site/scripts/twoslash-fsmap/index.mjs
@@ -1,0 +1,15 @@
+'use strict';
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+import generateTwoslashFsMap from './generate.mjs';
+
+const fsMap = generateTwoslashFsMap();
+
+const outputPath = new URL(
+  '../../generated/twoslash-fsmap.json',
+  import.meta.url
+);
+
+mkdirSync(new URL('.', outputPath), { recursive: true });
+writeFileSync(outputPath, JSON.stringify(fsMap), 'utf8');

--- a/apps/site/scripts/twoslash-fsmap/index.mjs
+++ b/apps/site/scripts/twoslash-fsmap/index.mjs
@@ -12,4 +12,4 @@ const outputPath = new URL(
 );
 
 mkdirSync(new URL('.', outputPath), { recursive: true });
-writeFileSync(outputPath, JSON.stringify(fsMap), 'utf8');
+writeFileSync(outputPath, JSON.stringify(Object.fromEntries(fsMap)), 'utf8');

--- a/apps/site/turbo.json
+++ b/apps/site/turbo.json
@@ -24,7 +24,7 @@
       ]
     },
     "build": {
-      "dependsOn": ["build:blog-data", "^build"],
+      "dependsOn": ["build:blog-data", "build:twoslash-fsmap", "^build"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -145,8 +145,12 @@
         "ENABLE_EXPERIMENTAL_COREPACK"
       ]
     },
+    "build:twoslash-fsmap": {
+      "inputs": ["scripts/twoslash-fsmap/**", "../../pnpm-lock.yaml"],
+      "outputs": ["generated/twoslash-fsmap.json"]
+    },
     "cloudflare:build:worker": {
-      "dependsOn": ["build:blog-data"],
+      "dependsOn": ["build:blog-data", "build:twoslash-fsmap"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",

--- a/apps/site/turbo.json
+++ b/apps/site/turbo.json
@@ -22,7 +22,7 @@
       ]
     },
     "build": {
-      "dependsOn": ["build:blog-data", "^build"],
+      "dependsOn": ["build:blog-data", "build:twoslash-fsmap", "^build"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",
@@ -137,8 +137,12 @@
         "ENABLE_EXPERIMENTAL_COREPACK"
       ]
     },
+    "build:twoslash-fsmap": {
+      "inputs": ["scripts/twoslash-fsmap/**", "../../pnpm-lock.yaml"],
+      "outputs": ["generated/twoslash-fsmap.json"]
+    },
     "cloudflare:build:worker": {
-      "dependsOn": ["build:blog-data"],
+      "dependsOn": ["build:blog-data", "build:twoslash-fsmap"],
       "inputs": [
         "{app,components,hooks,i18n,layouts,middlewares,pages,providers,types,util}/**/*.{ts,tsx}",
         "{app,components,layouts,pages,styles}/**/*.css",

--- a/packages/rehype-shiki/src/transformers/twoslash/index.mjs
+++ b/packages/rehype-shiki/src/transformers/twoslash/index.mjs
@@ -1,4 +1,8 @@
-import { transformerTwoslash } from '@shikijs/twoslash';
+import {
+  createTransformerFactory,
+  rendererRich,
+  transformerTwoslash,
+} from '@shikijs/twoslash';
 
 const compose = ({ token, cursor, popup }) => [
   {
@@ -10,39 +14,60 @@ const compose = ({ token, cursor, popup }) => [
   popup,
 ];
 
-export const twoslash = (options = {}) =>
-  transformerTwoslash({
-    langs: ['ts', 'js', 'cjs', 'mjs'],
-    rendererRich: {
-      jsdoc: false,
-      hast: {
-        hoverToken: { tagName: 'MDXTooltip' },
-        hoverPopup: { tagName: 'MDXTooltipContent' },
-        hoverCompose: compose,
+const rendererOptions = {
+  jsdoc: false,
+  hast: {
+    hoverToken: { tagName: 'MDXTooltip' },
+    hoverPopup: { tagName: 'MDXTooltipContent' },
+    hoverCompose: compose,
 
-        queryToken: { tagName: 'MDXTooltip' },
-        queryPopup: { tagName: 'MDXTooltipContent' },
-        queryCompose: compose,
+    queryToken: { tagName: 'MDXTooltip' },
+    queryPopup: { tagName: 'MDXTooltipContent' },
+    queryCompose: compose,
 
-        errorToken: { tagName: 'MDXTooltip' },
-        errorPopup: { tagName: 'MDXTooltipContent' },
-        errorCompose: compose,
+    errorToken: { tagName: 'MDXTooltip' },
+    errorPopup: { tagName: 'MDXTooltipContent' },
+    errorCompose: compose,
 
-        completionToken: {
-          tagName: 'MDXTooltip',
-          properties: {
-            open: true,
-          },
-        },
-        completionPopup: {
-          tagName: 'MDXTooltipContent',
-          properties: {
-            align: 'start',
-          },
-        },
-        completionCompose: compose,
+    completionToken: {
+      tagName: 'MDXTooltip',
+      properties: {
+        open: true,
       },
     },
-    throws: false,
-    ...options,
-  });
+    completionPopup: {
+      tagName: 'MDXTooltipContent',
+      properties: {
+        align: 'start',
+      },
+    },
+    completionCompose: compose,
+  },
+};
+
+const transformerOptions = {
+  langs: ['ts', 'js', 'cjs', 'mjs'],
+  rendererRich: rendererOptions,
+  throws: false,
+};
+
+/**
+ * Creates the Twoslash Shiki transformer.
+ *
+ * When `options.twoslasher` is provided, uses `createTransformerFactory`
+ * directly to avoid importing the default Node.js-dependent twoslasher from
+ * `twoslash`. This is needed for environments like Cloudflare Workers where
+ * the filesystem-backed default twoslasher cannot be used.
+ *
+ * @param {import('@shikijs/twoslash').TransformerTwoslashIndexOptions} [options]
+ */
+export const twoslash = (options = {}) => {
+  if (options.twoslasher) {
+    return createTransformerFactory(
+      options.twoslasher,
+      rendererRich(rendererOptions)
+    )({ ...transformerOptions, ...options });
+  }
+
+  return transformerTwoslash({ ...transformerOptions, ...options });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
+      '@typescript/vfs':
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.9.3)
       '@vcarl/remark-headings':
         specifier: ~0.1.0
         version: 0.1.0


### PR DESCRIPTION
## Description

> [!Note]
> Disclaimer, This PR has been authored mostly by Claude Opus 4.6 with minor tweaks from me.
> It does seem to work and the code makes sense to me.

Enables twoslash to work on Cloudflare (previously it would only work on the Vercel deployment):
<img width="1613" height="809" alt="Screenshot 2026-04-22 at 22 42 31" src="https://github.com/user-attachments/assets/54c1f758-77c6-4d3c-92cd-b1f3ac4d8b57" />

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

See: https://nodejs-website.dario-test.workers.dev/en

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
