### PR TITLE
feat: add NodeSource commercial support to EOL page

### DIFF
--- a/apps/site/pages/en/about/eol.mdx
+++ b/apps/site/pages/en/about/eol.mdx
@@ -41,6 +41,8 @@ Despite the obvious downsides of using EOL releases, in practice, organizations 
 
 HeroDevs provides [Never-Ending Support (NES)](https://nodejs.org/esp/herodevs) for Node.js versions past their official maintenance phase. This includes security patches, compliance assistance, and technical support to help bridge the gap while you plan your upgrade strategy.
 
+NodeSource offers commercial-grade upgrade assessments and expert support to safely modernize Node.js applications still running on EOL versions. Their guided [Upgrade Program](https://nodesource.com/products/nodejs-upgrade) delivers in-depth risk analysis, identifies migration blockers, and provides a custom roadmap to streamline your upgrade journey.
+
 TuxCare’s [Endless Lifecycle Support (ELS)](https://tuxcare.com/endless-lifecycle-support/) gives you continued security patching for end-of-life Node.js versions. Security fixes are backported from upstream, tested for integrity and regression, signed, SLA-backed, and delivered through your existing package managers.
 
 Using EOL releases through commercial support should be viewed as a temporary solution—the goal should always be to upgrade to actively supported versions.


### PR DESCRIPTION
## Summary

Adds the NodeSource Upgrade Program paragraph to the EOL page Commercial Support section, alongside the existing HeroDevs and TuxCare entries.

## Test plan

- [ ] Verify `/about/eol` renders the NodeSource paragraph after HeroDevs
- [ ] Confirm the Upgrade Program link works


Made with [Cursor](https://cursor.com)