### PR TITLE
i18n: translate Japanese search attribution

### DIFF
--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -208,7 +208,7 @@
       "initErrorChat": "チャットサービスを開始できません",
       "chatButtonLabel": "AIの情報を確認する",
       "searchButtonLabel": "検索",
-      "poweredBy": "Powered by",
+      "poweredBy": "提供元",
       "suggestionOne": "Node.jsをインストールするには？",
       "suggestionTwo": "HTTPサーバーを作成するには？",
       "suggestionThree": "Node.jsのバージョンアップ",


### PR DESCRIPTION
## Summary
- translate the Japanese search attribution label from `Powered by` to `提供元`

## Validation
- node -e "JSON.parse(require('fs').readFileSync('packages/i18n/src/locales/ja.json', 'utf8')); console.log('ok')"\n- pnpm exec prettier --check packages/i18n/src/locales/ja.json