### PR TITLE
chore: remove release + security categories for ESP partners

### DIFF
--- a/apps/site/public/static/partners/constants.json
+++ b/apps/site/public/static/partners/constants.json
@@ -18,7 +18,7 @@
     "name": "HeroDevs",
     "href": "https://herodevs.com",
     "weight": 3,
-    "categories": ["security", "esp", "release"]
+    "categories": ["esp"]
   },
   {
     "id": "DIGITALOCEAN",
@@ -46,7 +46,7 @@
     "name": "NodeSource",
     "href": "https://nodesource.com",
     "weight": 3,
-    "categories": ["security", "esp", "release"]
+    "categories": ["esp"]
   },
   {
     "id": "TUXCARE",


### PR DESCRIPTION
## Description

Coming out of today's web meeting discussion around #8995, we noticed that the partners JSON makes reference to `security` and `release` partner categories, [which are not actually used in code](https://github.com/nodejs/nodejs.org/blob/4fd34e29b03f58af5d2d526cc030af7633d0f603/apps/site/types/partners.ts#L32), leading to some confusion. To make it easier to grok how the current logic + associations work as the discussion continues, this removes those unused categories for clarity.

## Validation

No change in the partners rendered on the /about/partners page.

## Related Issues

cc #8995 https://github.com/nodejs/web-team/pull/162

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
