### PR TITLE
chore(open-next): avoid the use of DurableObjects by using `queueCache` with `memoryQueue` instead

### DIFF
--- a/apps/site/open-next.config.ts
+++ b/apps/site/open-next.config.ts
@@ -1,7 +1,8 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare';
 import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache';
 import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
-import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
+import memoryQueue from '@opennextjs/cloudflare/overrides/queue/memory-queue';
+import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 
 import type { OpenNextConfig } from '@opennextjs/cloudflare';
 
@@ -14,7 +15,7 @@ const cloudflareConfig = defineCloudflareConfig({
   incrementalCache: withRegionalCache(r2IncrementalCache, {
     mode: 'long-lived',
   }),
-  queue: doQueue,
+  queue: queueCache(memoryQueue),
   enableCacheInterception: true,
 });
 

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -45,20 +45,6 @@
       "bucket_name": "next-cache-r2-for-open-next-website",
     },
   ],
-  "durable_objects": {
-    "bindings": [
-      {
-        "name": "NEXT_CACHE_DO_QUEUE",
-        "class_name": "DOQueueHandler",
-      },
-    ],
-  },
-  "migrations": [
-    {
-      "tag": "v1",
-      "new_sqlite_classes": ["DOQueueHandler"],
-    },
-  ],
   "version_metadata": {
     // CF_VERSION_METADATA used for sentry
     // See: https://docs.sentry.io/platforms/javascript/guides/cloudflare/#release-configuration-optional


### PR DESCRIPTION
## Description

The use of DurableObjects breaks the open-next skew protection, so in order to make sure skew protection works this PR updates the queue to use `queueCache` with `memoryQueue` instead of durable objects 

## Validation

Site built and deployed to my personal account: https://8bf0874a-nodejs-website-1.dario-test.workers.dev

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
