### PR TITLE
fix: remove unmaintained Mastodon link from footer

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -85,11 +85,6 @@
       "alt": "Discord"
     },
     {
-      "icon": "mastodon",
-      "link": "https://social.lfx.dev/@nodejs",
-      "alt": "Mastodon"
-    },
-    {
       "icon": "bluesky",
       "link": "https://bsky.app/profile/nodejs.org",
       "alt": "Bluesky"


### PR DESCRIPTION
## Description

The Mastodon account @nodejs on social.lfx.dev is no longer maintained by the foundation's marketing team per [issue #7873](https://github.com/nodejs/nodejs.org/issues/7873).

## Changes
- Remove Mastodon entry from `apps/site/navigation.json` socialLinks array
- Discord and Bluesky remain as the community chat links

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>