### PR TITLE
feature: add Node.js Interactive at RenderATL banner

### DIFF
--- a/apps/site/site.json
+++ b/apps/site/site.json
@@ -29,11 +29,11 @@
   ],
   "websiteBanners": {
     "index": {
-      "startDate": "2026-03-24T03:00:00.000Z",
-      "endDate": "2026-03-31T03:00:00.000Z",
-      "text": "March Security Release is available",
-      "link": "https://nodejs.org/en/blog/vulnerability/march-2026-security-releases",
-      "type": "warning"
+      "startDate": "2026-06-16T00:00:00.000Z",
+      "endDate": "2026-08-13T23:59:59.000Z",
+      "text": "Node.js Interactive at RenderATL — August 12-13. Register now!",
+      "link": "https://www.renderatl.com/tickets",
+      "type": "default"
     }
   },
   "websiteBadges": {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a website banner announcing Node.js Interactive at RenderATL, August 12-13, 2026.
The banner links to the registration page and will display site-wide until the event ends.


## Validation

Banner appears at the top of all pages when visiting the site locally via `pnpm dev`.


## Related Issues

Closes #8957

### Check List



- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ x] I have run `pnpm format` to ensure the code follows the style guide.
- [ x] I have run `pnpm test` to check if all tests are passing.
- [ x] I have run `pnpm build` to check if the website builds without errors.
- [ x] I've covered new added functionality with unit tests if necessary.
