### PR TITLE
fix(doc-kit): add 'event' to the code-like array

### DIFF
--- a/packages/ui-components/src/constants.ts
+++ b/packages/ui-components/src/constants.ts
@@ -4,4 +4,5 @@ export const CODE_LIKE_TYPES = new Set([
   'function',
   'ctor',
   'property',
+  'event',
 ]);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This ensures that events (`'close'`) aren't bold in the sidebar.

Very similar to https://github.com/nodejs/nodejs.org/pull/8705 for properties.

## Validation

Current state: check https://beta.docs.nodejs.org/http.html, see that the various `'...'` events listed under `http.ClientRequest` in the sidebar are bold, unlike their neighbours.

<img width="237" height="443" alt="image" src="https://github.com/user-attachments/assets/07370b19-7f3e-4e8e-a358-38a96814a410" />

Fixed: manually rebuilt & verified in the new Node docs, works correctly:

<img width="263" height="450" alt="image" src="https://github.com/user-attachments/assets/ed4ba2f9-2436-4d17-8f67-ea229efe3b89" />

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
