### PR TITLE
fix: make mobile navigation toggle keyboard accessible

### DIFF
--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -9,7 +9,7 @@ const locators = {
   // Navigation elements
   mobileMenuToggleName:
     englishLocale.components.containers.navBar.controls.toggle,
-  navLinksLocator: `[aria-label="${englishLocale.components.containers.navBar.controls.toggle}"] + div`,
+  navLinksLocator: '#navbar-menu',
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
   themeToggleName: englishLocale.components.header.buttons.theme,
@@ -160,6 +160,14 @@ test.describe('Node.js Website', () => {
 
       // Toggle menu closed and verify it's hidden
       await mobileToggle.click();
+      await expect(navLinks.first()).not.toBeVisible();
+
+      // Toggle menu with keyboard and verify it's accessible
+      await mobileToggle.focus();
+      await page.keyboard.press('Enter');
+      await expect(navLinks.first()).toBeVisible();
+
+      await page.keyboard.press('Space');
       await expect(navLinks.first()).not.toBeVisible();
     });
   });

--- a/packages/ui-components/src/Containers/NavBar/index.module.css
+++ b/packages/ui-components/src/Containers/NavBar/index.module.css
@@ -38,25 +38,22 @@
           flex-1;
       }
 
-      .sidebarItemTogglerLabel {
-        @apply block
+      .sidebarItemTogglerButton {
+        @apply focus-visible:ring-brand-500
+          block
           cursor-pointer
+          appearance-none
+          border-0
+          bg-transparent
+          p-0
+          focus-visible:ring-2
+          focus-visible:outline-none
           xl:hidden;
 
         .navInteractionIcon {
           @apply size-6;
         }
       }
-    }
-
-    .sidebarItemToggler {
-      @apply absolute
-        right-4
-        -z-10
-        size-6
-        -translate-y-[200%]
-        appearance-none
-        opacity-0;
     }
 
     .main {

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -1,6 +1,7 @@
+'use client';
+
 import Hamburger from '@heroicons/react/24/solid/Bars3Icon';
 import XMark from '@heroicons/react/24/solid/XMarkIcon';
-import * as Label from '@radix-ui/react-label';
 import classNames from 'classnames';
 import { useState } from 'react';
 
@@ -20,6 +21,8 @@ const navInteractionIcons = {
   show: <Hamburger className={styles.navInteractionIcon} />,
   close: <XMark className={styles.navInteractionIcon} />,
 };
+
+const navMenuId = 'navbar-menu';
 
 type NavbarProps = {
   navItems?: Array<{
@@ -55,25 +58,25 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
             <Logo />
           </Component>
 
-          <Label.Root
-            className={styles.sidebarItemTogglerLabel}
-            htmlFor="sidebarItemToggler"
-            role="button"
+          <button
+            className={styles.sidebarItemTogglerButton}
+            type="button"
             aria-label={sidebarItemTogglerAriaLabel}
+            aria-controls={navMenuId}
+            aria-expanded={isMenuOpen}
+            onClick={() => setIsMenuOpen(isOpen => !isOpen)}
           >
             {navInteractionIcons[isMenuOpen ? 'close' : 'show']}
-          </Label.Root>
+          </button>
         </div>
 
-        <input
-          className={classNames('peer', styles.sidebarItemToggler)}
-          id="sidebarItemToggler"
-          type="checkbox"
-          onChange={e => setIsMenuOpen(() => e.target.checked)}
-          aria-label={sidebarItemTogglerAriaLabel}
-          tabIndex={-1}
-        />
-        <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
+        <div
+          id={navMenuId}
+          className={classNames(
+            styles.main,
+            isMenuOpen ? 'flex' : 'hidden xl:flex'
+          )}
+        >
           {navItems && navItems.length > 0 && (
             <div className={styles.navItems}>
               {navItems.map(({ text, link, target }) => (


### PR DESCRIPTION
## Summary

Make the mobile navigation menu toggle a native button so it can be reached and activated with keyboard navigation.

This also adds `aria-expanded`/`aria-controls` to expose the menu state and updates the existing mobile menu E2E coverage to verify Enter and Space activation.

Fixes: https://github.com/nodejs/nodejs.org/issues/7895

## Validation

- `pnpm exec prettier packages/ui-components/src/Containers/NavBar/index.tsx packages/ui-components/src/Containers/NavBar/index.module.css apps/site/tests/e2e/general-behavior.spec.ts --check`
- `pnpm --filter @node-core/ui-components lint`
- `pnpm --filter @node-core/ui-components lint:types`
- `pnpm --filter @node-core/website lint:js`
- `pnpm --filter @node-core/website lint:types`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 pnpm --filter @node-core/website playwright tests/e2e/general-behavior.spec.ts -g "functioning mobile menu" --project=chromium`
- `git diff --check`

Note: local validation was run with Node.js `v25.8.2`, so `apps/site` emitted its expected `node: 24.x` engine warning, but the checks above completed successfully.
