### PR TITLE
chore(remark-lint): various improvements

### DIFF
--- a/packages/remark-lint/src/rules/invalid-type-reference.mjs
+++ b/packages/remark-lint/src/rules/invalid-type-reference.mjs
@@ -11,10 +11,6 @@ const isTypeNode = node => {
     return QUERIES.normalizeTypes.test(node.value);
   }
 
-  if (node.type === 'html') {
-    return node.value.match(QUERIES.normalizeTypes)?.includes(node.value);
-  }
-
   return false;
 };
 


### PR DESCRIPTION
The linter (for some reason) get's confused when it sees comments, so we should just skip them