### PR TITLE
fix(i18n): fix Windows typo in Japanese locale

### DIFF
--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -296,7 +296,7 @@
           "nvm": "\"nvm\"はクロスプラットフォームに対応したNode.jsのバージョンマネージャーです。",
           "fnm": "\"fnm\"はクロスプラットフォームに対応したNode.jsのバージョンマネージャーです。",
           "brew": "HomebrewはmacOS用およびLinux用のパッケージマネージャーです。",
-          "choco": "ChocolateyはWIndows用のパッケージマネージャーです。",
+          "choco": "ChocolateyはWindows用のパッケージマネージャーです。",
           "docker": "Dockerはコンテナー化に関するプラットフォームです。",
           "n": "\"n\"はクロスプラットフォームに対応したNode.jsのバージョンマネージャーです。",
           "volta": "\"Volta\"はクロスプラットフォームに対応したNode.jsのバージョンマネージャーです。"


### PR DESCRIPTION
## Summary
- fix `WIndows` to `Windows` in the Japanese Chocolatey platform info

## Validation
- node -e "JSON.parse(require('fs').readFileSync('packages/i18n/src/locales/ja.json', 'utf8')); console.log('ok')"\n- pnpm exec prettier --check packages/i18n/src/locales/ja.json