### PR TITLE
chore: remove Mastodon from footer social links

### DIFF
--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -85,11 +85,6 @@
       "alt": "Discord"
     },
     {
-      "icon": "mastodon",
-      "link": "https://social.lfx.dev/@nodejs",
-      "alt": "Mastodon"
-    },
-    {
       "icon": "bluesky",
       "link": "https://bsky.app/profile/nodejs.org",
       "alt": "Bluesky"


### PR DESCRIPTION
## Summary

- remove Mastodon from the footer social links
- keep the existing hidden `rel="me"` Mastodon verification link in the site layout

Fixes #7873

## Validation

- `pnpm exec prettier --check apps/site/navigation.json`