### PR TITLE
fix(ui): fix sidebar height

### DIFF
--- a/packages/ui-components/src/Containers/Article/index.module.css
+++ b/packages/ui-components/src/Containers/Article/index.module.css
@@ -19,7 +19,7 @@
   > *:nth-child(1) {
     @apply ml:sticky
       ml:top-0
-      ml:h-svh
+      ml:h-[calc(100svh-var(--header-height))]
       ml:overflow-y-auto
       [grid-area:sidebar];
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.org/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix the sidebar height. It's a small detail, in the images you can see the differences. The sidebar was moving a few pixels down because of the header's height, so I calculated it in css: `100svh - header height` and that's it!

**Before**
<img width="406" height="208" alt="image (2)" src="https://github.com/user-attachments/assets/9ebb4ec9-50a8-4fd9-a5c8-18670557f04b" />

**After**
<img width="408" height="216" alt="image (4)" src="https://github.com/user-attachments/assets/9f1f5123-a74a-42ec-a218-961df4d9ca40" />


## Validation

Just go to any page that has the long sidebar, like /learn. For some reason, it redirects me to nodejs.org instead of a localhost url, so you can go to /en/about/get-involved/events and add several `<li>` items to the sidebar, and you'll be able to reproduce it!

## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `pnpm format` to ensure the code follows the style guide.
- [X] I have run `pnpm test` to check if all tests are passing.
- [X] I have run `pnpm build` to check if the website builds without errors.
- [X] I've covered new added functionality with unit tests if necessary.
