### PR TITLE
fix(blog): typo in Node 22->24 codemod

### DIFF
--- a/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
+++ b/apps/site/pages/en/blog/migrations/v22-to-v24.mdx
@@ -274,7 +274,7 @@ The source code for this codemod can be found in the [tls-create-secure-pair-to-
 You can find this codemod in the [Codemod Registry](https://app.codemod.com/registry/@nodejs/tls-create-secure-pair-to-tls-socket).
 
 ```bash
-npx codemod run @nodejs/tls-create-secure-pair-to-tls
+npx codemod run @nodejs/tls-create-secure-pair-to-tls-socket
 ```
 
 ## Examples


### PR DESCRIPTION
## Description

There's a typo in `/en/blog/migrations/v22-to-v24` that causes the `tls-create-secure-pair-to-tls-socket` codemod to not run when copied.

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `pnpm format` to ensure the code follows the style guide.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have run `pnpm build` to check if the website builds without errors.
- [x] I've covered new added functionality with unit tests if necessary.
