### PR TITLE
Fix formatting issues in release notes for v26.0.0

### DIFF
--- a/apps/site/pages/en/blog/release/v26.0.0.md
+++ b/apps/site/pages/en/blog/release/v26.0.0.md
@@ -44,11 +44,11 @@ Undici has been updated to version 8.0.2, bringing new features and improvements
 - \[[`dff46c07c3`](https://github.com/nodejs/node/commit/dff46c07c3)] - **(SEMVER-MAJOR)** **crypto**: move DEP0182 to End-of-Life (Tobias Nießen) [#61084](https://github.com/nodejs/node/pull/61084)
 - \[[`93c25815ee`](https://github.com/nodejs/node/commit/93c25815ee)] - **(SEMVER-MAJOR)** **http**: move writeHeader to end-of-life (Sebastian Beltran) [#60635](https://github.com/nodejs/node/pull/60635)
 
-`http.Server.prototype.writeHeader()` is now fully removed. Use `http.Server.prototype.writeHead()` instead.
+  `http.Server.prototype.writeHeader()` is now fully removed. Use `http.Server.prototype.writeHead()` instead.
 
 - \[[`c755b0113c`](https://github.com/nodejs/node/commit/c755b0113c)] - **(SEMVER-MAJOR)** **stream**: move \_stream\_\* to end-of-life (Sebastian Beltran) [#60657](https://github.com/nodejs/node/pull/60657)
 
-The legacy `_stream_wrap`, `_stream_readable`, `_stream_writable`, `_stream_duplex`, `_stream_transform`, and `_stream_passthrough` modules are now fully removed.
+  The legacy `_stream_wrap`, `_stream_readable`, `_stream_writable`, `_stream_duplex`, `_stream_transform`, and `_stream_passthrough` modules are now fully removed.
 
 - \[[`adac077484`](https://github.com/nodejs/node/commit/adac077484)] - **(SEMVER-MAJOR)** **crypto**: runtime-deprecate DEP0203 and DEP0204 (Filip Skokan) [#62453](https://github.com/nodejs/node/pull/62453)
 - \[[`ac6375417a`](https://github.com/nodejs/node/commit/ac6375417a)] - **(SEMVER-MAJOR)** **stream**: promote DEP0201 to runtime deprecation (René) [#62173](https://github.com/nodejs/node/pull/62173)


### PR DESCRIPTION
Without those spaces, those text block appear as paragraph, breaking up the list into three lists.
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
