### PR TITLE
chore(ci): make it clear that PR policy is for `packages/`

### DIFF
--- a/.github/workflows/pull-request-policy.yml
+++ b/.github/workflows/pull-request-policy.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - packages/**
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
It may be confusing for some members who are used to previous commit styles, e.g. `blog:` to see a failed check in their PR.