### PR TITLE
remove unmaintained mastodon link from footer (#7873)

### DIFF
--- a/apps/site/app/[locale]/layout.tsx
+++ b/apps/site/app/[locale]/layout.tsx
@@ -39,13 +39,6 @@ const RootLayout: FC<RootLayoutProps> = async ({ children, params }) => {
           </ThemeProvider>
         </NextIntlClientProvider>
 
-        <a
-          rel="me"
-          aria-hidden="true"
-          className="hidden"
-          href="https://social.lfx.dev/@nodejs"
-        />
-
         {VERCEL_ENV && (
           <>
             <Analytics />

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -85,11 +85,6 @@
       "alt": "Discord"
     },
     {
-      "icon": "mastodon",
-      "link": "https://social.lfx.dev/@nodejs",
-      "alt": "Mastodon"
-    },
-    {
       "icon": "bluesky",
       "link": "https://bsky.app/profile/nodejs.org",
       "alt": "Bluesky"

--- a/apps/site/util/__tests__/navigation.test.mjs
+++ b/apps/site/util/__tests__/navigation.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import navigation from '../../navigation.json' with { type: 'json' };
+
+describe('navigation config', () => {
+  it('does not expose the retired Mastodon account', () => {
+    assert.equal(
+      navigation.socialLinks.some(
+        ({ link }) => link === 'https://social.lfx.dev/@nodejs'
+      ),
+      false
+    );
+  });
+
+  it('does not keep the retired Mastodon profile in the root layout', async () => {
+    const layout = await readFile(
+      new URL('../../app/[locale]/layout.tsx', import.meta.url),
+      'utf8'
+    );
+
+    assert.equal(layout.includes('https://social.lfx.dev/@nodejs'), false);
+  });
+});


### PR DESCRIPTION
This closes #7873.

## Description

- remove the retired Mastodon link from the website footer
- remove the hidden `rel="me"` Mastodon reference from the root layout
- add a regression test so the retired URL is not added back

## Validation

- `pnpm format` passes
- `pnpm test` passes
- `pnpm build` passes
- `node --test apps/site/util/__tests__/navigation.test.mjs` passes
- `git diff --check` passes
- reviewers can confirm that the footer no longer shows the Mastodon icon/link and that the root layout no longer contains `https://social.lfx.dev/@nodejs`
- `pnpm build` prints an existing Next.js warning about the deprecated `middleware` file convention, but the build completes successfully

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
