### PR TITLE
feat(banner): add `x` for closing

### DIFF
--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -17,28 +17,28 @@ const WithBanner: FC<{ section: string }> = ({ section }) => {
   const banner = siteConfig.websiteBanners[section];
   const t = useTranslations();
 
-  const [dismissed, setDismissed] = useState(false);
+  const [open, setOpen] = useState(false);
 
-  // localStorage is only available on the client, so the banner is always
-  // rendered on the server and hidden after hydration if previously dismissed
   useEffect(() => {
     if (banner) {
-      setDismissed(localStorage.getItem(STORAGE_KEY) === banner.text);
+      // eslint-disable-next-line @eslint-react/set-state-in-effect
+      setOpen(localStorage.getItem(STORAGE_KEY) !== banner.text);
     }
   }, [banner]);
 
-  if (banner && !dismissed && dateIsBetween(banner.startDate, banner.endDate)) {
+  if (banner && open && dateIsBetween(banner.startDate, banner.endDate)) {
     const bannerType = banner.type || 'default';
 
     const onClose = () => {
       localStorage.setItem(STORAGE_KEY, banner.text);
-      setDismissed(true);
+      setOpen(false);
     };
 
     return (
       <Banner
         type={banner.type}
         aria-label={t(`components.banner.${bannerType}`)}
+        closeButtonAriaLabel={t('components.banner.close')}
         onClose={onClose}
       >
         {banner.link ? (

--- a/apps/site/components/withBanner.tsx
+++ b/apps/site/components/withBanner.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import Banner from '@node-core/ui-components/Common/Banner';
 import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
 
 import Link from '#site/components/Link';
 import { siteConfig } from '#site/next.json.mjs';
@@ -8,17 +11,35 @@ import { dateIsBetween } from '#site/util/date';
 
 import type { FC } from 'react';
 
+const STORAGE_KEY = 'banner-dismissal';
+
 const WithBanner: FC<{ section: string }> = ({ section }) => {
   const banner = siteConfig.websiteBanners[section];
   const t = useTranslations();
 
-  if (banner && dateIsBetween(banner.startDate, banner.endDate)) {
+  const [dismissed, setDismissed] = useState(false);
+
+  // localStorage is only available on the client, so the banner is always
+  // rendered on the server and hidden after hydration if previously dismissed
+  useEffect(() => {
+    if (banner) {
+      setDismissed(localStorage.getItem(STORAGE_KEY) === banner.text);
+    }
+  }, [banner]);
+
+  if (banner && !dismissed && dateIsBetween(banner.startDate, banner.endDate)) {
     const bannerType = banner.type || 'default';
+
+    const onClose = () => {
+      localStorage.setItem(STORAGE_KEY, banner.text);
+      setDismissed(true);
+    };
 
     return (
       <Banner
         type={banner.type}
         aria-label={t(`components.banner.${bannerType}`)}
+        onClose={onClose}
       >
         {banner.link ? (
           <Link href={banner.link}>{banner.text}</Link>

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -191,7 +191,8 @@
     "banner": {
       "default": "Announcement",
       "warning": "Warning notification",
-      "error": "Error notification"
+      "error": "Error notification",
+      "close": "Close banner"
     },
     "search": {
       "searchPlaceholder": "Start typing...",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "exports": {
     "./*": {

--- a/packages/ui-components/src/Common/Banner/index.module.css
+++ b/packages/ui-components/src/Common/Banner/index.module.css
@@ -1,13 +1,11 @@
 @reference "../../styles/index.css";
 
 .banner {
-  @apply relative
-    flex
+  @apply animate-fade-and-slide-down
+    relative
+    grid
     w-full
-    flex-row
-    items-center
-    justify-center
-    gap-2
+    grid-rows-1
     px-8
     py-3
     text-sm;
@@ -28,6 +26,15 @@
     @apply size-4
       text-white/50;
   }
+}
+
+.bannerContent {
+  @apply flex
+    min-h-0
+    flex-row
+    items-center
+    justify-center
+    gap-2;
 }
 
 .default {

--- a/packages/ui-components/src/Common/Banner/index.module.css
+++ b/packages/ui-components/src/Common/Banner/index.module.css
@@ -1,7 +1,8 @@
 @reference "../../styles/index.css";
 
 .banner {
-  @apply flex
+  @apply relative
+    flex
     w-full
     flex-row
     items-center
@@ -39,4 +40,16 @@
 
 .warning {
   @apply bg-warning-600;
+}
+
+.closeButton {
+  @apply absolute
+    right-4
+    text-lg;
+
+  span {
+    @apply text-white/60
+      transition-colors
+      hover:text-white;
+  }
 }

--- a/packages/ui-components/src/Common/Banner/index.stories.tsx
+++ b/packages/ui-components/src/Common/Banner/index.stories.tsx
@@ -26,4 +26,12 @@ export const Warning: Story = {
   },
 };
 
+export const Dismissible: Story = {
+  args: {
+    children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    type: 'default',
+    onClose: () => {},
+  },
+};
+
 export default { component: Banner } as Meta;

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -22,7 +22,9 @@ const Banner: FC<PropsWithChildren<BannerProps>> = ({
   ...props
 }) => {
   const [dismissed, setDismissed] = useState(false);
-  if (dismissed) {return null;}
+  if (dismissed) {
+    return null;
+  }
 
   return (
     <section

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -1,18 +1,17 @@
-'use client';
-
 import classNames from 'classnames';
-import {
-  useState,
-  type FC,
-  type HTMLAttributes,
-  type PropsWithChildren,
+
+import type {
+  FC,
+  HTMLAttributes,
+  MouseEventHandler,
+  PropsWithChildren,
 } from 'react';
 
 import styles from './index.module.css';
 
 export type BannerProps = {
   type?: 'default' | 'warning' | 'error';
-  onClose?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClose?: MouseEventHandler<HTMLButtonElement>;
 } & HTMLAttributes<HTMLElement>;
 
 const Banner: FC<PropsWithChildren<BannerProps>> = ({
@@ -20,31 +19,23 @@ const Banner: FC<PropsWithChildren<BannerProps>> = ({
   onClose,
   children,
   ...props
-}) => {
-  const [dismissed, setDismissed] = useState(false);
-  if (dismissed) {
-    return null;
-  }
-
-  return (
-    <section
-      className={classNames(styles.banner, styles[type] || styles.default)}
-      {...props}
-    >
-      {children}
+}) => (
+  <section
+    className={classNames(styles.banner, styles[type] || styles.default)}
+    {...props}
+  >
+    {children}
+    {onClose && (
       <button
         type="button"
         className={styles.closeButton}
         aria-label="Close banner"
-        onClick={e => {
-          setDismissed(true);
-          onClose?.(e);
-        }}
+        onClick={onClose}
       >
         <span aria-hidden="true">&times;</span>
       </button>
-    </section>
-  );
-};
+    )}
+  </section>
+);
 
 export default Banner;

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -1,22 +1,48 @@
-import type { FC, HTMLAttributes, PropsWithChildren } from 'react';
+'use client';
+
+import classNames from 'classnames';
+import {
+  useState,
+  type FC,
+  type HTMLAttributes,
+  type PropsWithChildren,
+} from 'react';
 
 import styles from './index.module.css';
 
 export type BannerProps = {
   type?: 'default' | 'warning' | 'error';
+  onClose?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 } & HTMLAttributes<HTMLElement>;
 
 const Banner: FC<PropsWithChildren<BannerProps>> = ({
   type = 'default',
+  onClose,
   children,
   ...props
-}) => (
-  <section
-    className={`${styles.banner} ${styles[type] || styles.default}`}
-    {...props}
-  >
-    {children}
-  </section>
-);
+}) => {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) {return null;}
+
+  return (
+    <section
+      className={classNames(styles.banner, styles[type] || styles.default)}
+      {...props}
+    >
+      {children}
+      <button
+        type="button"
+        className={styles.closeButton}
+        aria-label="Close banner"
+        onClick={e => {
+          setDismissed(true);
+          onClose?.(e);
+        }}
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </section>
+  );
+};
 
 export default Banner;

--- a/packages/ui-components/src/Common/Banner/index.tsx
+++ b/packages/ui-components/src/Common/Banner/index.tsx
@@ -11,11 +11,13 @@ import styles from './index.module.css';
 
 export type BannerProps = {
   type?: 'default' | 'warning' | 'error';
+  closeButtonAriaLabel?: string;
   onClose?: MouseEventHandler<HTMLButtonElement>;
 } & HTMLAttributes<HTMLElement>;
 
 const Banner: FC<PropsWithChildren<BannerProps>> = ({
   type = 'default',
+  closeButtonAriaLabel = 'Close banner',
   onClose,
   children,
   ...props
@@ -24,17 +26,19 @@ const Banner: FC<PropsWithChildren<BannerProps>> = ({
     className={classNames(styles.banner, styles[type] || styles.default)}
     {...props}
   >
-    {children}
-    {onClose && (
-      <button
-        type="button"
-        className={styles.closeButton}
-        aria-label="Close banner"
-        onClick={onClose}
-      >
-        <span aria-hidden="true">&times;</span>
-      </button>
-    )}
+    <div className={styles.bannerContent}>
+      {children}
+      {onClose && (
+        <button
+          type="button"
+          className={styles.closeButton}
+          aria-label={closeButtonAriaLabel}
+          onClick={onClose}
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      )}
+    </div>
   </section>
 );
 

--- a/packages/ui-components/src/styles/animations.css
+++ b/packages/ui-components/src/styles/animations.css
@@ -93,12 +93,14 @@
     from {
       grid-template-rows: 0fr;
       opacity: 0;
+      padding-block: 0;
       transform: translateY(-100%);
     }
 
     to {
       grid-template-rows: 1fr;
       opacity: 1;
+      padding-block: calc(var(--spacing, 0.25rem) * 3);
       transform: translateY(0);
     }
   }

--- a/packages/ui-components/src/styles/animations.css
+++ b/packages/ui-components/src/styles/animations.css
@@ -7,6 +7,8 @@
   --animate-dot-move-delay-400: dot-move 1.2s infinite ease-in-out 400ms;
   --animate-slide-to-left: slide-to-left 300ms ease-in-out;
   --animate-slide-to-right: slide-to-right 300ms ease-in-out;
+  --animate-fade-and-slide-down: fade-and-slide-down 300ms ease-out 400ms
+    backwards;
 
   @keyframes surf {
     0% {
@@ -84,6 +86,20 @@
 
     to {
       transform: translateX(0);
+    }
+  }
+
+  @keyframes fade-and-slide-down {
+    from {
+      grid-template-rows: 0fr;
+      opacity: 0;
+      transform: translateY(-100%);
+    }
+
+    to {
+      grid-template-rows: 1fr;
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 }


### PR DESCRIPTION
Makes the banner close-able.

**Note**: This just updated `ui-components`, and doesn't touch Next.js + cookie handling
<img width="1145" height="109" alt="Screenshot 2026-07-14 at 12 15 13 PM" src="https://github.com/user-attachments/assets/cfc97424-a0da-4378-aaf0-023b722d42a3" />
