### PR TITLE
fix(pnpm): warn > error

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "11.9.0",
-      "onFail": "error"
+      "onFail": "warn"
     }
   }
 }


### PR DESCRIPTION
Don't fail CI when Changesets uses `npm publish`.

cc @nodejs/web-infra fast-tracking