### PR TITLE
fix(i18n): preserve OpenJS Foundation trademark

### DIFF
--- a/packages/i18n/src/locales/fr.json
+++ b/packages/i18n/src/locales/fr.json
@@ -12,7 +12,7 @@
       "footer": {
         "legal": "Copyright © <foundationName>OpenJS Foundation</foundationName> et les contributeurs Node.js. Tous droits réservés.\nLa <foundationName>OpenJS Foundation</foundationName> détient des marques déposées et utilise des marques commerciales.\nPour consulter la liste des marques de la <foundationName>OpenJS Foundation</foundationName>, veuillez vous référer à notre <trademarkPolicy>Politique relative aux marques</trademarkPolicy> ainsi qu’à la <trademarkList>Liste des marques</trademarkList>.\nLes marques et logos qui ne figurent pas dans la <trademarkList>liste des marques de la OpenJS Foundation</trademarkList> sont des marques commerciales™ ou des marques déposées® appartenant à leurs détenteurs respectifs. Leur utilisation n’implique aucune affiliation ni approbation de leur part.",
         "links": {
-          "foundationName": "Fondation OpenJS",
+          "foundationName": "OpenJS Foundation",
           "aiCodingAssistantsPolicy": "Politique relative aux assistants de codage basés sur l'IA",
           "termsOfUse": "Conditions d’utilisation",
           "privacyPolicy": "Politique de confidentialité",

--- a/packages/i18n/src/locales/ro.json
+++ b/packages/i18n/src/locales/ro.json
@@ -3,7 +3,7 @@
     "containers": {
       "footer": {
         "links": {
-          "openJSFoundation": "Fundația OpenJS",
+          "openJSFoundation": "OpenJS Foundation",
           "trademarkPolicy": "Politică de mărci comerciale",
           "privacyPolicy": "Politică de confidențialitate",
           "codeOfConduct": "Cod de conduită",

--- a/packages/i18n/src/locales/ta.json
+++ b/packages/i18n/src/locales/ta.json
@@ -2,9 +2,9 @@
   "components": {
     "containers": {
       "footer": {
-        "legal": "பதிப்புரிமை <foundationName>OpenJS நிறுவனம்</foundationName> மற்றும் Node.js பங்களிப்பாளர்கள். அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டவை. <foundationName>OpenJS நிறுவனம்</foundationName> பதிவுசெய்யப்பட்ட வர்த்தக முத்திரைகளைக் கொண்டுள்ளது மற்றும் வர்த்தக முத்திரைகளைப் பயன்படுத்துகிறது. <foundationName>OpenJS நிறுவனம்</foundationName>-ன் வர்த்தக முத்திரைகளின் பட்டியலுக்கு, தயவுசெய்து எங்களது <trademarkPolicy>வர்த்தக முத்திரை கொள்கை</trademarkPolicy> மற்றும் <trademarkList>வர்த்தக முத்திரை பட்டியல் </trademarkList>-ஐப் பார்க்கவும்.<trademarkList>OpenJS Foundation வர்த்தக முத்திரைகளின் பட்டியலில்</trademarkList> குறிப்பிடப்படாத வர்த்தக முத்திரைகள் மற்றும் லோகோக்கள், அந்தந்த உரிமையாளர்களின் வர்த்தக முத்திரைகள்™ அல்லது பதிவுசெய்யப்பட்ட® வர்த்தக முத்திரைகள் ஆகும். அவற்றைப் பயன்படுத்துவது அவர்களுடனான எந்தவொரு தொடர்பையோ அல்லது அவர்களது அங்கீகாரத்தையோ குறிக்காது.",
+        "legal": "பதிப்புரிமை <foundationName>OpenJS Foundation</foundationName> மற்றும் Node.js பங்களிப்பாளர்கள். அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டவை. <foundationName>OpenJS Foundation</foundationName> பதிவுசெய்யப்பட்ட வர்த்தக முத்திரைகளைக் கொண்டுள்ளது மற்றும் வர்த்தக முத்திரைகளைப் பயன்படுத்துகிறது. <foundationName>OpenJS Foundation</foundationName>-ன் வர்த்தக முத்திரைகளின் பட்டியலுக்கு, தயவுசெய்து எங்களது <trademarkPolicy>வர்த்தக முத்திரை கொள்கை</trademarkPolicy> மற்றும் <trademarkList>வர்த்தக முத்திரை பட்டியல் </trademarkList>-ஐப் பார்க்கவும்.<trademarkList>OpenJS Foundation வர்த்தக முத்திரைகளின் பட்டியலில்</trademarkList> குறிப்பிடப்படாத வர்த்தக முத்திரைகள் மற்றும் லோகோக்கள், அந்தந்த உரிமையாளர்களின் வர்த்தக முத்திரைகள்™ அல்லது பதிவுசெய்யப்பட்ட® வர்த்தக முத்திரைகள் ஆகும். அவற்றைப் பயன்படுத்துவது அவர்களுடனான எந்தவொரு தொடர்பையோ அல்லது அவர்களது அங்கீகாரத்தையோ குறிக்காது.",
         "links": {
-          "foundationName": "OpenJS நிறுவனம்",
+          "foundationName": "OpenJS Foundation",
           "termsOfUse": "பயன்பாட்டு விதிமுறைகள்",
           "privacyPolicy": "தனியுரிமை கொள்கை",
           "bylaws": "துணை விதிகள்",


### PR DESCRIPTION
## Summary

- restore the `OpenJS Foundation` trademark text in translated footer strings
- update French, Romanian, and Tamil locale entries that translated the mark

Fixes #8072

## Validation

- `pnpm exec prettier --check packages/i18n/src/locales/fr.json packages/i18n/src/locales/ro.json packages/i18n/src/locales/ta.json`
- `rg -n 'Fondation OpenJS|Fundația OpenJS|OpenJS நிறுவனம்|オープンJS|OpenJS 基金会|OpenJS 재단|Fundación OpenJS|Fundação OpenJS' packages/i18n/src/locales/*.json || true`