### PR TITLE
fix(ui): always mount code tabs

### DIFF
--- a/.changeset/chubby-bats-work.md
+++ b/.changeset/chubby-bats-work.md
@@ -1,0 +1,5 @@
+---
+'@node-core/ui-components': patch
+---
+
+Always mount CodeTabs, even when inactive

--- a/packages/ui-components/src/Common/CodeTabs/index.module.css
+++ b/packages/ui-components/src/Common/CodeTabs/index.module.css
@@ -1,6 +1,11 @@
 @reference "../../styles/index.css";
 
 .root {
+  /* `forceMount` keeps every panel in the DOM, so hide the inactive ones here */
+  > [role='tabpanel'][data-state='inactive'] {
+    @apply hidden;
+  }
+
   > [role='tabpanel'] > :first-child {
     @apply rounded-t-none;
   }

--- a/packages/ui-components/src/MDX/CodeTabs.tsx
+++ b/packages/ui-components/src/MDX/CodeTabs.tsx
@@ -57,7 +57,11 @@ const MDXCodeTabs: FC<MDXCodeTabsProps> = ({
       {...props}
     >
       {languages.map((_, index) => (
-        <TabsPrimitive.Content key={tabs[index].key} value={tabs[index].key}>
+        <TabsPrimitive.Content
+          forceMount
+          key={tabs[index].key}
+          value={tabs[index].key}
+        >
           {codes[index]}
         </TabsPrimitive.Content>
       ))}


### PR DESCRIPTION
Use `forceMount` on `CodeTabs` so that SSRed CodeTabs do not lose the unmounted code data