### PR TITLE
fix: sidebar last items hidden behind header on scroll

### DIFF
--- a/packages/ui-components/src/Containers/Article/index.module.css
+++ b/packages/ui-components/src/Containers/Article/index.module.css
@@ -17,8 +17,8 @@
 
   > *:nth-child(1) {
     @apply ml:sticky
-      ml:top-0
-      ml:h-svh
+      ml:top-[var(--header-height)]
+      ml:h-[calc(100svh-var(--header-height))]
       ml:overflow-y-auto
       [grid-area:sidebar];
   }

--- a/packages/ui-components/src/Containers/Sidebar/index.module.css
+++ b/packages/ui-components/src/Containers/Sidebar/index.module.css
@@ -5,7 +5,6 @@
     ml:overflow-auto
     ml:border-r
     scrollbar-thin
-    ml:pb-[var(--header-height)]
     z-0
     flex
     w-full


### PR DESCRIPTION
## Summary

Fixes #8521

The sidebar navigation clips the last items when scrolled down. The root cause is that the sidebar container uses `h-svh` (100% of small viewport height) with `top-0`, but the NavBar sits at the top consuming ~4rem of vertical space. This means the last sidebar items are pushed below the visible viewport area.

## Changes

**`packages/ui-components/src/Containers/Article/index.module.css`:**
- Changed `ml:top-0` → `ml:top-[var(--header-height)]` — positions sidebar below the header
- Changed `ml:h-svh` → `ml:h-[calc(100svh-var(--header-height))]` — sizes sidebar to remaining viewport

**`packages/ui-components/src/Containers/Sidebar/index.module.css`:**
- Removed `ml:pb-[var(--header-height)]` — no longer needed since the container now correctly accounts for header height

## How to test

1. Navigate to any learn/docs page with a long sidebar (e.g., `/en/learn/getting-started/introduction-to-nodejs`)
2. Scroll the sidebar to the bottom
3. Verify that all sidebar items are visible and the last items are not clipped
4. Test with and without a banner visible (e.g., security release banner)
5. Test on different screen sizes (mobile, tablet, desktop)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>