### PR TITLE
meta: bump nvm to v0.40.6

### DIFF
--- a/apps/site/snippets/en/download/nvm.bash
+++ b/apps/site/snippets/en/download/nvm.bash
@@ -1,5 +1,5 @@
 # Download and install nvm:
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
 
 # in lieu of restarting the shell
 \. "$HOME/.nvm/nvm.sh"


### PR DESCRIPTION
Updates the English nvm install snippet to [`v0.40.6`](https://github.com/nvm-sh/nvm/releases/tag/v0.40.6). The translation system handles other locales.

Ref: https://github.com/nodejs/nodejs.org/issues/8628