### PR TITLE
i18n: translate Japanese footer legal text

### DIFF
--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -10,7 +10,7 @@
     },
     "containers": {
       "footer": {
-        "legal": "Copyright <foundationName>OpenJS Foundation</foundationName> and Node.js contributors. All rights reserved. The <foundationName>OpenJS Foundation</foundationName> has registered trademarks and uses trademarks.  For a list of trademarks of the <foundationName>OpenJS Foundation</foundationName>, please see our <trademarkPolicy>Trademark Policy</trademarkPolicy> and <trademarkList>Trademark List</trademarkList>.  Trademarks and logos not indicated on the <trademarkList>list of OpenJS Foundation trademarks</trademarkList> are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.",
+        "legal": "Copyright <foundationName>OpenJS Foundation</foundationName> および Node.js コントリビューター。すべての権利を保有します。<foundationName>OpenJS Foundation</foundationName> は登録商標および商標を保有し、使用しています。<foundationName>OpenJS Foundation</foundationName> の商標一覧については、<trademarkPolicy>商標ポリシー</trademarkPolicy>および<trademarkList>商標リスト</trademarkList>をご覧ください。<trademarkList>OpenJS Foundation の商標一覧</trademarkList>に記載されていない商標およびロゴは、それぞれの所有者の商標™または登録商標®です。それらの使用は、各所有者との提携または各所有者による支持を意味するものではありません。",
         "links": {
           "foundationName": "OpenJS Foundation",
           "aiCodingAssistantsPolicy": "AI生成コードの利用に関するポリシー",


### PR DESCRIPTION
## Summary
- translate the Japanese footer legal notice
- preserve OpenJS Foundation, Node.js, and existing link placeholders

## Validation
- node -e "JSON.parse(require('fs').readFileSync('packages/i18n/src/locales/ja.json', 'utf8')); console.log('ok')"\n- pnpm exec prettier --check packages/i18n/src/locales/ja.json