### PR TITLE
Fix typos in June 2026 security release notes

### DIFF
--- a/apps/site/pages/en/blog/vulnerability/june-2026-security-releases.md
+++ b/apps/site/pages/en/blog/vulnerability/june-2026-security-releases.md
@@ -29,9 +29,9 @@ This vulnerability affects all supported release lines: **Node.js 22**, **Node.j
 
 Thank you, to erichen for reporting this vulnerability and thank you Filip Skokan for fixing it.
 
-## Node.js unicode dot separator handling can lead to tls wildcard-depth authentication bypass due to resolver and verifier hostname normalization mismat (CVE-2026-48618) - (high)
+## Node.js unicode dot separator handling can lead to tls wildcard-depth authentication bypass due to resolver and verifier hostname normalization mismatch (CVE-2026-48618) - (high)
 
-A flaw in Node.js TLS hostname handling can cause Node.js unicode dot separator handling can lead to tls wildcard-depth authentication bypass due to resolver and verifier hostname normalization mismat.
+A flaw in Node.js TLS hostname handling can cause Node.js unicode dot separator handling can lead to tls wildcard-depth authentication bypass due to resolver and verifier hostname normalization mismatch.
 
 This can lead to confidentiality impact or bypass of the intended security boundary under affected configurations.
 


### PR DESCRIPTION
Corrected typos in the description of CVE-2026-48618.

## Description

Fixed a typo in the CVE-2026-48618 advisory description where "mismat" was incorrectly written instead of "mismatch".

## Validation

- The change is text-only and limited to fixing a spelling error in the CVE-2026-48618 description.
- Reviewers can verify by viewing the diff: the word "mismat" should now read "mismatch".
- No functional, visual, or build-affecting changes.

## Related Issues

<!-- Add issue reference here if one exists, e.g. Fixes #1234 -->
N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
