### PR TITLE
feat(download): add asdf install method

### DIFF
--- a/apps/site/snippets/en/download/asdf.bash
+++ b/apps/site/snippets/en/download/asdf.bash
@@ -1,0 +1,11 @@
+# asdf has specific installation instructions for each operating system.
+# See https://asdf-vm.com/guide/getting-started.html for setup instructions.
+
+# Install the Node.js plugin:
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+
+# Download and install Node.js:
+asdf install nodejs ${props.release.version}
+
+# Set the global Node.js version:
+asdf set -u nodejs ${props.release.version}

--- a/apps/site/types/release.ts
+++ b/apps/site/types/release.ts
@@ -8,7 +8,8 @@ export type InstallationMethod =
   | 'BREW'
   | 'DOCKER'
   | 'CHOCO'
-  | 'N';
+  | 'N'
+  | 'ASDF';
 export type PackageManager = 'NPM' | 'YARN' | 'PNPM';
 
 // Items with a pipe/default value mean that they are auto inferred

--- a/apps/site/util/download/constants.json
+++ b/apps/site/util/download/constants.json
@@ -187,6 +187,15 @@
       },
       "url": "https://github.com/tj/n",
       "info": "layouts.download.codeBox.platformInfo.n"
+    },
+    {
+      "id": "ASDF",
+      "name": "asdf",
+      "compatibility": {
+        "os": ["MAC", "LINUX"]
+      },
+      "url": "https://asdf-vm.com/guide/getting-started.html",
+      "info": "layouts.download.codeBox.platformInfo.asdf"
     }
   ],
   "packageManagers": [

--- a/apps/site/util/download/index.tsx
+++ b/apps/site/util/download/index.tsx
@@ -78,9 +78,17 @@ export const parseCompat = <
  */
 const createIcon = (
   IconModule: Record<string, ElementType>,
-  iconName: string
+  iconName?: string
 ) => {
+  if (!iconName) {
+    return undefined;
+  }
+
   const IconComponent = IconModule[iconName];
+  if (!IconComponent) {
+    return undefined;
+  }
+
   return <IconComponent width={16} height={16} />;
 };
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -299,7 +299,8 @@
           "choco": "Chocolatey is a package manager for Windows.",
           "docker": "Docker is a containerization platform.",
           "n": "\"n\" is a cross-platform Node.js version manager.",
-          "volta": "\"Volta\" is a cross-platform Node.js version manager."
+          "volta": "\"Volta\" is a cross-platform Node.js version manager.",
+          "asdf": "\"asdf\" is a cross-platform version manager that supports multiple languages."
         }
       }
     },


### PR DESCRIPTION
## Description

Adds asdf as a Community install method on the downloads page, with an English snippet and no custom icon.

## Validation

- `corepack pnpm prettier`
- `corepack pnpm --filter @node-core/website lint:js`
- `corepack pnpm --filter @node-core/ui-components lint:js`
- `corepack pnpm --filter @node-core/ui-components lint:css`
- `corepack pnpm --filter @node-core/website lint:types`
- `corepack pnpm --filter @node-core/ui-components lint:types`
- `corepack pnpm --filter @node-core/website test:unit -- util/__tests__/download.test.mjs`
- `corepack pnpm --filter @node-core/ui-components test`
- `corepack pnpm --filter @node-core/website build`

## Related Issues

Fixes #8488

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.