### PR TITLE
fix: show error details outside production

### DIFF
--- a/apps/site/app/[locale]/error.tsx
+++ b/apps/site/app/[locale]/error.tsx
@@ -7,8 +7,24 @@ import GlowingBackdropLayout from '#site/layouts/GlowingBackdrop';
 
 import type { FC } from 'react';
 
-const ErrorPage: FC<{ error: Error }> = () => {
+type ErrorWithDigest = Error & { digest?: string };
+
+const showErrorDetails =
+  process.env.NODE_ENV !== 'production' ||
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview';
+
+const getErrorDetails = (error: ErrorWithDigest) =>
+  [
+    error.name && `Name: ${error.name}`,
+    error.message && `Message: ${error.message}`,
+    error.digest && `Digest: ${error.digest}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+const ErrorPage: FC<{ error: ErrorWithDigest }> = ({ error }) => {
   const t = useTranslations();
+  const errorDetails = getErrorDetails(error);
 
   return (
     <GlowingBackdropLayout kind="default">
@@ -21,6 +37,12 @@ const ErrorPage: FC<{ error: Error }> = () => {
       <p className="-mt-4 max-w-sm text-center text-lg">
         {t('layouts.error.internalServerError.description')}
       </p>
+
+      {showErrorDetails && errorDetails && (
+        <pre className="max-w-2xl rounded-sm border border-neutral-200 bg-neutral-100 p-4 text-sm break-words whitespace-pre-wrap dark:border-neutral-900 dark:bg-neutral-950">
+          {errorDetails}
+        </pre>
+      )}
 
       <Button href="/">{t('layouts.error.backToHome')}</Button>
     </GlowingBackdropLayout>


### PR DESCRIPTION
## Summary

- show error name/message/digest on local and Vercel preview error pages
- keep production deployments on the generic 500 message

Fixes #7464

## Validation

- `pnpm exec prettier --check apps/site/app/[locale]/error.tsx`
- `pnpm --filter @node-core/website exec eslint app/[locale]/error.tsx`
- `pnpm --filter @node-core/website lint:types`