### PR TITLE
chore: remove Mastodon from footer social links

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -85,11 +85,6 @@
       "alt": "Discord"
     },
     {
-      "icon": "mastodon",
-      "link": "https://social.lfx.dev/@nodejs",
-      "alt": "Mastodon"
-    },
-    {
       "icon": "bluesky",
       "link": "https://bsky.app/profile/nodejs.org",
       "alt": "Bluesky"


### PR DESCRIPTION
## Summary

Remove the Mastodon account from the website footer social links because the account is no longer maintained.

The hidden `rel="me"` link in the root layout is left in place so the site can still preserve the account verification trace.

Fixes: https://github.com/nodejs/nodejs.org/issues/7873

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('apps/site/navigation.json','utf8')); console.log('navigation.json ok')"`
- `npx --yes pnpm@10.33.2 -C /Users/sorut/projects/nodejs.org exec prettier apps/site/navigation.json --check`
- `npx --yes pnpm@10.33.2 -C /Users/sorut/projects/nodejs.org --filter @node-core/website build:blog-data`
- `npx --yes pnpm@10.33.2 -C /Users/sorut/projects/nodejs.org --filter @node-core/website lint:types`
- `git diff --check`

Note: local validation was run with Node.js `v25.8.2`, so `apps/site` emitted its expected `node: 24.x` engine warning, but the checks above completed successfully.
