### PR TITLE
fix: fix the incorrect architecture detection in PlatformDropdown for Cloudflare builds

### DIFF
--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -16,14 +16,18 @@ const PlatformDropdown: FC = () => {
   const { architecture, bitness } = useClientContext();
 
   const release = use(ReleaseContext);
+
   const t = useTranslations();
+
+  // Compute the platform during render so it's available to both `useEffect` calls below in the same cycle
+  // (avoiding race conditions when architecture detection and OS detection arrive in the same batch)
+  const currentPlatform =
+    architecture && bitness ? getUserPlatform(architecture, bitness) : null;
 
   useEffect(
     () => {
-      if (architecture && bitness) {
-        const autoDetectedPlatform = getUserPlatform(architecture, bitness);
-
-        release.setPlatform(autoDetectedPlatform);
+      if (currentPlatform) {
+        release.setPlatform(currentPlatform);
       }
     },
     // Only react on the change of the Client Context Architecture and Bitness
@@ -49,12 +53,14 @@ const PlatformDropdown: FC = () => {
   useEffect(
     () => {
       if (release.os !== 'LOADING' && release.platform !== '') {
-        release.setPlatform(nextItem(release.platform, parsedPlatforms));
+        // Use the current platform if available, otherwise fall back to the current release platform
+        const currentTargetPlatform = currentPlatform ?? release.platform;
+        release.setPlatform(nextItem(currentTargetPlatform, parsedPlatforms));
       }
     },
     // We only want to react on the change of the OS and Version
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-    [release.os, release.version, release.platform]
+    [release.os, release.version]
   );
 
   return (

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -2,7 +2,7 @@
 
 import Select from '@node-core/ui-components/Common/Select';
 import { useTranslations } from 'next-intl';
-import { useEffect, use, useMemo } from 'react';
+import { useEffect, use, useMemo, useRef } from 'react';
 
 import useClientContext from '#site/hooks/useClientContext';
 import { ReleaseContext } from '#site/providers/releaseProvider';
@@ -24,9 +24,15 @@ const PlatformDropdown: FC = () => {
   const currentPlatform =
     architecture && bitness ? getUserPlatform(architecture, bitness) : null;
 
+  // Track whether the user has manually selected a platform via the dropdown.
+  // When true the OS/version effect will respect their choice instead of
+  // resetting to the auto-detected value.
+  const userSelectedPlatformRef = useRef(false);
+
   useEffect(
     () => {
       if (currentPlatform) {
+        userSelectedPlatformRef.current = false;
         release.setPlatform(currentPlatform);
       }
     },
@@ -53,9 +59,14 @@ const PlatformDropdown: FC = () => {
   useEffect(
     () => {
       if (release.os !== 'LOADING' && release.platform !== '') {
-        // Use the current platform if available, otherwise fall back to the current release platform
-        const currentTargetPlatform = currentPlatform ?? release.platform;
-        release.setPlatform(nextItem(currentTargetPlatform, parsedPlatforms));
+        // If the user has not manually selected a platform and there is a currently
+        // auto-detected one then use it otherwise fallback to the current release platform
+        const basePlatform =
+          !userSelectedPlatformRef.current && currentPlatform
+            ? currentPlatform
+            : release.platform;
+
+        release.setPlatform(nextItem(basePlatform, parsedPlatforms));
       }
     },
     // We only want to react on the change of the OS and Version
@@ -70,7 +81,12 @@ const PlatformDropdown: FC = () => {
       loading={release.os === 'LOADING' || release.platform === ''}
       placeholder={t('layouts.download.dropdown.unknown')}
       ariaLabel={t('layouts.download.dropdown.platform')}
-      onChange={platform => platform && release.setPlatform(platform)}
+      onChange={platform => {
+        if (platform) {
+          userSelectedPlatformRef.current = true;
+          release.setPlatform(platform);
+        }
+      }}
       className="min-w-28"
       inline={true}
     />

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -2,7 +2,7 @@
 
 import Select from '@node-core/ui-components/Common/Select';
 import { useTranslations } from 'next-intl';
-import { useEffect, use, useMemo, useRef } from 'react';
+import { useEffect, use, useMemo, useState } from 'react';
 
 import useClientContext from '#site/hooks/useClientContext';
 import { ReleaseContext } from '#site/providers/releaseProvider';
@@ -27,12 +27,13 @@ const PlatformDropdown: FC = () => {
   // Track whether the user has manually selected a platform via the dropdown.
   // When true the OS/version effect will respect their choice instead of
   // resetting to the auto-detected value.
-  const userSelectedPlatformRef = useRef(false);
+  const [userHasSelectedPlatform, setUserHasSelectedPlatform] = useState(false);
 
   useEffect(
     () => {
       if (currentPlatform) {
-        userSelectedPlatformRef.current = false;
+        // eslint-disable-next-line @eslint-react/set-state-in-effect
+        setUserHasSelectedPlatform(false);
         release.setPlatform(currentPlatform);
       }
     },
@@ -62,7 +63,7 @@ const PlatformDropdown: FC = () => {
         // If the user has not manually selected a platform and there is a currently
         // auto-detected one then use it otherwise fallback to the current release platform
         const basePlatform =
-          !userSelectedPlatformRef.current && currentPlatform
+          !userHasSelectedPlatform && currentPlatform
             ? currentPlatform
             : release.platform;
 
@@ -82,7 +83,7 @@ const PlatformDropdown: FC = () => {
       placeholder={t('layouts.download.dropdown.unknown')}
       ariaLabel={t('layouts.download.dropdown.platform')}
       onChange={platform => {
-        userSelectedPlatformRef.current = true;
+        setUserHasSelectedPlatform(true);
         release.setPlatform(platform);
       }}
       className="min-w-28"

--- a/apps/site/components/Downloads/Release/PlatformDropdown.tsx
+++ b/apps/site/components/Downloads/Release/PlatformDropdown.tsx
@@ -82,10 +82,8 @@ const PlatformDropdown: FC = () => {
       placeholder={t('layouts.download.dropdown.unknown')}
       ariaLabel={t('layouts.download.dropdown.platform')}
       onChange={platform => {
-        if (platform) {
-          userSelectedPlatformRef.current = true;
-          release.setPlatform(platform);
-        }
+        userSelectedPlatformRef.current = true;
+        release.setPlatform(platform);
       }}
       className="min-w-28"
       inline={true}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

OS detection and architecture detection can arrive in the same React render cycle. When that happens, both `useEffect` hooks in `PlatformDropdown` fire at the same time, the first one correctly dispatches `setPlatform('arm64')`, but the second one reads `release.platform` from its stale closure (still `'x64'`) and immediately calls `setPlatform('x64')` overriding the correct value. On Vercel I believe this worked by accident of timing, as the two detections land in separate render cycles, for whatever reason that doesn't seem to be the case in Cloudflare.

So the fix is to compute the platform during render and use it in both `useEffect`s, so that they share the same up-to-date value when they fire together.

## Validation

I've run the app locally via `pnpm dev` and `pnpm cloudflare:preview` and verified that now both correctly detect the correct architecture

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
