### PR TITLE
Fix header style for npm version check documentation

### DIFF
--- a/apps/site/snippets/ko/download/npm.bash
+++ b/apps/site/snippets/ko/download/npm.bash
@@ -1,2 +1,2 @@
-npm 버전 확인:
+# npm 버전 확인:
 npm -v # ${props.release.npm}가 출력되어야 합니다.


### PR DESCRIPTION
## Description

This PR updates the formatting of the npm version check comment in the documentation/code snippets. By adding a leading #, the comment now follows a more consistent header-style format, improving visual hierarchy and readability for users following the setup instructions.

## Validation

The change is a text-based update within a comment.

Reviewer check: Ensure the comment # npm 버전 확인: is correctly rendered and doesn't interfere with any code execution (it remains a valid comment).

Visual: The instruction block now has a clearer title/header.

## Related Issues


### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
