### PR TITLE
fix: FunctionSignature return type border

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-core/ui-components",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "type": "module",
   "exports": {
     "./*": {

--- a/packages/ui-components/src/Common/Signature/SignatureItem/index.tsx
+++ b/packages/ui-components/src/Common/Signature/SignatureItem/index.tsx
@@ -18,6 +18,7 @@ const SignatureItem: FC<PropsWithChildren<SignatureItemProps>> = ({
   children,
 }) => (
   <div
+    data-kind={kind}
     className={classNames(styles.item, {
       [styles.return]: kind === 'return',
     })}

--- a/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
+++ b/packages/ui-components/src/Common/Signature/SignatureRoot/index.module.css
@@ -22,4 +22,10 @@
     px-4
     py-3
     dark:border-neutral-900;
+
+  &:has(> [data-kind='return']:only-child) {
+    @apply border-0
+      px-0
+      py-0;
+  }
 }


### PR DESCRIPTION
## Description

The bordered wrapper component should not be rendered in the `FunctionSignature` component when only the return type is present.

Ref: https://openjs-foundation.slack.com/archives/CVAMEJ4UV/p1785348769820369

## Validation

The `FunctionSignature` "Return Type" variant should now be fixed in Chromatic, and the other variants shouldn't have any regressions.

