### PR TITLE
docs: update Orama link to their new docs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ These are maintained in different repositories and we urge users to open **issue
   - A really warm thank you to Cloudflare as we would not be able to serve our community without their immense support.
 - Thanks to [Sentry](https://sentry.io/welcome/) for providing an open source license for their error reporting, monitoring and diagnostic tools.
 - Thanks to [Crowdin](https://crowdin.com/) for providing a platform that allows us to localize the Node.js Website and collaborate with translators.
-- Thanks to [Orama](https://docs.oramasearch.com/) for providing a search platform that indexes our expansive content and provides lightning-fast results for our users.
+- Thanks to [Orama](https://docs.orama.com/) for providing a search platform that indexes our expansive content and provides lightning-fast results for our users.
 - Thanks to [DigitalOcean](https://www.digitalocean.com/) for generously providing Node.js with credits as part of their open source program.
 
 [code of conduct]: https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -24,7 +24,6 @@ const nextConfig = {
       'https://bestpractices.coreinfrastructure.org/**',
       'https://raw.githubusercontent.com/nodejs/**',
       'https://user-images.githubusercontent.com/**',
-      'https://website-assets.oramasearch.com/**',
     ].map(url => new URL(url)),
   },
   serverExternalPackages: ['twoslash'],

--- a/apps/site/pages/en/blog/announcements/diving-into-the-nodejs-website-redesign.md
+++ b/apps/site/pages/en/blog/announcements/diving-into-the-nodejs-website-redesign.md
@@ -50,7 +50,7 @@ The [OpenJS Foundation](https://openjsf.org/) was kind enough to help fund our r
 
 Realizing the design as code was next, and an effort distributed across the world. A lot of emphasis was placed on sequential build-up of foundational design elements and structured component hierarchies. We built variants of components from day one and considered internationalization at the outset. This reduced rework and made any task accessible to a newcomer. We started building components in isolation via [Storybook](https://storybook.js.org/) and [Chromatic](https://www.chromatic.com/)'s hosted instance. Storybook was a great place to prototype, iterate on, and test components. We choose to use [Tailwind CSS](https://tailwindcss.com/), but with an emphasis on design tokens and applied CSS. This common language helped newcomers orient to our approach and translate the Figma.
 
-[Orama](https://docs.oramasearch.com/) search puts all the site's content at a user's fingertips. They index our static content and provide lightning-fast results of API content, learning material, blog posts, and more. The team there directly contributed this integration and continues to help us deliver a superb experience. It's already hard to imagine _not_ having this feature.
+[Orama](https://docs.orama.com/) search puts all the site's content at a user's fingertips. They index our static content and provide lightning-fast results of API content, learning material, blog posts, and more. The team there directly contributed this integration and continues to help us deliver a superb experience. It's already hard to imagine _not_ having this feature.
 
 The reach that Node.js enjoys in our communities is important to us. As such, the old site was internationalized to almost 20 languages. An unfortunate combination of events led us to reset all translations, however. This was a hard decision, but the right one given the circumstances. We're working with [Crowdin](https://crowdin.com/) to re-establish our efforts. This will include a careful parsing of the new MDX-based content. We're looking forward to the continual internalization in the coming months.
 
@@ -102,7 +102,7 @@ Many people and organizations have contributed in both big and small ways to rea
 - [Cloudflare](https://cloudflare.com) for providing the infrastructure that serves Node.js's Website, Node.js's CDN, and more.
 - [Crowdin](https://crowdin.com/) for providing a platform that allows us to localize the Node.js Website and collaborate with translators.
 - [Hayden Bleasel](https://haydenbleasel.com/) for his design work on the Node.js redesign.
-- [Orama](https://docs.oramasearch.com/) for providing a search platform that indexes our content and provides lightning-fast results.
+- [Orama](https://docs.orama.com/) for providing a search platform that indexes our content and provides lightning-fast results.
 - [Sentry](https://sentry.io/welcome/) for providing an open source license for their error reporting, monitoring, and diagnostic tools.
 - [Vercel](https://www.vercel.com/) for providing the infrastructure that serves and powers the Node.js Website
 - and lastly, the [OpenJS Foundation](https://openjsf.org/) for their support and guidance.


### PR DESCRIPTION
## What
Updated the Orama link in the README from docs.oramasearch.com to docs.orama.com.

## Why
The old domain no longer resolves. Orama moved their docs to orama.com.

## Verification
docs.oramasearch.com fails DNS resolution, docs.orama.com returns 200.