### PR TITLE
Adds link to beta docs

### DIFF
--- a/apps/site/components/withNavBar.tsx
+++ b/apps/site/components/withNavBar.tsx
@@ -54,11 +54,14 @@ const WithNavBar: FC = () => {
       <WithBanner section="index" />
 
       <NavBar
-        navItems={navigationItems.map(([, { label, link, target }]) => ({
-          link,
-          text: label,
-          target,
-        }))}
+        navItems={navigationItems.map(
+          ([, { label, link, target, accent }]) => ({
+            link,
+            text: label,
+            target,
+            accent,
+          })
+        )}
         pathname={pathname}
         as={Link}
         Logo={WithNodejsLogo}

--- a/apps/site/hooks/useSiteNavigation.ts
+++ b/apps/site/hooks/useSiteNavigation.ts
@@ -19,6 +19,7 @@ type MappedNavigationEntry = {
   label: FormattedMessage;
   link: string;
   target?: HTMLAttributeAnchorTarget | undefined;
+  accent?: boolean;
 };
 
 // Provides Context replacement for variables within the Link. This is also something that is not going
@@ -44,13 +45,14 @@ const useSiteNavigation = () => {
       t.rich(label, context[key] || {}) as FormattedMessage;
 
     return Object.entries(entries).map(
-      ([key, { label, link, items, target }]): [
+      ([key, { label, link, items, target, accent }]): [
         string,
         MappedNavigationEntry,
       ] => [
         key,
         {
           target,
+          accent,
           label: label ? getFormattedMessage(label, key) : '',
           link: link ? replaceLinkWithContext(link, context[key]) : '',
           items: items ? mapNavigationEntries(items, context) : [],

--- a/apps/site/navigation.json
+++ b/apps/site/navigation.json
@@ -20,6 +20,12 @@
       "link": "https://nodejs.org/docs/latest/api/",
       "label": "components.containers.navBar.links.docs"
     },
+    "betaDocs": {
+      "link": "https://beta.docs.nodejs.org/",
+      "label": "components.containers.navBar.links.betaDocs",
+      "target": "_blank",
+      "accent": true
+    },
     "contribute": {
       "link": "https://github.com/nodejs/node/blob/main/CONTRIBUTING.md",
       "label": "components.containers.navBar.links.contribute",

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -10,6 +10,9 @@ const locators = {
   mobileMenuToggleName:
     englishLocale.components.containers.navBar.controls.toggle,
   navLinksLocator: `[aria-label="${englishLocale.components.containers.navBar.controls.toggle}"] + div`,
+  // The Beta Docs link renders untranslated (English) across locales, so we
+  // match on its English label to skip it during translation checks.
+  betaDocsName: englishLocale.components.containers.navBar.links.betaDocs,
   // Global UI controls
   languageDropdownName: englishLocale.components.common.languageDropdown.label,
   themeToggleName: englishLocale.components.header.buttons.theme,
@@ -51,14 +54,18 @@ const verifyTranslation = async (page: Page, locale: Locale | string) => {
     .all();
   const expectedTexts = Object.values(
     localeData.components.containers.navBar.links
-  )
-    // Filter out 'Beta Docs' link as it is not present in the navigation for some locales
-    .filter(entry => entry !== 'Beta Docs');
+  );
 
   // Verify each navigation link text matches an expected translation
   for (const link of links) {
-    const linkText = await link.textContent();
-    expect(expectedTexts).toContain(linkText!.trim());
+    const linkText = (await link.textContent())!.trim();
+    // Skip the Beta Docs link: it renders untranslated (English) across
+    // locales and has no translation entry in most locale files, so it
+    // won't appear in `expectedTexts` for non-English locales (e.g. es).
+    if (linkText === locators.betaDocsName) {
+      continue;
+    }
+    expect(expectedTexts).toContain(linkText);
   }
 };
 

--- a/apps/site/tests/e2e/general-behavior.spec.ts
+++ b/apps/site/tests/e2e/general-behavior.spec.ts
@@ -51,7 +51,9 @@ const verifyTranslation = async (page: Page, locale: Locale | string) => {
     .all();
   const expectedTexts = Object.values(
     localeData.components.containers.navBar.links
-  );
+  )
+    // Filter out 'Beta Docs' link as it is not present in the navigation for some locales
+    .filter(entry => entry !== 'Beta Docs');
 
   // Verify each navigation link text matches an expected translation
   for (const link of links) {

--- a/apps/site/types/navigation.ts
+++ b/apps/site/types/navigation.ts
@@ -16,6 +16,7 @@ export type NavigationKeys =
   | 'about'
   | 'download'
   | 'docs'
+  | 'betaDocs'
   | 'getInvolved'
   | 'certification'
   | 'learn'
@@ -26,6 +27,7 @@ export type NavigationEntry = {
   link?: string;
   items?: Record<string, NavigationEntry>;
   target?: HTMLAttributeAnchorTarget | undefined;
+  accent?: boolean;
 };
 
 export type SiteNavigation = {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -36,6 +36,7 @@
           "about": "About",
           "download": "Download",
           "docs": "Docs",
+          "betaDocs": "Beta Docs",
           "guides": "Guides",
           "learn": "Learn",
           "security": "Security",

--- a/packages/ui-components/src/Containers/NavBar/NavItem/index.module.css
+++ b/packages/ui-components/src/Containers/NavBar/NavItem/index.module.css
@@ -45,6 +45,30 @@
     }
   }
 
+  &.accent {
+    @apply bg-brand-100
+      ring-brand-600/20
+      dark:bg-brand-600/15
+      dark:ring-brand-400/20
+      ring-1
+      ring-inset;
+
+    .label {
+      @apply text-brand-700
+        dark:text-brand-400;
+    }
+
+    .icon {
+      @apply text-brand-600
+        dark:text-brand-400;
+    }
+
+    &:hover {
+      @apply bg-brand-200
+        dark:bg-brand-600/25;
+    }
+  }
+
   &.footer {
     .label {
       @apply text-neutral-800

--- a/packages/ui-components/src/Containers/NavBar/NavItem/index.module.css
+++ b/packages/ui-components/src/Containers/NavBar/NavItem/index.module.css
@@ -6,7 +6,8 @@
     gap-2
     rounded-sm
     px-3
-    py-2;
+    py-2
+    motion-safe:transition-colors;
 
   .label {
     @apply text-base
@@ -46,26 +47,15 @@
   }
 
   &.accent {
-    @apply bg-brand-100
-      ring-brand-600/20
-      dark:bg-brand-600/15
-      dark:ring-brand-400/20
+    @apply bg-transparent
       ring-1
-      ring-inset;
-
-    .label {
-      @apply text-brand-700
-        dark:text-brand-400;
-    }
-
-    .icon {
-      @apply text-brand-600
-        dark:text-brand-400;
-    }
+      ring-neutral-200
+      ring-inset
+      dark:ring-neutral-900;
 
     &:hover {
-      @apply bg-brand-200
-        dark:bg-brand-600/25;
+      @apply bg-neutral-200
+        dark:bg-neutral-900;
     }
   }
 

--- a/packages/ui-components/src/Containers/NavBar/NavItem/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/NavItem/index.tsx
@@ -15,6 +15,7 @@ type NavItemProps = {
   type?: NavItemType;
   className?: string;
   target?: HTMLAttributeAnchorTarget | undefined;
+  accent?: boolean;
 
   pathname: string;
   as: LinkLike;
@@ -26,12 +27,18 @@ const NavItem: FC<PropsWithChildren<NavItemProps>> = ({
   children,
   className,
   target,
+  accent,
   ...props
 }) => (
   <BaseActiveLink
     target={target}
     href={href}
-    className={classNames(styles.navItem, styles[type], className)}
+    className={classNames(
+      styles.navItem,
+      styles[type],
+      { [styles.accent]: accent },
+      className
+    )}
     activeClassName={styles.active}
     allowSubPath={href.startsWith('/')}
     {...props}

--- a/packages/ui-components/src/Containers/NavBar/index.stories.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.stories.tsx
@@ -30,6 +30,12 @@ export const Default: Story = {
         link: '/docs',
       },
       {
+        text: 'Beta Docs',
+        link: 'https://beta.docs.nodejs.org/',
+        target: '_blank',
+        accent: true,
+      },
+      {
         text: 'Download',
         link: '/download',
       },

--- a/packages/ui-components/src/Containers/NavBar/index.tsx
+++ b/packages/ui-components/src/Containers/NavBar/index.tsx
@@ -26,6 +26,7 @@ type NavbarProps = {
     text: FormattedMessage;
     link: string;
     target?: HTMLAttributeAnchorTarget | undefined;
+    accent?: boolean;
   }>;
   Logo: ElementType;
   as: LinkLike;
@@ -76,13 +77,14 @@ const NavBar: FC<PropsWithChildren<NavbarProps>> = ({
         <div className={classNames(styles.main, `hidden peer-checked:flex`)}>
           {navItems && navItems.length > 0 && (
             <div className={styles.navItems}>
-              {navItems.map(({ text, link, target }) => (
+              {navItems.map(({ text, link, target, accent }) => (
                 <NavItem
                   pathname={pathname}
                   as={Component}
                   key={link}
                   href={link}
                   target={target}
+                  accent={accent}
                 >
                   {text}
                 </NavItem>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Good feedback within https://github.com/nodejs/node/pull/62045 has mentioned that despite social media posts and github issues, most users may have not yet seen the [beta docs](https://beta.docs.nodejs.org/). To expand an ever-increasing feedback gathering campaign, I think we should publicize the beta docs on par with the official docs.

Unsure if this has been proposed before - apologies if I missed it.

Large Light/Dark
<img width="1314" height="62" alt="image" src="https://github.com/user-attachments/assets/fee4115f-a537-48be-88f3-0479052d3218" />
<img width="1310" height="61" alt="image" src="https://github.com/user-attachments/assets/cfe91c5e-120f-481a-94b2-8fddbbc90a53" />


Mobile
<img width="667" height="506" alt="image" src="https://github.com/user-attachments/assets/9f7f20b9-433b-4b1a-a70d-dfb035f793ca" />



## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
- View docs next to current.
- Should open in new tab

## Related Issues

https://github.com/nodejs/node/pull/62045

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
