### PR TITLE
fix: split repeated adjacent code tabs

### DIFF
--- a/packages/rehype-shiki/src/__tests__/plugin.test.mjs
+++ b/packages/rehype-shiki/src/__tests__/plugin.test.mjs
@@ -64,4 +64,39 @@ describe('rehypeShikiji', async () => {
     (await rehypeShikiji())(mockTree);
     assert.ok(parent.children.some(child => child.tagName === 'CodeTabs'));
   });
+
+  it('splits adjacent CodeTabs when a language repeats', async () => {
+    const createCodeBlock = language => ({
+      tagName: 'pre',
+      children: [
+        {
+          tagName: 'code',
+          data: { meta: `displayName="${language}"` },
+          properties: { className: [`language-${language}`] },
+        },
+      ],
+    });
+
+    const parent = {
+      children: [
+        createCodeBlock('cjs'),
+        createCodeBlock('esm'),
+        createCodeBlock('cjs'),
+        createCodeBlock('esm'),
+      ],
+    };
+
+    mockVisit.mock.mockImplementation((tree, selector, visitor) => {
+      if (selector === 'element') {
+        visitor(parent.children[0], 0, parent);
+      }
+    });
+
+    (await rehypeShikiji())(mockTree);
+
+    assert.equal(parent.children[0].tagName, 'CodeTabs');
+    assert.equal(parent.children[0].children.length, 2);
+    assert.equal(parent.children[1].tagName, 'pre');
+    assert.equal(parent.children[2].tagName, 'pre');
+  });
 });

--- a/packages/rehype-shiki/src/plugin.mjs
+++ b/packages/rehype-shiki/src/plugin.mjs
@@ -53,6 +53,17 @@ function isCodeBlock(node) {
   );
 }
 
+const getCodeLanguage = codeElement => {
+  if (!codeElement.properties.className?.length) {
+    return 'text';
+  }
+
+  const className = codeElement.properties.className.join(' ');
+  const matches = className.match(/language-(?<language>.*)/);
+
+  return matches?.groups.language ?? 'text';
+};
+
 /**
  * @param {import('#rs/index.mjs').HighlighterOptions & { highlighter: import('#rs/highlighter.mjs').SyntaxHighlighter }} options
  */
@@ -72,14 +83,13 @@ export default async function rehypeShikiji(options) {
       while (isCodeBlock(parent?.children[currentIndex])) {
         const codeElement = parent?.children[currentIndex].children[0];
         const meta = parseMeta(codeElement.data?.meta);
+        const language = getCodeLanguage(codeElement);
 
-        // We should get the language name from the class name
-        if (codeElement.properties.className?.length) {
-          const className = codeElement.properties.className.join(' ');
-          const matches = className.match(/language-(?<language>.*)/);
-
-          languages.push(matches?.groups.language ?? 'text');
+        if (languages.includes(language)) {
+          break;
         }
+
+        languages.push(language);
 
         // Map the display names of each variant for the CodeTab
         displayNames.push(meta.displayName?.replaceAll('|', '') ?? '');


### PR DESCRIPTION
## Summary

- stop merging adjacent code blocks into one CodeTabs group when a language repeats
- add regression coverage for `cjs`/`esm`/`cjs`/`esm` style sequences

Fixes #7803

## Validation

- `pnpm --filter @node-core/rehype-shiki test:unit`
- `pnpm exec prettier --check packages/rehype-shiki/src/plugin.mjs packages/rehype-shiki/src/__tests__/plugin.test.mjs`
- `pnpm --filter @node-core/rehype-shiki lint:js`
- `pnpm --filter @node-core/rehype-shiki lint:types`