### PR TITLE
fix(ui): show up to 12 partner logos and fix width

### DIFF
--- a/apps/site/components/Common/Partners/PartnerButton/index.module.css
+++ b/apps/site/components/Common/Partners/PartnerButton/index.module.css
@@ -25,6 +25,7 @@
 
   svg {
     @apply h-4
-      w-auto;
+      w-auto
+      max-w-4;
   }
 }

--- a/apps/site/components/Common/Partners/index.module.css
+++ b/apps/site/components/Common/Partners/index.module.css
@@ -5,6 +5,7 @@
     flex-row
     flex-wrap
     items-center
+    justify-center
     gap-2;
 }
 

--- a/apps/site/components/Common/Partners/index.tsx
+++ b/apps/site/components/Common/Partners/index.tsx
@@ -70,7 +70,7 @@ const PartnersList: FC<PartnersListProps> = async ({
 }) => {
   const isSmall = size === 'small';
 
-  const SMALL_PARTNER_LIMIT = 6;
+  const SMALL_PARTNER_LIMIT = 12;
 
   const partners = await getPartners(
     length ?? (isSmall ? SMALL_PARTNER_LIMIT : undefined),


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The home page hero renders the small partner list from a weighted shuffle whose
seed changes every 5 minutes, then truncates it to the first 6 entries. With 9
partners in `constants.json`, each render dropped 3 of them — so depending on
when (or from which cached render) you loaded the page, a given partner's logo
was simply missing. Some wide logos (≈2.2:1 aspect ratio) also rendered about
twice as wide as the roughly square marks next to them. The defined `weight`
in `constants.json` did not impact the width of the logo as still doesn't.

### Changes
- Raised `SMALL_PARTNER_LIMIT` from 6 to 12 so all current partners always
  render; the weighted shuffle still impacts the sort order.
- Added `justify-center` to the small partner list so rows stay centered when
  the icons wrap on different viewports.
- Added `max-w-4` to the small partner button SVG. Since the logos have a
  `viewBox`, wide marks scale down proportionally to fit the cap instead of
  stretching their button, so all partner buttons render at a uniform width.

## Validation

1. Visit the homepage
2. Notice the partner logos just below the main Get Node and Get Security buttons
3. Up to 12 are visible (currently 9 visible)
4. Try again on different viewports/devices

### Before

<img width="1584" height="782" alt="nodejs-org-before" src="https://github.com/user-attachments/assets/630fd4c7-90eb-4ac1-8840-a601bb945955" />

### After

<img width="1576" height="780" alt="nodejs-org-after" src="https://github.com/user-attachments/assets/c4328283-1a5d-440f-856b-d4becf52299c" />


## Related Issues

None

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
