### PR TITLE
chore: remove Codemod from partners list

### DIFF
--- a/apps/site/public/static/partners/constants.json
+++ b/apps/site/public/static/partners/constants.json
@@ -54,12 +54,5 @@
     "href": "https://tuxcare.com",
     "weight": 2,
     "categories": ["esp"]
-  },
-  {
-    "id": "CODEMOD",
-    "name": "Codemod",
-    "href": "https://codemod.com",
-    "weight": 1,
-    "categories": []
   }
 ]


### PR DESCRIPTION
After a brief check with @rginn, I can confirm there is no signed agreement for including the Codemod logo in our website. This is true for all other vendors listed.

Therefore, I'm removing it.