### PR TITLE
chore(ui): allow ChangeHistory to accept ReactNode

### DIFF
--- a/.changeset/soft-friends-camp.md
+++ b/.changeset/soft-friends-camp.md
@@ -1,0 +1,5 @@
+---
+'@node-core/ui-components': patch
+---
+
+Allow the ChangeHistory component to accept a ReactNode as it's content

--- a/packages/ui-components/src/Common/ChangeHistory/index.tsx
+++ b/packages/ui-components/src/Common/ChangeHistory/index.tsx
@@ -9,7 +9,7 @@ import styles from './index.module.css';
 export type HistoryChange = {
   versions: Array<string>;
   label: string;
-  content: ReactNode;
+  content?: ReactNode;
   url?: string;
 };
 

--- a/packages/ui-components/src/Common/ChangeHistory/index.tsx
+++ b/packages/ui-components/src/Common/ChangeHistory/index.tsx
@@ -2,13 +2,14 @@ import { ChevronDownIcon, ClockIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 
 import type { LinkLike } from '#ui/types';
-import type { FC, ComponentProps } from 'react';
+import type { FC, ComponentProps, ReactNode } from 'react';
 
 import styles from './index.module.css';
 
 export type HistoryChange = {
   versions: Array<string>;
   label: string;
+  content: ReactNode;
   url?: string;
 };
 
@@ -51,7 +52,9 @@ const ChangeHistory: FC<ChangeHistoryProps> = ({
                 aria-label={`${change.label}: ${change.versions.join(', ')}`}
                 href={change.url}
               >
-                <div className={styles.dropdownLabel}>{change.label}</div>
+                <div className={styles.dropdownLabel}>
+                  {change.content ?? change.label}
+                </div>
                 <div className={styles.dropdownVersions}>
                   {change.versions.join(', ')}
                 </div>


### PR DESCRIPTION
Blocking https://github.com/nodejs/doc-kit/pull/1049

Allows `ChangeHistory` to accept non-string labels, so that in `doc-kit`, we can parse these to HTML