### PR TITLE
fix(ui): ChangeHistory dropdown width collapses to its min-width

### DIFF
--- a/packages/ui-components/src/Common/ChangeHistory/index.module.css
+++ b/packages/ui-components/src/Common/ChangeHistory/index.module.css
@@ -34,7 +34,7 @@
     max-h-80
     w-max
     max-w-[min(26rem,calc(100vw-2rem))]
-    min-w-[12rem]
+    min-w-[min(12rem,calc(100vw-2rem))]
     overflow-hidden
     rounded-sm
     border

--- a/packages/ui-components/src/Common/ChangeHistory/index.module.css
+++ b/packages/ui-components/src/Common/ChangeHistory/index.module.css
@@ -32,8 +32,9 @@
     z-50
     mt-1
     max-h-80
-    w-[26rem]
-    max-w-[calc(100vw-2rem)]
+    w-max
+    max-w-[min(26rem,calc(100vw-2rem))]
+    min-w-[12rem]
     overflow-hidden
     rounded-sm
     border


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
close #9145
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `pnpm format` to ensure the code follows the style guide.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have run `pnpm build` to check if the website builds without errors.
- [ ] I've covered new added functionality with unit tests if necessary.
