### PR TITLE
feat(about): update Node.js release cycle information

### DIFF
--- a/apps/site/pages/en/about/previous-releases.mdx
+++ b/apps/site/pages/en/about/previous-releases.mdx
@@ -9,7 +9,7 @@ layout: about
 
 Major Node.js versions enter _Current_ release status for six months, which gives library authors time to add support for them.
 Historically (up to Node.js 26), odd-numbered releases (9, 11, etc.) become unsupported after six months, and even-numbered releases (10, 12, etc.) move to _Active LTS_ status and are ready for general use.
-Starting with Node.js 27, the release cycle will be annual and every major version will move to _Active LTS_ status after its six-month _Current_ phase.
+Starting with Node.js 27, the release cycle will be annual and every major version will move to _LTS_ status after its six-month _Current_ phase (and six additional months of _Alpha_ phase).
 _LTS_ release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
 Production applications should only use _Active LTS_ or _Maintenance LTS_ releases.
 

--- a/apps/site/pages/en/about/previous-releases.mdx
+++ b/apps/site/pages/en/about/previous-releases.mdx
@@ -8,7 +8,8 @@ layout: about
 <EOLAlertBox />
 
 Major Node.js versions enter _Current_ release status for six months, which gives library authors time to add support for them.
-After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to _Active LTS_ status and are ready for general use.
+Historically (up to Node.js 26), odd-numbered releases (9, 11, etc.) become unsupported after six months, and even-numbered releases (10, 12, etc.) move to _Active LTS_ status and are ready for general use.
+Starting with Node.js 27, the release cycle will be annual and every major version will move to _Active LTS_ status after its six-month _Current_ phase.
 _LTS_ release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
 Production applications should only use _Active LTS_ or _Maintenance LTS_ releases.
 


### PR DESCRIPTION
Clarified the release status of odd and even Node.js versions and updated information on the release cycle starting with Node.js 27. While the change has not happened yet, would be good to list this on the releases page so developers who missed the [announcement](https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule) are aware of it in good time.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Clarifies that the odd/even distinction will not happen in future.

## Validation

Documentation update only

## Related Issues



### Check List



- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
