### PR TITLE
chore(deps): change dependabot prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - 'github_actions:pull-request'
       - 'auto-merge'
     commit-message:
-      prefix: meta
+      prefix: chore(deps)
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -26,7 +26,7 @@ updates:
       - 'github_actions:pull-request'
       - 'auto-merge'
     commit-message:
-      prefix: meta
+      prefix: chore(deps)
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
Makes Dependabot follow Conventional Commits