### PR TITLE
fix: enable independent scrolling in sidebar navigation

### DIFF
--- a/packages/ui-components/src/Containers/Sidebar/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/index.module.css
@@ -1,7 +1,7 @@
 @reference "../../styles/index.css";
 
 .wrapper {
-  @apply ml:max-w-xs
+   @apply ml:max-w-xs
     ml:overflow-auto
     ml:border-r
     scrollbar-thin
@@ -16,18 +16,21 @@
     bg-white
     px-4
     pt-6
-    2xl:px-6
+     2xl:px-6
     dark:border-neutral-900
     dark:bg-neutral-950;
 
-  .navigation {
-    @apply ml:flex
+   .navigation {
+     @apply ml:flex
+      flex-1
+      overflow-y-auto
+      scroll-smooth
       hidden;
-  }
+    }
 
-  .mobileSelect {
-    @apply ml:hidden
+   .mobileSelect {
+     @apply ml:hidden
       flex
       w-full;
-  }
+    }
 }


### PR DESCRIPTION
## Description

When sidebar content overflows on desktop, users cannot scroll to see hidden items. This PR adds `flex-1`, `overflow-y-auto`, and `scroll-smooth` to the `.navigation` class so each sidebar section scrolls independently within the sticky page layout.

## Changes

- `packages/ui-components/src/Containers/Sidebar/index.module.css`: add `flex-1 overflow-y-auto scroll-smooth` to `.navigation`