### PR TITLE
docs(blog): add usage section for axios-to-fetch article

### DIFF
--- a/apps/site/pages/en/blog/migrations/axios-to-fetch.mdx
+++ b/apps/site/pages/en/blog/migrations/axios-to-fetch.mdx
@@ -41,6 +41,16 @@ The codemod supports the following Axios methods and converts them to their Fetc
 - `axios.putForm(url[, data[, config]])`
 - `axios.patchForm(url[, data[, config]])`
 
+## Usage:
+
+The source code for this codemod can be found in the [axios-to-whatwg-fetch directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/axios-to-whatwg-fetch).
+
+You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/axios-to-whatwg-fetch).
+
+```bash
+npx codemod @nodejs/axios-to-whatwg-fetch
+```
+
 ## Examples
 
 ### GET Request

--- a/apps/site/pages/en/blog/migrations/axios-to-fetch.mdx
+++ b/apps/site/pages/en/blog/migrations/axios-to-fetch.mdx
@@ -41,7 +41,7 @@ The codemod supports the following Axios methods and converts them to their Fetc
 - `axios.putForm(url[, data[, config]])`
 - `axios.patchForm(url[, data[, config]])`
 
-## Usage:
+## Usage
 
 The source code for this codemod can be found in the [axios-to-whatwg-fetch directory](https://github.com/nodejs/userland-migrations/tree/main/recipes/axios-to-whatwg-fetch).
 


### PR DESCRIPTION
## Description

In the article to migrate from axios to fetch, I'd love to have a section for usage. It was my first reference in the search engine and there was no link, nor command usage. I got inspired by the other article [apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx](https://github.com/nodejs/nodejs.org/blob/main/apps/site/pages/en/blog/migrations/chalk-to-styletext.mdx) which had all of that to make this contribution.


<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->


<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
